### PR TITLE
[E2E] Tests with AI groups and changed command group name added

### DIFF
--- a/tests/e2e/tests/regression/cli/cli-command-helper.e2e.ts
+++ b/tests/e2e/tests/regression/cli/cli-command-helper.e2e.ts
@@ -17,6 +17,7 @@ const userAgreementPage = new UserAgreementPage();
 const addRedisDatabasePage = new AddRedisDatabasePage();
 const COMMAND_GROUP_JSON = 'JSON';
 const COMMAND_GROUP_SEARCH = 'Search';
+const COMMAND_GROUP_HyperLogLog = 'HyperLogLog';
 
 fixture `CLI Command helper`
     .meta({ type: 'regression' })
@@ -47,7 +48,6 @@ test('Verify that user can see in Command helper and click on new group "JSON", 
     //Check that command info is displayed on the page
     await t.expect(cliPage.cliReadMoreJSONCommandDocumentation().textContent).contains('JSON.SET');
 });
-
 test('Verify that user can see in Command helper and click on new group "Search", can choose it and see list of commands in the group', async t => {
     const commandForCheck = 'FT.EXPLAIN';
     await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
@@ -64,4 +64,64 @@ test('Verify that user can see in Command helper and click on new group "Search"
     await t.expect(getPageUrl()).contains('/#ftexplain');
     //Check that command info is displayed on the page
     await t.expect(cliPage.cliReadMoreRediSearchCommandDocumentation().textContent).contains('FT.EXPLAIN');
+});
+test('Verify that user can see HyperLogLog title in Command Helper for this command group', async t => {
+    const commandForCheck = 'PFCOUNT';
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    //Open CLI
+    await t.click(cliPage.cliExpandButton);
+    //Select one command from the list
+    await cliPage.selectFilterGroupType(COMMAND_GROUP_HyperLogLog);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(commandForCheck));
+    //Verify results of opened command
+    await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('PFCOUNT key [key ...]', 'Selected command title');
+    //Click on Read More link for selected command
+    await t.click(cliPage.readMoreButton);
+    //Check new opened window page with the correct URL
+    await t.expect(getPageUrl()).contains('/pfcount');
+});
+test('Verify that user can see all separated groups for AI json file (model, tensor, inference, script)', async t => {
+    const AIGroups = [
+        'Model',
+        'Script',
+        'Inference',
+        'Tensor'
+    ];
+    const commandsForCheck = [
+        'AI.MODELDEL',
+        'AI.SCRIPTSTORE',
+        'AI.SCRIPTEXECUTE',
+        'AI.TENSORSET'
+    ];
+    const commandArgumentsCheck = [
+        'AI.MODELDEL key',
+        'AI.SCRIPTSTORE key CPU|GPU [TAG tag] ENTRY_POINTS entry_point_count entry_point [entry_point ...]',
+        'AI.SCRIPTEXECUTE key function [KEYS key_count key [key ...]] [INPUTS input_count input [input ...]] [ARGS arg_count arg [arg ...]] [OUTPUTS output_count output [output ...]] [TIMEOUT timeout]',
+        'AI.TENSORSET key FLOAT|DOUBLE|INT8|INT16|INT32|INT64|UINT8|UINT16|STRING|BOOL shape [shape ...] [BLOB blob] [VALUES value [VALUES value ...]]'
+    ];
+    const ExternalPage = [
+        '/#aimodeldel',
+        '/#aiscriptstore',
+        '/#aiscriptexecute',
+        '/#aitensorset'
+    ];
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    //Open CLI
+    await t.click(cliPage.cliExpandButton);
+    let i = 0;
+    while (i <= 3) {
+        //Select one group from the list
+        await cliPage.selectFilterGroupType(AIGroups[i]);
+        //Click on the group
+        await t.click(cliPage.cliHelperOutputTitles.withExactText(commandsForCheck[i]));
+        //Verify results of opened command
+        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsCheck[i], 'Selected command title');
+        //Click on Read More link for selected command
+        await t.click(cliPage.readMoreButton);
+        //Check new opened window page with the correct URL
+        await t.expect(getPageUrl()).contains(ExternalPage[i]);
+        //Close the window with external link to switch to the application window
+        await t.closeWindow();
+        i++;
+    }
 });


### PR DESCRIPTION
The following tests are added:
-Verify that user can see HyperLogLog title in Command Helper for this command group;
-Verify that user can see all separated groups for AI json file (model, tensor, inference, script).