### PR TITLE
#RI-3584 - Tree view is displayed on Browser page by default

### DIFF
--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -320,7 +320,11 @@ const keysSlice = createSlice({
 
     // reset keys for keys slice
     resetKeys: (state) => cloneDeep(
-      { ...initialState, selectedKey: getInitialSelectedKeyState(state as KeysStore) }
+      {
+        ...initialState,
+        viewType: localStorageService?.get(BrowserStorageItem.browserViewType) ?? KeyViewType.Browser,
+        selectedKey: getInitialSelectedKeyState(state as KeysStore)
+      }
     ),
 
     resetKeysData: (state) => {
@@ -397,7 +401,6 @@ export let sourceKeysFetch: Nullable<CancelTokenSource> = null
 
 export function setInitialStateByType(type: string) {
   return (dispatch: AppDispatch) => {
-
     if (type === KeyTypes.Hash) {
       dispatch(setHashInitialState())
     }


### PR DESCRIPTION
#RI-3584 - Tree view is displayed on Browser page by default when switching between databases