### PR TITLE
[E2E] Workbench tests are added

### DIFF
--- a/tests/e2e/pageObjects/workbench-page.ts
+++ b/tests/e2e/pageObjects/workbench-page.ts
@@ -47,6 +47,8 @@ export class WorkbenchPage {
   preselectGroupBy: Selector
   preselectArea: Selector
   expandArea: Selector
+  monacoHintWithArguments: Selector
+  noCommandHistorySection: Selector
 
   constructor() {
       //CSS selectors
@@ -97,6 +99,8 @@ export class WorkbenchPage {
       this.monacoCloseCommandDetails = Selector('span.codicon-close');
       this.monacoSuggestion = Selector('span.monaco-icon-name-container');
       this.iframe = Selector('.pluginIframe', { timeout: 90000 });
+      this.monacoHintWithArguments = Selector('[widgetid="editor.widget.parameterHintsWidget"]')
+      this.noCommandHistorySection = Selector('[data-testid=wb_no-results]')
       // Panel
       this.preselectArea = Selector('[data-testid=enablementArea]');
       this.expandArea = Selector('[]')

--- a/tests/e2e/pageObjects/workbench-page.ts
+++ b/tests/e2e/pageObjects/workbench-page.ts
@@ -49,6 +49,9 @@ export class WorkbenchPage {
   expandArea: Selector
   monacoHintWithArguments: Selector
   noCommandHistorySection: Selector
+  noCommandHistoryIcon: Selector
+  noCommandHistoryTitle: Selector
+  noCommandHistoryText: Selector
 
   constructor() {
       //CSS selectors
@@ -99,11 +102,13 @@ export class WorkbenchPage {
       this.monacoCloseCommandDetails = Selector('span.codicon-close');
       this.monacoSuggestion = Selector('span.monaco-icon-name-container');
       this.iframe = Selector('.pluginIframe', { timeout: 90000 });
-      this.monacoHintWithArguments = Selector('[widgetid="editor.widget.parameterHintsWidget"]')
-      this.noCommandHistorySection = Selector('[data-testid=wb_no-results]')
-      // Panel
+      this.monacoHintWithArguments = Selector('[widgetid="editor.widget.parameterHintsWidget"]');
+      this.noCommandHistorySection = Selector('[data-testid=wb_no-results]');
       this.preselectArea = Selector('[data-testid=enablementArea]');
-      this.expandArea = Selector('[]')
+      this.expandArea = Selector('[data-testid=enablement-area-container]');
+      this.noCommandHistoryIcon = Selector ('[data-testid=wb_no-results__icon]');
+      this.noCommandHistoryTitle = Selector ('[data-testid=wb_no-results__title]');
+      this.noCommandHistoryText = Selector ('[data-testid=wb_no-results__summary]');
   }
 
   /**

--- a/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
@@ -49,3 +49,45 @@ test('Verify that user can open the "read more" about the command by clicking on
     await t.pressKey('ctrl+space');
     await t.expect(await workbenchPage.monacoCommandDetails.exists).notOk('The "read more" about the command is closed');
 });
+test('Verify that user can see static list of arguments is displayed when he enters the command in Editor in Workbench', async t => {
+    const command = 'AI.SCRIPTEXECUTE'
+    //Type the command in Editing area
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    //Check that no hints are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed yet')
+    //Add space after the printed command
+    const command_hint = 'AI.SCRIPTEXECUTE '
+    await t.typeText(workbenchPage.queryInput, command_hint, { replace: true })
+    //Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
+});
+test('Verify that user can close the static list of arguments by pressing “ESC”', async t => {
+    const command = 'TS.DELETERULE '
+    await t.typeText(workbenchPage.queryInput, command, { replace: true })
+    //Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
+    //Remove hints with arguments
+    await t.pressKey('esc');
+    //Check no hints are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed')
+});
+test('Verify that user can see the static list of arguments when he uses “Ctrl+Shift+Space” combination for already entered command for Windows', async t => {
+    const command = 'JSON.ARRAPPEND'
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    //Verify that the list with auto-suggestions is displayed
+    await t.expect(await workbenchPage.monacoSuggestion.exists).ok('Auto-suggestions are displayed');
+    //Select the command from suggestion list
+    await t.pressKey('enter');
+    //Check that the command is displayed in Editing area after selecting
+    const script = await workbenchPage.queryInputScriptArea.textContent;
+    await t.expect(script.replace(/\s/g, ' ')).eql('JSON.ARRAPPEND key value ', 'Result of sent command exists');
+    //Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
+    //Remove hints with arguments
+    await t.pressKey('esc');
+    //Check no hints are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed')
+    //Check that using shortcut “Ctrl+Shift+Space” hints are displayed
+    await t.pressKey('ctrl+shift+space');
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
+});

--- a/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
@@ -56,8 +56,7 @@ test('Verify that user can see static list of arguments is displayed when he ent
     //Check that no hints are displayed
     await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed yet')
     //Add space after the printed command
-    const command_hint = 'AI.SCRIPTEXECUTE '
-    await t.typeText(workbenchPage.queryInput, command_hint, { replace: true })
+    await t.typeText(workbenchPage.queryInput, `${command} `, { replace: true })
     //Check that hint with arguments are displayed
     await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
 });

--- a/tests/e2e/tests/regression/workbench/empty-command-history.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/empty-command-history.e2e.ts
@@ -1,0 +1,42 @@
+import { Selector } from 'testcafe';
+import { addNewStandaloneDatabase } from '../../../helpers/database';
+import { MyRedisDatabasePage, UserAgreementPage, AddRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
+import {
+    commonUrl,
+    ossStandaloneConfig
+} from '../../../helpers/conf';
+
+const myRedisDatabasePage = new MyRedisDatabasePage();
+const userAgreementPage = new UserAgreementPage();
+const addRedisDatabasePage = new AddRedisDatabasePage();
+const workbenchPage = new WorkbenchPage();
+
+fixture `Empty command history in Workbench`
+    .meta({type: 'regression'})
+    .page(commonUrl)
+    .beforeEach(async t => {
+        await t.maximizeWindow();
+        await userAgreementPage.acceptLicenseTerms();
+        await t.expect(addRedisDatabasePage.addDatabaseButton.exists).ok('The add redis database view', {timeout: 20000});
+        await addNewStandaloneDatabase(ossStandaloneConfig);
+        //Connect to DB
+        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+        //Go to Workbench page
+        await t.click(myRedisDatabasePage.workbenchButton);
+    })
+test('Verify that user can see placeholder text in Workbench history if no commands have not been run yet', async t => {
+    //Verify that all the elements from empty command history placeholder are displayed
+    await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is visible')
+    await t.expect(workbenchPage.noCommandHistoryIcon.visible).ok('No command history icon is visible')
+    await t.expect(workbenchPage.noCommandHistoryTitle.visible).ok('No command history title is visible')
+    await t.expect(workbenchPage.noCommandHistoryText.visible).ok('No command history text is visible')
+    //Run a command
+    const commandToSend = 'info server';
+    await workbenchPage.sendCommandInWorkbench(commandToSend);
+    //Verify that empty command history placeholder is not displayed
+    await t.expect(workbenchPage.noCommandHistorySection.visible).notOk('No command history section is not visible')
+    //Delete the command result
+    await t.click(Selector(workbenchPage.cssDeleteCommandButton));
+    //Verify that empty command history placeholder is displayed
+    await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is visible')
+});


### PR DESCRIPTION
The following tests were added:
- Verify that user can see placeholder text in Workbench history if no commands have not been run yet
- Verify that user can see static list of arguments is displayed when he enters the command in Editor in Workbench
- Verify that user can close the static list of arguments by pressing “ESC”
- Verify that user can see the static list of arguments when he uses “Ctrl+Shift+Space” combination for already entered command for Windows