### PR TITLE
#RI-3102 - Consumer groups are empty after acknowledgement/claiming message

### DIFF
--- a/redisinsight/ui/src/slices/browser/stream.ts
+++ b/redisinsight/ui/src/slices/browser/stream.ts
@@ -963,6 +963,7 @@ export function claimPendingMessages(
       if (isStatusSuccessful(status)) {
         dispatch(claimConsumerMessagesSuccess())
         dispatch<any>(fetchConsumers())
+        dispatch<any>(fetchConsumerGroups())
         if (data.affected.length) {
           dispatch(deleteMessageFromList(data.affected[0]))
           dispatch(addMessageNotification(
@@ -1014,6 +1015,7 @@ export function ackPendingEntriesAction(
         dispatch(ackPendingEntriesSuccess())
         dispatch(deleteMessageFromList(entries[0]))
         dispatch<any>(fetchConsumers())
+        dispatch<any>(fetchConsumerGroups())
         dispatch(addMessageNotification(
           successMessages.MESSAGE_ACTION(entries[0], 'acknowledged')
         ))

--- a/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
@@ -1416,6 +1416,7 @@ describe('stream slice', () => {
           ackPendingEntriesSuccess(),
           deleteMessageFromList('0-1'),
           loadConsumerGroups(),
+          loadConsumerGroups(),
           addMessageNotification(
             successMessages.MESSAGE_ACTION(
               entries.join(''),
@@ -1482,6 +1483,7 @@ describe('stream slice', () => {
           claimConsumerMessages(),
           claimConsumerMessagesSuccess(),
           loadConsumerGroups(),
+          loadConsumerGroups(),
           deleteMessageFromList('0-1'),
           addMessageNotification(
             successMessages.MESSAGE_ACTION('0-1', 'claimed')
@@ -1516,6 +1518,7 @@ describe('stream slice', () => {
         const expectedActions = [
           claimConsumerMessages(),
           claimConsumerMessagesSuccess(),
+          loadConsumerGroups(),
           loadConsumerGroups(),
           addMessageNotification(
             successMessages.NO_CLAIMED_MESSAGES()


### PR DESCRIPTION
#RI-3102 - Consumer groups are empty after acknowledgement/claiming message