### PR TITLE
E2e/tests fixes

### DIFF
--- a/tests/e2e/pageObjects/browser-page.ts
+++ b/tests/e2e/pageObjects/browser-page.ts
@@ -205,7 +205,7 @@ export class BrowserPage {
     streamEntryRows = Selector(this.streamEntriesContainer.find('[aria-rowcount]'));
     streamEntryDate = Selector('[data-testid*=-date][data-testid*=stream-entry]');
     streamEntryIdValue = Selector('.streamItemId[data-testid*=stream-entry]');
-    streamFields = Selector('[data-testid=stream-entries-container] .truncateText span');
+    streamFields = Selector('[data-testid=stream-entries-container] .truncateText');
     streamEntryFields = Selector('[data-testid^=stream-entry-field]');
     confirmationMessagePopover = Selector('div.euiPopover__panel .euiText ');
     streamRangeLeftTimestamp = Selector('[data-testid=range-left-timestamp]');

--- a/tests/e2e/pageObjects/browser-page.ts
+++ b/tests/e2e/pageObjects/browser-page.ts
@@ -49,6 +49,7 @@ export class BrowserPage {
     expandJsonObject = Selector('[data-testid=expand-object]');
     toastCloseButton = Selector('[data-test-subj=toastCloseButton]');
     scoreButton = Selector('[data-testid=score-button]');
+    sortingButton = Selector('[data-testid=header-sorting-button]');
     editJsonObjectButton = Selector('[data-testid=edit-object-btn]');
     applyEditButton = Selector('[data-testid=apply-edit-btn]');
     scanMoreButton = Selector('[data-testid=scan-more]');

--- a/tests/e2e/pageObjects/browser-page.ts
+++ b/tests/e2e/pageObjects/browser-page.ts
@@ -141,6 +141,7 @@ export class BrowserPage {
     streamValue = Selector('[data-testid=field-value]');
     addStreamRow = Selector('[data-testid=add-new-item]');
     streamFieldsValues = Selector('[data-testid^=stream-entry-field-]');
+    streamEntryIDDateValue = Selector('[data-testid^=stream-entry-][data-testid$=date]');
     streamRangeEndInput = Selector('[data-testid=range-end-input]');
     groupNameInput = Selector('[data-testid=group-name-field]');
     consumerIdInput = Selector('[data-testid=id-field]');
@@ -420,15 +421,6 @@ export class BrowserPage {
         if (entryId !== undefined) {
             await t.typeText(this.streamEntryId, entryId);
         }
-    }
-
-    /**
-     * Get number of existed columns and rows of Stream key
-     */
-    async getStreamRowColumnNumber(): Promise<string[]> {
-        const columnStreamNumber = await this.streamEntriesContainer.find('[aria-colcount]').getAttribute('aria-colcount');
-        const rowStreamNumber = await this.streamEntriesContainer.find('[aria-rowcount]').getAttribute('aria-rowcount');
-        return [columnStreamNumber, rowStreamNumber];
     }
 
     /**

--- a/tests/e2e/pageObjects/settings-page.ts
+++ b/tests/e2e/pageObjects/settings-page.ts
@@ -18,15 +18,28 @@ export class SettingsPage {
     //TEXT INPUTS (also referred to as 'Text fields')
     keysToScanValue = Selector('[data-testid=keys-to-scan-value]');
     keysToScanInput = Selector('[data-testid=keys-to-scan-input]');
+    commandsInPipelineValue = Selector('[data-testid=pipeline-bunch-value]');
+    commandsInPipelineInput = Selector('[data-testid=pipeline-bunch-input]');
 
     /**
      * Change Keys to Scan value
      * @param value Value for scan
      */
-    async changeKeysToScanValue(value: string): Promise<void>{
+    async changeKeysToScanValue(value: string): Promise<void> {
         await t.hover(this.keysToScanValue);
         await t.click(this.keysToScanInput);
         await t.typeText(this.keysToScanInput, value, { replace: true });
+        await t.click(this.applyButton);
+    }
+
+    /**
+ * Change Commands In Pipeline value
+ * @param value Value for pipeline
+ */
+    async changeCommandsInPipeline(value: string): Promise<void> {
+        await t.hover(this.commandsInPipelineValue);
+        await t.click(this.commandsInPipelineInput);
+        await t.typeText(this.commandsInPipelineInput, value, { replace: true });
         await t.click(this.applyButton);
     }
 

--- a/tests/e2e/tests/critical-path/a-first-start-form/user-agreements-form.e2e.ts
+++ b/tests/e2e/tests/critical-path/a-first-start-form/user-agreements-form.e2e.ts
@@ -16,14 +16,13 @@ fixture `Agreements Verification`
         await t.maximizeWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.none })
-    ('Verify that user should accept User Agreements to continue working with the application, the Welcome page is opened after user agrees, the encryption enabled by default and specific message', async t => {
+    .meta({ env: env.web, rte: rte.none })('Verify that user should accept User Agreements to continue working with the application, the Welcome page is opened after user agrees, the encryption enabled by default and specific message', async t => {
         await t.expect(userAgreementPage.userAgreementsPopup.exists).ok('User Agreements Popup is shown');
         //Verify that section with plugin warning is displayed
         await t.expect(userAgreementPage.pluginSectionWithText.visible).ok('Plugin text is displayed');
         //Verify that text that is displayed in window is 'While adding new visualization plugins, use files only from trusted authors to avoid automatic execution of malicious code.'
         const pluginText = userAgreementPage.pluginSectionWithText.innerText;
-        await t.expect(pluginText).eql('While adding new visualization plugins, use files only from trusted authors to avoid automatic execution of malicious code.');
+        await t.expect(pluginText).eql('To avoid automatic execution of malicious code, when adding new Workbench plugins, use files from trusted authors only.');
         // Verify that encryption enabled by default
         await t.expect(userAgreementPage.switchOptionEncryption.withAttribute('aria-checked', 'true').exists).ok('Encryption enabled by default');
         await t.click(addRedisDatabasePage.addDatabaseButton);

--- a/tests/e2e/tests/critical-path/browser/stream-key-entry-deletion.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-key-entry-deletion.e2e.ts
@@ -42,8 +42,7 @@ test('Verify that the Stream information is refreshed and the deleted entry is r
     }
     //Open key details and remember the Stream information
     await browserPage.openKeyDetails(keyName);
-    await t.click(browserPage.fullScreenModeButton);
-    await t.expect(browserPage.streamFields.nth(0).textContent).eql(fieldForDeletion, 'The first field entry name');
+    await t.expect(browserPage.streamFields.nth(1).textContent).eql(fieldForDeletion, 'The first field entry name');
     const entriesCountBefore = (await browserPage.keyLengthDetails.textContent).split(': ')[1];
     //Delete entry from the Stream
     await browserPage.deleteStreamEntry();
@@ -55,7 +54,6 @@ test('Verify that the Stream information is refreshed and the deleted entry is r
         const fieldName = await browserPage.streamFields.nth(i).textContent;
         await t.expect(fieldName).notEql(fieldForDeletion, 'The deleted entry is removed from the Stream');
     }
-    await t.click(browserPage.fullScreenModeButton);
 });
 test('Verify that when user delete the last Entry from the Stream the Stream key is not deleted', async t => {
     keyName = chance.word({length: 20});

--- a/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
@@ -113,7 +113,7 @@ test('Verify that during new entry adding to existing Stream, user can clear the
 test('Verify that user can add several fields and values to the existing Stream Key', async t => {
     keyName = chance.word({ length: 20 });
     // Generate field value data
-    const entryQuantity = 10;
+    const entryQuantity = 5;
     const fields: string[] = [];
     const values: string[] = [];
     for (let i = 0; i < entryQuantity; i++) {
@@ -128,13 +128,15 @@ test('Verify that user can add several fields and values to the existing Stream 
     await browserPage.fulfillSeveralStreamFields(fields, values);
     await t.click(browserPage.saveElementButton);
     // Check that all data is saved in Stream
+    await t.click(browserPage.fullScreenModeButton);
     for (let i = 0; i < fields.length; i++) {
-        await t.expect(browserPage.streamEntriesContainer.find('span').withExactText(fields[i]).exists).ok('Added Field');
         await t.expect(browserPage.streamFieldsValues.find('span').withExactText(values[i]).exists).ok('Added Value');
+        await t.expect(browserPage.streamEntriesContainer.find('div').withExactText(fields[i]).exists).ok('Added Field');
     }
     // Check Stream length
     const streamLength = await browserPage.getKeyLength();
     await t.expect(streamLength).eql('2', 'Stream length after adding new entry');
+    await t.click(browserPage.fullScreenModeButton);
 });
 test('Verify that user can see the Stream range filter', async t => {
     keyName = chance.word({length: 20});

--- a/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
@@ -1,6 +1,5 @@
 import { Chance } from 'chance';
 import { Selector } from 'testcafe';
-import { toNumber, toString } from 'lodash';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabase, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage, CliPage } from '../../../pageObjects';
@@ -68,20 +67,21 @@ test('Verify that user can add several fields and values during Stream key creat
 test('Verify that user can add new Stream Entry for Stream data type key which has an Entry ID, Field and Value', async t => {
     keyName = chance.word({ length: 20 });
     const newField = chance.word({ length: 20 });
-    // Add New Stream Key
+    // Add New Stream Key and check columns and rows
     await browserPage.addStreamKey(keyName, keyField, keyValue);
-    // Verify that when user adds a new Entry with not existed Field name, a new Field is added to the Stream
-    const paramsBeforeEntryAdding = await browserPage.getStreamRowColumnNumber();
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(1, 'One Entry ID');
+    await t.expect(browserPage.streamFields.count).eql(4, 'One field in table');
+    await t.expect(browserPage.streamEntryFields.count).eql(1, 'One value in table');
+    // Create new field and value and check that new column is added
     await browserPage.addEntryToStream(newField, chance.word({ length: 20 }));
-    // Compare that after adding new entry, new column and row were added
-    const paramsAfterEntryAdding = await browserPage.getStreamRowColumnNumber();
-    await t.expect(paramsAfterEntryAdding[0]).eql(toString(toNumber(paramsBeforeEntryAdding[0]) + 1), 'Increased number of columns after adding');
-    await t.expect(paramsAfterEntryAdding[1]).eql(toString(toNumber(paramsBeforeEntryAdding[1]) + 1), 'Increased number of rows after adding');
-    // Verify that when user adds a new Entry with already existed Field name, a new Field is available as column in the Stream table
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(2, 'Two Entries ID');
+    await t.expect(browserPage.streamFields.count).eql(6, 'Two fields in table');
+    await t.expect(browserPage.streamEntryFields.count).eql(4, 'Four values in table');
+    // Create value to existed filed and check that new column was not added
     await browserPage.addEntryToStream(newField, chance.word({ length: 20 }));
-    const paramsAfterExistedFieldAdding = await browserPage.getStreamRowColumnNumber();
-    await t.expect(paramsAfterExistedFieldAdding[1]).eql(toString(toNumber(paramsAfterEntryAdding[1]) + 1), 'Increased number of rows after adding');
-    await t.expect(paramsAfterExistedFieldAdding[0]).eql(paramsAfterEntryAdding[0], 'The same number of columns after adding');
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(3, 'Three Entries ID');
+    await t.expect(browserPage.streamFields.count).eql(7, 'Still two fields in table');
+    await t.expect(browserPage.streamEntryFields.count).eql(6, 'Six values in table');
 });
 test('Verify that during new entry adding to existing Stream, user can clear the value and the row itself', async t => {
     keyName = chance.word({ length: 20 });

--- a/tests/e2e/tests/regression/browser/stream-key.e2e.ts
+++ b/tests/e2e/tests/regression/browser/stream-key.e2e.ts
@@ -60,7 +60,7 @@ test('Verify that user can sort ASC/DESC by Entry ID', async t => {
         await t.expect(entryDateFirstAsc).gt(entryDateSecondAsc, 'By default the table is sorted by Entry ID');
     }
     //Check the DESC sorting
-    await t.click(browserPage.scoreButton);
+    await t.click(browserPage.sortingButton);
     for(let i = 0; i < entryCount - 1; i++){
         const entryDateFirstDesc = Date.parse(await browserPage.streamEntryDate.nth(i).textContent);
         const entryDateSecondDesc = Date.parse(await browserPage.streamEntryDate.nth(i + 1).textContent);

--- a/tests/e2e/tests/regression/workbench/history-of-results.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/history-of-results.e2e.ts
@@ -66,12 +66,8 @@ test
         await t.expect(workbenchPage.queryCardContainer.nth(0).textContent).contains(firstCommand, 'The first executed command is in the workbench history');
         //Send 30 commands and check the results
         await workbenchPage.sendCommandInWorkbench(`${numberOfCommands} ${command}`);
-        for(let i = 0; i < numberOfCommands; i++) {
-            await t.expect(workbenchPage.queryCardContainer.nth(0).textContent).contains(command, 'The command executed after the first command is displayed');
-            await t.expect(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The command executed after the first command is displayed', { timeout: 10000 });
-            await t.click(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssDeleteCommandButton));
-        }
-        await t.expect(workbenchPage.noCommandHistoryTitle.visible).ok('The first command is deleted when user executes 31 command');
+        await t.expect(workbenchPage.queryCardCommand.find('span').withExactText(`${firstCommand}`)).notOk('The first command is not in the history result');
+        await t.expect(workbenchPage.queryCardCommand.count).eql(30, { timeout: 5000 });
     });
 test
     .meta({ rte: rte.none })('Verify that user can see cursor is at the first character when Editor is empty', async t => {

--- a/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
@@ -2,26 +2,27 @@ import { Chance } from 'chance';
 import { Selector } from 'testcafe';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabase, deleteDatabase } from '../../../helpers/database';
-import { MyRedisDatabasePage, WorkbenchPage, CliPage } from '../../../pageObjects';
+import { MyRedisDatabasePage, WorkbenchPage, CliPage, SettingsPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 const chance = new Chance();
 const cliPage = new CliPage();
+const settingsPage = new SettingsPage();
 
 const indexName = chance.word({ length: 5 });
 let keyName = chance.word({ length: 10 });
 
-fixture `Scripting area at Workbench`
-    .meta({type: 'regression'})
+fixture`Scripting area at Workbench`
+    .meta({ type: 'regression' })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabase(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         //Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async() => {
+    .afterEach(async () => {
         //Clear and delete database
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteDatabase(ossStandaloneConfig.databaseName);
@@ -35,17 +36,24 @@ test
             'HMSET product:1 price 20',
             'FT._LIST'
         ]
+        //Go to Settings page
+        await t.click(myRedisDatabasePage.settingsButton);
+        //Specify Commands in pipeline
+        await t.click(settingsPage.accordionAdvancedSettings);
+        await settingsPage.changeCommandsInPipeline('1');
+        //Go to Workbench page
+        await t.click(myRedisDatabasePage.workbenchButton);
         //Send commands in multiple lines
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'), 0.5);
         //Check the result
-        for(let i = 1; i < commandsForSend.length + 1; i++) {
+        for (let i = 1; i < commandsForSend.length + 1; i++) {
             const resultCommand = await workbenchPage.queryCardCommand.nth(i - 1).textContent;
             await t.expect(resultCommand).eql(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is in the result`);
         }
     });
 test
     .meta({ rte: rte.standalone })
-    .after(async() => {
+    .after(async () => {
         //Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keyName}`);
         await deleteDatabase(ossStandaloneConfig.databaseName);
@@ -56,17 +64,24 @@ test
             `HMSET ${keyName} price 20`,
             'FT._LIST'
         ];
+        //Go to Settings page
+        await t.click(myRedisDatabasePage.settingsButton);
+        //Specify Commands in pipeline
+        await t.click(settingsPage.accordionAdvancedSettings);
+        await settingsPage.changeCommandsInPipeline('1');
+        //Go to Workbench page
+        await t.click(myRedisDatabasePage.workbenchButton);
         //Send commands in multiple lines with double slashes (//) wrapped in double quotes
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n"//"'), 0.5);
         //Check that all commands are executed
-        for(let i = 1; i < commandsForSend.length + 1; i++) {
+        for (let i = 1; i < commandsForSend.length + 1; i++) {
             const resultCommand = await workbenchPage.queryCardCommand.nth(i - 1).textContent;
             await t.expect(resultCommand).contains(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is in the result`);
         }
     });
 test
     .meta({ rte: rte.standalone })
-    .after(async() => {
+    .after(async () => {
         //Clear and delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     })
@@ -86,7 +101,7 @@ test
     });
 test
     .meta({ rte: rte.standalone })
-    .after(async() => {
+    .after(async () => {
         //Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keyName}`);
         await deleteDatabase(ossStandaloneConfig.databaseName);
@@ -121,7 +136,7 @@ test
     });
 test
     .meta({ rte: rte.standalone })
-    .after(async() => {
+    .after(async () => {
         //Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     })
@@ -135,7 +150,7 @@ test
     });
 test
     .meta({ rte: rte.standalone })
-    .after(async() => {
+    .after(async () => {
         //Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     })


### PR DESCRIPTION
Fix the following tests:
- [Verify that user can see saved Key details and Keys tables size on Browser page when he returns back to Browser page](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-0)
- [Verify that user can sort ASC/DESC by Entry ID](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-1)
- [Verify that user can run multiple commands written in multiple lines in Workbench page](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-2)
- [Verify that user can use double slashes (//) wrapped in double quotes and these slashes will not comment out any characters](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-3)
- [Verify that the Stream information is refreshed and the deleted entry is removed when user confirm the deletion of an entry](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-4)
- [Verify that user should accept User Agreements to continue working with the application, the Welcome page is opened after user agrees, the encryption enabled by default and specific message](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-5)
- [Verify that user can add new Stream Entry for Stream data type key which has an Entry ID, Field and Value](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-6)
- [Verify that user can add several fields and values to the existing Stream Key](https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3114/workflows/9b66b7b9-ad5e-478b-a8a0-0c1648fc1a65/jobs/48578/tests#failed-test-7)