### PR TITLE
#RI-3643 - Graph line is displayed in the middle of graph

### DIFF
--- a/redisinsight/ui/src/components/charts/area-chart/AreaChart.tsx
+++ b/redisinsight/ui/src/components/charts/area-chart/AreaChart.tsx
@@ -115,7 +115,7 @@ const AreaChart = (props: IProps) => {
       .domain(d3.extent(cleanedData, (d) => d.index) as [number, number])
       .range([0, width])
 
-    let maxY = d3.max(cleanedData, (d) => d.y) || 0
+    let maxY = d3.max(cleanedData, (d) => d.y) || yCountTicks
 
     if (dataType === AreaChartDataType.Bytes) {
       const curriedTyBytes = curryRight(toBytes)


### PR DESCRIPTION
#RI-3643 - Graph line is displayed in the middle of graph when all keys with no expiry