### PR TITLE
#RI-3292, #RI-3287, #RI-3288

### DIFF
--- a/redisinsight/ui/src/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/components/virtual-tree/components/Node/Node.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { NodePublicState } from 'react-vtree/dist/es/Tree'
 import cx from 'classnames'
 import { EuiIcon, EuiToolTip, keys as ElasticKeys } from '@elastic/eui'
@@ -30,6 +30,12 @@ const Node = ({
     updateStatusOpen,
     updateStatusSelected,
   } = data
+
+  useEffect(() => {
+    if (isSelected && keys) {
+      updateStatusSelected?.(fullName, keys)
+    }
+  }, [keys, isSelected])
 
   const handleClick = () => {
     if (isLeaf && keys) {

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.tsx
@@ -40,8 +40,10 @@ const BulkDeleteContent = () => {
 
     return (
       <div style={style} className={styles.item} data-testid={`row-${index}`}>
-        <div color="subdued" className={styles.key}>{key}</div>
-        <div ref={rowRef} className={styles.error}>{error}</div>
+        <span ref={rowRef}>
+          <span className={styles.key}>{key}</span>
+          <span className={styles.error}>{error}</span>
+        </span>
       </div>
     )
   }

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -189,7 +189,6 @@ const KeysHeader = (props: Props) => {
         }
       })
     }
-    dispatch(resetKeys())
     dispatch(resetKeysData())
     dispatch(changeKeyViewType(type))
     dispatch(resetBrowserTree())


### PR DESCRIPTION
* #RI-3292 - Error messages overlappses if key name is too long
* #RI-3287 - Switching between tree view and browser, doesn't apply filters
* #RI-3288 - New part of keys are not displayed in Tree View when user scans more