### PR TITLE
#RI-3416 - Command result with nocontent option is not correct

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/utils/parseResponse.ts
+++ b/redisinsight/ui/src/packages/redisearch/src/utils/parseResponse.ts
@@ -90,8 +90,10 @@ const getChunkCountSearch = (command: string = '') => {
   return count
 }
 
-const getIsKeysOnly = (command: string = '') => (command.includes(CommandArgument.NoContent)
-    || command.includes(`${CommandArgument.Return} 0`))
+const getIsKeysOnly = (command: string = '') => (
+  command.toLowerCase().includes(CommandArgument.NoContent.toLowerCase())
+  || command.toLowerCase().includes(`${CommandArgument.Return.toLowerCase()} 0`)
+)
 
 export {
   parseInfoRawResponse,


### PR DESCRIPTION
#RI-3416 - Command result with nocontent option is not correct