### PR TITLE
#RI-3403 - Layout for scanned keys info is brocken for smaller screen resolution

### DIFF
--- a/redisinsight/ui/src/pages/browser/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/styles.module.scss
@@ -34,6 +34,7 @@ $breakpoint-to-hide-resize-panel: 1124px;
 }
 
 .resizePanelLeft {
+  min-width: 550px;
   :global(.euiResizablePanel__content) {
     @media (min-width: 1124px) {
       padding-right: 8px;


### PR DESCRIPTION
#RI-3403 - Layout for scanned keys info is brocken for smaller screen resolution