### PR TITLE
RI-3530 critical path tests refactoring

### DIFF
--- a/tests/e2e/tests/critical-path/browser/bulk-delete.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/bulk-delete.e2e.ts
@@ -54,27 +54,26 @@ test('Verify that user can access the bulk actions screen in the Browser', async
     await t.expect(bulkActionsPage.bulkApplyButton.visible).ok('Confirm deletion button not displayed');
 
 });
-test('Verify that user can see no pattern selected message when no key type and pattern applied for Bulk Delete', async t => {
-    const messageTitle = 'No pattern or key type set';
-    const messageText = 'To perform a bulk action, set the pattern or select the key type';
-    // Open bulk actions
-    await t.click(browserPage.bulkActionsButton);
-    await t.expect(bulkActionsPage.bulkActionsPlaceholder.textContent).contains(messageTitle, 'No pattern title not displayed');
-    await t.expect(bulkActionsPage.bulkActionsPlaceholder.textContent).contains(messageText, 'No pattern message not displayed');
-});
 test('Verify that user can see summary of scanned level', async t => {
     const expectedAmount = new RegExp('Expected amount: ~' + '10 ' + '.');
     const scannedKeys = new RegExp('Scanned 5% \\(....10 ...\\) and found ... keys');
+    const messageTitle = 'No pattern or key type set';
+    const messageText = 'To perform a bulk action, set the pattern or select the key type';
+
     // Add 10000 Hash keys
     await populateDBWithHashes(dbParameters.host, dbParameters.port, keyToAddParameters);
-    // Filter by Hash keys
-    await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
     // Open bulk actions
     await t.click(browserPage.bulkActionsButton);
+    // Verify that user can see no pattern selected message when no key type and pattern applied for Bulk Delete
+    await t.expect(bulkActionsPage.bulkActionsPlaceholder.textContent).contains(messageTitle, 'No pattern title not displayed');
+    await t.expect(bulkActionsPage.bulkActionsPlaceholder.textContent).contains(messageText, 'No pattern message not displayed');
+    // Filter by Hash keys
+    await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
     // Verify that prediction of # of keys matching the filter in the entire database displayed
     await t.expect(bulkActionsPage.bulkActionsSummary.textContent).match(expectedAmount, 'Bulk actions summary is not correct');
     // Verify that % of total keys scanned, # of keys scanned / total # of keys in the database, # of keys matching the filter displayed
     await t.expect(bulkActionsPage.bulkDeleteSummary.innerText).match(scannedKeys, 'Bulk delete summary is not correct');
+
 });
 test('Verify that user can see blue progress line during the process of bulk deletion', async t => {
     // Add 500000 Hash keys
@@ -136,7 +135,7 @@ test
     .before(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
         await addSetKeyApi(setKeyParameters, ossStandaloneRedisearch);
-        //Add 10000 Hash keys
+        // Add 10000 Hash keys
         await populateDBWithHashes(dbParameters.host, dbParameters.port, keyToAddParameters);
         // Filter by Hash keys
         await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
@@ -166,10 +165,7 @@ test('Verify that when user clicks on Close button when bulk delete is completed
     // Verify context not saved
     await t.expect(bulkActionsPage.bulkDeleteCompletedSummary.visible).notOk('Bulk delete completed summary still displayed');
     await t.expect(bulkActionsPage.bulkDeleteSummary.textContent).contains('Scanned 100% (2/2) and found 1 keys', 'Bulk delete summary is not correct');
-});
-test('Verify that when user clicks on cross icon when bulk delete is completed, panel is closed, no context is saved', async t => {
-    // Filter by Hash keys
-    await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
+    // Verify that when user clicks on cross icon when bulk delete is completed, panel is closed, no context is saved
     await bulkActionsPage.startBulkDelete();
     await t.click(bulkActionsPage.bulkClosePanelButton);
     await t.click(browserPage.bulkActionsButton);

--- a/tests/e2e/tests/critical-path/browser/consumer-group.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/consumer-group.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage, CliPage } from '../../../pageObjects';
@@ -7,15 +6,16 @@ import {
     ossStandaloneConfig
 } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 20 });
-let consumerGroupName = chance.word({ length: 20 });
-const keyField = chance.word({ length: 20 });
-const keyValue = chance.word({ length: 20 });
+let keyName = common.generateWord(20);
+let consumerGroupName = common.generateWord(20);
+const keyField = common.generateWord(20);
+const keyValue = common.generateWord(20);
 const entryIds = [
     '0',
     '$',
@@ -29,7 +29,7 @@ fixture `Consumer group`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async t => {
-        //Clear and delete database
+        // Clear and delete database
         if (await browserPage.closeKeyButton.visible) {
             await t.click(browserPage.closeKeyButton);
         }
@@ -46,25 +46,25 @@ test('Verify that user can create a new Consumer Group in the current Stream', a
         '0',
         'fetches the entire stream from the beginning.'
     ];
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = `qwerty123456${chance.word({ length: 20 })}!@#$%^&*()_+=`;
+    keyName = common.generateWord(20);
+    consumerGroupName = `qwerty123456${common.generateWord(20)}!@#$%^&*()_+=`;
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
     await t.click(browserPage.fullScreenModeButton);
     // Open Stream consumer groups and add group
     await t.click(browserPage.streamTabGroups);
     await browserPage.createConsumerGroup(consumerGroupName);
-    await t.expect(browserPage.streamGroupsContainer.textContent).contains(consumerGroupName, 'The new Consumer Group is added');
+    await t.expect(browserPage.streamGroupsContainer.textContent).contains(consumerGroupName, 'The new Consumer Group is not added');
     // Verify the tooltip under 'i' element
     await t.click(browserPage.addKeyValueItemsButton);
     await t.hover(browserPage.entryIdInfoIcon);
     for (const text of toolTip) {
-        await t.expect(await browserPage.tooltip.innerText).contains(text, 'The toolTip message');
+        await t.expect(await browserPage.tooltip.innerText).contains(text, 'The toolTip message not displayed');
     }
 });
 test('Verify that user can input the 0, $ and Valid Entry ID in the ID field', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
     await t.click(browserPage.fullScreenModeButton);
@@ -72,18 +72,20 @@ test('Verify that user can input the 0, $ and Valid Entry ID in the ID field', a
     await t.click(browserPage.streamTabGroups);
     for (const entryId of entryIds) {
         await browserPage.createConsumerGroup(`${consumerGroupName}${entryId}`, entryId);
-        await t.expect(browserPage.streamGroupsContainer.textContent).contains(`${consumerGroupName}${entryId}`, 'The new Consumer Group is added');
+        await t.expect(browserPage.streamGroupsContainer.textContent).contains(`${consumerGroupName}${entryId}`, 'The new Consumer Group is not added');
     }
 });
 test('Verify that user can see the Consumer group columns (Group Name, Consumers, Pending, Last Delivered ID)', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     const groupColumns = [
         'Group Name',
         'Consumers',
         'Pending',
         'Last Delivered ID'
     ];
+    const message = 'Your Consumer Group has no Consumers available.';
+
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
     await t.click(browserPage.fullScreenModeButton);
@@ -91,24 +93,15 @@ test('Verify that user can see the Consumer group columns (Group Name, Consumers
     await t.click(browserPage.streamTabGroups);
     await browserPage.createConsumerGroup(consumerGroupName);
     for (let i = 0; i < groupColumns.length; i++) {
-        await t.expect(browserPage.scoreButton.nth(i).textContent).eql(groupColumns[i], `The ${i} Consumer group column name`);
+        await t.expect(browserPage.scoreButton.nth(i).textContent).eql(groupColumns[i], `The ${i} Consumer group column name not correct`);
     }
-});
-test('Verify that user can see the message when there are no Consumers in the Consumer Group', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
-    const message = 'Your Consumer Group has no Consumers available.';
-    // Add New Stream Key
-    await browserPage.addStreamKey(keyName, keyField, keyValue);
-    // Open Stream consumer group and check message
-    await t.click(browserPage.streamTabGroups);
-    await browserPage.createConsumerGroup(consumerGroupName);
+    // Verify that user can see the message when there are no Consumers in the Consumer Group
     await t.click(browserPage.consumerGroup);
-    await t.expect(browserPage.streamConsumersContainer.textContent).contains(message, 'The message for empty Consumer Group');
+    await t.expect(browserPage.streamConsumersContainer.textContent).contains(message, 'The message for empty Consumer Group not displayed');
 });
 test('Verify that user can see the Consumer information columns (Consumer Name, Pendings, Idle Time,ms)', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
@@ -128,33 +121,16 @@ test('Verify that user can see the Consumer information columns (Consumer Name, 
     await t.click(browserPage.streamTabGroups);
     await t.click(browserPage.consumerGroup);
     for (let i = 0; i < consumerColumns.length; i++) {
-        await t.expect(browserPage.scoreButton.nth(i).textContent).eql(consumerColumns[i], `The ${i} Consumers info column name`);
+        await t.expect(browserPage.scoreButton.nth(i).textContent).eql(consumerColumns[i], `The ${i} Consumers info column name not correct`);
     }
-});
-test('Verify that user can navigate to Consumer Groups screen using the link in the breadcrumbs', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
-    const cliCommands = [
-        `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
-        `XADD ${keyName} * message apple`,
-        `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`
-    ];
-    // Add New Stream Key with groups and consumers
-    for (const command of cliCommands) {
-        await cliPage.sendCommandInCli(command);
-    }
-    // Open Stream consumer info view
-    await browserPage.openKeyDetails(keyName);
-    await t.click(browserPage.streamTabGroups);
-    await t.click(browserPage.consumerGroup);
-    // Check navigation
+    // Verify that user can navigate to Consumer Groups screen using the link in the breadcrumbs
     await t.expect(browserPage.streamTabs.visible).ok('Stream navigation tabs visibility');
     await t.click(browserPage.streamTabGroups);
-    await t.expect(browserPage.streamTabGroups.withAttribute('aria-selected', 'true').exists).ok('The Consumer Groups screen is opened');
+    await t.expect(browserPage.streamTabGroups.withAttribute('aria-selected', 'true').exists).ok('The Consumer Groups screen is not opened');
 });
 test('Verify that user can delete the Consumer from the Consumer Group', async t => {
-    keyName = chance.word({ length: 20 });
-    let consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    const consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
@@ -173,13 +149,13 @@ test('Verify that user can delete the Consumer from the Consumer Group', async t
     // Delete consumer and check results
     const consumerCountBefore = await browserPage.streamConsumerName.count;
     await t.click(browserPage.removeConsumerButton);
-    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(`will be removed from Consumer Group ${consumerGroupName}`, 'The confirmation message');
+    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(`will be removed from Consumer Group ${consumerGroupName}`, 'The confirmation message not displayed');
     await t.click(browserPage.removeConsumerButton.nth(2));
-    await t.expect(browserPage.streamConsumerName.count).eql(consumerCountBefore - 1, 'The Consumers number after deletion');
+    await t.expect(browserPage.streamConsumerName.count).eql(consumerCountBefore - 1, 'The Consumers number after deletion not correct');
 });
 test('Verify that user can delete a Consumer Group', async t => {
-    keyName = chance.word({ length: 20 });
-    let consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    const consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
@@ -192,33 +168,17 @@ test('Verify that user can delete a Consumer Group', async t => {
     // Open Stream consumer info view
     await browserPage.openKeyDetails(keyName);
     await t.click(browserPage.streamTabGroups);
-    // Delete consumer group and check results
-    await t.click(browserPage.removeConsumerGroupButton);
-    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(`${consumerGroupName}and all its consumers will be removed from ${keyName}`, 'The confirmation message');
-    await t.click(browserPage.removeConsumerGroupButton.nth(1));
-    await t.expect(browserPage.streamGroupsContainer.textContent).contains('Your Key has no Consumer Groups available.', 'The Consumer Group is removed from the table');
-});
-test('Verify that user can change the ID set for the Consumer Group when click on the Pencil button', async t => {
-    keyName = chance.word({ length: 20 });
-    let consumerGroupName = chance.word({ length: 20 });
-    const cliCommands = [
-        `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
-        `XADD ${keyName} * message apple`,
-        `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`
-    ];
-    // Add New Stream Key with groups and consumers
-    for (const command of cliCommands) {
-        await cliPage.sendCommandInCli(command);
-    }
-    // Open Stream consumer info view
-    await browserPage.openKeyDetails(keyName);
-    await t.click(browserPage.streamTabGroups);
-    // Change the ID set for the Consumer Group
+    // Verify that user can change the ID set for the Consumer Group when click on the Pencil button
     for (const id of entryIds) {
         const idBefore = await browserPage.streamGroupId.textContent;
         await t.click(browserPage.editStreamLastIdButton);
         await t.typeText(browserPage.lastIdInput, id, { replace: true });
         await t.click(browserPage.saveButton);
-        await t.expect(browserPage.streamGroupId.textContent).notEql(idBefore, 'The last delivered ID is modified and the table is reloaded');
+        await t.expect(browserPage.streamGroupId.textContent).notEql(idBefore, 'The last delivered ID is modified and the table is not reloaded');
     }
+    // Delete consumer group and check results
+    await t.click(browserPage.removeConsumerGroupButton);
+    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(`${consumerGroupName}and all its consumers will be removed from ${keyName}`, 'The confirmation message not displayed');
+    await t.click(browserPage.removeConsumerGroupButton.nth(1));
+    await t.expect(browserPage.streamGroupsContainer.textContent).contains('Your Key has no Consumer Groups available.', 'The Consumer Group is not removed from the table');
 });

--- a/tests/e2e/tests/critical-path/browser/context.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/context.e2e.ts
@@ -7,146 +7,128 @@ import {
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { Common } from '../../../helpers/common';
 import { KeyTypesTexts, rte } from '../../../helpers/constants';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
 const common = new Common();
-const chance = new Chance();
 
 const speed = 0.4;
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 let keys: string[];
 
 fixture `Browser Context`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
+    });
 // Update after resolving https://redislabs.atlassian.net/browse/RI-3299
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved CLI size on Browser page when he returns back to Browser page', async t => {
-        const offsetY = 200;
+test('Verify that user can see saved CLI size on Browser page when he returns back to Browser page', async t => {
+    const offsetY = 200;
 
-        await t.click(cliPage.cliExpandButton);
-        const cliAreaHeight = await cliPage.cliArea.clientHeight;
-        const cliAreaHeightEnd = cliAreaHeight + 150;
-        const cliResizeButton = await cliPage.cliResizeButton;
-        await t.hover(cliResizeButton);
-        // move resize 200px up
-        await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.01 });
-        await t.click(myRedisDatabasePage.myRedisDBButton);
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.expect(await cliPage.cliArea.clientHeight > cliAreaHeightEnd).ok('Saved context for resizable cli is incorrect');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved Key details and Keys tables size on Browser page when he returns back to Browser page', async t => {
-        const offsetX = 200;
+    await t.click(cliPage.cliExpandButton);
+    const cliAreaHeight = await cliPage.cliArea.clientHeight;
+    const cliAreaHeightEnd = cliAreaHeight + 150;
+    const cliResizeButton = await cliPage.cliResizeButton;
+    await t.hover(cliResizeButton);
+    // move resize 200px up
+    await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.01 });
+    await t.click(myRedisDatabasePage.myRedisDBButton);
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    await t.expect(await cliPage.cliArea.clientHeight > cliAreaHeightEnd).ok('Saved context for resizable cli is incorrect');
+});
+test('Verify that user can see saved Key details and Keys tables size on Browser page when he returns back to Browser page', async t => {
+    const offsetX = 200;
+    const keyListWidth = await browserPage.keyListTable.clientWidth;
+    const cliResizeButton = await browserPage.resizeBtnKeyList;
 
-        const keyListWidth = await browserPage.keyListTable.clientWidth;
-        const cliResizeButton = await browserPage.resizeBtnKeyList;
-        // move resize 200px right
-        await t.drag(cliResizeButton, offsetX, 0, { speed });
-        await t.click(myRedisDatabasePage.myRedisDBButton);
-
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-
-        await t.expect(await browserPage.keyListTable.clientWidth).gt(keyListWidth, 'Saved browser resizable context is proper');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved filter per key type applied when he returns back to Browser page', async t => {
-        //Filter per key type String and open Settings
-        await browserPage.selectFilterGroupType(KeyTypesTexts.String);
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Return back to Browser and check filter applied
-        await t.click(myRedisDatabasePage.browserButton);
-        await t.expect(await browserPage.selectedFilterTypeString.visible).eql(true, 'Filter per key type is still applied');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved executed commands in CLI on Browser page when he returns back to Browser page', async t => {
-        const commands = [
+    // move resize 200px right
+    await t.drag(cliResizeButton, offsetX, 0, { speed });
+    await t.click(myRedisDatabasePage.myRedisDBButton);
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    await t.expect(await browserPage.keyListTable.clientWidth).gt(keyListWidth, 'Saved browser resizable context is proper');
+});
+test('Verify that user can see saved filter per key type applied when he returns back to Browser page', async t => {
+    keyName = common.generateWord(10);
+    // Filter per key type String and open Settings
+    await browserPage.selectFilterGroupType(KeyTypesTexts.String);
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Return back to Browser and check filter applied
+    await t.click(myRedisDatabasePage.browserButton);
+    await t.expect(await browserPage.selectedFilterTypeString.visible).eql(true, 'Filter per key type is still applied');
+    // Clear filter
+    await t.click(browserPage.clearFilterButton);
+    // Filter per key name and open Settings
+    await browserPage.searchByKeyName(keyName);
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Return back to Browser and check filter applied
+    await t.click(myRedisDatabasePage.browserButton);
+    // Verify that user can see saved input entered into the filter per Key name when he returns back to Browser page
+    await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is still applied');
+});
+test('Verify that user can see saved executed commands in CLI on Browser page when he returns back to Browser page', async t => {
+    const commands = [
         'SET key',
         'client getname'
-        ];
-        //Execute command in CLI and open Settings page
-        await t.click(cliPage.cliExpandButton);
-        for(const command of commands) {
-            await t.typeText(cliPage.cliCommandInput, command);
-            await t.pressKey('enter');
-        }
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Return back to Browser and check executed command in CLI
-        await t.click(myRedisDatabasePage.browserButton);
-        for(const command of commands) {
-            await t.expect(await cliPage.cliCommandExecuted.withExactText(command).exists).ok(`Executed command '${command}' in CLI is saved`);
-        }
-    });
+    ];
+
+    // Execute command in CLI and open Settings page
+    await t.click(cliPage.cliExpandButton);
+    for(const command of commands) {
+        await t.typeText(cliPage.cliCommandInput, command);
+        await t.pressKey('enter');
+    }
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Return back to Browser and check executed command in CLI
+    await t.click(myRedisDatabasePage.browserButton);
+    for(const command of commands) {
+        await t.expect(await cliPage.cliCommandExecuted.withExactText(command).exists).ok(`Executed command '${command}' in CLI is saved`);
+    }
+});
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved input entered into the filter per Key name when he returns back to Browser page', async t => {
-        keyName = chance.word({ length: 10 });
-        //Filter per key name and open Settings
-        await browserPage.searchByKeyName(keyName);
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Return back to Browser and check filter applied
-        await t.click(myRedisDatabasePage.browserButton);
-        await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is still applied');
-    });
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can see key details selected when he returns back to Browser page', async t => {
-        //Add and open new key details and navigate to Settings
-        keyName = chance.word({ length: 10 });
+    })('Verify that user can see key details selected when he returns back to Browser page', async t => {
+        // Add and open new key details and navigate to Settings
+        keyName = common.generateWord(10);
         await browserPage.addHashKey(keyName);
         await browserPage.openKeyDetails(keyName);
         await t.click(myRedisDatabasePage.settingsButton);
-        //Return back to Browser and check key details selected
+        // Return back to Browser and check key details selected
         await t.click(myRedisDatabasePage.browserButton);
         await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('The key details is selected');
     });
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can see list of keys viewed on Browser page when he returns back to Browser page', async t => {
+    })('Verify that user can see list of keys viewed on Browser page when he returns back to Browser page', async t => {
         const numberOfItems = 5000;
         const scrollY = 3200;
-        //Open CLI
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Create new keys
+        // Create new keys
         keys = await common.createArrayWithKeyValue(numberOfItems);
         await t.typeText(cliPage.cliCommandInput, `MSET ${keys.join(' ')}`, {paste: true});
         await t.pressKey('enter');
         await t.click(cliPage.cliCollapseButton);
-
-        await t.click(browserPage.refreshKeysButton)
+        await t.click(browserPage.refreshKeysButton);
 
         const keyList = await browserPage.keyListTable;
         const keyListSGrid = await keyList.find(browserPage.cssSelectorGrid);
 
-        //Scroll key list
+        // Scroll key list
         await t.scroll(keyListSGrid, 0, scrollY);
-
-        //Find any key from list that is visible
+        // Find any key from list that is visible
         const renderedRows = await keyList.find(browserPage.cssSelectorRows);
         const renderedRowsCount = await renderedRows.count;
         const randomKey = renderedRows.nth(Math.floor((Math.random() * renderedRowsCount)));
@@ -155,7 +137,7 @@ test
         await t.click(myRedisDatabasePage.myRedisDBButton);
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
 
-        //Check that previous found key is still visible
+        // Check that previous found key is still visible
         const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(randomKeyName);
         await t.expect(isKeyIsDisplayedInTheList).ok('Scrolled position and saved key list is proper');
     });

--- a/tests/e2e/tests/critical-path/browser/filtering.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/filtering.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import {
@@ -12,10 +11,9 @@ import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
 const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keysData = keyTypes.map(object => ({ ...object }));
 keysData.forEach(key => key.keyName = `${key.keyName}` + '-' + `${common.generateWord(keyLength)}`);
 
@@ -26,24 +24,36 @@ fixture `Filtering per key name in Browser page`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that user can search a key with selected data type is filters', async t => {
-        keyName = chance.word({ length: 10 });
+        keyName = common.generateWord(10);
         //Add new key
         await browserPage.addStringKey(keyName);
-        //Search by key with full name & specified type
+        // Search by key with full name & specified type
         await browserPage.selectFilterGroupType(KeyTypesTexts.String);
         await browserPage.searchByKeyName(keyName);
-        //Verify that key was found
+        // Verify that key was found
         const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
         await t.expect(isKeyIsDisplayedInTheList).ok('The key was found');
+        // Verify that user can see filtering per key name starts when he press Enter or clicks the control to filter per key name
+        // Clear filter
+        await t.click(browserPage.clearFilterButton);
+        // Check the filtering starts by press Enter
+        await t.typeText(browserPage.filterByPatterSearchInput, 'InvalidText');
+        await t.pressKey('enter');
+        await t.expect(browserPage.searchAdvices.visible).ok('The filtering is set');
+        // Check the filtering starts by clicks the control
+        await common.reloadPage();
+        await t.typeText(browserPage.filterByPatterSearchInput, 'InvalidText');
+        await t.click(browserPage.searchButton);
+        await t.expect(browserPage.searchAdvices.visible).ok('The filtering is set');
     });
 test
     .after(async() => {
@@ -51,8 +61,8 @@ test
         await deleteKeysViaCli(keysData);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that user can filter keys per data type in Browser page', async t => {
-        keyName = chance.word({ length: 10 });
-        //Create new keys
+        keyName = common.generateWord(10);
+        // Create new keys
         await addKeysViaCli(keysData);
         for (const { textType, keyName } of keysData) {
             await browserPage.selectFilterGroupType(textType);
@@ -66,12 +76,12 @@ test
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     })('Verify that user see the key type label when filtering per key types and when removes label the filter is removed on Browser page', async t => { //Check filtering labels
         for (const { textType } of keyTypes) {
             await browserPage.selectFilterGroupType(textType);
-            //Check key type label
+            // Check key type label
             await t.expect((await browserPage.filteringLabel.textContent).toUpperCase).eql(textType.toUpperCase, `The label of type ${textType} is displayed`);
             if (['STREAM', 'GRAPH', 'TS'].includes(textType)) {
                 await t.expect(browserPage.keysNumberOfResults.textContent).eql('0', 'Number of found keys');
@@ -81,27 +91,8 @@ test
                 await t.expect(browserPage.keysNumberOfResults.textContent).match(regExp, 'Number of found keys');
             }
         }
-        //Check removing of the label
+        // Check removing of the label
         await t.click(browserPage.deleteFilterButton);
         await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The label of filtering type is removed');
         await t.expect(browserPage.keysSummary.textContent).contains('Total', 'The filter is removed');
-    });
-test
-    .after(async() => {
-    //Clear and delete database
-        await browserPage.deleteKeyByName(keyName);
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that user can see filtering per key name starts when he press Enter or clicks the control to filter per key name', async t => { //Check filtering labes
-        keyName = chance.word({ length: 10 });
-        //Add new key
-        await browserPage.addStringKey(keyName);
-        //Check the filtering starts by press Enter
-        await t.typeText(browserPage.filterByPatterSearchInput, 'InvalidText');
-        await t.pressKey('enter');
-        await t.expect(browserPage.searchAdvices.visible).ok('The filtering is set');
-        //Check the filtering starts by clicks the control
-        await common.reloadPage();
-        await t.typeText(browserPage.filterByPatterSearchInput, 'InvalidText');
-        await t.click(browserPage.searchButton);
-        await t.expect(browserPage.searchAdvices.visible).ok('The filtering is set');
     });

--- a/tests/e2e/tests/critical-path/browser/hash-field.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/hash-field.e2e.ts
@@ -2,61 +2,50 @@ import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyFieldValue = 'hashField11111';
 const keyValue = 'hashValue11111!';
 
 fixture `Hash Key fields verification`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search by full field name in Hash', async t => {
-        keyName = keyName = chance.word({ length: 10 });
-        await browserPage.addHashKey(keyName, keyTTL);
-        //Add field to the hash key
-        await browserPage.addFieldToHash(keyFieldValue, keyValue);
-        //Search by full field name
-        await browserPage.searchByTheValueInKeyDetails(keyFieldValue);
-        //Check the search result
-        const result = await browserPage.hashFieldsList.nth(0).textContent;
-        await t.expect(result).eql(keyFieldValue, 'The hash field');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search by part field name in Hash with pattern * in Hash', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addHashKey(keyName, keyTTL);
-        //Add field to the hash key
-        await browserPage.addFieldToHash(keyFieldValue, keyValue);
-        //Search by part field name and the * in the end
-        await browserPage.searchByTheValueInKeyDetails('hashField*');
-        //Check the search result
-        let result = await browserPage.hashFieldsList.nth(0).textContent;
-        await t.expect(result).eql(keyFieldValue, 'The hash field');
-        //Search by part field name and the * in the beggining
-        await browserPage.searchByTheValueInKeyDetails('*11111');
-        //Check the search result
-        result = await browserPage.hashFieldsList.nth(0).textContent;
-        await t.expect(result).eql(keyFieldValue, 'The hash field');
-        //Search by part field name and the * in the middle
-        await browserPage.searchByTheValueInKeyDetails('hash*11111');
-        //Check the search result
-        result = await browserPage.hashFieldsList.nth(0).textContent;
-        await t.expect(result).eql(keyFieldValue, 'The hash field');
-    });
+test('Verify that user can search by full field name in Hash', async t => {
+    keyName = keyName = common.generateWord(10);
+    await browserPage.addHashKey(keyName, keyTTL);
+    // Add field to the hash key
+    await browserPage.addFieldToHash(keyFieldValue, keyValue);
+    // Search by full field name
+    await browserPage.searchByTheValueInKeyDetails(keyFieldValue);
+    // Check the search result
+    let result = await browserPage.hashFieldsList.nth(0).textContent;
+    await t.expect(result).eql(keyFieldValue, 'The hash field not found by full field name');
+    // Verify that user can search by part field name in Hash with pattern * in Hash
+    await browserPage.searchByTheValueInKeyDetails('hashField*');
+    // Check the search result
+    await t.expect(result).eql(keyFieldValue, 'The hash field');
+    // Search by part field name and the * in the beggining
+    await browserPage.searchByTheValueInKeyDetails('*11111');
+    // Check the search result
+    result = await browserPage.hashFieldsList.nth(0).textContent;
+    await t.expect(result).eql(keyFieldValue, 'The hash field');
+    // Search by part field name and the * in the middle
+    await browserPage.searchByTheValueInKeyDetails('hash*11111');
+    // Check the search result
+    result = await browserPage.hashFieldsList.nth(0).textContent;
+    await t.expect(result).eql(keyFieldValue, 'The hash field not found by pattern');
+});

--- a/tests/e2e/tests/critical-path/browser/large-data.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/large-data.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { Common } from '../../../helpers/common';
 import { rte } from '../../../helpers/constants';
@@ -9,54 +8,39 @@ import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
 const common = new Common();
-const chance = new Chance();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Cases with large data`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see relevant information about key size', async t => {
-        keyName = chance.word({ length: 10 });
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Create new key with a lot of members
-        const arr = await common.createArrayWithKeyValue(500);
-        await t.typeText(cliPage.cliCommandInput, `HSET ${keyName} ${arr.join(' ')}`, { paste: true });
-        await t.pressKey('enter');
-        await t.click(cliPage.cliCollapseButton);
-        //Remember the values of the key size
-        await browserPage.openKeyDetails(keyName);
-        const keySizeText = await browserPage.keySizeDetails.textContent;
-        const sizeArray = keySizeText.split(' ');
-        const keySize = sizeArray[sizeArray.length - 2];
-        //Verify that user can see relevant information about key size
-        await t.expect(keySizeText).contains('KB', 'Key measure');
-        await t.expect(+keySize).gt(10, 'Key size value');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see relevant information about key length', async t => {
-        keyName = chance.word({ length: 10 });
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Create new key with a lot of members
-        const length = 500;
-        const arr = await common.createArrayWithKeyValue(length);
-        await t.typeText(cliPage.cliCommandInput, `HSET ${keyName} ${arr.join(' ')}`, { paste: true });
-        await t.pressKey('enter');
-        await t.click(cliPage.cliCollapseButton);
-        //Remember the values of the key size
-        await browserPage.openKeyDetails(keyName);
-        const keyLength = await browserPage.keyLengthDetails.textContent;
-        //Verify that user can see relevant information about key size
-        await t.expect(keyLength).eql(`Length: ${length}`, 'Key length');
-    });
+test('Verify that user can see relevant information about key size', async t => {
+    keyName = common.generateWord(10);
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Create new key with a lot of members
+    const length = 500;
+    const arr = await common.createArrayWithKeyValue(length);
+    await t.typeText(cliPage.cliCommandInput, `HSET ${keyName} ${arr.join(' ')}`, { paste: true });
+    await t.pressKey('enter');
+    await t.click(cliPage.cliCollapseButton);
+    await browserPage.openKeyDetails(keyName);
+    // Remember the values of the key size and length
+    const keySizeText = await browserPage.keySizeDetails.textContent;
+    const keyLength = await browserPage.keyLengthDetails.textContent;
+    const sizeArray = keySizeText.split(' ');
+    const keySize = sizeArray[sizeArray.length - 2];
+    // Verify that user can see relevant information about key length
+    await t.expect(keyLength).eql(`Length: ${length}`, 'Key length not correct');
+    // Verify that user can see relevant information about key size
+    await t.expect(keySizeText).contains('KB', 'Key measure not correct');
+    await t.expect(+keySize).gt(10, 'Key size value not correct');
+});

--- a/tests/e2e/tests/critical-path/browser/scan-keys.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/scan-keys.e2e.ts
@@ -26,49 +26,47 @@ const explicitErrorHandler = (): void => {
         if(e.message === 'ResizeObserver loop limit exceeded') {
             e.stopImmediatePropagation();
         }
-    })
-}
+    });
+};
 
 fixture `Browser - Specify Keys to Scan`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
     .clientScripts({ content: `(${explicitErrorHandler.toString()})()` })
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
+    .afterEach(async() => {
         //Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that the user can see this number of keys applied to new filter requests and to "scan more" functionality in Browser page', async t => {
-        const searchPattern = 'key[12]*';
-        //Go to Settings page
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Specify keys to scan
-        await t.click(settingsPage.accordionAdvancedSettings);
-        await settingsPage.changeKeysToScanValue('1000');
-        // Go to Browser Page
-        await t.click(myRedisDatabasePage.myRedisDBButton);
-        //Connect to DB
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Create new keys
-        keys = await common.createArrayWithKeyValue(2500);
-        await t.typeText(cliPage.cliCommandInput, `MSET ${keys.join(' ')}`, {paste: true});
-        await t.pressKey('enter');
-        await t.click(cliPage.cliCollapseButton);
-        //Search keys
-        await browserPage.searchByKeyName(searchPattern);
-        const keysNumberOfScanned = await browserPage.scannedValue.textContent;
-        //Verify that number of scanned is 1000
-        await t.expect(keysNumberOfScanned).contains('1 000', 'Number of scanned is 1000');
-        //Scan more
-        await t.click(browserPage.scanMoreButton);
-        const keysNumberOfScannedScanMore = await browserPage.scannedValue.textContent;
-        //Verify that number of results is 2000
-        await t.expect(keysNumberOfScannedScanMore).contains('2 000', 'Number of scanned is 2000');
     });
+test('Verify that the user can see this number of keys applied to new filter requests and to "scan more" functionality in Browser page', async t => {
+    const searchPattern = 'key[12]*';
+    // Go to Settings page
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Specify keys to scan
+    await t.click(settingsPage.accordionAdvancedSettings);
+    await settingsPage.changeKeysToScanValue('1000');
+    // Go to Browser Page
+    await t.click(myRedisDatabasePage.myRedisDBButton);
+    // Connect to DB
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Create new keys
+    keys = await common.createArrayWithKeyValue(2500);
+    await t.typeText(cliPage.cliCommandInput, `MSET ${keys.join(' ')}`, {paste: true});
+    await t.pressKey('enter');
+    await t.click(cliPage.cliCollapseButton);
+    // Search keys
+    await browserPage.searchByKeyName(searchPattern);
+    const keysNumberOfScanned = await browserPage.scannedValue.textContent;
+    // Verify that number of scanned is 1000
+    await t.expect(keysNumberOfScanned).contains('1 000', 'Number of scanned is not 1000');
+    // Scan more
+    await t.click(browserPage.scanMoreButton);
+    const keysNumberOfScannedScanMore = await browserPage.scannedValue.textContent;
+    // Verify that number of results is 2000
+    await t.expect(keysNumberOfScannedScanMore).contains('2 000', 'Number of scanned is not 2000');
+});

--- a/tests/e2e/tests/critical-path/browser/set-key.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/set-key.e2e.ts
@@ -2,60 +2,49 @@ import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyMember = '1111setMember11111';
 
 fixture `Set Key fields verification`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search by part member name with pattern * in Set', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addSetKey(keyName, keyTTL, '1111');
-        //Add member to the Set key
-        await browserPage.addMemberToSet(keyMember);
-        //Search by part member name in the end
-        await browserPage.searchByTheValueInSetKey('1111set*');
-        //Check the search result
-        let result = await browserPage.setMembersList.nth(0).textContent;
-        await t.expect(result).eql(keyMember, 'The set member');
-        //Search by part member name in the beggining
-        await browserPage.searchByTheValueInSetKey('*Member11111');
-        //Check the search result
-        result = await browserPage.setMembersList.nth(0).textContent;
-        await t.expect(result).eql(keyMember, 'The set member');
-        //Search by part member name in the middle
-        await browserPage.searchByTheValueInSetKey('1111*11111');
-        //Check the search result
-        result = await browserPage.setMembersList.nth(0).textContent;
-        await t.expect(result).eql(keyMember, 'The set member');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search by full member name in Set', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addSetKey(keyName, keyTTL, '1111');
-        //Add member to the Set key
-        await browserPage.addMemberToSet(keyMember);
-        //Search by full member name
-        await browserPage.searchByTheValueInSetKey(keyMember);
-        //Check the search result
-        const result = await browserPage.setMembersList.nth(0).textContent;
-        await t.expect(result).eql(keyMember, 'The set member');
-    });
+test('Verify that user can search by full member name in Set', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addSetKey(keyName, keyTTL, '1111');
+    // Add member to the Set key
+    await browserPage.addMemberToSet(keyMember);
+    await browserPage.searchByTheValueInSetKey(keyMember);
+    // Verify search by full member name
+    let result = await browserPage.setMembersList.nth(0).textContent;
+    await t.expect(result).eql(keyMember, 'The set member not found');
+
+    // Verify that user can search by part member name with pattern * in Set
+    await browserPage.searchByTheValueInSetKey('1111set*');
+    // Verify search by part member name in the end
+    await t.expect(result).eql(keyMember, 'The set member by part member name in the end not found');
+
+    await browserPage.searchByTheValueInSetKey('*Member11111');
+    // Verify search by part member name in the beggining
+    result = await browserPage.setMembersList.nth(0).textContent;
+    await t.expect(result).eql(keyMember, 'The set member by part member name in the beggining not found');
+
+    await browserPage.searchByTheValueInSetKey('1111*11111');
+    // Verify search by part member name in the middle
+    result = await browserPage.setMembersList.nth(0).textContent;
+    await t.expect(result).eql(keyMember, 'The set member by part member name in the middle not found');
+});

--- a/tests/e2e/tests/critical-path/browser/stream-key-entry-deletion.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-key-entry-deletion.e2e.ts
@@ -1,15 +1,15 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { rte } from '../../../helpers/constants';
 import { BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({length: 20});
+let keyName = common.generateWord(20);
 const fields = [
     'Pressure',
     'Humidity',
@@ -22,10 +22,7 @@ const values = [
 ];
 
 fixture `Stream key entry deletion`
-    .meta({
-        type: 'critical_path',
-        rte: rte.standalone
-    })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
@@ -35,37 +32,37 @@ fixture `Stream key entry deletion`
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that the Stream information is refreshed and the deleted entry is removed when user confirm the deletion of an entry', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const fieldForDeletion = fields[2];
-    //Add new Stream key with 3 fields
+    // Add new Stream key with 3 fields
     for(let i = 0; i < fields.length; i++){
         await cliPage.sendCommandInCli(`XADD ${keyName} * ${fields[i]} ${values[i]}`);
     }
-    //Open key details and remember the Stream information
+    // Open key details and remember the Stream information
     await browserPage.openKeyDetails(keyName);
-    await t.expect(browserPage.streamFields.nth(1).textContent).eql(fieldForDeletion, 'The first field entry name');
+    await t.expect(browserPage.streamFields.nth(1).textContent).eql(fieldForDeletion, 'The first field entry name not found');
     const entriesCountBefore = (await browserPage.keyLengthDetails.textContent).split(': ')[1];
-    //Delete entry from the Stream
+    // Delete entry from the Stream
     await browserPage.deleteStreamEntry();
-    //Check results
+    // Check results
     const entriesCountAfter = (await browserPage.keyLengthDetails.textContent).split(': ')[1];
-    await t.expect(Number(entriesCountBefore) - 1).eql(Number(entriesCountAfter), 'The Entries length is refreshed');
+    await t.expect(Number(entriesCountBefore) - 1).eql(Number(entriesCountAfter), 'The Entries length is not refreshed');
     const fieldsLengthAfter = await browserPage.streamFields.count;
     for(let i = fieldsLengthAfter - 1; i <= 0; i--){
         const fieldName = await browserPage.streamFields.nth(i).textContent;
-        await t.expect(fieldName).notEql(fieldForDeletion, 'The deleted entry is removed from the Stream');
+        await t.expect(fieldName).notEql(fieldForDeletion, 'The deleted entry is not removed from the Stream');
     }
 });
 test('Verify that when user delete the last Entry from the Stream the Stream key is not deleted', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const emptyStreamMessage = 'There are no Entries in the Stream.';
-    //Add new Stream key with 1 field
+    // Add new Stream key with 1 field
     await cliPage.sendCommandInCli(`XADD ${keyName} * ${fields[0]} ${values[0]}`);
-    //Open key details and delete entry from the Stream
+    // Open key details and delete entry from the Stream
     await browserPage.openKeyDetails(keyName);
     await browserPage.deleteStreamEntry();
-    //Check results
-    await t.expect(browserPage.streamEntriesContainer.textContent).contains(emptyStreamMessage, 'The message after deletion of the last Entry from the Stream');
+    // Check results
+    await t.expect(browserPage.streamEntriesContainer.textContent).contains(emptyStreamMessage, 'The message after deletion of the last Entry from the Stream not found');
     await browserPage.searchByKeyName(keyName);
-    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The Stream key is not deleted');
+    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The Stream key is deleted');
 });

--- a/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-key.e2e.ts
@@ -8,14 +8,16 @@ import {
     ossStandaloneConfig
 } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
 const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 20 });
-const keyField = chance.word({ length: 20 });
-const keyValue = chance.word({ length: 20 });
+let keyName = common.generateWord(20);
+const keyField = common.generateWord(20);
+const keyValue = common.generateWord(20);
 
 fixture `Stream Key`
     .meta({ type: 'critical_path', rte: rte.standalone })
@@ -29,26 +31,27 @@ fixture `Stream Key`
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can create Stream key via Add New Key form', async t => {
-    keyName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
     // Verify that user can see Stream details opened after key creation
-    await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).visible).ok('Stream Key Name');
+    await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).visible).ok('Stream Key Name not visible');
     // Verify that user can see newly added Stream key in key list clicking on keys refresh button
     await t.click(browserPage.refreshKeysButton);
     const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-    await t.expect(isKeyIsDisplayedInTheList).ok('Stream is added');
+    await t.expect(isKeyIsDisplayedInTheList).ok('Stream is not added');
 });
 test('Verify that user can add several fields and values during Stream key creation', async t => {
-    const keyName = chance.word({ length: 20 });
+    const keyName = common.generateWord(20);
     // Create an array with different data types for Stream fields
-    const streamData = {'string': chance.word({ length: 20 }), 'array': `[${chance.word({ length: 20 })}, ${chance.integer()}]`, 'integer': `${chance.integer()}`, 'json': '{\'test\': \'test\'}', 'null': 'null', 'boolean': 'true'};
+    const streamData = {'string': common.generateWord(20), 'array': `[${common.generateWord(20)}, ${chance.integer()}]`, 'integer': `${chance.integer()}`, 'json': '{\'test\': \'test\'}', 'null': 'null', 'boolean': 'true'};
     const scrollSelector = Selector('.eui-yScroll').nth(-1);
+
     // Open Add New Stream Key Form
     await browserPage.commonAddNewKey(keyName);
     await t.click(browserPage.streamOption);
     // Verify that user can see Entity ID filled by * by default on add Stream key form
-    await t.expect(browserPage.streamEntryId.withAttribute('value', '*').visible).ok('Preselected Stream Entity ID field');
+    await t.expect(browserPage.streamEntryId.withAttribute('value', '*').visible).ok('Preselected Stream Entity ID field not correct');
     // Verify that user can specify valid custom value for Entry ID
     await t.typeText(browserPage.streamEntryId, '0-1', {replace: true});
     // Filled fields and value by different data types
@@ -56,7 +59,7 @@ test('Verify that user can add several fields and values during Stream key creat
         await t.typeText(browserPage.streamField.nth(-1), Object.keys(streamData)[i]);
         await t.typeText(browserPage.streamValue.nth(-1), Object.values(streamData)[i]);
         await t.scroll(scrollSelector, 'bottom');
-        await t.expect(browserPage.streamField.count).eql(i + 1, 'Number of added fields');
+        await t.expect(browserPage.streamField.count).eql(i + 1, 'Number of added fields not correct');
         if (i < Object.keys(streamData).length - 1) {
             await t.click(browserPage.addStreamRow);
         }
@@ -66,29 +69,31 @@ test('Verify that user can add several fields and values during Stream key creat
     await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).visible).ok('Stream Key Name');
 });
 test('Verify that user can add new Stream Entry for Stream data type key which has an Entry ID, Field and Value', async t => {
-    keyName = chance.word({ length: 20 });
-    const newField = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    const newField = common.generateWord(20);
+
     // Add New Stream Key and check columns and rows
     await browserPage.addStreamKey(keyName, keyField, keyValue);
-    await t.expect(browserPage.streamEntryIDDateValue.count).eql(1, 'One Entry ID');
-    await t.expect(browserPage.streamFields.count).eql(4, 'One field in table');
-    await t.expect(browserPage.streamEntryFields.count).eql(1, 'One value in table');
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(1, 'One Entry ID not displayed');
+    await t.expect(browserPage.streamFields.count).eql(4, 'One field in table not displayed');
+    await t.expect(browserPage.streamEntryFields.count).eql(1, 'One value in table not displayed');
     // Create new field and value and check that new column is added
-    await browserPage.addEntryToStream(newField, chance.word({ length: 20 }));
-    await t.expect(browserPage.streamEntryIDDateValue.count).eql(2, 'Two Entries ID');
-    await t.expect(browserPage.streamFields.count).eql(7, 'Two fields in table');
-    await t.expect(browserPage.streamEntryFields.count).eql(4, 'Four values in table');
+    await browserPage.addEntryToStream(newField, common.generateWord(20));
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(2, 'Two Entries ID not displayed');
+    await t.expect(browserPage.streamFields.count).eql(7, 'Two fields in table not displayed');
+    await t.expect(browserPage.streamEntryFields.count).eql(4, 'Four values in table not displayed');
     // Create value to existed filed and check that new column was not added
-    await browserPage.addEntryToStream(newField, chance.word({ length: 20 }));
-    await t.expect(browserPage.streamEntryIDDateValue.count).eql(3, 'Three Entries ID');
-    await t.expect(browserPage.streamFields.count).eql(8, 'Still two fields in table');
-    await t.expect(browserPage.streamEntryFields.count).eql(6, 'Six values in table');
+    await browserPage.addEntryToStream(newField, common.generateWord(20));
+    await t.expect(browserPage.streamEntryIDDateValue.count).eql(3, 'Three Entries ID not displayed');
+    await t.expect(browserPage.streamFields.count).eql(8, 'Still two fields in table not displayed');
+    await t.expect(browserPage.streamEntryFields.count).eql(6, 'Six values in table not displayed');
 });
 test('Verify that during new entry adding to existing Stream, user can clear the value and the row itself', async t => {
-    keyName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
     // Generate data for stream
-    const fields = [keyField, chance.word({ length: 20 })];
-    const values = [keyValue, chance.word({ length: 20 })];
+    const fields = [keyField, common.generateWord(20)];
+    const values = [keyValue, common.generateWord(20)];
+
     // Add New Stream Key
     await browserPage.addStreamKey(keyName, keyField, keyValue);
     await t.click(browserPage.addNewStreamEntry);
@@ -98,25 +103,26 @@ test('Verify that during new entry adding to existing Stream, user can clear the
     // Click on delete field for the last entity
     await t.click(browserPage.clearStreamEntryInputs.nth(-1));
     const fieldsNumberAfterDeletion = await browserPage.streamField.count;
-    await t.expect(fieldsNumberAfterDeletion).lt(fieldsNumberBeforeDeletion, 'Number of fields after deletion');
+    await t.expect(fieldsNumberAfterDeletion).lt(fieldsNumberBeforeDeletion, 'Number of fields after deletion not correct');
     // Validate that the last field and value were fulfilled
-    await t.expect(browserPage.streamField.withAttribute('value', keyField).exists).ok('Filled input for field');
-    await t.expect(browserPage.streamValue.withAttribute('value', keyValue).exists).ok('Filled input for value');
+    await t.expect(browserPage.streamField.withAttribute('value', keyField).exists).ok('Input for field not filled');
+    await t.expect(browserPage.streamValue.withAttribute('value', keyValue).exists).ok('Input for value not filled');
     // Click on clear button
     await t.hover(browserPage.streamValue);
     await t.click(browserPage.clearStreamEntryInputs);
     // Validate that data was cleared
-    await t.expect(browserPage.streamField.withAttribute('value', keyField).exists).notOk('Cleared input for field');
-    await t.expect(browserPage.streamValue.withAttribute('value', keyValue).exists).notOk('Cleared input for value');
+    await t.expect(browserPage.streamField.withAttribute('value', keyField).exists).notOk('Input for field not cleared');
+    await t.expect(browserPage.streamValue.withAttribute('value', keyValue).exists).notOk('Input for value not cleared');
     // Validate that the form is still displayed
-    await t.expect(browserPage.streamField.count).eql(fieldsNumberAfterDeletion, 'Number of fields after deletion');
+    await t.expect(browserPage.streamField.count).eql(fieldsNumberAfterDeletion, 'Number of fields after deletion not correct');
 });
 test('Verify that user can add several fields and values to the existing Stream Key', async t => {
-    keyName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
     // Generate field value data
     const entryQuantity = 5;
     const fields: string[] = [];
     const values: string[] = [];
+
     for (let i = 0; i < entryQuantity; i++) {
         const randomGeneratorValue = chance.integer({ min: 1, max: 50 });
         fields.push(chance.word({ length: randomGeneratorValue }));
@@ -131,21 +137,21 @@ test('Verify that user can add several fields and values to the existing Stream 
     // Check that all data is saved in Stream
     await t.click(browserPage.fullScreenModeButton);
     for (let i = 0; i < fields.length; i++) {
-        await t.expect(browserPage.streamFieldsValues.find('span').withExactText(values[i]).exists).ok('Added Value');
-        await t.expect(browserPage.streamEntriesContainer.find('div').withExactText(fields[i]).exists).ok('Added Field');
+        await t.expect(browserPage.streamFieldsValues.find('span').withExactText(values[i]).exists).ok('Added Value not displayed');
+        await t.expect(browserPage.streamEntriesContainer.find('div').withExactText(fields[i]).exists).ok('Added Field not displayed');
     }
     // Check Stream length
     const streamLength = await browserPage.getKeyLength();
-    await t.expect(streamLength).eql('2', 'Stream length after adding new entry');
+    await t.expect(streamLength).eql('2', 'Stream length after adding new entry not correct');
     await t.click(browserPage.fullScreenModeButton);
 });
 test('Verify that user can see the Stream range filter', async t => {
-    keyName = chance.word({length: 20});
-    //Add new Stream key with 1 field
+    keyName = common.generateWord(20);
+    // Add new Stream key with 1 field
     await cliPage.sendCommandInCli(`XADD ${keyName} * fields values`);
-    //Open key details and check filter
+    // Open key details and check filter
     await browserPage.openKeyDetails(keyName);
-    await t.expect(browserPage.rangeLeftTimestamp.visible).ok('The stream range start timestamp visibility');
-    await t.expect(browserPage.rangeRightTimestamp.visible).ok('The stream range end timestamp visibility');
-    await t.expect(browserPage.streamRangeBar.visible).ok('The stream range bar visibility');
+    await t.expect(browserPage.rangeLeftTimestamp.visible).ok('The stream range start timestamp not visible');
+    await t.expect(browserPage.rangeRightTimestamp.visible).ok('The stream range end timestamp not visible');
+    await t.expect(browserPage.streamRangeBar.visible).ok('The stream range bar not visible');
 });

--- a/tests/e2e/tests/critical-path/browser/stream-pending-messages.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/stream-pending-messages.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage, CliPage } from '../../../pageObjects';
@@ -7,13 +6,14 @@ import {
     ossStandaloneConfig
 } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 20 });
-let consumerGroupName = chance.word({ length: 20 });
+let keyName = common.generateWord(20);
+let consumerGroupName = common.generateWord(20);
 
 fixture `Acknowledge and Claim of Pending messages`
     .meta({ type: 'critical_path', rte: rte.standalone })
@@ -22,7 +22,7 @@ fixture `Acknowledge and Claim of Pending messages`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async t => {
-        //Clear and delete database
+        // Clear and delete database
         if (await browserPage.closeKeyButton.visible){
             await t.click(browserPage.closeKeyButton);
         }
@@ -30,13 +30,14 @@ fixture `Acknowledge and Claim of Pending messages`
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can acknowledge any message in the list of pending messages', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
         `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`
     ];
+
     // Add New Stream Key with pending message
     for(const command of cliCommands){
         await cliPage.sendCommandInCli(command);
@@ -50,8 +51,8 @@ test('Verify that user can acknowledge any message in the list of pending messag
     await t.expect(browserPage.streamMessagesContainer.textContent).contains('Your Consumer has no pending messages.', 'The messages is acknowledged from the table');
 });
 test('Verify that user can claim any message in the list of pending messages', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
@@ -59,6 +60,7 @@ test('Verify that user can claim any message in the list of pending messages', a
         `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`,
         `XREADGROUP GROUP ${consumerGroupName} Bob COUNT 1 STREAMS ${keyName} >`
     ];
+
     // Add New Stream Key with pending message
     for(const command of cliCommands){
         await cliPage.sendCommandInCli(command);
@@ -75,8 +77,8 @@ test('Verify that user can claim any message in the list of pending messages', a
     await t.expect(browserPage.streamMessage.count).eql(2, 'The claimed messages is in the selected Consumer');
 });
 test('Verify that claim with optional parameters, the message removed from this Consumer and appeared in the selected Consumer', async t => {
-    keyName = chance.word({ length: 20 });
-    consumerGroupName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
+    consumerGroupName = common.generateWord(20);
     const cliCommands = [
         `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
         `XADD ${keyName} * message apple`,
@@ -84,6 +86,7 @@ test('Verify that claim with optional parameters, the message removed from this 
         `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`,
         `XREADGROUP GROUP ${consumerGroupName} Bob COUNT 1 STREAMS ${keyName} >`
     ];
+
     // Add New Stream Key with pending message
     for(const command of cliCommands){
         await cliPage.sendCommandInCli(command);

--- a/tests/e2e/tests/critical-path/browser/zset-key.e2e.ts
+++ b/tests/e2e/tests/critical-path/browser/zset-key.e2e.ts
@@ -3,61 +3,55 @@ import { Common } from '../../../helpers/common';
 import { rte } from '../../../helpers/constants';
 import { BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
 const common = new Common();
-const chance = new Chance();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyMember = '1111ZsetMember11111';
 
 fixture `ZSet Key fields verification`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })  
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search by member in Zset', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addZSetKey(keyName, '0', keyTTL, '12345qwerty');
-        //Add member to the ZSet key
-        await browserPage.addMemberToZSet(keyMember, '3');
-        //Search by member name
-        await browserPage.searchByTheValueInKeyDetails(keyMember);
-        //Check the search result
-        const result = await browserPage.zsetMembersList.nth(0).textContent;
-        await t.expect(result).eql(keyMember, 'The Zset member');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can sort Zset members by score by DESC and ASC', async t => {
-        keyName = chance.word({ length: 10 });
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Create new key with a lot of members
-        const arr = await common.createArray(100);
-        await t.typeText(cliPage.cliCommandInput, `ZADD ${keyName} ${arr.join(' ')}`, { paste: true });
-        await t.pressKey('enter');
-        await t.click(cliPage.cliCollapseButton);
-        //Open key details
-        await browserPage.openKeyDetails(keyName);
-        //Sort Zset members by score by DESC and verify result
-        await t.click(browserPage.scoreButton);
-        let result = await browserPage.zsetScoresList.textContent;
-        await t.expect(result).eql(arr[100 - 1], 'The Zset sort by desc');
-        //Sort Zset members by score by ASC and verify result
-        await t.click(browserPage.scoreButton);
-        result = await browserPage.zsetScoresList.textContent;
-        await t.expect(result).eql(arr[1], 'The Zset sort by desc');
-    });
+test('Verify that user can search by member in Zset', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addZSetKey(keyName, '0', keyTTL, '12345qwerty');
+    // Add member to the ZSet key
+    await browserPage.addMemberToZSet(keyMember, '3');
+    // Search by member name
+    await browserPage.searchByTheValueInKeyDetails(keyMember);
+    // Check the search result
+    const result = await browserPage.zsetMembersList.nth(0).textContent;
+    await t.expect(result).eql(keyMember, 'The Zset member');
+});
+test('Verify that user can sort Zset members by score by DESC and ASC', async t => {
+    keyName = common.generateWord(10);
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    //Create new key with a lot of members
+    const arr = await common.createArray(100);
+    await t.typeText(cliPage.cliCommandInput, `ZADD ${keyName} ${arr.join(' ')}`, { paste: true });
+    await t.pressKey('enter');
+    await t.click(cliPage.cliCollapseButton);
+    // Open key details
+    await browserPage.openKeyDetails(keyName);
+    // Sort Zset members by score by DESC and verify result
+    await t.click(browserPage.scoreButton);
+    let result = await browserPage.zsetScoresList.textContent;
+    await t.expect(result).eql(arr[100 - 1], 'The Zset sort by desc');
+    // Sort Zset members by score by ASC and verify result
+    await t.click(browserPage.scoreButton);
+    result = await browserPage.zsetScoresList.textContent;
+    await t.expect(result).eql(arr[1], 'The Zset sort by desc');
+});

--- a/tests/e2e/tests/critical-path/cli/cli-command-helper.e2e.ts
+++ b/tests/e2e/tests/critical-path/cli/cli-command-helper.e2e.ts
@@ -15,139 +15,104 @@ const COMMAND_GROUP_TIMESERIES = 'TimeSeries';
 const COMMAND_GROUP_GRAPH = 'Graph';
 
 fixture `CLI Command helper`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
+test('Verify Command Helper search and filter', async t => {
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Verify default text
+    await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is not shown');
+    // Search any command
+    await t.typeText(cliPage.cliHelperSearch, 'SET');
+    await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were not found');
+    // Clear search input
+    const clearButton = cliPage.cliHelper.find('[aria-label="Clear input"]');
+    await t.click(clearButton);
+    // Verify that when user clears the input in the Search of CLI Helper (via x icon), he can see the default screen with proper the text
+    await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is not shown');
+
+    // Verify that user can unselect the command filtered to remove filters
+    await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
+    await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were not found');
+    // Unselect previous command from list
+    await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
+    await t.expect(cliPage.cliHelperOutputTitles.count).eql(0, 'List of commands were not cleared');
+    await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is not shown');
+
+    // Verify that user can see relevant search results in Command Helper per every entered symbol
+    await t.click(cliPage.cliHelperSearch);
+    await t.typeText(cliPage.cliHelperSearch, 's');
+    // Verify that we found commands
+    await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were not found');
+    const countCommandsOfOneLetterSearch = await cliPage.cliHelperOutputTitles.count;
+    // Continue typing
+    await t.typeText(cliPage.cliHelperSearch, 'a');
+    const countCommandsOfTwoLettersSearch = await cliPage.cliHelperOutputTitles.count;
+    // Verify that first list has more count than the second
+    await t.expect(countCommandsOfOneLetterSearch).gt(countCommandsOfTwoLettersSearch, 'Count of commands with 1 letter not more than 2');
+
+    // Verify that when user has used search and apply filters, search results include only commands from the filter group applied
+    await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
+    await t.expect(cliPage.cliHelperOutputTitles.withText('SAVE').exists).notOk('Commands found from another group');
+    await t.expect(cliPage.cliHelperOutputTitles.withText('SADD').exists).ok('Proper command was not found');
+
+    // Verify that Command helper cleared when user runs the command in CLI
+    await t.click(cliPage.cliExpandButton);
+    // Enter command into CLI
+    await t.typeText(cliPage.cliCommandInput, COMMAND_APPEND, { speed: 0.5 });
+    await t.expect(cliPage.filterGroupTypeButton.textContent).notContains(COMMAND_GROUP_SET, 'Filter was not cleared');
+    await t.expect(cliPage.cliHelperSearch.value).eql('', 'Search was not cleared');
+
+    // Verify that when user enters command in CLI, Helper displays additional info about the command
+    await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('APPEND key value', 'Command name and syntax not displayed');
+    await t.expect(cliPage.cliHelperTitle.innerText).contains('STRING', 'Command Group badge not displayed');
+    await t.expect(cliPage.cliHelperSummary.innerText).contains('Append a value to a key', 'Command summary not displayed');
+});
 test
-    .meta({ rte: rte.standalone })('Verify that user can see relevant search results in Command Helper per every entered symbol', async t => {
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Start search from 1 symbol
-        await t.typeText(cliPage.cliHelperSearch, 's');
-        //Verify that we found commands
-        await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were found');
-        const countCommandsOfOneLetterSearch = await cliPage.cliHelperOutputTitles.count;
-        //Continue typing
-        await t.typeText(cliPage.cliHelperSearch, 'e');
-        const countCommandsOfTwoLettersSearch = await cliPage.cliHelperOutputTitles.count;
-        //Verify that first list has more count than the second
-        await t.expect(countCommandsOfOneLetterSearch).gt(countCommandsOfTwoLettersSearch, 'Count of commands with 1 letter more than 2');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user clears the input in the Search of CLI Helper (via x icon), he can see the default screen with proper the text', async t => {
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Verify default text
-        await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is shown');
-        //Search any command
-        await t.typeText(cliPage.cliHelperSearch, 'SET');
-        await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were found');
-        //Clear search input
-        const clearButton = cliPage.cliHelper.find('[aria-label="Clear input"]');
-        await t.click(clearButton);
-        //Verify default text after clear
-        await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is shown');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user enters command in CLI, Helper displays additional info about the command', async t => {
-        //Open CLI and Helper
-        await t.click(cliPage.cliExpandButton);
-        await t.click(cliPage.expandCommandHelperButton);
-        //Enter command into CLI
-        await t.typeText(cliPage.cliCommandInput, COMMAND_APPEND);
-        //Verify details of the command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('APPEND key value', 'Command name and syntax');
-        await t.expect(cliPage.cliHelperTitle.innerText).contains('STRING', 'Command Group badge');
-        await t.expect(cliPage.cliHelperSummary.innerText).contains('Append a value to a key', 'Command summary');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that Command helper cleared when user runs the command in CLI', async t => {
-        const searchText = 'sa';
-        //Open CLI and Helper
-        await t.click(cliPage.cliExpandButton);
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select group from list
-        await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Type text in search
-        await t.typeText(cliPage.cliHelperSearch, searchText, { speed: 0.5 });
-        //Enter command into CLI
-        await t.typeText(cliPage.cliCommandInput, COMMAND_APPEND, { speed: 0.5 });
-        //Verify that CLI Helper Search & Filter were cleared
-        await t.expect(cliPage.filterGroupTypeButton.textContent).notContains(COMMAND_GROUP_SET, 'Filter was cleared');
-        await t.expect(cliPage.cliHelperSearch.value).eql('', 'Search was cleared');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can unselect the command filtered to remove filters', async t => {
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from list
-        await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        await t.expect(cliPage.cliHelperOutputTitles.count).gt(0, 'List of commands were found');
-        //Unselect previous command from list
-        await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Verify that no any commands are shown
-        await t.expect(cliPage.cliHelperOutputTitles.count).eql(0, 'List of commands were cleared');
-        //Verify default text after clear
-        await t.expect(cliPage.cliHelperText.textContent).eql(defaultHelperText, 'Default text for CLI Helper is shown');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user has used search and apply filters, search results include only commands from the filter group applied', async t => {
-        const searchText = 'sa';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select group from list
-        await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Type text in search
-        await t.typeText(cliPage.cliHelperSearch, searchText, { speed: 0.5 });
-        //Check that no another commands were found
-        await t.expect(cliPage.cliHelperOutputTitles.withText('SAVE').exists).notOk('No command found from another group');
-        //Check that command from 'Set' group was found
-        await t.expect(cliPage.cliHelperOutputTitles.withText('SADD').exists).ok('Proper command was found');
-    });
-test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can type TS. in Command helper and see commands from RedisTimeSeries commands.json', async t => {
+    .meta({ env: env.web })('Verify that user can type TS. in Command helper and see commands from RedisTimeSeries commands.json', async t => {
         const commandForSearch = 'TS.';
-        //Open Command Helper
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Select group from list and remember commands
+        // Select group from list and remember commands
         await cliPage.selectFilterGroupType(COMMAND_GROUP_TIMESERIES);
         const commandsFilterCount = await cliPage.cliHelperOutputTitles.count;
         const timeSeriesCommands: string[] = [];
         for(let i = 0; i < commandsFilterCount; i++) {
             timeSeriesCommands.push(await cliPage.cliHelperOutputTitles.nth(i).textContent);
         }
-        //Unselect group from list
+        // Unselect group from list
         await cliPage.selectFilterGroupType(COMMAND_GROUP_TIMESERIES);
-        //Search per part of command and check all opened commands
+        // Search per part of command and check all opened commands
         await cliActions.checkSearchedCommandInCommandHelper(commandForSearch, timeSeriesCommands);
-        //Check the first command documentation url
+        // Check the first command documentation url
         await cliPage.checkURLCommand(timeSeriesCommands[0], `https://redis.io/commands/${timeSeriesCommands[0].toLowerCase()}/`);
         await t.switchToParentWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can type GRAPH. in Command helper and see auto-suggestions from RedisGraph commands.json', async t => {
+    .meta({ env: env.web })('Verify that user can type GRAPH. in Command helper and see auto-suggestions from RedisGraph commands.json', async t => {
         const commandForSearch = 'GRAPH.';
         const externalPageLink = 'https://redis.io/commands/graph.config-get/';
-        //Open Command Helper
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Select group from list and remember commands
+        // Select group from list and remember commands
         await cliPage.selectFilterGroupType(COMMAND_GROUP_GRAPH);
         const commandsFilterCount = await cliPage.cliHelperOutputTitles.count;
         const graphCommands: string[] = [];
         for(let i = 0; i < commandsFilterCount; i++) {
             graphCommands.push(await cliPage.cliHelperOutputTitles.nth(i).textContent);
         }
-        //Unselect group from list
+        // Unselect group from list
         await cliPage.selectFilterGroupType(COMMAND_GROUP_GRAPH);
-        //Search per part of command and check all opened commands
+        // Search per part of command and check all opened commands
         await cliActions.checkSearchedCommandInCommandHelper(commandForSearch, graphCommands);
-        //Check the first command documentation url
+        // Check the first command documentation url
         await cliPage.checkURLCommand(graphCommands[0], externalPageLink);
         await t.switchToParentWindow();
     });

--- a/tests/e2e/tests/critical-path/cli/cli-critical.e2e.ts
+++ b/tests/e2e/tests/critical-path/cli/cli-critical.e2e.ts
@@ -1,8 +1,9 @@
+import { Chance } from 'chance';
 import { Common } from '../../../helpers/common';
 import { rte } from '../../../helpers/constants';
 import { BrowserPage, CliPage } from '../../../pageObjects';
-import { 
-    acceptLicenseTermsAndAddDatabaseApi, 
+import {
+    acceptLicenseTermsAndAddDatabaseApi,
     acceptLicenseTermsAndAddOSSClusterDatabase
 } from '../../../helpers/database';
 import {
@@ -10,7 +11,6 @@ import {
     ossClusterConfig,
     ossStandaloneConfig
 } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteOSSClusterDatabaseApi, deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 
 const cliPage = new CliPage();
@@ -20,82 +20,78 @@ const chance = new Chance();
 
 const pairsToSet = common.createArrayPairsWithKeyValue(4);
 const MAX_AUTOCOMPLETE_EXECUTIONS = 100;
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 let value = chance.natural({ length: 5 });
 
 fixture `CLI critical`
     .meta({ type: 'critical_path' })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
+    });
 test
     .meta({ rte: rte.ossCluster })
-    .before(async () => {
+    .before(async() => {
         await acceptLicenseTermsAndAddOSSClusterDatabase(ossClusterConfig, ossClusterConfig.ossClusterDatabaseName);
     })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
-    })
-    ('Verify that user is redirected to another node when he works in CLI with OSS Cluster', async t => {
-        keyName = chance.word({ length: 10 });
-        //Open CLI
+    })('Verify that user is redirected to another node when he works in CLI with OSS Cluster', async t => {
+        keyName = common.generateWord(10);
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Add key from CLI
+        // Add key from CLI
         for ([keyName, value] of pairsToSet) {
             await t.typeText(cliPage.cliCommandInput, `SET ${keyName} ${value}`);
             await t.pressKey('enter');
         }
-        //Check that user is redirected
-        await t.expect(await cliPage.cliArea.textContent).contains('Redirected to', 'User command was redirected to another node');
+        // Check that user is redirected
+        await t.expect(await cliPage.cliArea.textContent).contains('Redirected to', 'User command was not redirected to another node');
     });
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that Redis returns error if command is not correct when user works with CLI', async t => {
+    .meta({ rte: rte.standalone })('Verify that Redis returns error if command is not correct when user works with CLI', async t => {
         //Open CLI
         await t.click(cliPage.cliExpandButton);
 
         await t.typeText(cliPage.cliCommandInput, 'SET key');
         await t.pressKey('enter');
-        //Check error
-        const errWrongArgs = cliPage.cliOutputResponseFail.withText('ERR wrong number of arguments for \'set\' command')
-        await t.expect(errWrongArgs.exists).ok('Error with wrong number of arguments was shown');
+        // Check error
+        const errWrongArgs = cliPage.cliOutputResponseFail.withText('ERR wrong number of arguments for \'set\' command');
+        await t.expect(errWrongArgs.exists).ok('Error with wrong number of arguments was not shown');
 
         await t.typeText(cliPage.cliCommandInput, 'lorem');
         await t.pressKey('enter');
-        //Check error
-        const errWrongCmnd = cliPage.cliOutputResponseFail.withText('ERR unknown command')
-        await t.expect(errWrongCmnd.exists).ok('Error unknown command was shown');
-});
+        // Check error
+        const errWrongCmnd = cliPage.cliOutputResponseFail.withText('ERR unknown command');
+        await t.expect(errWrongCmnd.exists).ok('Error unknown command was not shown');
+    });
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can scroll commands using "Tab" in CLI & execute it', async t => {
+    .meta({ rte: rte.standalone })('Verify that user can scroll commands using "Tab" in CLI & execute it', async t => {
         const commandToAutoComplete = 'INFO';
         const commandStartsWith = 'I';
-        //Open CLI
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
         await t.typeText(cliPage.cliCommandInput, commandStartsWith);
-        //Press tab while we won't find 'INFO' command
-        //Avoid endless cycle
+        // Press tab while we won't find 'INFO' command
+        // Avoid endless cycle
         let operationsCount = 0;
         while (await cliPage.cliCommandInput.textContent !== commandToAutoComplete && operationsCount < MAX_AUTOCOMPLETE_EXECUTIONS) {
             await t.pressKey('tab');
             ++operationsCount;
         }
         await t.pressKey('enter');
-        //Check that command was executed and user got success result
-        await t.expect(cliPage.cliOutputResponseSuccess.exists).ok('Command from autocomplete was found & executed');
+        // Check that command was executed and user got success result
+        await t.expect(cliPage.cliOutputResponseSuccess.exists).ok('Command from autocomplete was not found & executed');
     });
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user enters in CLI RediSearch/JSON commands (FT.CREATE, FT.DROPINDEX/JSON.GET, JSON.DEL), he can see hints with arguments', async t => {
-        const commandHints =[
+    .meta({ rte: rte.standalone })('Verify that when user enters in CLI RediSearch/JSON commands (FT.CREATE, FT.DROPINDEX/JSON.GET, JSON.DEL), he can see hints with arguments', async t => {
+        const commandHints = [
             'index [data_type] [prefix] [filter] [default_lang] [lang_attribute] [default_score] [score_attribute] [payload_attribute] [maxtextfields] [seconds] [nooffsets] [nohl] [nofields] [nofreqs] [stopwords] [skipinitialscan] schema field [field ...]',
             'index [delete docs]',
             'key [indent] [newline] [space] [paths [paths ...]]',
@@ -107,22 +103,18 @@ test
             'JSON.GET',
             'JSON.DEL'
         ];
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Enter commands and check hints with arguments
-        for(let command of commands) {
-            await t.typeText(cliPage.cliCommandInput, command, { replace: true });
-            await t.expect(cliPage.cliCommandAutocomplete.textContent).eql(commandHints[commands.indexOf(command)], `The hints with arguments for command ${command}`);
-        }
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can type AI command in CLI and see agruments in hints from RedisAI commands.json', async t => {
-        const commandHints = 'key [META] [BLOB]';
+        const commandHint = 'key [META] [BLOB]';
         const command = 'ai.modelget';
-        //Open CLI and type AI command
+
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
         await t.typeText(cliPage.cliCommandInput, command, { replace: true });
-        //Verify the hints
-        await t.expect(cliPage.cliCommandAutocomplete.textContent).eql(commandHints, `The hints with arguments for command ${command}`);
+        // Verify that user can type AI command in CLI and see agruments in hints from RedisAI commands.json
+        await t.expect(cliPage.cliCommandAutocomplete.textContent).eql(commandHint, `The hints with arguments for command ${command} not shown`);
+
+        // Enter commands and check hints with arguments
+        for(const command of commands) {
+            await t.typeText(cliPage.cliCommandInput, command, { replace: true });
+            await t.expect(cliPage.cliCommandAutocomplete.textContent).eql(commandHints[commands.indexOf(command)], `The hints with arguments for command ${command} not shown`);
+        }
     });

--- a/tests/e2e/tests/critical-path/database/clone-databases.e2e.ts
+++ b/tests/e2e/tests/critical-path/database/clone-databases.e2e.ts
@@ -21,12 +21,12 @@ fixture `Clone databases`
     .meta({ type: 'critical_path' })
     .page(commonUrl);
 test
-    .before(async () => {
+    .before(async() => {
         await acceptLicenseTerms();
         await addNewStandaloneDatabaseApi(ossStandaloneConfig);
         await common.reloadPage();
     })
-    .after(async () => {
+    .after(async() => {
         // Delete databases
         const dbNumber = await myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).count;
         for (let i = 0; i < dbNumber; i++) {
@@ -53,7 +53,7 @@ test
         await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).count).eql(2, 'DB was not cloned');
     });
 test
-    .before(async () => {
+    .before(async() => {
         await acceptLicenseTerms();
         await addNewOSSClusterDatabaseApi(ossClusterConfig);
         await common.reloadPage();
@@ -77,13 +77,13 @@ test
         await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossClusterConfig.ossClusterDatabaseName).visible).ok('Original DB is not displayed');
     });
 test
-    .before(async () => {
+    .before(async() => {
         await acceptLicenseTerms();
         // Add Sentinel databases
         await discoverSentinelDatabaseApi(ossSentinelConfig);
         await common.reloadPage();
     })
-    .after(async () => {
+    .after(async() => {
         // Delete all primary groups
         const sentinelCopy = ossSentinelConfig;
         sentinelCopy.masters.push(ossSentinelConfig.masters[1]);

--- a/tests/e2e/tests/critical-path/database/connecting-to-the-db.e2e.ts
+++ b/tests/e2e/tests/critical-path/database/connecting-to-the-db.e2e.ts
@@ -13,11 +13,13 @@ fixture `Connecting to the databases verifications`
     });
 test
     .meta({ rte: rte.none })('Verify that user can see error message if he can not connect to added Database', async t => {
-        //Fill the add database form
+        const errorMessage = `Could not connect to ${invalidOssStandaloneConfig.host}:${invalidOssStandaloneConfig.port}, please check the connection details.`;
+
+        // Fill the add database form
         await addRedisDatabasePage.addRedisDataBase(invalidOssStandaloneConfig);
-        //Click for saving
+        // Click for saving
         await t.click(addRedisDatabasePage.addRedisDatabaseButton);
-        //Verify that the database is not in the list
-        await t.expect(addRedisDatabasePage.errorMessage.textContent).contains('Error', 'Error message displaying', { timeout: 10000 });
-        await t.expect(addRedisDatabasePage.errorMessage.textContent).contains(`Could not connect to ${invalidOssStandaloneConfig.host}:${invalidOssStandaloneConfig.port}, please check the connection details.`, 'Error message displaying', { timeout: 10000 });
+        // Verify that the database is not in the list
+        await t.expect(addRedisDatabasePage.errorMessage.textContent).contains('Error', 'Error message not displayed', { timeout: 10000 });
+        await t.expect(addRedisDatabasePage.errorMessage.textContent).contains(errorMessage, 'Error message not displayed', { timeout: 10000 });
     });

--- a/tests/e2e/tests/critical-path/database/logical-databases.e2e.ts
+++ b/tests/e2e/tests/critical-path/database/logical-databases.e2e.ts
@@ -8,7 +8,7 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 const indexDbMessage = 'When the database is added, you can select logical databases only in CLI. To work with other logical databases in Browser and Workbench, add another database with the same host and port, but a different database index.';
 
 fixture `Logical databases`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTerms();
@@ -17,31 +17,21 @@ fixture `Logical databases`
         //Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add DB with logical index via host and port from Add DB manually form', async t => {
-        const index = '0';
-        await addRedisDatabasePage.addRedisDataBase(ossStandaloneConfig);
-        //Enter logical index
-        await t.click(addRedisDatabasePage.databaseIndexCheckbox);
-        await t.typeText(addRedisDatabasePage.databaseIndexInput, index, { paste: true });
-        //Verify that user when users select DB index they can see info message how to work with DB index in add DB screen
-        await t.expect(addRedisDatabasePage.databaseIndexMessage.visible).ok('Index message');
-        await t.expect(addRedisDatabasePage.databaseIndexMessage.innerText).eql(indexDbMessage);
-        await t.expect(addRedisDatabasePage.databaseIndexCheckbox.parent().withExactText('Select Logical Database').exists).ok('Checkbox text');
-        //Click for saving
-        await t.click(addRedisDatabasePage.addRedisDatabaseButton);
-        //Verify that the database is in the list
-        await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).exists).ok('The existence of the database', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that if user adds DB with logical DB > 0, DB name contains postfix "space+[{database index}]"', async t => {
-        const index = '10';
-        await addRedisDatabasePage.addRedisDataBase(ossStandaloneConfig);
-        //Enter logical index
-        await t.click(addRedisDatabasePage.databaseIndexCheckbox);
-        await t.typeText(addRedisDatabasePage.databaseIndexInput, index, { paste: true });
-        //Click for saving
-        await t.click(addRedisDatabasePage.addRedisDatabaseButton);
-        //Verify that the database name contains postfix
-        await t.expect(myRedisDatabasePage.dbNameList.textContent).eql(`${ossStandaloneConfig.databaseName} [${index}]`, 'The postfix is added to the database name', { timeout: 10000 });
-    });
+test('Verify that user can add DB with logical index via host and port from Add DB manually form', async t => {
+    const index = '10';
+
+    await addRedisDatabasePage.addRedisDataBase(ossStandaloneConfig);
+    // Enter logical index
+    await t.click(addRedisDatabasePage.databaseIndexCheckbox);
+    await t.typeText(addRedisDatabasePage.databaseIndexInput, index, { paste: true });
+    // Verify that user when users select DB index they can see info message how to work with DB index in add DB screen
+    await t.expect(addRedisDatabasePage.databaseIndexMessage.visible).ok('Index message not displayed')
+        .expect(addRedisDatabasePage.databaseIndexMessage.innerText).eql(indexDbMessage)
+        .expect(addRedisDatabasePage.databaseIndexCheckbox.parent().withExactText('Select Logical Database').exists).ok('Checkbox text not displayed');
+    // Click for saving
+    await t.click(addRedisDatabasePage.addRedisDatabaseButton);
+    // Verify that the database is in the list
+    await t.expect(myRedisDatabasePage.dbNameList.withText(ossStandaloneConfig.databaseName).exists).ok('Database not exist', { timeout: 10000 });
+    // Verify that if user adds DB with logical DB > 0, DB name contains postfix "space+[{database index}]"
+    await t.expect(myRedisDatabasePage.dbNameList.textContent).eql(`${ossStandaloneConfig.databaseName} [${index}]`, 'The postfix is not added to the database name', { timeout: 10000 });
+});

--- a/tests/e2e/tests/critical-path/database/modules.e2e.ts
+++ b/tests/e2e/tests/critical-path/database/modules.e2e.ts
@@ -16,48 +16,48 @@ const moduleList = [myRedisDatabasePage.moduleSearchIcon, myRedisDatabasePage.mo
 fixture `Database modules`
     .meta({ type: 'critical_path' })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
         await addNewStandaloneDatabaseApi(ossStandaloneRedisearch);
         // Reload Page
         await common.reloadPage();
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
 test
     .meta({ rte: rte.standalone, env: env.web })('Verify that user can see DB modules on DB list page for Standalone DB', async t => {
-        //Check module column on DB list page
-        await t.expect(myRedisDatabasePage.moduleColumn.exists).ok('Module column');
-        //Verify that user can see the following sorting order: Search, JSON, Graph, TimeSeries, Bloom, Gears, AI for modules
+        // Check module column on DB list page
+        await t.expect(myRedisDatabasePage.moduleColumn.exists).ok('Module column not found');
+        // Verify that user can see the following sorting order: Search, JSON, Graph, TimeSeries, Bloom, Gears, AI for modules
         const databaseLine = await myRedisDatabasePage.dbNameList.withExactText(ossStandaloneRedisearch.databaseName).parent('tr');
         const moduleIcons = await databaseLine.find('[data-testid^=Redi]');
         const numberOfIcons = await moduleIcons.count;
         for (let i = 0; i < numberOfIcons; i++) {
             const moduleName = await moduleIcons.nth(i).getAttribute('data-testid');
-            await t.expect(moduleName).eql(await moduleList[i].getAttribute('data-testid'), 'Correct icon');
+            await t.expect(moduleName).eql(await moduleList[i].getAttribute('data-testid'), 'Correct icon not found');
         }
         //Minimize the window to check quantifier
         await t.resizeWindow(1000, 700);
         //Verify that user can see +N icon (where N>1) on DB list page when modules icons don't fit the Module column width
         await t.expect(myRedisDatabasePage.moduleQuantifier.textContent).eql('+3');
-        await t.expect(myRedisDatabasePage.moduleQuantifier.exists).ok('Quantifier icon');
+        await t.expect(myRedisDatabasePage.moduleQuantifier.exists).ok('Quantifier icon not found');
         //Verify that user can hover over the module icons and see tooltip with all modules name
         await t.hover(myRedisDatabasePage.moduleQuantifier);
-        await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Module tooltip');
+        await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Module tooltip not found');
         //Verify that user can hover over the module icons and see tooltip with version.
         await myRedisDatabasePage.checkModulesInTooltip(moduleNameList);
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can see full module list in the Edit mode', async t => {
-        //Verify that module column is displayed
-        await t.expect(myRedisDatabasePage.moduleColumn.visible).ok('Module column');
-        //Open Edit mode
+        // Verify that module column is displayed
+        await t.expect(myRedisDatabasePage.moduleColumn.visible).ok('Module column not found');
+        // Open Edit mode
         await t.click(myRedisDatabasePage.editDatabaseButton);
-        //Verify that module column is not displayed
-        await t.expect(myRedisDatabasePage.moduleColumn.visible).notOk('Module column');
-        //Verify modules in Edit mode
+        // Verify that module column is not displayed
+        await t.expect(myRedisDatabasePage.moduleColumn.visible).notOk('Module column not found');
+        // Verify modules in Edit mode
         await myRedisDatabasePage.checkModulesOnPage(moduleList);
     });
 test
@@ -69,11 +69,11 @@ test
         const numberOfIcons = await moduleIcons.count;
         for (let i = 0; i < numberOfIcons; i++) {
             const moduleName = await moduleIcons.nth(i).getAttribute('data-testid');
-            await t.expect(moduleName).eql(await moduleList[i].getAttribute('data-testid'), 'Correct icon');
+            await t.expect(moduleName).eql(await moduleList[i].getAttribute('data-testid'), 'Correct icon not found');
         }
         // Verify that if DB has more than 6 modules loaded, user can click on three dots and see other modules in the tooltip
         await t.click(databaseOverviewPage.overviewMoreInfo);
         for (let j = numberOfIcons; j < moduleNameList.length; j++) {
-            await t.expect(databaseOverviewPage.overviewTooltip.withText(moduleNameList[j]).visible).ok('Tooltip module');
+            await t.expect(databaseOverviewPage.overviewTooltip.withText(moduleNameList[j]).visible).ok('Tooltip module not found');
         }
     });

--- a/tests/e2e/tests/critical-path/files-auto-update/promo-button-autoupdate.e2e.ts
+++ b/tests/e2e/tests/critical-path/files-auto-update/promo-button-autoupdate.e2e.ts
@@ -41,15 +41,12 @@ if (fs.existsSync(workingDirectory)) {
             const timestampPathNew = editJsonFile(timestampPromoButtonPath);
             const contentPathNew = editJsonFile(contentPromoButtonPath);
             // Check the promo button after the opening of app
-            await t.expect(myRedisDatabasePage.promoButton.textContent).notContains(newPromoButtonText, 'Promo button text is updated');
+            await t.expect(myRedisDatabasePage.promoButton.textContent).notContains(newPromoButtonText, 'Promo button text is not updated');
             // Get the values from build.json and create-redis.json files
             const actualTimestamp = await timestampPathNew.get('timestamp');
             const actualPromoButtonTitle = await contentPathNew.get('cloud.title');
             const actualPromoButtonDescription = await contentPathNew.get('cloud.description');
             // Check the json files are automatically updated
-            console.log(`timestamp: ${actualTimestamp}`);
-            console.log(`actualPromoButtonTitle: ${actualPromoButtonTitle}`);
-            console.log(`actualPromoButtonDescription: ${actualPromoButtonDescription}`);
             await t.expect(actualPromoButtonTitle).notEql(newPromoButtonText, 'The cloud title in the create-redis.json file is automatically updated');
             await t.expect(actualPromoButtonDescription).notEql(newPromoButtonText, 'The cloud description in the create-redis.json file is automatically updated');
             await t.expect(actualTimestamp).notEql(newTimestamp, 'The timestamp in the build.json file is automatically updated');

--- a/tests/e2e/tests/critical-path/monitor/monitor.e2e.ts
+++ b/tests/e2e/tests/critical-path/monitor/monitor.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import {
     MyRedisDatabasePage,
@@ -13,16 +12,17 @@ import {
 } from '../../../helpers/conf';
 import { rte } from '../../../helpers/constants';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const cliPage = new CliPage();
 const monitorPage = new MonitorPage();
 const workbenchPage = new WorkbenchPage();
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-const keyName = `${chance.word({ length: 20 })}-key`;
-const keyValue = `${chance.word({ length: 10 })}-value`;
+const keyName = `${common.generateWord(20)}-key`;
+const keyValue = `${common.generateWord(10)}-value`;
 
 fixture `Monitor`
     .meta({ type: 'critical_path', rte: rte.standalone })

--- a/tests/e2e/tests/critical-path/monitor/save-commands.e2e.ts
+++ b/tests/e2e/tests/critical-path/monitor/save-commands.e2e.ts
@@ -29,104 +29,102 @@ async function findByFileStarts(dir: string): Promise<number> {
             }
         }
         return matchedFiles.length;
-    } else {
-        return 0;
     }
+    return 0;
+
 }
 
 fixture `Save commands`
-    .meta({ type: 'critical_path' })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         downloadedFilePath = await getFileDownloadPath();
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see a tooltip and toggle that allows to save Profiler log or not in the Profiler', async t => {
-        const toolTip = [
-            'Allows you to download the generated log file after pausing the Profiler',
-            'Profiler log is saved to a file on your local machine with no size limitation. The temporary log file will be automatically rewritten when the Profiler is reset.'
-        ];
-        await t.click(monitorPage.expandMonitor);
-        //Check the toggle and Tooltip for Save log
-        await t.expect(monitorPage.saveLogSwitchButton.visible).ok('The toggle that allows to save Profiler log is displayed');
-        await t.hover(monitorPage.saveLogSwitchButton);
-        for (const message of toolTip) {
-            await t.expect(monitorPage.saveLogToolTip.textContent).contains(message, 'The toolTip for save log in Profiler is displayed');
-        }
-        //Check toggle state
-        await t.expect(monitorPage.saveLogSwitchButton.getAttribute('aria-checked')).eql('false', 'The toggle state is OFF when opens Profiler');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see that toggle is not displayed when Profiler is started', async t => {
-        //Start Monitor without save logs
-        await monitorPage.startMonitor();
-        //Check the toggle
-        await t.expect(monitorPage.saveLogSwitchButton.visible).notOk('The toggle is not displayed when Profiler is started');
-        //Restart Monitor with Save logs
-        await monitorPage.stopMonitor();
-        await t.click(monitorPage.resetProfilerButton);
-        await t.click(monitorPage.saveLogSwitchButton);
-        await t.click(monitorPage.startMonitorButton);
-        //Check the toggle
-        await t.expect(monitorPage.saveLogSwitchButton.visible).notOk('The toggle is not displayed when Profiler is started');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user switch toggle to ON and started the Profiler, temporary Log file Created and recording', async t => {
-        const cli_command = 'command';
-        //Remember the number of files in Temp
-        const numberOfTempFiles = fs.readdirSync(tempDir).length;
-        //Start Monitor with Save logs
-        await monitorPage.startMonitorWithSaveLog();
-        //Send command in CLI
-        await cliPage.getSuccessCommandResultFromCli(cli_command);
-        await monitorPage.checkCommandInMonitorResults(cli_command);
-        //Verify that temporary Log file Created
-        await t.expect(numberOfTempFiles).lt(fs.readdirSync(tempDir).length, 'The temporary Log file is not created');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user switch toggle to OFF and started the Profiler, temporary Log file is not Created and recording', async t => {
-        //Remember the number of files in Temp
-        const numberOfTempFiles = fs.readdirSync(tempDir).length;
-        //Start Monitor with Save logs
-        await monitorPage.startMonitor();
-        //Verify that temporary Log file is not created
-        await t.expect(numberOfTempFiles).gte(fs.readdirSync(tempDir).length, 'The temporary Log file is created');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify the Profiler Button panel when toggle was switched to ON and user pauses/resumes the Profiler', async t => {
-        //Start Monitor with Save logs
-        await monitorPage.startMonitorWithSaveLog();
-        //Pause the Profiler
-        await t.click(monitorPage.runMonitorToggle);
-        //Check the panel
-        await t.expect(monitorPage.downloadLogPanel.visible).ok('The download log panel appears');
-        await t.expect(monitorPage.resetProfilerButton.visible).ok('The Reset Profiler button visibility');
-        await t.expect(monitorPage.downloadLogButton.visible).ok('The Download button visibility');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user see the toggle is OFF - Profiler logs are not being saved', async t => {
-        //Remember the number of files in Temp
-        const numberOfDownloadFiles = await findByFileStarts(downloadedFilePath);
-        //Start Monitor without Save logs
-        await monitorPage.startMonitor();
-        await t.wait(3000);
-        //Check the download files
-        await t.expect(await findByFileStarts(downloadedFilePath)).eql(numberOfDownloadFiles, 'The Profiler logs are saved');
-    });
+test('Verify that user can see a tooltip and toggle that allows to save Profiler log or not in the Profiler', async t => {
+    const toolTip = [
+        'Allows you to download the generated log file after pausing the Profiler',
+        'Profiler log is saved to a file on your local machine with no size limitation. The temporary log file will be automatically rewritten when the Profiler is reset.'
+    ];
+
+    await t.click(monitorPage.expandMonitor);
+    // Check the toggle and Tooltip for Save log
+    await t.expect(monitorPage.saveLogSwitchButton.visible).ok('The toggle that allows to save Profiler log is not displayed');
+    await t.hover(monitorPage.saveLogSwitchButton);
+    for (const message of toolTip) {
+        await t.expect(monitorPage.saveLogToolTip.textContent).contains(message, 'The toolTip for save log in Profiler is not displayed');
+    }
+    // Check toggle state
+    await t.expect(monitorPage.saveLogSwitchButton.getAttribute('aria-checked')).eql('false', 'The toggle state is not OFF when Profiler opened');
+});
+test('Verify that user can see that toggle is not displayed when Profiler is started', async t => {
+    // Start Monitor without save logs
+    await monitorPage.startMonitor();
+    // Check the toggle
+    await t.expect(monitorPage.saveLogSwitchButton.visible).notOk('The toggle is displayed when Profiler is started');
+    // Restart Monitor with Save logs
+    await monitorPage.stopMonitor();
+    await t.click(monitorPage.resetProfilerButton);
+    await t.click(monitorPage.saveLogSwitchButton);
+    await t.click(monitorPage.startMonitorButton);
+    // Check the toggle
+    await t.expect(monitorPage.saveLogSwitchButton.visible).notOk('The toggle is displayed when Profiler is started');
+});
+test('Verify that when user switch toggle to ON and started the Profiler, temporary Log file Created and recording', async t => {
+    const cli_command = 'command';
+    // Remember the number of files in Temp
+    const numberOfTempFiles = fs.readdirSync(tempDir).length;
+
+    // Start Monitor with Save logs
+    await monitorPage.startMonitorWithSaveLog();
+    // Send command in CLI
+    await cliPage.getSuccessCommandResultFromCli(cli_command);
+    await monitorPage.checkCommandInMonitorResults(cli_command);
+    // Verify that temporary Log file Created
+    await t.expect(numberOfTempFiles).lt(fs.readdirSync(tempDir).length, 'The temporary Log file is not created');
+});
+test('Verify that when user switch toggle to OFF and started the Profiler, temporary Log file is not Created and recording', async t => {
+    // Remember the number of files in Temp
+    const numberOfTempFiles = fs.readdirSync(tempDir).length;
+
+    // Start Monitor without Save logs
+    await monitorPage.startMonitor();
+    // Verify that temporary Log file is not created
+    await t.expect(numberOfTempFiles).gte(fs.readdirSync(tempDir).length, 'The temporary Log file is created');
+});
+test('Verify the Profiler Button panel when toggle was switched to ON and user pauses/resumes the Profiler', async t => {
+    // Start Monitor with Save logs
+    await monitorPage.startMonitorWithSaveLog();
+    // Pause the Profiler
+    await t.click(monitorPage.runMonitorToggle);
+    // Check the panel
+    await t.expect(monitorPage.downloadLogPanel.visible).ok('The download log panel not appeared');
+    await t.expect(monitorPage.resetProfilerButton.visible).ok('The Reset Profiler button not visible');
+    await t.expect(monitorPage.downloadLogButton.visible).ok('The Download button not visible');
+});
+test('Verify that when user see the toggle is OFF - Profiler logs are not being saved', async t => {
+    // Remember the number of files in Temp
+    const numberOfDownloadFiles = await findByFileStarts(downloadedFilePath);
+
+    // Start Monitor without Save logs
+    await monitorPage.startMonitor();
+    await t.wait(3000);
+    // Check the download files
+    await t.expect(await findByFileStarts(downloadedFilePath)).eql(numberOfDownloadFiles, 'The Profiler logs are saved');
+});
 // Skipped due to testCafe issue https://github.com/DevExpress/testcafe/issues/5574
-test.skip
-    .meta({ rte: rte.standalone })('Verify that when user see the toggle is ON - Profiler logs are being saved', async t => {
-        //Remember the number of files in Temp
-        const numberOfDownloadFiles = await findByFileStarts(downloadedFilePath);
-        //Start Monitor with Save logs
-        await monitorPage.startMonitorWithSaveLog();
-        //Download logs and check result
-        await monitorPage.stopMonitor();
-        await t.click(monitorPage.downloadLogButton);
-        await t.expect(await findByFileStarts(downloadedFilePath)).gt(numberOfDownloadFiles, 'The Profiler logs not saved', { timeout: 5000 });
-    });
+test.skip('Verify that when user see the toggle is ON - Profiler logs are being saved', async t => {
+    // Remember the number of files in Temp
+    const numberOfDownloadFiles = await findByFileStarts(downloadedFilePath);
+
+    // Start Monitor with Save logs
+    await monitorPage.startMonitorWithSaveLog();
+    // Download logs and check result
+    await monitorPage.stopMonitor();
+    await t.click(monitorPage.downloadLogButton);
+    await t.expect(await findByFileStarts(downloadedFilePath)).gt(numberOfDownloadFiles, 'The Profiler logs not saved', { timeout: 5000 });
+});

--- a/tests/e2e/tests/critical-path/overview/overview.e2e.ts
+++ b/tests/e2e/tests/critical-path/overview/overview.e2e.ts
@@ -33,6 +33,7 @@ fixture `Overview`
     });
 test('Overview tab header for OSS Cluster', async t => {
     const uptime = /[1-9][0-9]\s|[0-9]\smin|[1-9][0-9]\smin|[0-9]\sh/;
+
     // Verify that user see "Overview" tab by default for OSS Cluster
     await t.expect(overviewPage.overviewTab.withAttribute('aria-selected', 'true').exists).ok('The Overview tab not opened');
     // Verify that user see "Overview" header with OSS Cluster info
@@ -54,6 +55,7 @@ test
         const initialValues: number[] = [];
         const nodes = (await getClusterNodesApi(ossClusterConfig)).sort();
         const columns = ['Commands/s', 'Clients', 'Total Keys', 'Network Input', 'Network Output', 'Total Memory'];
+
         for (const column in columns) {
             initialValues.push(await overviewPage.getTotalValueByColumnName(column));
         }

--- a/tests/e2e/tests/critical-path/pub-sub/subscribe-unsubscribe.e2e.ts
+++ b/tests/e2e/tests/critical-path/pub-sub/subscribe-unsubscribe.e2e.ts
@@ -22,20 +22,19 @@ fixture `Subscribe/Unsubscribe from a channel`
     .afterEach(async() => {
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test('Verify that user is unsubscribed from the pubsub channel when he go to the pubsub window after launching application for the first time', async t => {
-    //Verify that the Channel field placeholder is 'Enter Channel Name'
+test('Verify that when user subscribe to the pubsub channel he can see all the messages being published to my database from the moment of my subscription', async t => {
+    // Verify that the Channel field placeholder is 'Enter Channel Name'
     await t.expect(pubSubPage.channelNameInput.getAttribute('placeholder')).eql('Enter Channel Name', 'No placeholder in Channel field');
-    //Verify that the Message field placeholder is 'Enter Message'
+    // Verify that the Message field placeholder is 'Enter Message'
     await t.expect(pubSubPage.messageInput.getAttribute('placeholder')).eql('Enter Message', 'No placeholder in Message field');
-    //Verify that user is unsubscribed by default
+    // Verify that user is unsubscribed from the pubsub channel when he go to the pubsub window after launching application for the first time
     await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are not subscribed', 'User is not unsubscribed');
     await t.expect(pubSubPage.subscribeButton.textContent).eql('Subscribe', 'Subscribe button is not displayed');
-});
-test('Verify that when user subscribe to the pubsub channel he can see all the messages being published to my database from the moment of my subscription', async t => {
-    //Subscribe to channel
+
+    // Subscribe to channel
     await t.click(pubSubPage.subscribeButton);
     await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are  subscribed', 'User is not subscribed', { timeout: 10000 });
-    //Verify that user can publish a message to a channel
+    // Verify that user can publish a message to a channel
     await pubSubPage.publishMessage('test', 'published message');
     await verifyMessageDisplayingInPubSub('published message', true);
     await t.click(pubSubPage.unsubscribeButton);
@@ -46,19 +45,22 @@ test('Verify that when user subscribe to the pubsub channel he can see all the m
     //Verify that message is not displayed
     await verifyMessageDisplayingInPubSub('message in unsubscribed status', false);
 });
-test('Verify that my subscription state is preserved when user navigate through the app while connected to current database and in current app session', async t => {
-    await pubSubPage.subsribeToChannelAndPublishMessage('test', 'message');
-    //Go to Browser Page
-    await t.click(myRedisDatabasePage.myRedisDBButton);
-    //Go back to PubSub page
-    await t.click(myRedisDatabasePage.pubSubButton);
-    await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are  subscribed', 'User is not subscribed', { timeout: 10000 });
-});
-test('Verify that the focus gets always shifted to a newest message (auto-scroll)', async() => {
+test('Verify that the focus gets always shifted to a newest message (auto-scroll)', async t => {
     await pubSubPage.subsribeToChannelAndPublishMessage('test', 'first message');
-    //Publish 100 messages
+    // Verify that when user click Publish and the publication is successful, he can see a response: badge with the number <# of clients received>
+    await t.expect(pubSubPage.clientBadge.visible).ok('Client badge is not displayed');
+    await t.expect(pubSubPage.clientBadge.textContent).eql('1', 'Client badge is not displayed', { timeout: 10000 });
+
+    // Go to My Redis databases Page
+    await t.click(myRedisDatabasePage.myRedisDBButton);
+    // Go back to PubSub page
+    await t.click(myRedisDatabasePage.pubSubButton);
+    // Verify that my subscription state is preserved when user navigate through the app while connected to current database and in current app session
+    await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are  subscribed', 'User is not subscribed', { timeout: 10000 });
+
+    // Publish 100 messages
     await cliPage.sendCommandInCli('100 publish channel test100Message');
-    //Verify that the first message is not visible in view port
+    // Verify that the first message is not visible in view port
     await verifyMessageDisplayingInPubSub('first message', false);
     await verifyMessageDisplayingInPubSub('test100Message', true);
 });
@@ -69,7 +71,7 @@ test
         await addNewStandaloneDatabaseApi(ossStandaloneConfig);
         await common.reloadPage();
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Go to PubSub page
+        // Go to PubSub page
         await t.click(myRedisDatabasePage.pubSubButton);
     })
     .after(async() => {
@@ -77,68 +79,63 @@ test
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that user subscription state is changed to unsubscribed, all the messages are cleared and total message counter is reset when user connect to another database', async t => {
         await t.click(pubSubPage.subscribeButton);
-        //Publish 10 messages
+        // Publish 10 messages
         await cliPage.sendCommandInCli('10 publish channel message');
         await verifyMessageDisplayingInPubSub('message', true);
-        //Verify that user can see total number of messages received
+        // Verify that user can see total number of messages received
         await t.expect(pubSubPage.totalMessagesCount.textContent).contains('10', 'Total counter value is incorrect');
-        //Connect to second database
+        // Connect to second database
         await t.click(myRedisDatabasePage.myRedisDBButton);
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneV5Config.databaseName);
-        //Verify no subscription, messages and total messages
+        // Verify no subscription, messages and total messages
         await t.click(myRedisDatabasePage.pubSubButton);
         await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are not subscribed', 'User is not unsubscribed', { timeout: 10000 });
         await verifyMessageDisplayingInPubSub('message', false);
         await t.expect(pubSubPage.totalMessagesCount.exists).notOk('Total counter is still displayed');
     });
 test('Verify that user can see a internal link to pubsub window under word “Pub/Sub” when he try to run PSUBSCRIBE command in CLI or Workbench', async t => {
-    //Go to Browser Page
+    // Go to Browser Page
     await t.click(myRedisDatabasePage.browserButton);
-    //Verify that user can see a custom message when he try to run PSUBSCRIBE command in CLI or Workbench: “Use Pub/Sub to see the messages published to all channels in your database”
+    // Verify that user can see a custom message when he try to run PSUBSCRIBE command in CLI or Workbench: “Use Pub/Sub to see the messages published to all channels in your database”
     await cliPage.sendCommandInCli('PSUBSCRIBE');
     await t.click(cliPage.cliExpandButton);
     await t.expect(cliPage.cliWarningMessage.textContent).eql('Use Pub/Sub to see the messages published to all channels in your database.', 'Message is not displayed', { timeout: 10000 });
-    //Verify internal link to pubsub page in CLI
+    // Verify internal link to pubsub page in CLI
     await t.expect(cliPage.cliLinkToPubSub.exists).ok('Link to pubsub page is not displayed');
     await t.click(cliPage.cliLinkToPubSub);
     await t.expect(pubSubPage.pubSubPageContainer.visible).ok('Pubsub page is opened');
 });
-test('Verify that when user click Publish and the publication is successful, he can see a response: badge with the number <# of clients received>', async t => {
-    await pubSubPage.subsribeToChannelAndPublishMessage('test', 'message');
-    await t.expect(pubSubPage.clientBadge.visible).ok('Client badge is not displayed');
-    await t.expect(pubSubPage.clientBadge.textContent).eql('1', 'Client badge is not displayed', { timeout: 10000 });
-});
 test('Verify that the Message field input is preserved until user Publish a message', async t => {
-    //Fill in Channel and Message inputs
+    // Fill in Channel and Message inputs
     await t.click(pubSubPage.subscribeButton);
     await t.click(pubSubPage.channelNameInput);
     await t.typeText(pubSubPage.channelNameInput, 'testChannel', { replace: true });
     await t.click(pubSubPage.messageInput);
     await t.typeText(pubSubPage.messageInput, 'message', { replace: true });
     await t.expect(pubSubPage.messageInput.value).eql('message', 'Message input is empty', { timeout: 10000 });
-    //Go to Browser Page
+    // Go to Browser Page
     await t.click(myRedisDatabasePage.myRedisDBButton);
-    //Go to PubSub page
+    // Go to PubSub page
     await t.click(myRedisDatabasePage.pubSubButton);
     // Verify that message is preserved until publishing
     await t.expect(pubSubPage.messageInput.value).eql('message', 'Message input is empty', { timeout: 10000 });
     await t.click(pubSubPage.publishButton);
     await t.expect(pubSubPage.messageInput.value).eql('', 'Message input is empty', { timeout: 10000 });
-    //Verify that the Channel field input is preserved until user modify it (publishing a message does not clear the field)
+    // Verify that the Channel field input is preserved until user modify it (publishing a message does not clear the field)
     await t.expect(pubSubPage.channelNameInput.value).eql('testChannel', 'Channel input is empty', { timeout: 10000 });
 });
 test('Verify that user can clear all the messages from the pubsub window', async t => {
     await pubSubPage.subsribeToChannelAndPublishMessage('testChannel', 'message');
     await pubSubPage.publishMessage('testChannel2', 'second m');
-    //Verify the tooltip text 'Clear Messages' appears on hover the clear button
+    // Verify the tooltip text 'Clear Messages' appears on hover the clear button
     await t.hover(pubSubPage.clearPubSubButton);
     await t.expect(pubSubPage.clearButtonTooltip.textContent).contains('Clear Messages', 'Clear Messages tooltip not displayed');
     await t.click(pubSubPage.clearPubSubButton);
-    //Verify that the clear of the messages does not affect the subscription state
+    // Verify that the clear of the messages does not affect the subscription state
     await t.expect(pubSubPage.subscribeStatus.textContent).eql('You are  subscribed', 'User is not subscribed', { timeout: 10000 });
-    //Verify that the Messages counter is reset after clear messages
+    // Verify that the Messages counter is reset after clear messages
     await t.expect(pubSubPage.totalMessagesCount.textContent).contains('0', 'Total counter value is incorrect');
-    //Verify messages are cleared
+    // Verify messages are cleared
     await verifyMessageDisplayingInPubSub('message', false);
     await verifyMessageDisplayingInPubSub('second m', false);
 });

--- a/tests/e2e/tests/critical-path/settings/settings.e2e.ts
+++ b/tests/e2e/tests/critical-path/settings/settings.e2e.ts
@@ -13,46 +13,42 @@ const explicitErrorHandler = (): void => {
         if(e.message === 'ResizeObserver loop limit exceeded') {
             e.stopImmediatePropagation();
         }
-    })
-}
+    });
+};
 
 fixture `Settings`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.none})
     .page(commonUrl)
     .clientScripts({ content: `(${explicitErrorHandler.toString()})()` })
-    .beforeEach(async t => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
-    })
-test
-    .meta({ rte: rte.none })
-    ('Verify that user can customize a number of keys to scan in filters per key name or key type', async t => {
-        //Go to Settings page
-        await t.click(myRedisDatabasePage.settingsButton);
-        // Change keys to Scan
-        await t.click(settingsPage.accordionAdvancedSettings);
-        await settingsPage.changeKeysToScanValue('1500');
+    });
+test('Verify that user can customize a number of keys to scan in filters per key name or key type', async t => {
+    // Go to Settings page
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Change keys to Scan
+    await t.click(settingsPage.accordionAdvancedSettings);
+    await settingsPage.changeKeysToScanValue('1500');
+    // Reload Page
+    await common.reloadPage();
+    // Check that value was set
+    await t.click(settingsPage.accordionAdvancedSettings);
+    await t.expect(settingsPage.keysToScanValue.textContent).eql('1500', 'Keys to Scan has proper value');
+});
+test('Verify that user can turn on/off Analytics in Settings in the application', async t => {
+    // Go to Settings page
+    await t.click(myRedisDatabasePage.settingsButton);
+    await t.click(settingsPage.accordionPrivacySettings);
+
+    const currentValue = await settingsPage.getAnalyticsSwitcherValue();
+    // We sort the values so as not to be tied to the current setting
+    const equalValues = ['true', 'false'].sort((_, b) => b === currentValue ? -1 : 0);
+
+    for (const value of equalValues) {
+        await t.click(settingsPage.switchAnalyticsOption);
         // Reload Page
         await common.reloadPage();
-        // Check that value was set
-        await t.click(settingsPage.accordionAdvancedSettings);
-        await t.expect(settingsPage.keysToScanValue.textContent).eql('1500', 'Keys to Scan has proper value');
-    });
-test
-    .meta({ rte: rte.none })
-    ('Verify that user can turn on/off Analytics in Settings in the application', async t => {
-        //Go to Settings page
-        await t.click(myRedisDatabasePage.settingsButton);
         await t.click(settingsPage.accordionPrivacySettings);
-
-        const currentValue = await settingsPage.getAnalyticsSwitcherValue();
-        //We sort the values so as not to be tied to the current setting
-        const equalValues = ['true', 'false'].sort((_, b) => b === currentValue ? -1 : 0)
-
-        for (const value of equalValues) {
-            await t.click(settingsPage.switchAnalyticsOption);
-            // Reload Page
-            await common.reloadPage();
-            await t.click(settingsPage.accordionPrivacySettings);
-            await t.expect(await settingsPage.getAnalyticsSwitcherValue()).eql(value, 'Analytics was switched properly');
-        }
-    });
+        await t.expect(await settingsPage.getAnalyticsSwitcherValue()).eql(value, 'Analytics was switched properly');
+    }
+});

--- a/tests/e2e/tests/critical-path/slow-log/slow-log.e2e.ts
+++ b/tests/e2e/tests/critical-path/slow-log/slow-log.e2e.ts
@@ -44,7 +44,7 @@ test('Verify that user can see "No Slow Logs found" message when slowlog-max-len
     await slowLogPage.changeMaxLengthParameter(maxCommandLength);
     await t.click(slowLogPage.slowLogRefreshButton);
     // Check that no records are displayed in SlowLog table
-    await t.expect(slowLogPage.slowLogEmptyResult.exists).ok('Empty results');
+    await t.expect(slowLogPage.slowLogEmptyResult.exists).ok('Empty results not found');
     // Verify that user can see not more that number of commands that was specified in configuration
     maxCommandLength = 30;
     await slowLogPage.changeSlowerThanParameter(slowerThanParameter);
@@ -55,17 +55,6 @@ test('Verify that user can see "No Slow Logs found" message when slowlog-max-len
     await t.click(myRedisDatabasePage.analysisPageButton);
     // Compare number of logged commands with maxLength
     await t.expect(slowLogPage.slowLogCommandStatistics.withText(`${maxCommandLength} entries`).exists).ok('Number of displayed commands is less than ');
-});
-test('Verify that user can clear Slow Log', async t => {
-    // Set slowlog-max-len=0
-    command = 'info';
-    await slowLogPage.changeSlowerThanParameter(slowerThanParameter);
-    await cliPage.sendCommandInCli('info');
-    await t.click(slowLogPage.slowLogRefreshButton);
-    await t.expect(slowLogPage.slowLogCommandValue.withExactText(command).exists).ok('Logged command');
-    await t.click(slowLogPage.slowLogClearButton);
-    await t.click(slowLogPage.slowLogConfirmClearButton);
-    await t.expect(slowLogPage.slowLogEmptyResult.exists).ok('Slow log is cleared');
 });
 test('Verify that users can specify number of commands that they want to display (10, 25, 50, 100, Max) in Slow Log', async t => {
     maxCommandLength = 128;
@@ -80,10 +69,10 @@ test('Verify that users can specify number of commands that they want to display
     for (let i = 0; i < numberOfCommandsArray.length; i++) {
         await slowLogPage.changeDisplayUpToParameter(numberOfCommandsArray[i]);
         if (i === numberOfCommandsArray.length - 1) {
-            await t.expect(slowLogPage.slowLogCommandStatistics.withText(`${maxCommandLength} entries`).exists).ok('Number of displayed commands is equal to 128');
+            await t.expect(slowLogPage.slowLogCommandStatistics.withText(`${maxCommandLength} entries`).exists).ok('Number of displayed commands is not equal to 128');
         }
         else {
-            await t.expect(slowLogPage.slowLogCommandStatistics.withText(`${numberOfCommandsArray[i]} entries`).exists).ok(`Number of displayed commands is equal to ${numberOfCommandsArray[i]}`);
+            await t.expect(slowLogPage.slowLogCommandStatistics.withText(`${numberOfCommandsArray[i]} entries`).exists).ok(`Number of displayed commands is not equal to ${numberOfCommandsArray[i]}`);
         }
     }
 });
@@ -115,6 +104,17 @@ test('Verify that user can set slowlog-log-slower-than value in milliseconds and
     await t.expect(parseFloat(microsecondsDuration.replace(' ', ''))).eql(parseFloat(millisecondsDuration) * 1000);
 });
 test('Verify that user can reset settings to default on Slow Log page', async t => {
+    // Set slowlog-max-len=0
+    command = 'info';
+    await slowLogPage.changeSlowerThanParameter(slowerThanParameter);
+    await cliPage.sendCommandInCli('info');
+    await t.click(slowLogPage.slowLogRefreshButton);
+    await t.expect(slowLogPage.slowLogCommandValue.withExactText(command).exists).ok('Logged command not found');
+    await t.click(slowLogPage.slowLogClearButton);
+    await t.click(slowLogPage.slowLogConfirmClearButton);
+    // Verify that user can clear Slow Log
+    await t.expect(slowLogPage.slowLogEmptyResult.exists).ok('Slow log is not cleared');
+
     // Set slower than parameter and max length
     await slowLogPage.changeSlowerThanParameter(slowerThanParameter);
     await slowLogPage.changeMaxLengthParameter(maxCommandLength);

--- a/tests/e2e/tests/critical-path/tree-view/delimiter.e2e.ts
+++ b/tests/e2e/tests/critical-path/tree-view/delimiter.e2e.ts
@@ -12,30 +12,19 @@ import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 const browserPage = new BrowserPage();
 
 fixture `Delimiter tests`
-    .meta({
-        type: 'critical_path',
-        rte: rte.standalone
-    })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
     })
     .afterEach(async() => {
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
-    })
-test('Verify that when user changes the delimiter and clicks on Save button delimiter is applied', async t => {
-    // Switch to tree view
-    await t.click(browserPage.treeViewButton);
-    // Change delimiter
-    await browserPage.changeDelimiterInTreeView('-');
-    // Check tree view according to the applied delimiter
-    await browserPage.checkTreeViewFoldersStructure([['device_us', 'west'], ['mobile_eu', 'central'], ['mobile_us', 'east'], ['user_us', 'west'], ['device_eu', 'central'], ['user_eu', 'central']], '-', true);
-});
+    });
 test('Verify that user can see that input is not saved when the Cancel button is clicked', async t => {
     // Switch to tree view
     await t.click(browserPage.treeViewButton);
     // Check the default delimiter value
-    await t.expect(browserPage.treeViewDelimiterButton.withExactText(':').exists).ok('Default delimiter');
+    await t.expect(browserPage.treeViewDelimiterButton.withExactText(':').exists).ok('Default delimiter not applied');
     // Open delimiter popup
     await t.click(browserPage.treeViewDelimiterButton);
     // Apply new value to the field
@@ -43,5 +32,10 @@ test('Verify that user can see that input is not saved when the Cancel button is
     // Click on Cancel button
     await t.click(browserPage.treeViewDelimiterValueCancel);
     // Check the previous delimiter value
-    await t.expect(browserPage.treeViewDelimiterButton.withExactText(':').exists).ok('Previous delimiter');
+    await t.expect(browserPage.treeViewDelimiterButton.withExactText(':').exists).ok('Previous delimiter not applied');
+
+    // Change delimiter
+    await browserPage.changeDelimiterInTreeView('-');
+    // Verify that when user changes the delimiter and clicks on Save button delimiter is applied
+    await browserPage.checkTreeViewFoldersStructure([['device_us', 'west'], ['mobile_eu', 'central'], ['mobile_us', 'east'], ['user_us', 'west'], ['device_eu', 'central'], ['user_eu', 'central']], '-', true);
 });

--- a/tests/e2e/tests/critical-path/tree-view/tree-view.e2e.ts
+++ b/tests/e2e/tests/critical-path/tree-view/tree-view.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import {
@@ -10,74 +9,65 @@ import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
 const common = new Common();
 
-const keyNameFilter = `keyName${chance.word({ length: 10 })}`;
+const keyNameFilter = `keyName${common.generateWord(10)}`;
 
 fixture `Tree view verifications`
-    .meta({type: 'critical_path'})
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that when user opens the application he can see that Tree View is disabled by default(Browser is selected by default)', async t => {
-        //Verify that Browser view is selected by default and Tree view is disabled
-        await t.expect(browserPage.browserViewButton.getStyleProperty('background-color')).eql('rgb(41, 47, 71)', 'The Browser is selected by default');
-        await t.expect(browserPage.treeViewArea.visible).notOk('The tree view is not displayed', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see that "Tree view" mode is enabled state is saved when refreshes the page', async t => {
-        await t.click(browserPage.treeViewButton);
-        await common.reloadPage();
-        //Verify that "Tree view" mode enabled state is saved
-        await t.expect(browserPage.treeViewArea.visible).ok('The tree view is displayed');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can scan DB by 10K in tree view', async t => {
-        await t.click(browserPage.treeViewButton);
-        //Verify that user can use the "Scan More" button to search per another 10000 keys
-        await browserPage.verifyScannningMore();
-    });
+test('Verify that user can see that "Tree view" mode is enabled state is saved when refreshes the page', async t => {
+    // Verify that when user opens the application he can see that Tree View is disabled by default(Browser is selected by default)
+    await t.expect(browserPage.browserViewButton.getStyleProperty('background-color')).eql('rgb(41, 47, 71)', 'The Browser is not selected by default');
+    await t.expect(browserPage.treeViewArea.visible).notOk('The tree view is displayed', { timeout: 10000 });
+
+    await t.click(browserPage.treeViewButton);
+    await common.reloadPage();
+    // Verify that "Tree view" mode enabled state is saved
+    await t.expect(browserPage.treeViewArea.visible).ok('The tree view is not displayed');
+
+    // Verify that user can scan DB by 10K in tree view
+    await browserPage.verifyScannningMore();
+});
 test
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyNameFilter);
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
-    })
-    .meta({ rte: rte.standalone })('Verify that when user enables filtering by key name he can see only folder with appropriate keys are displayed and the number of keys and percentage is recalculated', async t => {
+    })('Verify that when user enables filtering by key name he can see only folder with appropriate keys are displayed and the number of keys and percentage is recalculated', async t => {
         await browserPage.addHashKey(keyNameFilter);
         await t.click(browserPage.treeViewButton);
         const numberOfKeys = await browserPage.treeViewKeysNumber.textContent;
         const percentage = await browserPage.treeViewPercentage.textContent;
-        //Set filter by key name
+        // Set filter by key name
         await browserPage.searchByKeyName(keyNameFilter);
-        await t.expect(browserPage.treeViewKeysItem.visible).ok('The key appears after the filtering', { timeout: 10000 });
+        await t.expect(browserPage.treeViewKeysItem.visible).ok('The key not appeared after the filtering', { timeout: 10000 });
         await t.click(browserPage.treeViewKeysItem);
-        //Verify the results
-        await t.expect(browserPage.treeViewKeysNumber.textContent).notEql(numberOfKeys, 'The number of keys is recalculated');
-        await t.expect(browserPage.treeViewPercentage.textContent).notEql(percentage, 'The percentage is recalculated');
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyNameFilter)).ok('The appropriate keys are displayed');
+        // Verify the results
+        await t.expect(browserPage.treeViewKeysNumber.textContent).notEql(numberOfKeys, 'The number of keys is not recalculated');
+        await t.expect(browserPage.treeViewPercentage.textContent).notEql(percentage, 'The percentage is not recalculated');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyNameFilter)).ok('The appropriate keys are not displayed');
     });
-test
-    .meta({ rte: rte.standalone })('Verify that when user switched from Tree View to Browser and goes back state of filer by key name/key type is saved', async t => {
-        const keyName = 'user*';
-        await t.click(browserPage.treeViewButton);
-        await browserPage.searchByKeyName(keyName);
-        await t.click(browserPage.browserViewButton);
-        await t.click(browserPage.treeViewButton);
-        //Verify that state of filer by key name is saved
-        await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is still applied');
-        await t.click(browserPage.treeViewButton);
-        //Set filter by key type
-        await browserPage.selectFilterGroupType(KeyTypesTexts.String);
-        await t.click(browserPage.browserViewButton);
-        await t.click(browserPage.treeViewButton);
-        //Verify that state of filer by key type is saved
-        await t.expect(await browserPage.selectedFilterTypeString.visible).eql(true, 'Filter per key type is still applied');
-    });
+test('Verify that when user switched from Tree View to Browser and goes back state of filer by key name/key type is saved', async t => {
+    const keyName = 'user*';
+    await t.click(browserPage.treeViewButton);
+    await browserPage.searchByKeyName(keyName);
+    await t.click(browserPage.browserViewButton);
+    await t.click(browserPage.treeViewButton);
+    // Verify that state of filer by key name is saved
+    await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is not applied');
+    await t.click(browserPage.treeViewButton);
+    // Set filter by key type
+    await browserPage.selectFilterGroupType(KeyTypesTexts.String);
+    await t.click(browserPage.browserViewButton);
+    await t.click(browserPage.treeViewButton);
+    // Verify that state of filer by key type is saved
+    await t.expect(await browserPage.selectedFilterTypeString.visible).eql(true, 'Filter per key type is not applied');
+});

--- a/tests/e2e/tests/critical-path/workbench/autocomplete.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/autocomplete.e2e.ts
@@ -8,84 +8,74 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 
 fixture `Autocomplete for entered commands`
-    .meta({type: 'critical_path'})
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can select a command from the list with auto-suggestions when type in any character in the Editor', async t => {
-        //Start type characters and select command
-        await t.typeText(workbenchPage.queryInput, 'AC', { replace: true });
-        //Verify that the list with auto-suggestions is displayed
-        await t.expect(await workbenchPage.monacoSuggestion.exists).ok('Auto-suggestions are displayed');
-        //Select command and check result
-        await t.pressKey('enter');
-        const script = await workbenchPage.queryInputScriptArea.textContent;
-        await t.expect(script.replace(/\s/g, ' ')).eql('ACL ', 'Result of sent command exists');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user have selected a command (via “Enter” from the list of auto-suggested commands), user can see the required arguments inserted to the Editor', async t => {
-        const command = 'LINDEX'
-        const commandArguments = [
-            'key',
-            'index'
-        ];
-        //Select command via Enter
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        await t.pressKey('enter');
-        //Check the required arguments inserted
-        const script = await workbenchPage.queryInputScriptArea.textContent;
-        for(let argument of commandArguments) {
-            await t.expect(script).contains(argument, `The required argument ${argument} is inserted`);
-        }
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can change any required argument inserted', async t => {
-        const command = 'HMGET'
-        const commandArguments = [
-            'key',
-            'field'
-        ];
-        const commandArgumentsForChange = [
-            'firstArgument',
-            'secondArgument'
-        ];
-        //Select command via Enter
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        await t.pressKey('enter');
-        //Change required arguments
-        const scriptBeforeEdit = await workbenchPage.queryInputScriptArea.textContent;
-        await t.typeText(workbenchPage.queryInput, commandArgumentsForChange[0]);
-        await t.pressKey('tab');
-        await t.typeText(workbenchPage.queryInput, commandArgumentsForChange[1]);
-        const scriptAfterEdit = await workbenchPage.queryInputScriptArea.textContent;
-        //Verify the command after changes
-        await t.expect(scriptBeforeEdit).notEql(scriptAfterEdit, `The required arguments are editable`);
-        for(let argument of commandArguments) {
-            await t.expect(scriptAfterEdit).notContains(argument, `The argument ${argument} is changed`);
-        }
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that the list of optional arguments will not be inserted with autocomplete', async t => {
-        const command = 'ZPOPMAX'
-        const commandRequiredArgument = 'key';
-        const commandOptionalArgument = 'count';
-        //Select command via Enter
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        await t.pressKey('enter');
-        //Verify the command arguments inserted
-        const script = await workbenchPage.queryInputScriptArea.textContent;
-        await t.expect(script).contains(commandRequiredArgument, `The required argument is inserted`);
-        await t.expect(script).notContains(commandOptionalArgument, `The optional argument is not inserted`);
-    });
+test('Verify that when user have selected a command (via “Enter” from the list of auto-suggested commands), user can see the required arguments inserted to the Editor', async t => {
+    const commandArguments = [
+        'key',
+        'index'
+    ];
+
+    // Start type characters and select command
+    await t.typeText(workbenchPage.queryInput, 'LI', { replace: true });
+    // Verify that the list with auto-suggestions is displayed
+    await t.expect(await workbenchPage.monacoSuggestion.exists).ok('Auto-suggestions are displayed');
+    // Select command and check result
+    await t.pressKey('enter');
+    const script = await workbenchPage.queryInputScriptArea.textContent;
+    // Verify that user can select a command from the list with auto-suggestions when type in any character in the Editor
+    await t.expect(script.replace(/\s/g, ' ')).contains('LINDEX ', 'Result of sent command exists');
+
+    // Check the required arguments inserted
+    for (const argument of commandArguments) {
+        await t.expect(script).contains(argument, `The required argument ${argument} is inserted`);
+    }
+});
+test('Verify that user can change any required argument inserted', async t => {
+    const command = 'HMGET';
+    const commandArguments = [
+        'key',
+        'field'
+    ];
+    const commandArgumentsForChange = [
+        'firstArgument',
+        'secondArgument'
+    ];
+
+    // Select command via Enter
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    await t.pressKey('enter');
+    // Change required arguments
+    const scriptBeforeEdit = await workbenchPage.queryInputScriptArea.textContent;
+    await t.typeText(workbenchPage.queryInput, commandArgumentsForChange[0]);
+    await t.pressKey('tab');
+    await t.typeText(workbenchPage.queryInput, commandArgumentsForChange[1]);
+    const scriptAfterEdit = await workbenchPage.queryInputScriptArea.textContent;
+    // Verify the command after changes
+    await t.expect(scriptBeforeEdit).notEql(scriptAfterEdit, 'The required arguments are editable');
+    for(const argument of commandArguments) {
+        await t.expect(scriptAfterEdit).notContains(argument, `The argument ${argument} is changed`);
+    }
+});
+test('Verify that the list of optional arguments will not be inserted with autocomplete', async t => {
+    const command = 'ZPOPMAX';
+    const commandRequiredArgument = 'key';
+    const commandOptionalArgument = 'count';
+
+    // Select command via Enter
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    await t.pressKey('enter');
+    // Verify the command arguments inserted
+    const script = await workbenchPage.queryInputScriptArea.textContent;
+    await t.expect(script).contains(commandRequiredArgument, 'The required argument is inserted');
+    await t.expect(script).notContains(commandOptionalArgument, 'The optional argument is not inserted');
+});

--- a/tests/e2e/tests/critical-path/workbench/command-results.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/command-results.e2e.ts
@@ -1,109 +1,98 @@
-import { Chance } from 'chance';
 import { env, rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
 const commandForSend1 = 'info';
 const commandForSend2 = 'FT._LIST';
-let indexName = chance.word({ length: 5 });
+let indexName = common.generateWord(5);
 
 fixture `Command results at Workbench`
     .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async t => {
-        //Drop index, documents and database
+        // Drop index, documents and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can see re-run icon near the already executed command and re-execute the command by clicking on the icon in Workbench page', async t => {
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandForSend1);
-        await workbenchPage.sendCommandInWorkbench(commandForSend2);
-        //Verify that re-run icon is displayed
-        await t.expect(await workbenchPage.reRunCommandButton.visible).ok('Re-run icon is displayed');
-        //Re-run the last command in results
-        const containerOfCommand = await workbenchPage.getCardContainerByCommand(commandForSend1);
-        await t.click(containerOfCommand.find(workbenchPage.cssReRunCommandButton));
-        //Verify that command is re-executed
-        await t.expect(workbenchPage.queryCardCommand.textContent).eql(commandForSend1, 'The command is re-executed');
-    });
-test('Verify that user can see expanded result after command re-run at the top of results table in Workbench', async t => {
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandForSend1);
-        await workbenchPage.sendCommandInWorkbench(commandForSend2);
-        //Re-run the last command in results
-        const containerOfCommand = await workbenchPage.getCardContainerByCommand(commandForSend1);
-        await t.click(containerOfCommand.find(workbenchPage.cssReRunCommandButton));
-        //Verify that re-executed command is expanded
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryCardOutputResponseSuccess).visible).ok('Re-executed command is expanded');
-        //Verify that re-executed command is at the top of results
-        await t.expect(workbenchPage.queryCardCommand.nth(0).textContent).eql(commandForSend1, 'The re-executed command is at the top of results table');
-    });
-test('Verify that user can delete command with result from table with results in Workbench', async t => {
-        //Send command
-        await workbenchPage.sendCommandInWorkbench(commandForSend1);
-        //Delete the command from results
-        const containerOfCommand = await workbenchPage.getCardContainerByCommand(commandForSend1);
-        await t.click(containerOfCommand.find(workbenchPage.cssDeleteCommandButton));
-        //Verify that deleted command is not in results
-        await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend1).exists).notOk(`Command ${commandForSend1} is deleted from table with results`);
-    });
+    // Send commands
+    await workbenchPage.sendCommandInWorkbench(commandForSend1);
+    await workbenchPage.sendCommandInWorkbench(commandForSend2);
+    const containerOfCommand = await workbenchPage.getCardContainerByCommand(commandForSend1);
+    const containerOfCommand2 = await workbenchPage.getCardContainerByCommand(commandForSend2);
+    // Verify that re-run icon is displayed
+    await t.expect(await workbenchPage.reRunCommandButton.visible).ok('Re-run icon is not displayed');
+    // Re-run the last command in results
+    await t.click(containerOfCommand.find(workbenchPage.cssReRunCommandButton));
+    // Verify that command is re-executed
+    await t.expect(workbenchPage.queryCardCommand.textContent).eql(commandForSend1, 'The command is not re-executed');
+
+    // Verify that user can see expanded result after command re-run at the top of results table in Workbench
+    await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryCardOutputResponseSuccess).visible).ok('Re-executed command is not expanded');
+    await t.expect(workbenchPage.queryCardCommand.nth(0).textContent).eql(commandForSend1, 'The re-executed command is not at the top of results table');
+
+    // Delete the command from results
+    await t.click(containerOfCommand2.find(workbenchPage.cssDeleteCommandButton));
+    // Verify that user can delete command with result from table with results in Workbench
+    await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend2).exists).notOk(`Command ${commandForSend2} is not deleted from table with results`);
+});
 test('Verify that user can see the results found in the table view by default for FT.INFO, FT.SEARCH and FT.AGGREGATE', async t => {
-        const commands = [
-            'FT.INFO',
-            'FT.SEARCH',
-            'FT.AGGREGATE'
-        ];
-        //Send commands and check table view is default
-        for(const command of commands) {
-            await workbenchPage.sendCommandInWorkbench(command);
-            await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssTableViewTypeOption).visible).ok(`The table view is selected by default for command ${command}`);
-        }
-    });
+    const commands = [
+        'FT.INFO',
+        'FT.SEARCH',
+        'FT.AGGREGATE'
+    ];
+        // Send commands and check table view is default
+    for(const command of commands) {
+        await workbenchPage.sendCommandInWorkbench(command);
+        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssTableViewTypeOption).visible).ok(`The table view is not selected by default for command ${command}`);
+    }
+});
 test
     .meta({ env: env.desktop })('Verify that user can switches between views and see results according to the view rules in Workbench in results', async t => {
-        indexName = chance.word({ length: 5 });
+        indexName = common.generateWord(5);
         const commands = [
             'hset doc:10 title "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud" url "redis.io" author "Test" rate "undefined" review "0" comment "Test comment"',
             `FT.CREATE ${indexName} ON HASH PREFIX 1 doc: SCHEMA title TEXT WEIGHT 5.0 body TEXT url TEXT author TEXT rate TEXT review TEXT comment TEXT`,
             `FT.SEARCH ${indexName} * limit 0 10000`
         ];
-        //Send commands and check table view is default for Search command
+        // Send commands and check table view is default for Search command
         for (const command of commands) {
             await workbenchPage.sendCommandInWorkbench(command);
         }
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssTableViewTypeOption).visible).ok('The table view is selected by default for command FT.SEARCH');
+        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssTableViewTypeOption).visible).ok('The table view is not selected by default for command FT.SEARCH');
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(await workbenchPage.queryTableResult.visible).ok('The table result is displayed for command FT.SEARCH');
-        //Select Text view and check result
+        await t.expect(await workbenchPage.queryTableResult.visible).ok('The table result is not displayed for command FT.SEARCH');
+        // Select Text view and check result
         await t.switchToMainWindow();
         await workbenchPage.selectViewTypeText();
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The result is displayed in Text view');
+        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The result is not displayed in Text view');
     });
 // Skipped due to issue https://redislabs.atlassian.net/browse/RI-3524
 test.skip('Verify that user can switches between Table and Text for Client List and see results corresponding to their views', async t => {
-        const command = 'CLIENT LIST';
-        //Send command and check table view is default
-        await workbenchPage.sendCommandInWorkbench(command);
-        await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssCustomPluginTableResult).visible).ok('The search results are displayed in  Custom Table view by default');
-        //Select Text view from dropdown and check search results
-        await t.switchToMainWindow();
-        await workbenchPage.selectViewTypeText();
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The result is displayed in Text view');
-    });
+    const command = 'CLIENT LIST';
+    // Send command and check table view is default
+    await workbenchPage.sendCommandInWorkbench(command);
+    await t.switchToIframe(workbenchPage.iframe);
+    await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssCustomPluginTableResult).visible).ok('The search results are not displayed in  Custom Table view by default');
+    // Select Text view from dropdown and check search results
+    await t.switchToMainWindow();
+    await workbenchPage.selectViewTypeText();
+    await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The result is not displayed in Text view');
+});
 test
     .after(async() => {
         //Drop database
@@ -114,7 +103,7 @@ test
             'RANDOMKEY',
             'set'
         ];
-        //Send commands
+        // Send commands
         for(const command of commands) {
             await workbenchPage.sendCommandInWorkbench(command);
         }
@@ -123,10 +112,10 @@ test
             .click(workbenchPage.queryInput)
             .pressKey('ctrl+a')
             .pressKey('delete');
-        //Verify the quick access to command history by up button
+        // Verify the quick access to command history by up button
         for (const command of commands.reverse()) {
             await t.pressKey('up');
             const script = await workbenchPage.scriptsLines.textContent;
-            await t.expect(script.replace(/\s/g, ' ')).contains(command, 'Result of Manual command is displayed');
+            await t.expect(script.replace(/\s/g, ' ')).contains(command, 'Result of Manual command is not displayed');
         }
     });

--- a/tests/e2e/tests/critical-path/workbench/context.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/context.e2e.ts
@@ -2,38 +2,36 @@ import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
 const speed = 0.4;
-let indexName = chance.word({ length: 5 });
+let indexName = common.generateWord(5);
 
 fixture `Workbench Context`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Drop index, documents and database
+    .afterEach(async() => {
+        // Drop index, documents and database
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved input in Editor when navigates away to any other page', async t => {
-        indexName = chance.word({ length: 5 });
-        const command = `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`;
-        //Enter the command in the Workbench editor and navigate to Browser
-        await t.typeText(workbenchPage.queryInput, command, { replace: true, speed: speed});
-        await t.click(myRedisDatabasePage.browserButton);
-        //Return back to Workbench and check input in editor
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect((await workbenchPage.queryInputScriptArea.textContent).replace(/\s/g, ' ')).eql(command, 'Input in Editor is saved');
     });
+test('Verify that user can see saved input in Editor when navigates away to any other page', async t => {
+    indexName = common.generateWord(5);
+    const command = `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`;
+    // Enter the command in the Workbench editor and navigate to Browser
+    await t.typeText(workbenchPage.queryInput, command, { replace: true, speed: speed});
+    await t.click(myRedisDatabasePage.browserButton);
+    // Return back to Workbench and check input in editor
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect((await workbenchPage.queryInputScriptArea.textContent).replace(/\s/g, ' ')).eql(command, 'Input in Editor is saved');
+});

--- a/tests/e2e/tests/critical-path/workbench/cypher.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/cypher.e2e.ts
@@ -8,49 +8,47 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 
 fixture `Cypher syntax at Workbench`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Drop database
+        // Drop database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see popover Editor when clicks on “Use Cypher Syntax” popover in the Editor or “Shift+Space”', async t => {
-        const command = 'GRAPH.QUERY graph';
-        //Type command and put the cursor inside
-        await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
-        await t.pressKey('left');
-        //Open popover editor by clicks on “Use Cypher Syntax”
-        await t.click(workbenchPage.monacoWidget);
-        await t.expect(await workbenchPage.queryInput.nth(1).visible).ok('The user can see opened popover Editor');
-        //Close popover editor and re-open by shortcut
-        await t.pressKey('esc');
-        await t.expect(await workbenchPage.queryInput.nth(1).visible).notOk('The popover Editor is closed');
-        await t.pressKey('shift+space');
-        await t.expect(await workbenchPage.queryInput.nth(1).visible).ok('The user can see opened popover Editor');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that popover Editor is populated with the script that was detected between the quotes or it is blank if quotes were empty', async t => {
-        const command = 'GRAPH.QUERY graph';
-        const script = 'query'
-        //Type command with empty script and open popover
-        await t.typeText(workbenchPage.queryInput, `${command} ""`, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Verify that the Editor is blank
-        await t.expect(workbenchPage.scriptsLines.nth(1).textContent).eql('', 'The user can see blank Editor');
-        //Close popover editor and re-open with added script
-        await t.pressKey('esc');
-        await t.typeText(workbenchPage.queryInput, `${command} "${script}`, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Verify that the Editor is populated with the script
-        await t.expect(workbenchPage.scriptsLines.nth(1).textContent).eql(script, 'The user can see editor populated with the script that was detected between the quotes');
-    });
+test('Verify that user can see popover Editor when clicks on “Use Cypher Syntax” popover in the Editor or “Shift+Space”', async t => {
+    const command = 'GRAPH.QUERY graph';
+
+    // Type command and put the cursor inside
+    await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
+    await t.pressKey('left');
+    // Open popover editor by clicks on “Use Cypher Syntax”
+    await t.click(workbenchPage.monacoWidget);
+    await t.expect(await workbenchPage.queryInput.nth(1).visible).ok('The user can not see opened popover Editor');
+    // Close popover editor and re-open by shortcut
+    await t.pressKey('esc');
+    await t.expect(await workbenchPage.queryInput.nth(1).visible).notOk('The popover Editor is not closed');
+    await t.pressKey('shift+space');
+    await t.expect(await workbenchPage.queryInput.nth(1).visible).ok('The user can not see opened popover Editor');
+});
+test('Verify that popover Editor is populated with the script that was detected between the quotes or it is blank if quotes were empty', async t => {
+    const command = 'GRAPH.QUERY graph';
+    const script = 'query';
+
+    // Type command with empty script and open popover
+    await t.typeText(workbenchPage.queryInput, `${command} ""`, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Verify that the Editor is blank
+    await t.expect(workbenchPage.scriptsLines.nth(1).textContent).eql('', 'The user can not see blank Editor');
+    // Close popover editor and re-open with added script
+    await t.pressKey('esc');
+    await t.typeText(workbenchPage.queryInput, `${command} "${script}`, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Verify that the Editor is populated with the script
+    await t.expect(workbenchPage.scriptsLines.nth(1).textContent).eql(script, 'The user can not see editor populated with the script that was detected between the quotes');
+});

--- a/tests/e2e/tests/critical-path/workbench/default-scripts-area.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/default-scripts-area.e2e.ts
@@ -13,21 +13,21 @@ let indexName = chance.word({ length: 5 });
 let keyName = chance.word({ length: 5 });
 
 fixture `Default scripts area at Workbench`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async t => {
-        //Drop index, documents and database
+        // Drop index, documents and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
 test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can edit and run automatically added "FT._LIST" and "FT.INFO {index}" scripts in Workbench and see the results', async t => {
+    .meta({ env: env.desktop })('Verify that user can edit and run automatically added "FT._LIST" and "FT.INFO {index}" scripts in Workbench and see the results', async t => {
         indexName = chance.word({ length: 5 });
         keyName = chance.word({ length: 5 });
         const commandsForSend = [
@@ -35,27 +35,27 @@ test
             `HMSET product:1 name "${keyName}"`,
             `HMSET product:2 name "${keyName}"`
         ];
-        //Send commands
+        // Send commands
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Run automatically added "FT._LIST" and "FT.INFO {index}" scripts
+        // Run automatically added "FT._LIST" and "FT.INFO {index}" scripts
         await t.click(workbenchPage.documentButtonInQuickGuides);
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
         await t.click(workbenchPage.preselectIndexInformation);
-        //Replace the {index} with indexName value in script and send
+        // Replace the {index} with indexName value in script and send
         let addedScript = await workbenchPage.queryInputScriptArea.nth(2).textContent;
         addedScript = addedScript.replace('"idx:schools"', indexName);
         addedScript = addedScript.replace(/\s/g, ' ');
         await t.click(workbenchPage.submitCommandButton);
         await t.pressKey('ctrl+a delete');
         await workbenchPage.sendCommandInWorkbench(addedScript);
-        //Check the FT._LIST result
-        await t.expect(workbenchPage.queryTextResult.textContent).contains(indexName, 'The result of the FT._LIST command');
-        //Check the FT.INFO result
+        // Check the FT._LIST result
+        await t.expect(workbenchPage.queryTextResult.textContent).contains(indexName, 'The result of the FT._LIST command not found');
+        // Check the FT.INFO result
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryColumns.textContent).contains('name', 'The result of the FT.INFO command');
+        await t.expect(workbenchPage.queryColumns.textContent).contains('name', 'The result of the FT.INFO command not found');
     });
 test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can edit and run automatically added "Search" script in Workbench and see the results', async t => {
+    .meta({ env: env.desktop })('Verify that user can edit and run automatically added "Search" script in Workbench and see the results', async t => {
         indexName = chance.word({ length: 5 });
         keyName = chance.word({ length: 5 });
         const commandsForSend = [
@@ -64,23 +64,23 @@ test
             `HMSET product:2 name "${keyName}"`
         ];
         const searchCommand = `FT.SEARCH ${indexName} "${keyName}"`;
-        //Send commands
+        // Send commands
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Run automatically added FT.SEARCH script with edits
+        // Run automatically added FT.SEARCH script with edits
         await t.click(workbenchPage.documentButtonInQuickGuides);
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
         await t.click(workbenchPage.preselectExactSearch);
         await t.pressKey('ctrl+a delete');
         await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Check the FT.SEARCH result
+        // Check the FT.SEARCH result
         await t.switchToIframe(workbenchPage.iframe);
         const key = workbenchPage.queryTableResult.withText('product:1');
         const name = workbenchPage.queryTableResult.withText(keyName);
-        await t.expect(key.exists).ok('The added key is in the Search result');
-        await t.expect(name.exists).ok('The added key name field is in the Search result');
+        await t.expect(key.exists).ok('The added key is not in the Search result');
+        await t.expect(name.exists).ok('The added key name field is not in the Search result');
     });
 test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can edit and run automatically added "Aggregate" script in Workbench and see the results', async t => {
+    .meta({ env: env.desktop })('Verify that user can edit and run automatically added "Aggregate" script in Workbench and see the results', async t => {
         indexName = chance.word({ length: 5 });
         const aggregationResultField = 'max_price';
         const commandsForSend = [
@@ -89,34 +89,33 @@ test
             'HMSET product:2 price 100'
         ];
         const searchCommand = `FT.Aggregate ${indexName} * GROUPBY 0 REDUCE MAX 1 @price AS ${aggregationResultField}`;
-        //Send commands
+        // Send commands
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'), 0.5);
-        //Run automatically added FT.Aggregate script with edits
+        // Run automatically added FT.Aggregate script with edits
         await t.click(workbenchPage.documentButtonInQuickGuides);
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
         await t.click(workbenchPage.preselectGroupBy);
         await t.pressKey('ctrl+a delete');
         await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Check the FT.Aggregate result
+        // Check the FT.Aggregate result
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryTableResult.textContent).contains(aggregationResultField, 'The aggregation field name is in the Search result');
-        await t.expect(workbenchPage.queryTableResult.textContent).contains('100', 'The aggregation max value is in the Search result');
+        await t.expect(workbenchPage.queryTableResult.textContent).contains(aggregationResultField, 'The aggregation field name is not in the Search result');
+        await t.expect(workbenchPage.queryTableResult.textContent).contains('100', 'The aggregation max value is in not the Search result');
     });
-test
-    .meta({ rte: rte.standalone })('Verify that when the “Manual” option clicked, user can see the Editor is automatically prepopulated with the information', async t => {
-        const information = [
-            '// Workbench is the advanced Redis command-line interface that allows to send commands to Redis, read and visualize the replies sent by the server.',
-            '// Enter multiple commands at different rows to run them at once.',
-            '// Start a new line with an indent (Tab) to specify arguments for any Redis command in multiple line mode.'
-        ];
-        //Click on the Manual option
-        await t.click(workbenchPage.preselectManual);
-        //Resize the scripting area
-        const offsetY = 200;
-        await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.4 });
-        //Check the result
-        const script = await workbenchPage.scriptsLines.textContent;
-        for(const info of information) {
-            await t.expect(script.replace(/\s/g, ' ')).contains(info, 'Result of Manual command is displayed');
-        }
-    });
+test('Verify that when the “Manual” option clicked, user can see the Editor is automatically prepopulated with the information', async t => {
+    const information = [
+        '// Workbench is the advanced Redis command-line interface that allows to send commands to Redis, read and visualize the replies sent by the server.',
+        '// Enter multiple commands at different rows to run them at once.',
+        '// Start a new line with an indent (Tab) to specify arguments for any Redis command in multiple line mode.'
+    ];
+        // Click on the Manual option
+    await t.click(workbenchPage.preselectManual);
+    // Resize the scripting area
+    const offsetY = 200;
+    await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.4 });
+    // Check the result
+    const script = await workbenchPage.scriptsLines.textContent;
+    for(const info of information) {
+        await t.expect(script.replace(/\s/g, ' ')).contains(info, 'Result of Manual command is not displayed');
+    }
+});

--- a/tests/e2e/tests/critical-path/workbench/index-schema.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/index-schema.e2e.ts
@@ -12,7 +12,7 @@ const common = new Common();
 let indexName = common.generateWord(5);
 
 fixture `Index Schema at Workbench`
-    .meta({ type: 'critical_path', env: env.desktop, rte: rte.standalone })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
@@ -25,7 +25,8 @@ fixture `Index Schema at Workbench`
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
-test('Verify that user can open results in Text and Table views for FT.INFO for Hash in Workbench', async t => {
+test
+.meta({ env: env.desktop })('Verify that user can open results in Text and Table views for FT.INFO for Hash in Workbench', async t => {
     indexName = common.generateWord(5);
     const commandsForSend = [
         `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
@@ -46,7 +47,8 @@ test('Verify that user can open results in Text and Table views for FT.INFO for 
     // Check that result is displayed in Text view
     await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
 });
-test('Verify that user can open results in Text and Table views for FT.INFO for JSON in Workbench', async t => {
+test
+.meta({ env: env.desktop })('Verify that user can open results in Text and Table views for FT.INFO for JSON in Workbench', async t => {
     indexName = common.generateWord(5);
     const commandsForSend = [
         `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,

--- a/tests/e2e/tests/critical-path/workbench/index-schema.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/index-schema.e2e.ts
@@ -2,68 +2,68 @@ import { rte, env } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneRedisearch } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
-let indexName = chance.word({ length: 5 });
+let indexName = common.generateWord(5);
 
 fixture `Index Schema at Workbench`
-    .meta({type: 'critical_path'})
+    .meta({ type: 'critical_path', env: env.desktop, rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async t => {
-        //Drop index, documents and database
+        // Drop index, documents and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
-test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can open results in Text and Table views for FT.INFO for Hash in Workbench', async t => {
-        indexName = chance.word({ length: 5 });
-        const commandsForSend = [
-            `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
-            'HMSET product:1 name "Apple Juice"'
-        ];
-        const searchCommand = `FT.INFO ${indexName}`;
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Send search command
-        await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Check that result is displayed in Table view
-        await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
-        //Select Text view type
-        await t.switchToMainWindow();
-        await workbenchPage.selectViewTypeText();
-        //Check that result is displayed in Text view
-        await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
-    });
-test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can open results in Text and Table views for FT.INFO for JSON in Workbench', async t => {
-        indexName = chance.word({ length: 5 });
-        const commandsForSend = [
-            `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
-            `JSON.SET myDoc1 $ '{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}'`
-        ];
-        const searchCommand = `FT.INFO ${indexName}`;
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Send search command
-        await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Check that result is displayed in Table view
-        await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
-        //Select Text view type
-        await t.switchToMainWindow();
-        await workbenchPage.selectViewTypeText();
-        //Check that result is displayed in Text view
-        await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
-    });
+test('Verify that user can open results in Text and Table views for FT.INFO for Hash in Workbench', async t => {
+    indexName = common.generateWord(5);
+    const commandsForSend = [
+        `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
+        'HMSET product:1 name "Apple Juice"'
+    ];
+    const searchCommand = `FT.INFO ${indexName}`;
+
+    // Send commands
+    await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
+    // Send search command
+    await workbenchPage.sendCommandInWorkbench(searchCommand);
+    // Check that result is displayed in Table view
+    await t.switchToIframe(workbenchPage.iframe);
+    await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
+    // Select Text view type
+    await t.switchToMainWindow();
+    await workbenchPage.selectViewTypeText();
+    // Check that result is displayed in Text view
+    await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
+});
+test('Verify that user can open results in Text and Table views for FT.INFO for JSON in Workbench', async t => {
+    indexName = common.generateWord(5);
+    const commandsForSend = [
+        `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
+        'JSON.SET myDoc1 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}\''
+    ];
+    const searchCommand = `FT.INFO ${indexName}`;
+
+    // Send commands
+    await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
+    // Send search command
+    await workbenchPage.sendCommandInWorkbench(searchCommand);
+    // Check that result is displayed in Table view
+    await t.switchToIframe(workbenchPage.iframe);
+    await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
+    // Select Text view type
+    await t.switchToMainWindow();
+    await workbenchPage.selectViewTypeText();
+    // Check that result is displayed in Text view
+    await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
+});

--- a/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
@@ -12,7 +12,7 @@ const common = new Common();
 let indexName = common.generateWord(5);
 
 fixture `JSON verifications at Workbench`
-    .meta({ type: 'critical_path', env: env.desktop, rte: rte.standalone })
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
@@ -25,7 +25,8 @@ fixture `JSON verifications at Workbench`
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
-test('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
+test
+.meta({ env: env.desktop })('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
     indexName = common.generateWord(5);
     const commandsForSend = [
         `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,

--- a/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
@@ -1,49 +1,49 @@
-import { Chance } from 'chance';
 import { env, rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneRedisearch } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
-let indexName = chance.word({ length: 5 });
+let indexName = common.generateWord(5);
 
 fixture `JSON verifications at Workbench`
-    .meta({type: 'critical_path'})
+    .meta({ type: 'critical_path', env: env.desktop, rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async t => {
-        //Drop index, documents and database
+        // Drop index, documents and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
-test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
-        indexName = chance.word({ length: 5 });
-        const commandsForSend = [
-            `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
-            `JSON.SET myDoc1 $ '{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}'`,
-            `JSON.SET myDoc2 $ '{"user":{"name":"John Smith","tag":"foo,bar","hp":500, "dmg":300}}'`
-        ];
-        const searchCommand = `FT.AGGREGATE ${indexName} "*" LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY "@hp-@dmg" AS points`;
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Send search command
-        await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Check that result is displayed in Table view
-        await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
-        //Select Text view type
-        await t.switchToMainWindow();
-        await workbenchPage.selectViewTypeText();
-        //Check that result is displayed in Text view
-        await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
-    });
+test('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
+    indexName = common.generateWord(5);
+    const commandsForSend = [
+        `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
+        'JSON.SET myDoc1 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}\'',
+        'JSON.SET myDoc2 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":500, "dmg":300}}\''
+    ];
+    const searchCommand = `FT.AGGREGATE ${indexName} "*" LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY "@hp-@dmg" AS points`;
+
+    // Send commands
+    await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
+    // Send search command
+    await workbenchPage.sendCommandInWorkbench(searchCommand);
+    // Check that result is displayed in Table view
+    await t.switchToIframe(workbenchPage.iframe);
+    await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
+    // Select Text view type
+    await t.switchToMainWindow();
+    await workbenchPage.selectViewTypeText();
+    // Check that result is displayed in Text view
+    await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
+});

--- a/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/json-workbench.e2e.ts
@@ -26,25 +26,25 @@ fixture `JSON verifications at Workbench`
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
 test
-.meta({ env: env.desktop })('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
-    indexName = common.generateWord(5);
-    const commandsForSend = [
-        `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
-        'JSON.SET myDoc1 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}\'',
-        'JSON.SET myDoc2 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":500, "dmg":300}}\''
-    ];
-    const searchCommand = `FT.AGGREGATE ${indexName} "*" LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY "@hp-@dmg" AS points`;
+    .meta({ env: env.desktop })('Verify that user can see result in Table and Text view for JSON data types for FT.AGGREGATE command in Workbench', async t => {
+        indexName = common.generateWord(5);
+        const commandsForSend = [
+            `FT.CREATE ${indexName} ON JSON SCHEMA $.user.name AS name TEXT $.user.tag AS country TAG`,
+            'JSON.SET myDoc1 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":1000, "dmg":150}}\'',
+            'JSON.SET myDoc2 $ \'{"user":{"name":"John Smith","tag":"foo,bar","hp":500, "dmg":300}}\''
+        ];
+        const searchCommand = `FT.AGGREGATE ${indexName} "*" LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY "@hp-@dmg" AS points`;
 
-    // Send commands
-    await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-    // Send search command
-    await workbenchPage.sendCommandInWorkbench(searchCommand);
-    // Check that result is displayed in Table view
-    await t.switchToIframe(workbenchPage.iframe);
-    await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
-    // Select Text view type
-    await t.switchToMainWindow();
-    await workbenchPage.selectViewTypeText();
-    // Check that result is displayed in Text view
-    await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
-});
+        // Send commands
+        await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
+        // Send search command
+        await workbenchPage.sendCommandInWorkbench(searchCommand);
+        // Check that result is displayed in Table view
+        await t.switchToIframe(workbenchPage.iframe);
+        await t.expect(workbenchPage.queryTableResult.exists).ok('The result is displayed in Table view');
+        // Select Text view type
+        await t.switchToMainWindow();
+        await workbenchPage.selectViewTypeText();
+        // Check that result is displayed in Text view
+        await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
+    });

--- a/tests/e2e/tests/critical-path/workbench/redisearch-module-not-available.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/redisearch-module-not-available.e2e.ts
@@ -10,22 +10,20 @@ const workbenchPage = new WorkbenchPage();
 const commandForSend = 'FT._LIST';
 
 fixture `Redisearch module not available`
-    .meta({type: 'critical_path'})
+    .meta({ type: 'critical_path', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneV5Config, ossStandaloneV5Config.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneV5Config);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the information message that the RediSearch module is not available when he runs any input with "FT." prefix in Workbench', async t => {
-        //Send command with 'FT.'
-        await workbenchPage.sendCommandInWorkbench(commandForSend);
-        //Verify the information message
-        await t.expect(await workbenchPage.queryCardNoModuleOutput.textContent).eql('RediSearch module is not loaded for this database', 'The information message');
     });
+test('Verify that user can see the information message that the RediSearch module is not available when he runs any input with "FT." prefix in Workbench', async t => {
+    // Send command with 'FT.'
+    await workbenchPage.sendCommandInWorkbench(commandForSend);
+    // Verify the information message
+    await t.expect(await workbenchPage.queryCardNoModuleOutput.textContent).eql('RediSearch module is not loaded for this database', 'The information message');
+});

--- a/tests/e2e/tests/critical-path/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/scripting-area.e2e.ts
@@ -1,20 +1,20 @@
-import { Chance } from 'chance';
 import { rte, env } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let indexName = chance.word({ length: 5 });
-let keyName = chance.word({ length: 5 });
+let indexName = common.generateWord(5);
+let keyName = common.generateWord(5);
 
 fixture `Scripting area at Workbench`
-    .meta({type: 'critical_path'})
+    .meta({type: 'critical_path', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
@@ -27,30 +27,28 @@ fixture `Scripting area at Workbench`
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can run any script from CLI in Workbench and see the results', async t => {
-        const commandForSend = 'info';
-        //Send command
-        await workbenchPage.sendCommandInWorkbench(commandForSend);
-        // Check if results exist
-        await t.expect(await workbenchPage.queryCardContainer.exists).ok('Query card was added');
-        const sentCommandText = await workbenchPage.queryCardCommand.withExactText(commandForSend);
-        await t.expect(sentCommandText.exists).ok('Result of sent command exists');
-    });
 // Update after resolving https://redislabs.atlassian.net/browse/RI-3299
+test('Verify that user can resize scripting area in Workbench', async t => {
+    const commandForSend = 'info';
+    const offsetY = 200;
+    const inputHeightStart = await workbenchPage.queryInput.clientHeight;
+    const inputHeightEnd = inputHeightStart + 150;
+
+    await workbenchPage.sendCommandInWorkbench(commandForSend);
+    // Verify that user can run any script from CLI in Workbench and see the results
+    await t.expect(await workbenchPage.queryCardContainer.exists).ok('Query card was added');
+    const sentCommandText = await workbenchPage.queryCardCommand.withExactText(commandForSend);
+    await t.expect(sentCommandText.exists).ok('Result of sent command exists');
+
+    await t.hover(workbenchPage.resizeButtonForScriptingAndResults);
+    await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.01 });
+    // Verify that user can resize scripting area
+    await t.expect(await workbenchPage.queryInput.clientHeight > inputHeightEnd).ok('Scripting area after resize has incorrect size');
+});
 test
-    .meta({ rte: rte.standalone })('Verify that user can resize scripting area in Workbench', async t => {
-        const offsetY = 200;
-        const inputHeightStart = await workbenchPage.queryInput.clientHeight;
-        const inputHeightEnd = inputHeightStart + 150;
-        await t.hover(workbenchPage.resizeButtonForScriptingAndResults);
-        await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY, { speed: 0.01 });
-        await t.expect(await workbenchPage.queryInput.clientHeight > inputHeightEnd).ok('Scripting area after resize has incorrect size');
-    });
-test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user when he have more than 10 results can request to view more results in Workbench', async t => {
-        indexName = chance.word({ length: 5 });
-        keyName = chance.word({ length: 5 });
+    .meta({ env: env.desktop })('Verify that user when he have more than 10 results can request to view more results in Workbench', async t => {
+        indexName = common.generateWord(5);
+        keyName = common.generateWord(5);
         const commandsForSendInCli = [
             `HMSET product:1 name "${keyName}"`,
             `HMSET product:2 name "${keyName}"`,
@@ -85,9 +83,9 @@ test
         await t.expect(workbenchPage.paginationButtonNext.exists).ok('Pagination next button exists');
     });
 test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can see result in Table and Text views for Hash data types for FT.SEARCH command in Workbench', async t => {
-        indexName = chance.word({ length: 5 });
-        keyName = chance.word({ length: 5 });
+    .meta({ env: env.desktop })('Verify that user can see result in Table and Text views for Hash data types for FT.SEARCH command in Workbench', async t => {
+        indexName = common.generateWord(5);
+        keyName = common.generateWord(5);
         const commandsForSend = [
             `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
             `HMSET product:1 name "${keyName}"`,
@@ -107,37 +105,35 @@ test
         //Check that result is displayed in Text view
         await t.expect(workbenchPage.queryTextResult.exists).ok('The result is displayed in Text view');
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can run one command in multiple lines in Workbench page', async t => {
-        indexName = chance.word({ length: 5 });
-        const multipleLinesCommand = [
-            `FT.CREATE ${indexName}`,
-            'ON HASH PREFIX 1 product:',
-            'SCHEMA price NUMERIC SORTABLE'
-        ];
+test('Verify that user can run one command in multiple lines in Workbench page', async t => {
+    indexName = common.generateWord(5);
+    const multipleLinesCommand = [
+        `FT.CREATE ${indexName}`,
+        'ON HASH PREFIX 1 product:',
+        'SCHEMA price NUMERIC SORTABLE'
+    ];
         //Send command in multiple lines
-        await workbenchPage.sendCommandInWorkbench(multipleLinesCommand.join('\n\t'), 0.5);
-        //Check the result
-        const resultCommand = await workbenchPage.queryCardCommand.nth(0).textContent;
-        for(const commandPart of multipleLinesCommand) {
-            await t.expect(resultCommand).contains(commandPart, 'The multiple lines command is in the result');
-        }
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can use one indent to indicate command in several lines in Workbench page', async t => {
-        indexName = chance.word({ length: 5 });
-        const multipleLinesCommand = [
-            `FT.CREATE ${indexName}`,
-            'ON HASH PREFIX 1 product: SCHEMA price NUMERIC SORTABLE'
-        ];
+    await workbenchPage.sendCommandInWorkbench(multipleLinesCommand.join('\n\t'), 0.5);
+    //Check the result
+    const resultCommand = await workbenchPage.queryCardCommand.nth(0).textContent;
+    for(const commandPart of multipleLinesCommand) {
+        await t.expect(resultCommand).contains(commandPart, 'The multiple lines command is in the result');
+    }
+});
+test('Verify that user can use one indent to indicate command in several lines in Workbench page', async t => {
+    indexName = common.generateWord(5);
+    const multipleLinesCommand = [
+        `FT.CREATE ${indexName}`,
+        'ON HASH PREFIX 1 product: SCHEMA price NUMERIC SORTABLE'
+    ];
         //Send command in multiple lines
-        await t.typeText(workbenchPage.queryInput, multipleLinesCommand[0]);
-        await t.pressKey('enter tab');
-        await t.typeText(workbenchPage.queryInput, multipleLinesCommand[1]);
-        await t.click(workbenchPage.submitCommandButton);
-        //Check the result
-        const resultCommand = await workbenchPage.queryCardCommand.nth(0).textContent;
-        for(const commandPart of multipleLinesCommand) {
-            await t.expect(resultCommand).contains(commandPart, 'The multiple lines command is in the result');
-        }
-    });
+    await t.typeText(workbenchPage.queryInput, multipleLinesCommand[0]);
+    await t.pressKey('enter tab');
+    await t.typeText(workbenchPage.queryInput, multipleLinesCommand[1]);
+    await t.click(workbenchPage.submitCommandButton);
+    //Check the result
+    const resultCommand = await workbenchPage.queryCardCommand.nth(0).textContent;
+    for(const commandPart of multipleLinesCommand) {
+        await t.expect(resultCommand).contains(commandPart, 'The multiple lines command is in the result');
+    }
+});


### PR DESCRIPTION
Refactoring of e2e critical-path tests from https://redislabs.atlassian.net/browse/RI-3530
Fixed:
1) Many small tests are merged to save test execution time
2) Comments are reduced to one formatting
3) chance.word() replaced by common.generateWord()
4) Error messages of expects are fixed (previously most of them were incorrect)
5) "rte: rte.standalone" moved from tests meta to fixture meta
6) Different updates for some tests