### PR TITLE
#RI-2856, #RI-2857, #RI-2854, #RI-2879

### DIFF
--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -187,7 +187,7 @@ const InlineItemEditor = (props: Props) => {
                       aria-label="Cancel editing"
                       className={cx(styles.btn, styles.declineBtn)}
                       onClick={onDecline}
-                      disabled={isLoading}
+                      isDisabled={isLoading}
                       data-testid="cancel-btn"
                     />
                     <EuiButtonIcon
@@ -196,8 +196,8 @@ const InlineItemEditor = (props: Props) => {
                       color="primary"
                       type="submit"
                       aria-label="Apply"
-                      className={cx(styles.btn, styles.applyBtn, { [styles.applyBtnDisabled]: isDisabledApply() })}
-                      disabled={isDisabledApply()}
+                      className={cx(styles.btn, styles.applyBtn)}
+                      isDisabled={isDisabledApply()}
                       data-testid="apply-btn"
                     />
                   </div>

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -196,7 +196,7 @@ const InlineItemEditor = (props: Props) => {
                       color="primary"
                       type="submit"
                       aria-label="Apply"
-                      className={cx(styles.btn, styles.applyBtn)}
+                      className={cx(styles.btn, styles.applyBtn, { [styles.applyBtnDisabled]: isDisabledApply() })}
                       disabled={isDisabledApply()}
                       data-testid="apply-btn"
                     />

--- a/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
+++ b/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
@@ -83,8 +83,12 @@
   color: var(--euiColorColorDanger) !important;
 }
 
-.applyBtn:hover {
+.applyBtn:hover:not(.applyBtnDisabled) {
   color: var(--euiColorPrimary) !important;
+}
+
+.applyBtnDisabled {
+  background-color: initial !important;
 }
 
 .keyHiddenText {

--- a/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
+++ b/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
@@ -83,12 +83,8 @@
   color: var(--euiColorColorDanger) !important;
 }
 
-.applyBtn:hover:not(.applyBtnDisabled) {
+.applyBtn:hover:not([class*="isDisabled"]) {
   color: var(--euiColorPrimary) !important;
-}
-
-.applyBtnDisabled {
-  background-color: initial !important;
 }
 
 .keyHiddenText {

--- a/redisinsight/ui/src/pages/browser/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/pages/browser/components/auto-refresh/AutoRefresh.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react'
 import { EuiButtonIcon, EuiPopover, EuiSwitch, EuiTextColor, EuiToolTip } from '@elastic/eui'
 import cx from 'classnames'
 
-import { MIN_REFRESH_RATE, Nullable, validateRefreshRateNumber } from 'uiSrc/utils'
+import {
+  errorValidateRefreshRateNumber,
+  MIN_REFRESH_RATE,
+  Nullable,
+  validateRefreshRateNumber
+} from 'uiSrc/utils'
 import InlineItemEditor from 'uiSrc/components/inline-item-editor'
 import { localStorageService } from 'uiSrc/services'
 import { BrowserStorageItem } from 'uiSrc/constants'
@@ -218,6 +223,7 @@ const AutoRefresh = ({
                   placeholder={DEFAULT_REFRESH_RATE}
                   isLoading={loading}
                   validation={validateRefreshRateNumber}
+                  disableByValidation={errorValidateRefreshRateNumber}
                   onDecline={() => handleDeclineAutoRefreshRate()}
                   onApply={(value) => handleApplyAutoRefreshRate(value)}
                 />

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -34,7 +34,7 @@ import AutoRefresh from '../auto-refresh'
 
 import styles from './styles.module.scss'
 
-const HIDE_REFRESH_LABEL_WIDTH = 550
+const HIDE_REFRESH_LABEL_WIDTH = 600
 const FULL_SCREEN_RESOLUTION = 1260
 
 interface IViewType {

--- a/redisinsight/ui/src/pages/browser/components/stream-details/StreamDetails/StreamDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/components/stream-details/StreamDetails/StreamDetails.tsx
@@ -96,14 +96,14 @@ const StreamDetails = (props: Props) => {
             data-testid="progress-key-stream"
           />
         )}
-        <div className={styles.columnManager}>
+        {/* <div className={styles.columnManager}>
           <EuiButtonIcon iconType="boxesVertical" aria-label="manage columns" />
-        </div>
+        </div> */}
         <VirtualTable
           hideProgress
           selectable={false}
           keyName={key}
-          headerHeight={headerHeight}
+          headerHeight={entries?.length ? headerHeight : 0}
           rowHeight={rowHeight}
           columns={columns}
           footerHeight={0}
@@ -115,10 +115,10 @@ const StreamDetails = (props: Props) => {
           onChangeSorting={onChangeSorting}
           noItemsMessage={noItemsMessageString}
           tableWidth={columns.length * minColumnWidth - actionsWidth}
-          sortedColumn={{
+          sortedColumn={entries?.length ? {
             column: sortedColumnName,
             order: sortedColumnOrder,
-          }}
+          } : undefined}
         />
       </div>
     </>

--- a/redisinsight/ui/src/pages/browser/components/stream-details/StreamDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/components/stream-details/StreamDetailsWrapper.tsx
@@ -169,6 +169,8 @@ const StreamDetailsWrapper = (props: Props) => {
       headerClassName: styles.actionsHeader,
       textAlignment: TableCellTextAlignment.Left,
       absoluteWidth: actionsWidth,
+      maxWidth: actionsWidth,
+      minWidth: actionsWidth,
       render: function Actions(_act: any, { id }: StreamEntryDto) {
         return (
           <div>

--- a/redisinsight/ui/src/pages/slowLog/components/Actions/Actions.tsx
+++ b/redisinsight/ui/src/pages/slowLog/components/Actions/Actions.tsx
@@ -161,7 +161,7 @@ const Actions = (props: Props) => {
               onClick={() => showClearPopover()}
               data-testid="clear-btn"
             />
-            )}
+          )}
         >
           {ToolTipContent}
         </EuiPopover>

--- a/redisinsight/ui/src/pages/slowLog/components/SlowLogConfig/SlowLogConfig.tsx
+++ b/redisinsight/ui/src/pages/slowLog/components/SlowLogConfig/SlowLogConfig.tsx
@@ -24,7 +24,7 @@ import { ConnectionType } from 'uiSrc/slices/interfaces'
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { setDBConfigStorageField } from 'uiSrc/services'
 import { patchSlowLogConfigAction, slowLogConfigSelector, slowLogSelector } from 'uiSrc/slices/slowlog/slowlog'
-import { validateNumber } from 'uiSrc/utils'
+import { errorValidateNegativeInteger, validateNumber } from 'uiSrc/utils'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { openCli } from 'uiSrc/slices/cli/cli-settings'
 import styles from './styles.module.scss'
@@ -89,10 +89,13 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
     e.preventDefault()
     history.push(Pages.workbench(instanceId))
   }
+
   const handleOpenCli = (e: React.MouseEvent) => {
     e.preventDefault()
     dispatch(openCli())
   }
+
+  const disabledApplyBtn = () => errorValidateNegativeInteger(slowerThan)
 
   const clusterContent = () => (
     <>
@@ -213,7 +216,13 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
             <EuiButton color="secondary" onClick={handleCancel} data-testid="slowlog-config-cancel-btn">
               Cancel
             </EuiButton>
-            <EuiButton fill color="secondary" onClick={handleSave} data-testid="slowlog-config-save-btn">
+            <EuiButton
+              fill
+              color="secondary"
+              isDisabled={disabledApplyBtn()}
+              onClick={handleSave}
+              data-testid="slowlog-config-save-btn"
+            >
               Save
             </EuiButton>
           </div>

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -24,7 +24,6 @@ import {
   CreateSetWithExpireDto,
 } from 'apiSrc/modules/browser/dto'
 import { CreateStreamDto } from 'apiSrc/modules/browser/dto/stream.dto'
-import { AppDispatch, RootState } from '../store'
 import { fetchString } from './string'
 import { setZsetInitialState, fetchZSetMembers } from './zset'
 import { fetchSetMembers } from './set'
@@ -34,6 +33,7 @@ import { setListInitialState, fetchListElements } from './list'
 import { fetchStreamEntries } from './stream'
 import { addErrorNotification, addMessageNotification } from '../app/notifications'
 import { KeysStore, KeyViewType } from '../interfaces/keys'
+import { AppDispatch, RootState } from '../store'
 
 export const initialState: KeysStore = {
   loading: false,

--- a/redisinsight/ui/src/utils/tests/validations.spec.ts
+++ b/redisinsight/ui/src/utils/tests/validations.spec.ts
@@ -13,6 +13,7 @@ import {
   validateCertName,
   validateRefreshRateNumber,
   MAX_REFRESH_RATE,
+  errorValidateRefreshRateNumber,
 } from '../validations'
 
 const text1 = '123 123 123'
@@ -199,6 +200,28 @@ describe('Validations utils', () => {
     ])('for input: %s (input), should be output: %s',
       (input, expected) => {
         const result = validateRefreshRateNumber(input)
+        expect(result).toBe(expected)
+      })
+  })
+
+  describe('errorValidateRefreshRateNumber', () => {
+    it.each([
+      [validateRefreshRateNumber(text1), false],
+      [validateRefreshRateNumber(text2), false],
+      [validateRefreshRateNumber(text3), true],
+      [validateRefreshRateNumber(text4), true],
+      [validateRefreshRateNumber(text5), true],
+      [validateRefreshRateNumber(text6), false],
+      [validateRefreshRateNumber(text7), false],
+      [validateRefreshRateNumber(text8), false],
+      [validateRefreshRateNumber(text9), false],
+      [validateRefreshRateNumber(text10), false],
+      [validateRefreshRateNumber(text12), false],
+      [validateRefreshRateNumber(text13), false],
+
+    ])('for input: %s (input), should be output: %s',
+      (input, expected) => {
+        const result = errorValidateRefreshRateNumber(input)
         expect(result).toBe(expected)
       })
   })

--- a/redisinsight/ui/src/utils/tests/validations.spec.ts
+++ b/redisinsight/ui/src/utils/tests/validations.spec.ts
@@ -14,6 +14,7 @@ import {
   validateRefreshRateNumber,
   MAX_REFRESH_RATE,
   errorValidateRefreshRateNumber,
+  errorValidateNegativeInteger,
 } from '../validations'
 
 const text1 = '123 123 123'
@@ -222,6 +223,28 @@ describe('Validations utils', () => {
     ])('for input: %s (input), should be output: %s',
       (input, expected) => {
         const result = errorValidateRefreshRateNumber(input)
+        expect(result).toBe(expected)
+      })
+  })
+
+  describe('errorValidateNegativeInteger', () => {
+    it.each([
+      [validateRefreshRateNumber(text1), true],
+      [validateRefreshRateNumber(text2), true],
+      [validateRefreshRateNumber(text3), true],
+      [validateRefreshRateNumber(text4), true],
+      [validateRefreshRateNumber(text5), true],
+      [validateRefreshRateNumber(text6), true],
+      [validateRefreshRateNumber(text7), true],
+      [validateRefreshRateNumber(text8), true],
+      [validateRefreshRateNumber(text9), true],
+      [validateRefreshRateNumber(text10), true],
+      [validateRefreshRateNumber(text12), false],
+      [validateRefreshRateNumber(text13), false],
+
+    ])('for input: %s (input), should be output: %s',
+      (input, expected) => {
+        const result = errorValidateNegativeInteger(input)
         expect(result).toBe(expected)
       })
   })

--- a/redisinsight/ui/src/utils/validations.ts
+++ b/redisinsight/ui/src/utils/validations.ts
@@ -103,6 +103,11 @@ export const errorValidateRefreshRateNumber = (value: string) => {
   return !decimalsRegexp.test(value)
 }
 
+export const errorValidateNegativeInteger = (value: string) => {
+  const negativeIntegerRegexp = /^-?\d+$/
+  return !negativeIntegerRegexp.test(value)
+}
+
 export const validateCertName = (initValue: string) =>
   initValue.replace(/[^ a-zA-Z0-9!@#$%^&*-_()[\]]+/gi, '').toString()
 

--- a/redisinsight/ui/src/utils/validations.ts
+++ b/redisinsight/ui/src/utils/validations.ts
@@ -98,6 +98,11 @@ export const validateRefreshRateNumber = (initValue: string) => {
   return value.toString()
 }
 
+export const errorValidateRefreshRateNumber = (value: string) => {
+  const decimalsRegexp = /^\d+(\.\d{1})?$/
+  return !decimalsRegexp.test(value)
+}
+
 export const validateCertName = (initValue: string) =>
   initValue.replace(/[^ a-zA-Z0-9!@#$%^&*-_()[\]]+/gi, '').toString()
 


### PR DESCRIPTION
* #RI-2856 - The 'three dots' button shouldn't be visible
* #RI-2857 - The 'Entry ID' column header should be hidden when there are no entries in the Stream
* #RI-2854 - The delete button position shifts to the right after deletion of entry when the number of fields decreases
* #RI-2879 - The incorrect rate is applied in the auto-refresh value after reload of the page