### PR TITLE
#RI-2513, #RI-2514, #RI-2515, #RI-2516, #RI-2517, #RI-2521

### DIFF
--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
@@ -197,9 +197,7 @@ const DatabaseListModules = React.memo((props: Props) => {
           display="inlineBlock"
           content={Content}
         >
-          <>
-            {Modules()}
-          </>
+          {Modules()}
         </EuiToolTip>
       )}
 

--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
@@ -78,7 +78,8 @@ export const modulesDefaultInit = {
   },
 }
 
-const DatabaseListModules = React.memo(({ modules, inCircle, highlight, tooltipTitle, maxViewModules }: Props) => {
+const DatabaseListModules = React.memo((props: Props) => {
+  const { modules, inCircle, highlight, tooltipTitle, maxViewModules } = props
   const { theme } = useContext(ThemeContext)
 
   const mainContent = []
@@ -112,7 +113,7 @@ const DatabaseListModules = React.memo(({ modules, inCircle, highlight, tooltipT
   })
 
   // set count of hidden modules
-  if (maxViewModules && newModules.length > maxViewModules) {
+  if (maxViewModules && newModules.length > maxViewModules + 1) {
     newModules.length = maxViewModules
     newModules.push({
       icon: null,
@@ -138,42 +139,70 @@ const DatabaseListModules = React.memo(({ modules, inCircle, highlight, tooltipT
     </div>
   ))
 
+  const Module = (moduleName: string = '', abbreviation: string = '', icon: string, content: string = '') => (
+    <span key={moduleName || abbreviation || content}>
+      {icon ? (
+        <EuiButtonIcon
+          iconType={icon}
+          className={cx(styles.icon, { [styles.circle]: inCircle })}
+          onClick={() => handleCopy(content)}
+          data-testid={`${content}_module`}
+          aria-labelledby={`${content}_module`}
+        />
+      ) : (
+        <EuiTextColor
+          className={cx(styles.icon, styles.abbr, { [styles.circle]: inCircle })}
+          onClick={() => handleCopy(content)}
+          data-testid={`${content}_module`}
+          aria-labelledby={`${content}_module`}
+        >
+          {abbreviation}
+        </EuiTextColor>
+      )}
+    </span>
+  )
+
+  const Modules = () => (
+    newModules.map(({ icon, content, abbreviation, moduleName }, i) => (
+      !inCircle
+        ? Module(moduleName, abbreviation, icon, content)
+        : (
+          <EuiToolTip
+            position="bottom"
+            display="inlineBlock"
+            content={Content[i]}
+            anchorClassName={styles.anchorModuleTooltip}
+            key={moduleName}
+          >
+            <>
+              {Module(moduleName, abbreviation, icon, content)}
+            </>
+          </EuiToolTip>
+        )
+    ))
+  )
+
   return (
     <div className={cx(styles.container, {
       [styles.highlight]: highlight,
       [styles.containerCircle]: inCircle,
     })}
     >
-      <EuiToolTip
-        position="bottom"
-        title={tooltipTitle ?? undefined}
-        display="inlineBlock"
-        content={Content}
-      >
-        <>
-          {newModules.map(({ icon, content, abbreviation, moduleName }) => (
-            icon ? (
-              <EuiButtonIcon
-                iconType={icon}
-                className={cx(styles.icon, { [styles.circle]: inCircle })}
-                onClick={() => handleCopy(content)}
-                data-testid={`${content}_module`}
-                aria-labelledby={`${content}_module`}
-                key={moduleName}
-              />
-            ) : (
-              <EuiTextColor
-                className={cx(styles.icon, styles.abbr, { [styles.circle]: inCircle })}
-                onClick={() => handleCopy(content)}
-                data-testid={`${content}_module`}
-                aria-labelledby={`${content}_module`}
-                key={moduleName}
-              >
-                {abbreviation}
-              </EuiTextColor>
-            )))}
-        </>
-      </EuiToolTip>
+      { inCircle ? (
+        Modules()
+      ) : (
+        <EuiToolTip
+          position="bottom"
+          title={tooltipTitle ?? undefined}
+          display="inlineBlock"
+          content={Content}
+        >
+          <>
+            {Modules()}
+          </>
+        </EuiToolTip>
+      )}
+
     </div>
   )
 })

--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
@@ -174,9 +174,7 @@ const DatabaseListModules = React.memo((props: Props) => {
             anchorClassName={styles.anchorModuleTooltip}
             key={moduleName}
           >
-            <>
-              {Module(moduleName, abbreviation, icon, content)}
-            </>
+            {Module(moduleName, abbreviation, icon, content)}
           </EuiToolTip>
         )
     ))

--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
@@ -174,7 +174,9 @@ const DatabaseListModules = React.memo((props: Props) => {
             anchorClassName={styles.anchorModuleTooltip}
             key={moduleName}
           >
-            {Module(moduleName, abbreviation, icon, content)}
+            <>
+              {Module(moduleName, abbreviation, icon, content)}
+            </>
           </EuiToolTip>
         )
     ))
@@ -195,7 +197,9 @@ const DatabaseListModules = React.memo((props: Props) => {
           display="inlineBlock"
           content={Content}
         >
-          {Modules()}
+          <>
+            {Modules()}
+          </>
         </EuiToolTip>
       )}
 

--- a/redisinsight/ui/src/components/database-list-modules/styles.module.scss
+++ b/redisinsight/ui/src/components/database-list-modules/styles.module.scss
@@ -1,12 +1,14 @@
 .container {
   height: 24px;
   line-height: 20px;
+  display: inline-block;
+  width: auto;
+  padding-left: 6px;
+  padding-right: 6px;
 
   &.highlight {
     background-color: var(--hoverInListColorLight);
     border-radius: 12px;
-    padding-left: 6px;
-    padding-right: 6px;
   }
 
   &.containerCircle {
@@ -20,8 +22,8 @@
     max-width: 28px !important;
     height: 27px !important;
     border-radius: 50% !important;
-    margin-right: 14px;
     padding: 4px;
+    margin-right: 0;
 
     &:hover,
     &:focus,
@@ -36,8 +38,8 @@
 }
 
 .icon img {
-  width: 18px !important;
-  max-width: 18px !important;
+  width: 16px !important;
+  max-width: 16px !important;
   height: 16px !important;
 }
 
@@ -51,4 +53,8 @@
 
 .abbr {
   vertical-align: text-top;
+}
+
+.anchorModuleTooltip {
+  margin-right: 18px;
 }

--- a/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/InstanceForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/InstanceForm.tsx
@@ -57,6 +57,7 @@ import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { resetKeys } from 'uiSrc/slices/keys'
 import { appContextSelector, setAppContextInitialState } from 'uiSrc/slices/app/context'
 import DatabaseAlias from 'uiSrc/pages/home/components/DatabaseAlias'
+import { DatabaseListModules } from 'uiSrc/components'
 import {
   LoadingInstanceText,
   SubmitBtnText,
@@ -160,6 +161,7 @@ const AddStandaloneForm = (props: Props) => {
       selectedCaCertName,
       username,
       password,
+      modules,
       sentinelMasterPassword,
       sentinelMasterUsername,
     },
@@ -185,6 +187,7 @@ const AddStandaloneForm = (props: Props) => {
     password,
     tls,
     db,
+    modules,
     showDb: !!db,
     newCaCert: '',
     newCaCertName: '',
@@ -455,6 +458,22 @@ const AddStandaloneForm = (props: Props) => {
             </EuiText>
             )}
         />
+      )}
+
+      {!!modules?.length && (
+        <>
+          <EuiListGroupItem
+            className={styles.dbInfoModulesLabel}
+            label={(
+              <EuiText color="subdued" size="s">
+                Modules:
+              </EuiText>
+            )}
+          />
+          <EuiTextColor color="default" className={cx(styles.dbInfoListValue, styles.dbInfoModules)}>
+            <DatabaseListModules modules={modules} />
+          </EuiTextColor>
+        </>
       )}
     </EuiListGroup>
   )

--- a/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/styles.module.scss
@@ -14,8 +14,11 @@
 }
 
 .dbInfoGroup {
-  padding-bottom: 12px !important;
   max-width: 100% !important;
+  background-color: var(--euiColorLightestShade) !important;
+  border: 1px solid var(--separatorColor) !important;
+  padding: 10px 18px !important;
+  border-radius: 4px;
 
   :global {
     .euiListGroupItem__label {
@@ -25,19 +28,37 @@
     }
 
     .euiListGroupItem {
-      padding: 3px 13px;
+      padding: 4px 0;
       margin-top: 0 !important;
-
-      &:nth-of-type(odd) {
-        border: 1px solid var(--tableDarkestBorderColor);
-        background-color: var(--browserTableRowEven) !important;
-      }
     }
   }
 }
 
 .dbInfoListValue {
   margin-left: 10px;
+}
+
+.dbInfoModules {
+  padding-right: 0;
+  margin-left: 0;
+  height: 27px;
+  & > div {
+    display: inline-block;
+    line-height: 20px;
+    margin-top: 5px;
+    vertical-align: top;
+  }
+}
+
+.dbInfoModulesLabel {
+  position: relative;
+  display: inline-block !important;
+  padding-right: 0 !important;
+  width: auto;
+
+  :global(.euiListGroupItem__text) {
+    padding-right: 0 !important;
+  }
 }
 
 .anchorEndpoints {

--- a/redisinsight/ui/src/pages/home/components/DatabasesListComponent/DatabasesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/DatabasesListComponent/DatabasesListWrapper.tsx
@@ -14,6 +14,7 @@ import React, { useContext, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import cx from 'classnames'
+import AutoSizer from 'react-virtualized-auto-sizer'
 
 import {
   checkConnectToInstanceAction,
@@ -33,9 +34,8 @@ import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import { formatLongName, getDbIndex, Nullable, replaceSpaces } from 'uiSrc/utils'
 import { appContextSelector, setAppContextInitialState } from 'uiSrc/slices/app/context'
 import { resetCliHelperSettings, resetCliSettingsAction } from 'uiSrc/slices/cli/cli-settings'
-import DatabaseListModules, { ModulesListType } from 'uiSrc/components/database-list-modules/DatabaseListModules'
+import DatabaseListModules from 'uiSrc/components/database-list-modules/DatabaseListModules'
 import RediStackSVG from 'uiSrc/assets/img/modules/RediStack.svg'
-import { RedisModuleDto } from 'apiSrc/modules/instances/dto/database-instance.dto'
 import DatabasesList from './DatabasesList/DatabasesList'
 
 import styles from './styles.module.scss'
@@ -287,25 +287,31 @@ const DatabasesListWrapper = ({
     },
     {
       field: 'modules',
-      className: 'column_modules',
+      className: styles.columnModules,
       name: 'Modules',
-      width: '150px',
+      width: '30%',
       dataType: 'string',
-      render: (cellData, { modules = [], port, isRediStack }: Instance) => {
-        return (
-          <DatabaseListModules
-            highlight={isRediStack}
-            modules={modules}
-            maxViewModules={3}
-            tooltipTitle={isRediStack ? (
-              <>
-                <EuiIcon type={RediStackSVG} className={styles.redistackIcon} />
-                <span style={{ verticalAlign: 'middle' }}>Redis Stack</span>
-              </>
-            ) : ''}
-          />
-        )
-      },
+      render: (_cellData, { modules = [], isRediStack }: Instance) => (
+        <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+          <AutoSizer>
+            {({ width: columnWidth }) => (
+              <div style={{ width: columnWidth, height: 40 }}>
+                <DatabaseListModules
+                  highlight={isRediStack}
+                  modules={modules}
+                  maxViewModules={Math.floor((columnWidth - 12) / 28) - 1}
+                  tooltipTitle={isRediStack ? (
+                    <>
+                      <EuiIcon type={RediStackSVG} className={styles.redistackIcon} />
+                      <span style={{ verticalAlign: 'middle' }}>Redis Stack</span>
+                    </>
+                  ) : ''}
+                />
+              </div>
+            )}
+          </AutoSizer>
+        </div>
+      ),
     },
     {
       field: 'lastConnection',

--- a/redisinsight/ui/src/pages/home/components/DatabasesListComponent/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/components/DatabasesListComponent/styles.module.scss
@@ -106,3 +106,8 @@ $breakpoint-l: 1400px;
   margin-right: 6px;
   vertical-align: bottom;
 }
+
+.columnModules {
+  height: 40px;
+  padding-right: 0 !important;
+}

--- a/redisinsight/ui/src/pages/home/styles.scss
+++ b/redisinsight/ui/src/pages/home/styles.scss
@@ -290,6 +290,7 @@
     padding: 40px 30px 25px;
     border: 1px solid var(--euiColorPrimary);
     margin-right: 5px;
+    border-radius: 4px;
 
     @media only screen and (max-width: 767px) {
       height: calc(100vh - 340px);
@@ -315,6 +316,7 @@
     padding: 3px 18px 18px;
     background-color: var(--euiColorLightestShade) !important;
     border: 1px solid var(--euiColorLightShade);
+    border-radius: 4px;
 
     .euiSelect,
     .euiSuperSelectControl,

--- a/redisinsight/ui/src/utils/redistack.ts
+++ b/redisinsight/ui/src/utils/redistack.ts
@@ -4,21 +4,25 @@ import { Instance } from 'uiSrc/slices/interfaces'
 export const REDISTACK_PORT = 6379
 export const REDISTACK_MODULES = ['ReJSON', 'graph', 'timeseries', 'search', 'bf'].sort()
 
+const checkRediStackModules = (modules: any[]) => isEqual(map(modules, 'name').sort(), REDISTACK_MODULES)
+
 const checkRediStack = (instances: Instance[]): Instance[] => {
-  let isRediStack = false
+  let isRediStackCheck = false
 
   let newInstances = instances.map((instance) => {
-    isRediStack = instance.port === REDISTACK_PORT && isEqual(map(instance.modules, 'name').sort(), REDISTACK_MODULES)
+    const isRediStack = +instance.port === REDISTACK_PORT && checkRediStackModules(instance.modules)
+
+    isRediStackCheck = isRediStackCheck || isRediStack
     return {
       ...instance,
       isRediStack
     }
   })
 
-  if (!isRediStack) {
+  if (!isRediStackCheck) {
     newInstances = newInstances.map((instance) => ({
       ...instance,
-      isRediStack: isEqual(map(instance.modules, 'name').sort(), REDISTACK_MODULES)
+      isRediStack: checkRediStackModules(instance.modules)
     }))
   }
 

--- a/redisinsight/ui/src/utils/tests/redistack.spec.ts
+++ b/redisinsight/ui/src/utils/tests/redistack.spec.ts
@@ -5,6 +5,10 @@ const unmapWithName = (arr: any[]) => arr.map((item) => ({ name: item }))
 const REDISTACK_MODULE_DEFAULT = unmapWithName(REDISTACK_MODULES)
 
 const getOutputCheckRediStackTests: any[] = [
+  [[{ port: REDISTACK_PORT, modules: REDISTACK_MODULE_DEFAULT },
+    { port: 12000, modules: REDISTACK_MODULE_DEFAULT }],
+  [{ port: REDISTACK_PORT, modules: REDISTACK_MODULE_DEFAULT, isRediStack: true },
+    { port: 12000, modules: REDISTACK_MODULE_DEFAULT, isRediStack: false }]],
   [[{ port: REDISTACK_PORT, modules: REDISTACK_MODULE_DEFAULT }],
     [{ port: REDISTACK_PORT, modules: REDISTACK_MODULE_DEFAULT, isRediStack: true }]],
   [[{ port: REDISTACK_PORT, modules: unmapWithName(['']) }], [{ port: REDISTACK_PORT, modules: unmapWithName(['']), isRediStack: false }]],


### PR DESCRIPTION
#RI-2513 - Edit mode doesn't have modules list
#RI-2514 - Number of icons should be depend on screen resolution
#RI-2515 - Hovering over each module icon, tooltip hides and appears again
#RI-2516 - On Browser page module icon should display tooltip with info per 1 module
#RI-2517 - +N number should be displayed only when N>=2
#RI-2521 - When user adds new DB with port not 6379 but with relevant list of modules, DB is highlighted