### PR TITLE
E2e/desktop fix

### DIFF
--- a/tests/e2e/pageObjects/browser-page.ts
+++ b/tests/e2e/pageObjects/browser-page.ts
@@ -758,6 +758,7 @@ export class BrowserPage {
         await t.typeText(this.treeViewDelimiterInput, delimiter, { replace: true });
         // Click on save button
         await t.click(this.treeViewDelimiterValueSave);
+        await t.expect(this.treeViewDelimiterButton.withExactText(delimiter).exists).ok('Delimiter is not changed');
     }
 
     //Delete entry from Stream key

--- a/tests/e2e/tests/critical-path/browser/stream-pending-messages.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-pending-messages.e2e.ts
@@ -64,7 +64,6 @@ test('Verify that user can claim any message in the list of pending messages', a
     }
     // Open Stream pendings view
     await browserPage.openStreamPendingsView(keyName);
-    await t.click(browserPage.fullScreenModeButton);
     // Claim message and check result
     await t.click(browserPage.claimPendingMessageButton);
     await t.expect(browserPage.pendingCount.textContent).eql('pending: 1', 'The number of pending messages for selected consumer');

--- a/tests/e2e/tests/critical-path/monitor/save-commands.e2e.ts
+++ b/tests/e2e/tests/critical-path/monitor/save-commands.e2e.ts
@@ -14,7 +14,7 @@ const tempDir = os.tmpdir();
 const downloadsDir = `C:*****\\Downloads`;
 
 fixture `Save commands`
-    .meta({ type: 'regression' })
+    .meta({ type: 'critical_path' })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabase(ossStandaloneConfig, ossStandaloneConfig.databaseName);

--- a/tests/e2e/tests/regression/browser/consumer-group.e2e.ts
+++ b/tests/e2e/tests/regression/browser/consumer-group.e2e.ts
@@ -36,7 +36,6 @@ test('Verify that when user enter invalid Group Name the error message appears',
     const error = 'BUSYGROUP Consumer Group name already exists';
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
-    await t.click(browserPage.fullScreenModeButton);
     // Open Stream consumer groups and add group
     await t.click(browserPage.streamTabGroups);
     await browserPage.createConsumerGroup(consumerGroupName);
@@ -55,7 +54,6 @@ test('Verify that when user enter invalid format ID the error message appears', 
     ];
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
-    await t.click(browserPage.fullScreenModeButton);
     // Open Stream consumer groups and enter invalid EntryIds
     await t.click(browserPage.streamTabGroups);
     await t.click(browserPage.addKeyValueItemsButton);

--- a/tests/e2e/tests/regression/browser/filtering.e2e.ts
+++ b/tests/e2e/tests/regression/browser/filtering.e2e.ts
@@ -12,7 +12,7 @@ let keyName2 = chance.word({ length: 20 });
 const COMMAND_GROUP_SET = 'Set';
 
 fixture `Filtering per key name in Browser page`
-    .meta({type: 'critical_path', rte: rte.standalone})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabase(ossStandaloneConfig, ossStandaloneConfig.databaseName);

--- a/tests/e2e/tests/regression/browser/stream-pending-messages.e2e.ts
+++ b/tests/e2e/tests/regression/browser/stream-pending-messages.e2e.ts
@@ -69,7 +69,6 @@ test('Verify that the message is claimed only if its idle time is greater than t
     }
     // Open Stream pendings view
     await browserPage.openStreamPendingsView(keyName);
-    await t.click(browserPage.fullScreenModeButton);
     const streamMessageBefore = await browserPage.streamMessage.count;
     // Claim message and check result when Min Idle Time is greater than the idle time
     await t.click(browserPage.claimPendingMessageButton);


### PR DESCRIPTION
fixes for tests https://app.circleci.com/pipelines/github/RedisInsight/RedisInsight/3176/workflows/78b7edea-3064-4256-932b-ff08a8c84f21/jobs/49642
Verify that user can claim any message in the list of pending messages
Verify that when user changes the delimiter and clicks on Save button delimiter is applied
Verify that when user enter invalid Group Name the error message appears
Verify that when user enter invalid format ID the error message appears
Verify that user can see TTL in the list of keys rounded down to the nearest unit
Verify that user can see message "No keys to display." when there are no keys in the database
Verify that the message is claimed only if its idle time is greater than the Min Idle Time