### PR TITLE
updates for tests

### DIFF
--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "@types/chance": "1.1.3",
     "@types/edit-json-file": "1.7.0",
+    "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "4.28.2",
     "@typescript-eslint/parser": "4.28.2",
-    "@types/supertest": "^2.0.8",
     "chance": "1.1.8",
     "cross-env": "^7.0.3",
     "dotenv-cli": "^5.0.0",
@@ -38,12 +38,12 @@
     "eslint": "7.32.0",
     "eslint-plugin-import": "2.24.2",
     "supertest": "^4.0.2",
-    "testcafe": "1.14.2",
-    "testcafe-browser-provider-electron": "0.0.18",
+    "testcafe": "^1.19.0",
+    "testcafe-browser-provider-electron": "^0.0.18",
     "testcafe-reporter-html": "1.4.6",
     "testcafe-reporter-json": "2.2.0",
     "testcafe-reporter-spec": "2.1.1",
-    "ts-node": "^10.5.0",
-    "typescript": "4.1.5"
+    "ts-node": "^10.9.1",
+    "typescript": "4.7.4"
   }
 }

--- a/tests/e2e/tests/critical-path/browser/context.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/context.e2e.ts
@@ -32,13 +32,14 @@ fixture `Browser Context`
 test
     .meta({ rte: rte.standalone })
     ('Verify that user can see saved CLI size on Browser page when he returns back to Browser page', async t => {
-        const offsetY = 200;
+        const offsetY = 50;
 
         await t.click(cliPage.cliExpandButton);
         const cliAreaHeight = await cliPage.cliArea.clientHeight;
         const cliResizeButton = await cliPage.cliResizeButton;
-        // move resize 200px up
-        await t.drag(cliResizeButton, 0, -offsetY, { speed });
+        await t.hover(cliResizeButton);
+        // move resize 50px up
+        await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.1 });
         await t.click(myRedisDatabasePage.myRedisDBButton);
 
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);

--- a/tests/e2e/tests/critical-path/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/scripting-area.e2e.ts
@@ -38,9 +38,10 @@ test
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can resize scripting area in Workbench', async t => {
-        const offsetY = 200;
+        const offsetY = 50;
         const inputHeightStart = await workbenchPage.queryInput.clientHeight;
-        await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.4 });
+        await t.hover(workbenchPage.resizeButtonForScriptingAndResults);
+        await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.1 });
         await t.expect(await workbenchPage.queryInput.clientHeight).eql(inputHeightStart + offsetY, 'Scripting area after resize has proper size');
     });
 test

--- a/tests/e2e/tests/regression/workbench/context.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/context.e2e.ts
@@ -1,6 +1,6 @@
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabase, deleteDatabase } from '../../../helpers/database';
-import { MyRedisDatabasePage, CliPage, WorkbenchPage } from '../../../pageObjects';
+import { MyRedisDatabasePage, CliPage, WorkbenchPage, BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
@@ -34,13 +34,14 @@ test
 test
     .meta({ rte: rte.standalone })
     ('Verify that user can see saved CLI size when navigates away to any other page', async t => {
-        const offsetY = 200;
+        const offsetY = 50;
 
         await t.click(cliPage.cliExpandButton);
         const cliAreaHeight = await cliPage.cliArea.clientHeight;
         const cliResizeButton = await cliPage.cliResizeButton;
-        //Resize CLI 200px up and navigate to the My Redis databases page
-        await t.drag(cliResizeButton, 0, -offsetY, { speed });
+        await t.hover(cliResizeButton);
+        //Resize CLI 50px up and navigate to the My Redis databases page
+        await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.1 });
         await t.click(myRedisDatabasePage.myRedisDBButton);
         //Navigate back to the database Workbench and check CLI size
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);


### PR DESCRIPTION
fixes for tests:
Verify that user can see saved CLI size on Browser page when he returns back to Browser page
Verify that user can see saved CLI size when navigates away to any other page
Verify that user can resize scripting area in Workbench