### PR TITLE
#RI-2539, #RI-2540, #RI-2544, #RI-2545, #RI-2547, #RI-2548, #RI-2552, #RI-2554

### DIFF
--- a/redisinsight/ui/src/components/virtual-table/styles.module.scss
+++ b/redisinsight/ui/src/components/virtual-table/styles.module.scss
@@ -56,8 +56,9 @@ $footerHeight: 38px;
   .tableRow {
     cursor: pointer;
     border-top-width: 0;
-    & > div:last-of-type {
-      border-right: 1px solid transparent;
+
+    & > div:first-of-type {
+      border-left: 3px solid transparent;
     }
   }
 
@@ -66,14 +67,10 @@ $footerHeight: 38px;
   }
 
   :global(.table-row-selected) {
-    background: var(--tableRowSelectedColor) !important;
-    border-top: 1px solid var(--euiColorPrimary) !important;
-    border-bottom: 1px solid var(--euiColorPrimary) !important;
+    background: var(--browserViewTypeActive) !important;
     & > div:first-of-type {
-      border-left: 1px solid var(--euiColorPrimary) !important;
-    }
-    & > div:last-of-type {
-      border-right: 1px solid var(--euiColorPrimary) !important;
+      border-left: 3px solid transparent;
+      border-left-color: var(--euiColorPrimary) !important;
     }
   }
 

--- a/redisinsight/ui/src/components/virtual-tree/VirtualTree.spec.tsx
+++ b/redisinsight/ui/src/components/virtual-tree/VirtualTree.spec.tsx
@@ -88,6 +88,7 @@ describe('VirtualTree', () => {
     render(
       <VirtualTree
         {...instance(mockedProps)}
+        selectDefaultLeaf
         items={mockedItems}
         setConstructingTree={mockConstructingTreeFn}
         onStatusSelected={mockOnStatusSelected}

--- a/redisinsight/ui/src/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/components/virtual-tree/components/Node/Node.tsx
@@ -60,7 +60,7 @@ const Node = ({
       onFocus={() => {}}
       data-testid={fullName}
     >
-      <div>
+      <div className={styles.nodeName}>
         {!isLeaf && (
         <>
           <EuiIcon
@@ -78,17 +78,17 @@ const Node = ({
         )}
 
         {isLeaf && (
-        <>
-          <EuiIcon
-            type={leafIcon}
-            className={cx(styles.nodeIcon, styles.nodeIconLeaf)}
-            data-test-subj={`leaf-icon_${fullName}`}
-          />
-          Keys
-        </>
+          <>
+            <EuiIcon
+              type={leafIcon}
+              className={cx(styles.nodeIcon, styles.nodeIconLeaf)}
+              data-test-subj={`leaf-icon_${fullName}`}
+            />
+            Keys
+          </>
         )}
       </div>
-      <div data-testid={`count_${fullName}`}>
+      <div className={styles.options} data-testid={`count_${fullName}`}>
         <span>{keyCount ?? ''}</span>
         <span className={styles.approximate} data-testid={`percentage_${fullName}`}>
           {keyApproximate ? `${keyApproximate < 1 ? '<1' : Math.round(keyApproximate)}%` : '' }

--- a/redisinsight/ui/src/components/virtual-tree/components/Node/styles.module.scss
+++ b/redisinsight/ui/src/components/virtual-tree/components/Node/styles.module.scss
@@ -28,13 +28,18 @@
 }
 
 .nodeSelected {
-  // border-left: 3px solid transparent;
   border-left-color: var(--euiColorPrimary) !important;
   background-color: var(--browserTreeNodeOpen);
 
   .nodeContent {
     color: var(--euiColorFullShade) !important;
   }
+}
+
+.nodeName {
+  position: relative;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nodeIcon {
@@ -59,4 +64,10 @@
   display: inline-block;
   width: 36px;
   text-align: end;
+}
+
+.options {
+  padding-left: 12px;
+  font-size: 12px;
+  font-weight: 300;
 }

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -170,7 +170,7 @@ const BrowserPage = () => {
                   id={firstPanelId}
                   scrollable={false}
                   initialSize={sizes[firstPanelId] ?? 50}
-                  minSize="670px"
+                  minSize="600px"
                   paddingSize="none"
                   wrapperProps={{
                     className: cx(styles.resizePanelLeft, {

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -1,6 +1,5 @@
 import { cloneDeep } from 'lodash'
 import React from 'react'
-import { instance, mock } from 'ts-mockito'
 import {
   cleanup,
   clearStoreActions,
@@ -12,7 +11,7 @@ import {
 import { loadKeys, setFilter } from 'uiSrc/slices/keys'
 import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances'
 import { KeyTypes } from 'uiSrc/constants'
-import { setBrowserTreeNodesOpen, setBrowserTreeSelectedLeaf } from 'uiSrc/slices/app/context'
+import { resetBrowserTree } from 'uiSrc/slices/app/context'
 import FilterKeyType from './FilterKeyType'
 
 let store: typeof mockedStore
@@ -65,8 +64,7 @@ describe('FilterKeyType', () => {
     const expectedActions = [
       setFilter(KeyTypes.Hash),
       loadKeys(),
-      setBrowserTreeNodesOpen({}),
-      setBrowserTreeSelectedLeaf({})
+      resetBrowserTree()
     ]
     expect(clearStoreActions(store.getActions())).toEqual(
       clearStoreActions(expectedActions)

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
@@ -15,7 +15,7 @@ import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances'
 import { fetchKeys, keysSelector, setFilter } from 'uiSrc/slices/keys'
 import { isVersionHigherOrEquals } from 'uiSrc/utils'
 import HelpTexts from 'uiSrc/constants/help-texts'
-import { setBrowserTreeNodesOpen, setBrowserTreeSelectedLeaf } from 'uiSrc/slices/app/context'
+import { resetBrowserTree } from 'uiSrc/slices/app/context'
 import { KeyViewType } from 'uiSrc/slices/interfaces/keys'
 import { FILTER_KEY_TYPE_OPTIONS } from './constants'
 
@@ -73,8 +73,7 @@ const FilterKeyType = () => {
     dispatch(fetchKeys('0', viewType === KeyViewType.Browser ? SCAN_COUNT_DEFAULT : SCAN_TREE_COUNT_DEFAULT))
 
     // reset browser tree context
-    dispatch(setBrowserTreeNodesOpen({}))
-    dispatch(setBrowserTreeSelectedLeaf({}))
+    dispatch(resetBrowserTree())
   }
 
   const UnsupportedInfo = () => (

--- a/redisinsight/ui/src/pages/browser/components/key-list/KeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-list/KeyList.tsx
@@ -198,18 +198,6 @@ const KeyList = (props: Props) => {
         )
       }
     },
-    {
-      id: 'actions',
-      label: '',
-      alignment: TableCellAlignment.Center,
-      absoluteWidth: 50,
-      minWidth: 50,
-      render: () => (
-        <span className={styles.action}>
-          <EuiIcon style={{ cursor: 'pointer' }} type="arrowRight" />
-        </span>
-      ),
-    },
   ]
 
   return (

--- a/redisinsight/ui/src/pages/browser/components/key-list/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/key-list/styles.module.scss
@@ -1,7 +1,6 @@
 .page {
   height: 100%;
   overflow: hidden;
-  padding-right: 1px;
 }
 
 .tooltip {

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.spec.tsx
@@ -106,7 +106,7 @@ describe('KeyTree', () => {
     expect(container.querySelector('[data-test-subj="key-list-panel"]')).toBeInTheDocument()
   })
 
-  it.only('"setBrowserTreeNodesOpen" should be called for Open a node', () => {
+  it('"setBrowserTreeNodesOpen" should be called for Open a node', () => {
     render(<KeyTree {...propsMock} />)
 
     fireEvent.click(screen.getByTestId(mockVirtualTreeResult?.[0]?.fullName))

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.tsx
@@ -9,6 +9,7 @@ import {
   setBrowserTreeSelectedLeaf
 } from 'uiSrc/slices/app/context'
 import { constructKeysToTree } from 'uiSrc/helpers'
+import { keysSelector } from 'uiSrc/slices/keys'
 import VirtualTree from 'uiSrc/components/virtual-tree'
 import { DEFAULT_SEPARATOR } from 'uiSrc/constants'
 import { IKeyListPropTypes, } from 'uiSrc/constants/prop-types/keys'
@@ -32,6 +33,7 @@ const KeyTree = (props: Props) => {
   const firstPanelId = 'tree'
   const secondPanelId = 'keys'
 
+  const { filter, search } = useSelector(keysSelector)
   const { panelSizes, openNodes, selectedLeaf } = useSelector(appContextBrowserTree)
 
   const [statusSelected, setStatusSelected] = useState(selectedLeaf)
@@ -40,6 +42,7 @@ const KeyTree = (props: Props) => {
   const [separator, setSeparator] = useState<string>(DEFAULT_SEPARATOR)
   const [keyListState, setKeyListState] = useState<IKeyListPropTypes>(keysState)
   const [constructingTree, setConstructingTree] = useState(false)
+  const [selectDefaultLeaf, setSelectDefaultLeaf] = useState(true)
 
   const dispatch = useDispatch()
 
@@ -57,6 +60,11 @@ const KeyTree = (props: Props) => {
       updateKeysList(Object.values(selectedLeaf)[0])
     }
   }, [selectedLeaf])
+
+  useEffect(() => {
+    // select default leaf "Keys" after each search or filter
+    setSelectDefaultLeaf(true)
+  }, [filter, search])
 
   const options: EuiSuperSelectOption<string>[] = [{
     value: DEFAULT_SEPARATOR,
@@ -123,28 +131,34 @@ const KeyTree = (props: Props) => {
                   }}
                 >
                   <div className={styles.tree}>
-                    <EuiSuperSelect
-                      disabled={loading}
-                      options={options}
-                      valueOfSelected={separator}
-                      popoverClassName={styles.separatorSelect}
-                      itemClassName={styles.separatorSelectItem}
-                      onChange={(value: string) => onChangeSeparator(value)}
-                      data-testid="select-tree-view-separator"
-                    />
-                    <VirtualTree
-                      items={keysState.keys}
-                      loadingIcon={TreeViewSVG}
-                      separator={separator}
-                      statusSelected={statusSelected}
-                      statusOpen={statusOpen}
-                      loading={loading || constructingTree}
-                      setConstructingTree={setConstructingTree}
-                      webworkerFn={constructKeysToTree}
-                      onSelectLeaf={updateKeysList}
-                      onStatusSelected={handleStatusSelected}
-                      onStatusOpen={handleStatusOpen}
-                    />
+                    <div className={styles.treeHeader}>
+                      <EuiSuperSelect
+                        disabled={loading}
+                        options={options}
+                        valueOfSelected={separator}
+                        popoverClassName={styles.separatorSelect}
+                        itemClassName={styles.separatorSelectItem}
+                        onChange={(value: string) => onChangeSeparator(value)}
+                        data-testid="select-tree-view-separator"
+                      />
+                    </div>
+                    <div className={styles.treeContent}>
+                      <VirtualTree
+                        items={keysState.keys}
+                        loadingIcon={TreeViewSVG}
+                        separator={separator}
+                        statusSelected={statusSelected}
+                        statusOpen={statusOpen}
+                        loading={loading || constructingTree}
+                        setConstructingTree={setConstructingTree}
+                        webworkerFn={constructKeysToTree}
+                        onSelectLeaf={updateKeysList}
+                        onStatusSelected={handleStatusSelected}
+                        onStatusOpen={handleStatusOpen}
+                        selectDefaultLeaf={selectDefaultLeaf}
+                        disableSelectDefaultLeaf={() => setSelectDefaultLeaf(false)}
+                      />
+                    </div>
                   </div>
                 </EuiResizablePanel>
 

--- a/redisinsight/ui/src/pages/browser/components/key-tree/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/styles.module.scss
@@ -53,9 +53,14 @@ $selectSeparatorHeight: 18px;
   padding-top: 6px;
 
   height: calc(100% - 90px);
-  overflow: hidden;
 
   flex: 1;
+}
+
+.treeContent {
+  height: calc(100% - 25px);
+  position: relative;
+  width: 100%;
 }
 
 .list {

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -17,7 +17,8 @@ import {
   keysSelector,
 } from 'uiSrc/slices/keys'
 import {
-  setBrowserKeyListDataLoaded, setBrowserTreeNodesOpen, setBrowserTreeSelectedLeaf,
+  resetBrowserTree,
+  setBrowserKeyListDataLoaded,
 } from 'uiSrc/slices/app/context'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -36,7 +37,7 @@ import SearchKeyList from '../search-key-list'
 import styles from './styles.module.scss'
 
 const TIMEOUT_TO_UPDATE_REFRESH_TIME = 1_000 * 60 // once a minute
-const HIDE_REFRESH_LABEL_WIDTH = 650
+const HIDE_REFRESH_LABEL_WIDTH = 700
 
 interface IViewType {
   tooltipText: string
@@ -106,6 +107,18 @@ const KeysHeader = (props: Props) => {
   }
 
   useEffect(() => {
+    globalThis.addEventListener('resize', updateSizes)
+
+    return () => {
+      globalThis.removeEventListener('resize', updateSizes)
+    }
+  }, [])
+
+  useEffect(() => {
+    updateSizes()
+  }, [sizes])
+
+  useEffect(() => {
     updateLastRefresh()
 
     interval = setInterval(() => {
@@ -116,12 +129,10 @@ const KeysHeader = (props: Props) => {
     return () => clearInterval(interval)
   }, [lastRefreshTime])
 
-  useEffect(() => {
+  const updateSizes = () => {
     const isShowRefreshLabel = (rootDivRef?.current?.offsetWidth || 0) > HIDE_REFRESH_LABEL_WIDTH
-    if (isShowRefreshLabel !== showRefreshLabel) {
-      setShowRefreshLabel(isShowRefreshLabel)
-    }
-  }, [sizes])
+    setShowRefreshLabel(isShowRefreshLabel)
+  }
 
   const handleRefreshKeys = () => {
     sendEventTelemetry({
@@ -136,8 +147,7 @@ const KeysHeader = (props: Props) => {
       () => dispatch(setBrowserKeyListDataLoaded(true)),
       () => dispatch(setBrowserKeyListDataLoaded(false)),
     ))
-    dispatch(setBrowserTreeNodesOpen({}))
-    dispatch(setBrowserTreeSelectedLeaf({}))
+    dispatch(resetBrowserTree())
   }
 
   const handleScanMore = (config: any) => {
@@ -165,6 +175,7 @@ const KeysHeader = (props: Props) => {
 
   const handleSwitchView = (type: KeyViewType) => {
     dispatch(changeKeyViewType(type))
+    dispatch(resetBrowserTree())
     localStorageService.set(BrowserStorageItem.browserViewType, type)
     loadKeys(type)
   }

--- a/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { SCAN_COUNT_DEFAULT, SCAN_TREE_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import { replaceSpaces } from 'uiSrc/utils'
 import { fetchKeys, keysSelector, setSearchMatch } from 'uiSrc/slices/keys'
-import { setBrowserTreeNodesOpen, setBrowserTreeSelectedLeaf } from 'uiSrc/slices/app/context'
+import { resetBrowserTree } from 'uiSrc/slices/app/context'
 import { KeyViewType } from 'uiSrc/slices/interfaces/keys'
 
 import styles from './styles.module.scss'
@@ -17,8 +17,7 @@ const SearchKeyList = () => {
     dispatch(fetchKeys('0', viewType === KeyViewType.Browser ? SCAN_COUNT_DEFAULT : SCAN_TREE_COUNT_DEFAULT))
 
     // reset browser tree context
-    dispatch(setBrowserTreeNodesOpen({}))
-    dispatch(setBrowserTreeSelectedLeaf({}))
+    dispatch(resetBrowserTree())
   }
 
   const handleChangeValue = (initValue: string) => {

--- a/redisinsight/ui/src/slices/app/context.ts
+++ b/redisinsight/ui/src/slices/app/context.ts
@@ -85,6 +85,10 @@ const appContextSlice = createSlice({
       state.workbench.enablementArea.guidePath = ''
       state.workbench.enablementArea.guideScrollTop = 0
     },
+    resetBrowserTree: (state) => {
+      state.browser.tree.selectedLeaf = {}
+      state.browser.tree.openNodes = {}
+    }
   },
 })
 
@@ -98,6 +102,7 @@ export const {
   setBrowserPanelSizes,
   setBrowserTreeSelectedLeaf,
   setBrowserTreeNodesOpen,
+  resetBrowserTree,
   setBrowserTreePanelSizes,
   setWorkbenchScript,
   setWorkbenchVerticalPanelSizes,

--- a/redisinsight/ui/src/slices/tests/app/context.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/context.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { KeyTypes } from 'uiSrc/constants'
 
 import {
   cleanup,
@@ -22,7 +23,12 @@ import reducer, {
   setWorkbenchEAGuide,
   appContextWorkbenchEA,
   setWorkbenchEAGuideScrollTop,
-  resetWorkbenchEAGuide
+  resetWorkbenchEAGuide,
+  setBrowserTreeNodesOpen,
+  setBrowserTreePanelSizes,
+  resetBrowserTree,
+  appContextBrowserTree,
+  setBrowserTreeSelectedLeaf
 } from '../../app/context'
 
 jest.mock('uiSrc/services')
@@ -311,6 +317,143 @@ describe('slices', () => {
       })
 
       expect(appContextSelector(rootState)).toEqual(state)
+    })
+  })
+  describe('setBrowserTreeNodesOpen', () => {
+    it('should properly set open nodes in the tree', () => {
+      // Arrange
+      const openNodes = {
+        '1o2313': true,
+        eu12313: false,
+      }
+      const prevState = {
+        ...initialState,
+        browser: {
+          ...initialState.browser,
+          tree: {
+            ...initialState.browser.tree,
+            openNodes
+          }
+        },
+      }
+
+      const state = {
+        ...initialState.browser.tree,
+        openNodes
+      }
+
+      // Act
+      const nextState = reducer(prevState, setBrowserTreeNodesOpen(openNodes))
+
+      // Assert
+      const rootState = Object.assign(initialStateDefault, {
+        app: { context: nextState },
+      })
+
+      expect(appContextBrowserTree(rootState)).toEqual(state)
+    })
+  })
+  describe('setBrowserTreeSelectedLeaf', () => {
+    it('should properly set selected keys in the tree', () => {
+      // Arrange
+      const selectedLeaf = {
+        key1: [{
+          name: 'test',
+          type: KeyTypes.Hash,
+          ttl: 123,
+          size: 123,
+          length: 321
+        }]
+      }
+      const prevState = {
+        ...initialState,
+        browser: {
+          ...initialState.browser,
+          tree: {
+            ...initialState.browser.tree,
+            selectedLeaf
+          }
+        },
+      }
+
+      const state = {
+        ...initialState.browser.tree,
+        selectedLeaf
+      }
+
+      // Act
+      const nextState = reducer(prevState, setBrowserTreeSelectedLeaf(selectedLeaf))
+
+      // Assert
+      const rootState = Object.assign(initialStateDefault, {
+        app: { context: nextState },
+      })
+
+      expect(appContextBrowserTree(rootState)).toEqual(state)
+    })
+  })
+  describe('setBrowserTreePanelSizes', () => {
+    it('should properly set browser tree panel widths', () => {
+      // Arrange
+      const panelSizes = {
+        first: 50,
+        second: 400
+      }
+      const state = {
+        ...initialState.browser.tree,
+        panelSizes
+      }
+
+      // Act
+      const nextState = reducer(initialState, setBrowserTreePanelSizes(panelSizes))
+
+      // Assert
+      const rootState = Object.assign(initialStateDefault, {
+        app: { context: nextState },
+      })
+
+      expect(appContextBrowserTree(rootState)).toEqual(state)
+    })
+  })
+  describe('resetBrowserTree', () => {
+    it('should properly set last page', () => {
+      // Arrange
+      const prevState = {
+        ...initialState,
+        browser: {
+          ...initialState.browser,
+          tree: {
+            ...initialState.browser.tree,
+            openNodes: {
+              test: true
+            },
+            selectedLeaf: {
+              key1: [{
+                name: 'test',
+                type: KeyTypes.Hash,
+                ttl: 123,
+                size: 123,
+                length: 321
+              }]
+            }
+          }
+        },
+      }
+      const state = {
+        ...initialState.browser.tree,
+        openNodes: {},
+        selectedLeaf: {}
+      }
+
+      // Act
+      const nextState = reducer(prevState, resetBrowserTree())
+
+      // Assert
+      const rootState = Object.assign(initialStateDefault, {
+        app: { context: nextState },
+      })
+
+      expect(appContextBrowserTree(rootState)).toEqual(state)
     })
   })
 })


### PR DESCRIPTION
#RI-2539 - Namespaces and number of keys do not have space between them when resizing tree area
#RI-2540 - Part of "No Limit" column is hiding under the "Key name" column when resizing the tree area
#RI-2544 - Selector in the list of keys is not according to the mockups
#RI-2545 - Part of the tree area is hiding when resizing it
#RI-2547 - Autoselect for keys doesn't work for filtering or searching
#RI-2548 - Long name of folder is not truncated in tree area
#RI-2552 - Keys are saved in the context for the previous view when goes back to Tree view from Browser page
#RI-2554 - Font size and font weight for number of keys and percentages are not according with the mockups