### PR TITLE
#RI-3223-add hex formatter

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/key-details-header/components/Formatter/KeyValueFormatter.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-details-header/components/Formatter/KeyValueFormatter.tsx
@@ -65,6 +65,10 @@ const KeyValueFormatter = (props: Props) => {
     dispatch(setViewFormat(value))
   }
 
+  if (!options.length) {
+    return null
+  }
+
   return (
     <div className={styles.container}>
       <EuiSuperSelect

--- a/redisinsight/ui/src/pages/browser/components/key-details-header/components/Formatter/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/key-details-header/components/Formatter/constants.ts
@@ -21,9 +21,15 @@ export const KEY_VALUE_FORMATTER_OPTIONS = [
     iconLight: 'kqlSelector',
     value: KeyValueFormat.Msgpack,
   },
+  {
+    text: 'HEX',
+    iconDark: 'kqlSelector',
+    iconLight: 'kqlSelector',
+    value: KeyValueFormat.HEX,
+  },
 ]
 
-export const KEY_VALUE_JSON_FORMATTER_OPTIONS = [KeyValueFormat.Unicode]
+export const KEY_VALUE_JSON_FORMATTER_OPTIONS = []
 
 export const getKeyValueFormatterOptions = (viewFormat?: KeyTypes | ModulesKeyTypes) => (
   viewFormat !== KeyTypes.ReJSON

--- a/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
+++ b/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
@@ -29,7 +29,6 @@ const bufferToHex = (reply: RedisResponseBuffer): string => {
     result += byte.toString(16)
   })
 
-  // return result.replace(/\s/g, '').replace(/(.{2})/g, '$1 ')
   return result
 }
 
@@ -96,7 +95,6 @@ const UTF8ToBuffer = (reply: string): RedisResponseBuffer => anyToBuffer(encoder
 const stringToBuffer = (data: string): RedisResponseBuffer => UTF8ToBuffer(data)
 
 const hexToBuffer = (data: string): RedisResponseBuffer => {
-  // let stringWithoutSpaces = data.replace(/ /g, '')
   let string = data
   const result = []
   while (string.length >= 2) {

--- a/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
+++ b/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
@@ -26,7 +26,8 @@ const bufferToHex = (reply: RedisResponseBuffer): string => {
   let result = ''
 
   reply.data.forEach((byte: number) => {
-    result += byte.toString(16)
+    // eslint-disable-next-line
+    result += ('0' + (byte & 0xFF).toString(16)).slice(-2)
   })
 
   return result

--- a/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
+++ b/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
@@ -22,6 +22,17 @@ const decimalToHexString = (d: number, padding = 2) => {
   return '0'.repeat(padding).substr(0, padding - hex.length) + hex
 }
 
+const bufferToHex = (reply: RedisResponseBuffer): string => {
+  let result = ''
+
+  reply.data.forEach((byte: number) => {
+    result += byte.toString(16)
+  })
+
+  // return result.replace(/\s/g, '').replace(/(.{2})/g, '$1 ')
+  return result
+}
+
 const bufferToASCII = (reply: RedisResponseBuffer): string => {
   let result = ''
   reply.data.forEach((byte: number) => {
@@ -84,6 +95,17 @@ const UTF8ToBuffer = (reply: string): RedisResponseBuffer => anyToBuffer(encoder
 // common formatters
 const stringToBuffer = (data: string): RedisResponseBuffer => UTF8ToBuffer(data)
 
+const hexToBuffer = (data: string): RedisResponseBuffer => {
+  // let stringWithoutSpaces = data.replace(/ /g, '')
+  let string = data
+  const result = []
+  while (string.length >= 2) {
+    result.push(parseInt(string.substring(0, 2), 16))
+    string = string.substring(2, string.length)
+  }
+  return { type: RedisResponseBufferType.Buffer, data: result }
+}
+
 const bufferToString = (data: RedisString = '', formatResult: RedisResponseEncoding = RedisResponseEncoding.UTF8): string => {
   let string = data
 
@@ -101,6 +123,7 @@ export default bufferToString
 export {
   bufferToUTF8,
   bufferToASCII,
+  bufferToHex,
   UTF8ToBuffer,
   decimalToHexString,
   ASCIIToBuffer,
@@ -108,6 +131,7 @@ export {
   stringToBuffer,
   bufferToString,
   UintArrayToString,
+  hexToBuffer,
   anyToBuffer,
 }
 

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -36,6 +36,7 @@ const formattingBuffer = (
     }
     case KeyValueFormat.HEX: {
       return { value: bufferToHex(reply), isValid: true }
+    }
     case KeyValueFormat.ASCII: {
       return { value: bufferToASCII(reply), isValid: true }
     }

--- a/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
@@ -7,16 +7,18 @@ import {
   bufferToASCII,
   UTF8ToBuffer,
   isEqualBuffers,
+  hexToBuffer,
+  bufferToHex,
 } from 'uiSrc/utils'
 
 const defaultValues = [
-  { unicode: 'test', ascii: 'test', uint8Array: [116, 101, 115, 116] },
-  { unicode: 'test test', ascii: 'test test', uint8Array: [116, 101, 115, 116, 32, 116, 101, 115, 116] },
-  { unicode: '嘿', ascii: '\\xe5\\x98\\xbf', uint8Array: [229, 152, 191] },
-  { unicode: '\xea12 \x12 p5', ascii: '\\xc3\\xaa12 \\x12 p5', uint8Array: [195, 170, 49, 50, 32, 18, 32, 112, 53] },
-  { unicode: 'hi \n hi \t', ascii: 'hi \\n hi \\t', uint8Array: [104, 105, 32, 10, 32, 104, 105, 32, 9] },
-  { unicode: '!@#54ueo\'6&*(){', ascii: '!@#54ueo\'6&*(){', uint8Array: [33, 64, 35, 53, 52, 117, 101, 111, 39, 54, 38, 42, 40, 41, 123] },
-  { unicode: 'привет', ascii: '\\xd0\\xbf\\xd1\\x80\\xd0\\xb8\\xd0\\xb2\\xd0\\xb5\\xd1\\x82', uint8Array: [208, 191, 209, 128, 208, 184, 208, 178, 208, 181, 209, 130] },
+  { unicode: 'test', ascii: 'test', hex: '74657374', uint8Array: [116, 101, 115, 116] },
+  { unicode: 'test test', ascii: 'test test', hex: '746573742074657374', uint8Array: [116, 101, 115, 116, 32, 116, 101, 115, 116] },
+  { unicode: '嘿', ascii: '\\xe5\\x98\\xbf', hex: 'e598bf', uint8Array: [229, 152, 191] },
+  { unicode: '\xea12 \x12 p5', ascii: '\\xc3\\xaa12 \\x12 p5', hex: 'c3aa31322012207035', uint8Array: [195, 170, 49, 50, 32, 18, 32, 112, 53] },
+  { unicode: 'hi \n hi \t', ascii: 'hi \\n hi \\t', hex: '6869200a2068692009', uint8Array: [104, 105, 32, 10, 32, 104, 105, 32, 9] },
+  { unicode: '!@#54ueo\'6&*(){', ascii: '!@#54ueo\'6&*(){', hex: '214023353475656f2736262a28297b', uint8Array: [33, 64, 35, 53, 52, 117, 101, 111, 39, 54, 38, 42, 40, 41, 123] },
+  { unicode: 'привет', ascii: '\\xd0\\xbf\\xd1\\x80\\xd0\\xb8\\xd0\\xb2\\xd0\\xb5\\xd1\\x82', hex: 'd0bfd180d0b8d0b2d0b5d182', uint8Array: [208, 191, 209, 128, 208, 184, 208, 178, 208, 181, 209, 130] },
 ]
 
 const getStringToBufferTests = defaultValues.map(({ unicode, uint8Array }) =>
@@ -38,6 +40,18 @@ describe('anyToBuffer', () => {
   test.each(getAnyToBufferTests)('%j', ({ input, expected }) => {
     // @ts-ignore
     const result = anyToBuffer(input)
+    result.data = Array.from(result.data)
+    expect(result).toEqual(expected)
+  })
+})
+
+const getHexToBufferTests = defaultValues.map(({ hex, uint8Array }) =>
+  ({ input: hex, expected: { data: uint8Array, type: RedisResponseBufferType.Buffer } }))
+
+describe('hexToBuffer', () => {
+  test.each(getHexToBufferTests)('%j', ({ input, expected }) => {
+    // @ts-ignore
+    const result = hexToBuffer(input)
     result.data = Array.from(result.data)
     expect(result).toEqual(expected)
   })
@@ -67,6 +81,16 @@ describe('bufferToASCII', () => {
   test.each(getBufferToASCIITests)('%j', ({ input, expected }) => {
     // @ts-ignore
     expect(bufferToASCII(input)).toEqual(expected)
+  })
+})
+
+const getBufferToHexTests = defaultValues.map(({ hex, uint8Array }) =>
+  ({ input: anyToBuffer(uint8Array), expected: hex }))
+
+describe('bufferToASCII', () => {
+  test.each(getBufferToHexTests)('%j', ({ input, expected }) => {
+    // @ts-ignore
+    expect(bufferToHex(input)).toEqual(expected)
   })
 })
 


### PR DESCRIPTION
-  add HEX formatter
- hex string validation: (no spaces, no /n, % 2 === 0, includes only 0-9 and a-f symbols, A-F symbols