### PR TITLE
RI-3530 regression tests refactoring

### DIFF
--- a/tests/e2e/pageObjects/browser-page.ts
+++ b/tests/e2e/pageObjects/browser-page.ts
@@ -91,6 +91,7 @@ export class BrowserPage {
     editZsetButton = Selector('[data-testid^=zset-edit-button-]');
     editListButton = Selector('[data-testid^=edit-list-button-]');
     workbenchLinkButton = Selector('[data-test-subj=workbench-page-btn]');
+    cancelStreamGroupBtn = Selector('[data-testid=cancel-stream-groups-btn]');
     //CONTAINERS
     streamGroupsContainer = Selector('[data-testid=stream-groups-container]');
     streamConsumersContainer = Selector('[data-testid=stream-consumers-container]');

--- a/tests/e2e/pageObjects/my-redis-databases-page.ts
+++ b/tests/e2e/pageObjects/my-redis-databases-page.ts
@@ -144,7 +144,7 @@ export class MyRedisDatabasePage {
      * Get all databases from List of DBs page
      */
     async getAllDatabases(): Promise<string[]> {
-        const databases = [];
+        const databases: string[] = [];
         const n = await this.dbNameList.count;
         for(let k = 0; k < n; k++) {
             const name = await this.dbNameList.nth(k).textContent;

--- a/tests/e2e/tests/regression/browser/add-keys.e2e.ts
+++ b/tests/e2e/tests/regression/browser/add-keys.e2e.ts
@@ -30,15 +30,15 @@ test('Verify that user can create different types(string, number, null, array, b
         await browserPage.addJsonKey(jsonKeys[i][0], jsonKeys[i][1]);
         await t.click(browserPage.toastCloseButton);
         await t.click(browserPage.refreshKeysButton);
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(jsonKeys[i][0])).ok('New keys is displayed');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(jsonKeys[i][0])).ok('New keys are not displayed');
         // Add additional check for array elements
         if (jsonKeys[i][0].includes('array')) {
             for (const j of JSON.parse(jsonKeys[i][1])) {
-                await t.expect(browserPage.jsonScalarValue.withText(j.toString()).exists).ok('JSON value');
+                await t.expect(browserPage.jsonScalarValue.withText(j.toString()).exists).ok('JSON value not correct');
             }
         }
         else {
-            await t.expect(browserPage.jsonKeyValue.withText(jsonKeys[i][1]).exists).ok('JSON value');
+            await t.expect(browserPage.jsonKeyValue.withText(jsonKeys[i][1]).exists).ok('JSON value not correct');
         }
     }
 });

--- a/tests/e2e/tests/regression/browser/context.e2e.ts
+++ b/tests/e2e/tests/regression/browser/context.e2e.ts
@@ -6,68 +6,62 @@ import {
 } from '../../../pageObjects';
 import { rte } from '../../../helpers/constants';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
 const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Browser Context`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that if user has saved context on Browser page and go to Settings page, Browser and Workbench icons are displayed and user is able to open Browser with saved context', async t => {
-        keyName = chance.word({ length: 10 });
-        const command = 'HSET';
-        //Create context modificaions and navigate to Settings
-        await browserPage.addStringKey(keyName);
-        await browserPage.openKeyDetails(keyName);
-        await t.click(cliPage.cliExpandButton);
-        await t.typeText(cliPage.cliCommandInput, command);
-        await t.pressKey('enter');
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Verify that Browser and Workbench icons are displayed
-        await t.expect(await myRedisDatabasePage.browserButton.visible).ok('Browser icon is displayed');
-        await t.expect(await myRedisDatabasePage.workbenchButton.visible).ok('Workbench icon is displayed');
-        //Open Browser page and verify context
-        await t.click(myRedisDatabasePage.browserButton);
-        await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is still applied');
-        await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('The key details is selected');
-        await t.expect(await cliPage.cliCommandExecuted.withExactText(command).exists).ok(`Executed command '${command}' in CLI is saved`);
-        await t.click(cliPage.cliCollapseButton);
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user reload the window with saved context(on any page), context is not saved when he returns back to Browser page', async t => {
-        keyName = chance.word({ length: 10 });
-        //Create context modificaions and navigate to Workbench
-        await browserPage.addStringKey(keyName);
-        await browserPage.openKeyDetails(keyName);
-        await t.click(myRedisDatabasePage.workbenchButton);
-        //Open Browser page and verify context
-        await t.click(myRedisDatabasePage.browserButton);
-        await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is still applied');
-        await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('The key details is selected');
-        //Navigate to Workbench and reload the window
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await common.reloadPage();
-        //Return back to Browser and check context is not saved
-        await t.click(myRedisDatabasePage.browserButton);
-        await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).notOk('Filter per key name is not applied');
-        await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('The key details is not selected');
-    });
+test('Verify that if user has saved context on Browser page and go to Settings page, Browser and Workbench icons are displayed and user is able to open Browser with saved context', async t => {
+    keyName = common.generateWord(10);
+    const command = 'HSET';
+    // Create context modificaions and navigate to Settings
+    await browserPage.addStringKey(keyName);
+    await browserPage.openKeyDetails(keyName);
+    await t.click(cliPage.cliExpandButton);
+    await t.typeText(cliPage.cliCommandInput, command);
+    await t.pressKey('enter');
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Verify that Browser and Workbench icons are displayed
+    await t.expect(await myRedisDatabasePage.browserButton.visible).ok('Browser icon is not displayed');
+    await t.expect(await myRedisDatabasePage.workbenchButton.visible).ok('Workbench icon is not displayed');
+    // Open Browser page and verify context
+    await t.click(myRedisDatabasePage.browserButton);
+    await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is not applied');
+    await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('The key details is not selected');
+    await t.expect(await cliPage.cliCommandExecuted.withExactText(command).exists).ok(`Executed command '${command}' in CLI is not saved`);
+    await t.click(cliPage.cliCollapseButton);
+});
+test('Verify that when user reload the window with saved context(on any page), context is not saved when he returns back to Browser page', async t => {
+    keyName = common.generateWord(10);
+    // Create context modificaions and navigate to Workbench
+    await browserPage.addStringKey(keyName);
+    await browserPage.openKeyDetails(keyName);
+    await t.click(myRedisDatabasePage.workbenchButton);
+    // Open Browser page and verify context
+    await t.click(myRedisDatabasePage.browserButton);
+    await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).ok('Filter per key name is not applied');
+    await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('The key details is not selected');
+    // Navigate to Workbench and reload the window
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await common.reloadPage();
+    // Return back to Browser and check context is not saved
+    await t.click(myRedisDatabasePage.browserButton);
+    await t.expect(await browserPage.filterByPatterSearchInput.withAttribute('value', keyName).exists).notOk('Filter per key name is applied');
+    await t.expect(await browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('The key details is selected');
+});

--- a/tests/e2e/tests/regression/browser/database-info.e2e.ts
+++ b/tests/e2e/tests/regression/browser/database-info.e2e.ts
@@ -13,29 +13,28 @@ const workbenchPage = new WorkbenchPage();
 const browserPage = new BrowserPage();
 
 fixture `Database info tooltips`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see an (i) icon next to the database name on Browser and Workbench pages', async t => {
-        await t.expect(browserPage.databaseInfoIcon.visible).ok('User can see (i) icon on Browser page', { timeout: 10000 });
-        //Move to the Workbench page and check icon
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(workbenchPage.overviewTotalMemory.visible).ok('User can see (i) icon on Workbench page', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see DB name, endpoint, connection type, Redis version, user name in tooltip when hover over the (i) icon', async t => {
-        const version = /[0-9].[0-9].[0-9]/;
-        await t.hover(browserPage.databaseInfoIcon);
-        await t.expect(browserPage.databaseInfoToolTip.textContent).contains(ossStandaloneConfig.databaseName, 'User can see database name in tooltip');
-        await t.expect(browserPage.databaseInfoToolTip.textContent).contains(`${ossStandaloneConfig.host}:${ossStandaloneConfig.port}`, 'User can see endpoint in tooltip');
-        await t.expect(browserPage.databaseInfoToolTip.textContent).contains('Standalone', 'User can see connection type in tooltip');
-        await t.expect(browserPage.databaseInfoToolTip.textContent).match(version, 'User can see Redis version in tooltip');
-        await t.expect(browserPage.databaseInfoToolTip.textContent).contains('Default', 'User can see user name in tooltip');
-    });
+test('Verify that user can see DB name, endpoint, connection type, Redis version, user name in tooltip when hover over the (i) icon', async t => {
+    const version = /[0-9].[0-9].[0-9]/;
+
+    await t.hover(browserPage.databaseInfoIcon);
+    await t.expect(browserPage.databaseInfoToolTip.textContent).contains(ossStandaloneConfig.databaseName, 'User can see database name in tooltip');
+    await t.expect(browserPage.databaseInfoToolTip.textContent).contains(`${ossStandaloneConfig.host}:${ossStandaloneConfig.port}`, 'User can see endpoint in tooltip');
+    await t.expect(browserPage.databaseInfoToolTip.textContent).contains('Standalone', 'User can not see connection type in tooltip');
+    await t.expect(browserPage.databaseInfoToolTip.textContent).match(version, 'User can not see Redis version in tooltip');
+    await t.expect(browserPage.databaseInfoToolTip.textContent).contains('Default', 'User can not see user name in tooltip');
+
+    // Verify that user can see an (i) icon next to the database name on Browser and Workbench pages
+    await t.expect(browserPage.databaseInfoIcon.visible).ok('User can not see (i) icon on Browser page', { timeout: 10000 });
+    // Move to the Workbench page and check icon
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(workbenchPage.overviewTotalMemory.visible).ok('User can not see (i) icon on Workbench page', { timeout: 10000 });
+});

--- a/tests/e2e/tests/regression/browser/database-overview-keys.e2e.ts
+++ b/tests/e2e/tests/regression/browser/database-overview-keys.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { t } from 'testcafe';
 import { acceptLicenseTermsAndAddDatabase, acceptLicenseTermsAndAddRECloudDatabase, deleteDatabase } from '../../../helpers/database';
 import {
@@ -19,10 +18,9 @@ const cliPage = new CliPage();
 const common = new Common();
 const browserPage = new BrowserPage();
 const addRedisDatabasePage = new AddRedisDatabasePage();
-const chance = new Chance();
 
 let keys: string[];
-const keyName = chance.word({ length: 10 });
+const keyName = common.generateWord(10);
 const keysAmount = 5;
 const index = '1';
 const verifyTooltipContainsText = async(text: string, contains: boolean): Promise<void> => {
@@ -35,7 +33,7 @@ fixture `Database overview`
     .meta({ type: 'regression' })
     .page(commonUrl)
     .beforeEach(async t => {
-        //Create databases and keys
+        // Create databases and keys
         await acceptLicenseTermsAndAddDatabase(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         await browserPage.addStringKey(keyName);
         await t.click(myRedisDatabasePage.myRedisDBButton);
@@ -45,7 +43,7 @@ fixture `Database overview`
         await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
     })
     .afterEach(async t => {
-        //Clear and delete databases
+        // Clear and delete databases
         await t.click(myRedisDatabasePage.myRedisDBButton);
         await myRedisDatabasePage.clickOnDBByName(`${ossStandaloneConfig.databaseName} [${index}]`);
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
@@ -56,21 +54,19 @@ fixture `Database overview`
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can see total and current logical database number of keys (if there are any keys in other logical DBs)', async t => {
-        //Wait for Total Keys number refreshed
+        // Wait for Total Keys number refreshed
         await t.expect(browserPage.overviewTotalKeys.withText(`${keysAmount + 1}`).exists).ok('Total keys are not changed', { timeout: 10000 });
         await t.hover(workbenchPage.overviewTotalKeys);
-        //Verify that user can see total number of keys and number of keys in current logical database
+        // Verify that user can see total number of keys and number of keys in current logical database
         await t.expect(browserPage.tooltip.visible).ok('Total keys tooltip not displayed');
         await verifyTooltipContainsText(`${keysAmount + 1}Total Keys`, true);
         await verifyTooltipContainsText(`db1:${keysAmount}Keys`, true);
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see total number of keys and not it current logical database (if there are no any keys in other logical DBs)', async t => {
-        //Open Database
+
+        // Open Database
         await t.click(myRedisDatabasePage.myRedisDBButton);
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
         await t.hover(workbenchPage.overviewTotalKeys);
-        //Verify that user can see only total number of keys
+        // Verify that user can see total number of keys and not it current logical database (if there are no any keys in other logical DBs)
         await t.expect(browserPage.tooltip.visible).ok('Total keys tooltip not displayed');
         await verifyTooltipContainsText(`${keysAmount + 1}Total Keys`, true);
         await verifyTooltipContainsText('db1', false);
@@ -81,11 +77,11 @@ test
         await acceptLicenseTermsAndAddRECloudDatabase(cloudDatabaseConfig);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(cloudDatabaseConfig.databaseName);
     })('Verify that when users hover over keys icon in Overview for Cloud DB, they see only total number of keys in tooltip', async t => {
         await t.hover(workbenchPage.overviewTotalKeys);
-        //Verify that user can see only total number of keys
+        // Verify that user can see only total number of keys
         await t.expect(browserPage.tooltip.visible).ok('Total keys tooltip not displayed');
         await verifyTooltipContainsText('Total Keys', true);
         await verifyTooltipContainsText('db1', false);

--- a/tests/e2e/tests/regression/browser/database-overview.e2e.ts
+++ b/tests/e2e/tests/regression/browser/database-overview.e2e.ts
@@ -19,35 +19,27 @@ const browserPage = new BrowserPage();
 let keys: string[];
 
 fixture `Database overview`
-    .meta({type: 'regression'})
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see total memory and total number of keys updated in DB header in Workbench page', async t => {
-        //Create new keys
-        keys = await common.createArrayWithKeyValue(10);
-        await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
-        //Open Workbench
-        await t.click(myRedisDatabasePage.workbenchButton);
-        //Verify that user can see total memory and total number of keys
-        await t.expect(workbenchPage.overviewTotalKeys.exists).ok('User can see total keys');
-        await t.expect(workbenchPage.overviewTotalMemory.exists).ok('User can see total memory');
-    });
-test
-    .meta({ rte: rte.standalone })
-    .after(async() => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that user can connect to DB and see breadcrumbs at the top of the application', async t => {
-        //Verify that user can see breadcrumbs in Browser and Workbench views
-        await t.expect(browserPage.breadcrumbsContainer.visible).ok('User can see breadcrumbs in Browser page', { timeout: 10000 });
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(browserPage.breadcrumbsContainer.visible).ok('User can see breadcrumbs in Workbench page', { timeout: 10000 });
-    });
+test('Verify that user can connect to DB and see breadcrumbs at the top of the application', async t => {
+    // Create new keys
+    keys = await common.createArrayWithKeyValue(10);
+    await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
+
+    // Verify that user can see breadcrumbs in Browser and Workbench views
+    await t.expect(browserPage.breadcrumbsContainer.visible).ok('User can not see breadcrumbs in Browser page', { timeout: 10000 });
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(browserPage.breadcrumbsContainer.visible).ok('User can not see breadcrumbs in Workbench page', { timeout: 10000 });
+
+    // Verify that user can see total memory and total number of keys updated in DB header in Workbench page
+    await t.expect(workbenchPage.overviewTotalKeys.exists).ok('User can not see total keys');
+    await t.expect(workbenchPage.overviewTotalMemory.exists).ok('User can not see total memory');
+});

--- a/tests/e2e/tests/regression/browser/filtering-iteratively.e2e.ts
+++ b/tests/e2e/tests/regression/browser/filtering-iteratively.e2e.ts
@@ -18,33 +18,33 @@ fixture `Filtering iteratively in Browser page`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can see search results per 500 keys if number of results is 500', async t => {
-        //Create new keys
+        // Create new keys
         keys = await common.createArrayWithKeyValue(500);
         await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
-        //Search all keys
+        // Search all keys
         await browserPage.searchByKeyName('*');
         const keysNumberOfResults = await browserPage.keysNumberOfResults.textContent;
-        //Verify that number of results is 500
-        await t.expect(keysNumberOfResults).contains('500', 'Number of results is 500');
+        // Verify that number of results is 500
+        await t.expect(keysNumberOfResults).contains('500', 'Number of results is not 500');
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can search iteratively via Scan more for search pattern and selected data type', async t => {
-        //Create new keys
+        // Create new keys
         keys = await common.createArrayWithKeyValue(1000);
         await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
-        //Search all string keys
+        // Search all string keys
         await browserPage.selectFilterGroupType(KeyTypesTexts.String);
         await browserPage.searchByKeyName('*');
-        //Verify that scan more button is shown
+        // Verify that scan more button is shown
         await t.expect(browserPage.scanMoreButton.exists).ok('Scan more is not shown');
         await t.click(browserPage.scanMoreButton);
-        //Verify that number of results is 1000
+        // Verify that number of results is 1000
         const keysNumberOfResults = await browserPage.keysNumberOfResults.textContent;
         await t.expect(keysNumberOfResults).contains('1 000', 'Number of results is not 1 000');
     });
@@ -54,21 +54,21 @@ test
         await acceptLicenseTermsAndAddOSSClusterDatabase(ossClusterConfig, ossClusterConfig.ossClusterDatabaseName);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keys.join(' ')}`);
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })('Verify that user can search via Scan more for search pattern and selected data type in OSS Cluster DB', async t => {
-        //Create new keys
+        // Create new keys
         keys = await common.createArrayWithKeyValueForOSSCluster(1000);
         await cliPage.sendCommandInCli(`MSET ${keys.join(' ')}`);
-        //Search all string keys
+        // Search all string keys
         await browserPage.selectFilterGroupType(KeyTypesTexts.String);
         await browserPage.searchByKeyName('*');
-        //Verify that scan more button is shown
+        // Verify that scan more button is shown
         await t.expect(browserPage.scanMoreButton.exists).ok('Scan more is not shown');
         await t.click(browserPage.scanMoreButton);
         const regExp = new RegExp('1 0' + '.');
-        //Verify that number of results is 1000
+        // Verify that number of results is 1000
         const scannedValueText = await browserPage.scannedValue.textContent;
         await t.expect(scannedValueText).match(regExp, 'Number of results is not 1 000');
     });
@@ -79,16 +79,16 @@ test
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     })('Verify that user use Scan More in DB with 10-50 millions of keys (when search by pattern/)', async t => {
-        //Search all string keys
+        // Search all string keys
         await browserPage.searchByKeyName('*');
-        //Verify that scan more button is shown
+        // Verify that scan more button is shown
         await t.expect(browserPage.scanMoreButton.exists).ok('Scan more is not shown');
         await t.click(browserPage.scanMoreButton);
         const regExp = new RegExp('1 0' + '.');
-        //Verify that number of results is 1000
+        // Verify that number of results is 1000
         const scannedValueText = await browserPage.scannedValue.textContent;
         await t.expect(scannedValueText).match(regExp, 'Number of results is not 1 000');
     });

--- a/tests/e2e/tests/regression/browser/filtering.e2e.ts
+++ b/tests/e2e/tests/regression/browser/filtering.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { Selector } from 'testcafe';
 import { KeyTypesTexts, rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
@@ -6,12 +5,13 @@ import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig, ossStandaloneBigConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { keyTypes } from '../../../helpers/keys';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 20 });
-let keyName2 = chance.word({ length: 20 });
+let keyName = common.generateWord(20);
+let keyName2 = common.generateWord(20);
 const COMMAND_GROUP_SET = 'Set';
 
 fixture `Filtering per key name in Browser page`
@@ -21,157 +21,115 @@ fixture `Filtering per key name in Browser page`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that when user searches not existed key, he can see the standard screen when there are no keys found', async t => {
-    keyName = chance.word({ length: 20 });
-    //Add new key
-    await browserPage.addStringKey(keyName);
-    //Search not existed key
+    keyName = `KeyForSearch*${common.generateWord(10)}?[]789`;
     const searchedKeyName = 'key00000qwertyuiop[asdfghjkl';
+    const searchedValue = 'KeyForSear*';
+
+    // Add new key
+    await browserPage.addStringKey(keyName);
+    // Search not existed key
     await browserPage.searchByKeyName(searchedKeyName);
-    //Verify the standard screen when there are no keys found
+    // Verify the standard screen when there are no keys found
     const noResultsFound = await browserPage.noResultsFound.textContent;
     const searchAdvices = await browserPage.searchAdvices.textContent;
-    await t.expect(noResultsFound).eql('No results found.', 'The no results text');
-    await t.expect(searchAdvices).eql('Check the spelling.Check upper and lower cases.Use an asterisk (*) in your request for more generic results.', 'The advices text');
-});
-test('Verify that user can filter per pattern with * (matches keys with any number of characters instead of *)', async t => {
-    keyName = `KeyForSearch*${chance.word({ length: 10 })}?[]789`;
-    //Add new key
-    await browserPage.addStringKey(keyName);
-    //Filter per pattern with *
-    const searchedValue = 'KeyForSear*';
+    await t.expect(noResultsFound).eql('No results found.', 'The no results text not displayed');
+    await t.expect(searchAdvices).eql('Check the spelling.Check upper and lower cases.Use an asterisk (*) in your request for more generic results.', 'The advices text not displayed');
+
+    // Filter per pattern with *
     await browserPage.searchByKeyName(searchedValue);
-    //Verify that key was found
-    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
+    // Verify that user can filter per pattern with * (matches keys with any number of characters instead of *)
+    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
 });
 test('Verify that user can filter per pattern with ? (matches keys with any character (only one) instead of ?)', async t => {
-    const randomValue = chance.word({ length: 10 });
-    keyName = `KeyForSearch*?[]789${randomValue}`;
-    //Add new key
-    await browserPage.addStringKey(keyName);
-    //Filter per pattern with ?
+    const randomValue = common.generateWord(10);
     const searchedValue = `?eyForSearch\\*\\?\\[]789${randomValue}`;
+    keyName = `KeyForSearch*?[]789${randomValue}`;
+
+    // Add new key
+    await browserPage.addStringKey(keyName);
+    // Filter per pattern with ?
     await browserPage.searchByKeyName(searchedValue);
-    //Verify that key was found
-    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
+    // Verify that key was found
+    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
 });
 test
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await browserPage.deleteKeyByName(keyName2);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that user can filter per pattern with [xy] (matches one symbol: either x or y))', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        keyName2 = `KeyForFearch${chance.word({ length: 10 })}`;
-        //Add keys
+        keyName = `KeyForSearch${common.generateWord(10)}`;
+        keyName2 = `KeyForFearch${common.generateWord(10)}`;
+        const searchedValue1 = 'KeyFor[SF]*';
+        const searchedValue2 = 'KeyFor[^F]*';
+        const searchedValue3 = 'KeyFor[A-G]*';
+
+        // Add keys
         await browserPage.addStringKey(keyName);
         await browserPage.addHashKey(keyName2);
-        //Filter per pattern with [XY]
-        const searchedValue = 'KeyFor[SF]*';
-        await browserPage.searchByKeyName(searchedValue);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).ok('The key was found');
+        // Filter per pattern with [XY]
+        await browserPage.searchByKeyName(searchedValue1);
+        // Verify that key was found with filter per pattern with [xy]
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).ok('The key was not found');
+
+        await browserPage.searchByKeyName(searchedValue2);
+        // Verify that user can filter per pattern with [^x] (matches one symbol except x)
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).notOk('The wrong key found');
+
+        await browserPage.searchByKeyName(searchedValue3);
+        // Verify that user can filter per pattern with [a-z] (matches any symbol in range from A till Z)
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).ok('The key was not found');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).notOk('The wrong key found');
     });
 test
     .after(async() => {
-        //Clear and delete database
-        await browserPage.deleteKeyByName(keyName);
-        await browserPage.deleteKeyByName(keyName2);
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that user can filter per pattern with [^x] (matches one symbol except x)', async t => {
-        const randomValue = chance.word({ length: 5 });
-        keyName = `KeyForSearch${randomValue}`;
-        keyName2 = `KeyForFearch${randomValue}`;
-        //Add keys
-        await browserPage.addStringKey(keyName);
-        await browserPage.addHashKey(keyName2);
-        //Filter per pattern with [^x]
-        const searchedValue = 'KeyFor[^F]*';
-        await browserPage.searchByKeyName(searchedValue);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).notOk('The key wasn\'t found');
-    });
-test
-    .after(async() => {
-        //Clear and delete database
-        await browserPage.deleteKeyByName(keyName);
-        await browserPage.deleteKeyByName(keyName2);
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that user can filter per pattern with [a-z] (matches any symbol in range from A till Z)', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        keyName2 = `KeyForFearch${chance.word({ length: 10 })}`;
-        //Add keys
-        await browserPage.addStringKey(keyName);
-        await browserPage.addHashKey(keyName2);
-        //Filter per pattern with [a-z]
-        const searchedValue = 'KeyFor[A-G]*';
-        await browserPage.searchByKeyName(searchedValue);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).ok('The key was found');
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).notOk('The key wasn\'t found');
-    });
-test
-    .after(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that when user clicks on “clear” control with no filter per key name applied all characters and filter per key type are removed, “clear” control is disappeared', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        //Set filter by key type and type characters
-        await t.typeText(browserPage.filterByPatterSearchInput, keyName);
-        await browserPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Verify the clear control
-        await t.click(browserPage.clearFilterButton);
-        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is removed');
-        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'All characters from filter input are removed');
-        await t.expect(browserPage.clearFilterButton.visible).notOk('The clear control is disappeared');
-    });
-test
-    .after(async() => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that when user clicks on “clear” control and filter per key name is applied all characters and filter per key type are removed, “clear” control is disappeared', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        //Set filter by key type and filter per key name
+        keyName = `KeyForSearch${common.generateWord(10)}`;
+
+        // Set filter by key type and filter per key name
         await browserPage.searchByKeyName(keyName);
         await browserPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Verify the clear control
+        // Verify that when user clicks on “clear” control and filter per key name is applied all characters and filter per key type are removed, “clear” control is disappeared
         await t.click(browserPage.clearFilterButton);
-        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is removed');
-        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'All characters from filter input are removed');
-        await t.expect(browserPage.clearFilterButton.visible).notOk('The clear control is disappeared');
-    });
-test('Verify that when user clicks on “clear” control and filter per key name is applied filter is reset and rescan initiated', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 50 })}`;
-        //Add keys
+        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is not removed');
+        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'All characters from filter input are not removed');
+        await t.expect(browserPage.clearFilterButton.visible).notOk('The clear control is not disappeared');
+
         await browserPage.addStringKey(keyName);
-        //Search for not existed key name
+        // Search for not existed key name
         await browserPage.searchByKeyName(keyName2);
-        await t.expect(browserPage.keyListTable.textContent).contains('No results found.', 'Key is not found');
-        //Verify the clear control
+        await t.expect(browserPage.keyListTable.textContent).contains('No results found.', 'Key is not found message not displayed');
+        // Verify that when user clicks on “clear” control and filter per key name is applied filter is reset and rescan initiated
         await t.click(browserPage.clearFilterButton);
-        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'The filtering is reset');
-        await t.expect(browserPage.noResultsFound.exists).notOk('No results found message is hidden');
-    });
-test
-    .after(async() => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })('Verify that when user clicks "Clear selection button" in Dropdown with key data types selected data type is reseted', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        //Set filter by key type and type characters
+        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'The filtering is not reset');
+        await t.expect(browserPage.noResultsFound.exists).notOk('No results found message is not hidden');
+
+        // Set filter by key type and type characters
         await t.typeText(browserPage.filterByPatterSearchInput, keyName);
         await browserPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        //Verify the Clear selection button
+        // Verify the clear control with no filter per key name
+        await t.click(browserPage.clearFilterButton);
+        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is not removed');
+        await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql('', 'All characters from filter input are not removed');
+        await t.expect(browserPage.clearFilterButton.visible).notOk('The clear control is not disappeared');
+
+        // Set filter by key type and type characters
+        await t.typeText(browserPage.filterByPatterSearchInput, keyName);
+        await browserPage.selectFilterGroupType(COMMAND_GROUP_SET);
+        // Verify that when user clicks "Clear selection button" in Dropdown with key data types selected data type is reseted
         await t.click(browserPage.filterOptionTypeSelected.nth(1));
         await t.click(browserPage.clearSelectionButton);
-        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is removed');
+        await t.expect(browserPage.multiSearchArea.find(browserPage.cssFilteringLabel).visible).notOk('The filter per key type is not removed');
         await t.expect(browserPage.filterByPatterSearchInput.getAttribute('value')).eql(keyName, 'All characters from filter input are not removed');
     });
 test
@@ -185,17 +143,17 @@ test
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     })('Verify that user can filter per exact key without using any patterns in DB with 10 millions of keys', async t => {
         // Create new key
-        keyName = `KeyForSearch-${chance.word({ length: 10 })}`;
+        keyName = `KeyForSearch-${common.generateWord(10)}`;
         await browserPage.addSetKey(keyName);
         // Search by key name
         await browserPage.searchByKeyName(keyName);
         // Verify that required key is displayed
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Found key');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Key not found');
         // Switch to tree view
         await t.click(browserPage.treeViewButton);
         // Check searched key in tree view
         await t.click(browserPage.treeViewNotPatternedKeys);
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Found key');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Key not found');
     });
 test
     .before(async() => {
@@ -215,18 +173,12 @@ test
                 .expect(browserPage.keyNameInTheList.nth(i).textContent).contains('set', 'Keys filtered incorrectly by key type');
         }
         await t.click(browserPage.treeViewButton);
-        //Verify that user can use the "Scan More" button to search per another 10000 keys
+        // Verify that user can use the "Scan More" button to search per another 10000 keys
         await browserPage.verifyScannningMore();
-    });
-test
-    .before(async() => {
-        // Add Big standalone DB
-        await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
-    })
-    .after(async() => {
-        // Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
-    })('Verify that user can filter per key type in DB with 10-50 millions of keys', async t => {
+
+        // Verify that user can filter per key type in DB with 10-50 millions of keys
+        await t.click(browserPage.browserViewButton);
+        await t.click(browserPage.clearFilterButton);
         for (let i = 0; i < keyTypes.length - 2; i++) {
             await browserPage.selectFilterGroupType(keyTypes[i].textType);
             const filteredTypeKeys = keyTypes[i].keyName === 'json'

--- a/tests/e2e/tests/regression/browser/format-switcher.e2e.ts
+++ b/tests/e2e/tests/regression/browser/format-switcher.e2e.ts
@@ -68,16 +68,16 @@ test
         // Verify that formatters selection is saved when user switches between databases
         await t.expect(browserPage.formatSwitcher.withExactText('JSON').visible).ok('Formatter value is not saved');
     });
-test('Verify that user don`t see format switcher for JSON, GRAPH, TS keys', async t => {
+test('Verify that user can see switcher icon for narrow screen and tooltip by hovering', async t => {
     // Create array with JSON, GRAPH, TS keys
     const keysWithoutSwitcher = [keysData[5], keysData[7], keysData[8]];
+
     for (let i = 0; i < keysWithoutSwitcher.length; i++) {
         await browserPage.openKeyDetailsByKeyName(keysWithoutSwitcher[i].keyName);
-        // Verify that format switcher is not displayed
+        // Verify that user don`t see format switcher for JSON, GRAPH, TS keys
         await t.expect(browserPage.formatSwitcher.visible).notOk(`Formatter is displayed for ${keysWithoutSwitcher[i].textType} type`, { timeout: 1000 });
     }
-});
-test('Verify that user can see switcher icon for narrow screen and tooltip by hovering', async t => {
+
     await browserPage.openKeyDetails(keysData[0].keyName);
     await browserPage.selectFormatter('JSON');
     // Verify icon is not displayed with high screen resolution

--- a/tests/e2e/tests/regression/browser/formatter-warning.e2e.ts
+++ b/tests/e2e/tests/regression/browser/formatter-warning.e2e.ts
@@ -1,18 +1,18 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
 const jsonInvalidStructure = '"{\"test\": 123"';
 const title = 'Value will be saved as Unicode';
 const reason = 'as it is not valid in the selected format.';
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Warning for invalid formatter value`
     .meta({
@@ -50,7 +50,7 @@ test('Verify that user can see warning message when editing value', async t => {
         .expect(browserPage.stringValueAsJson.exists).ok('Value is not converted to JSON object');
 });
 test('Verify that user can remove invalid format value warning the message by clicking on ESC button', async t => {
-    keyName = chance.word({ length: 10 });
+    keyName = common.generateWord(10);
     const keyValue = 'a:1:{s:8:"glossary";a:2:{s:5:"title";s:7:"example";s:8:"GlossDiv";a:2:{s:5:"title";s:1:"S";s:9:"GlossList";a:1:{s:10:"GlossEntry";a:3:{s:2:"ID";s:4:"SGML";s:8:"GlossDef";a:2:{s:4:"para";s:8:"language";s:12:"GlossSeeAlso";a:1:{i:0;s:3:"XML";}}s:8:"GlossSee";s:6:"markup";}}}}}';
     await browserPage.addHashKey(keyName, '5000', 'PHP Serialized', keyValue);
     await browserPage.selectFormatter('PHP serialized');

--- a/tests/e2e/tests/regression/browser/full-screen.e2e.ts
+++ b/tests/e2e/tests/regression/browser/full-screen.e2e.ts
@@ -1,24 +1,24 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { rte } from '../../../helpers/constants';
 import {commonUrl, ossStandaloneConfig} from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-const keyName = chance.word({ length: 20 });
-const keyValue = chance.word({ length: 20 });
+const keyName = common.generateWord(20);
+const keyValue = common.generateWord(20);
 
 fixture `Full Screen`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test
@@ -30,35 +30,33 @@ test
     .after(async() => {
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    .meta({ rte: rte.standalone })('Verify that user can switch to full screen from key details in Browser', async t => {
+    })('Verify that user can switch to full screen from key details in Browser', async t => {
         // Save tables size before switching to full screen mode
         const widthBeforeFullScreen = await browserPage.keyDetailsTable.clientWidth;
         // Switch to full screen mode
         await t.click(browserPage.fullScreenModeButton);
         // Compare size of details table after switching
         const widthAfterFullScreen = await browserPage.keyDetailsTable.clientWidth;
-        await t.expect(widthAfterFullScreen).gt(widthBeforeFullScreen, 'Width after switching to full screen');
-        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('Key Details Table');
-        await t.expect(browserPage.stringKeyValueInput.withExactText(keyValue).exists).ok('Key Value in Details');
+        await t.expect(widthAfterFullScreen).gt(widthBeforeFullScreen, 'Width after switching to full screen not greater then before');
+        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('Key Details Table not displayed');
+        await t.expect(browserPage.stringKeyValueInput.withExactText(keyValue).exists).ok('Key Value in Details not displayed');
         // Verify that user can exit full screen in key details and two tables with keys and key details are displayed
         await t.click(browserPage.fullScreenModeButton);
         const widthAfterExitFullScreen = await browserPage.keyDetailsTable.clientWidth;
-        await t.expect(widthAfterExitFullScreen).lt(widthAfterFullScreen, 'Width after switching from full screen');
+        await t.expect(widthAfterExitFullScreen).lt(widthAfterFullScreen, 'Width after switching from full screen not less then before');
     });
-test
-    .meta({ rte: rte.standalone })('Verify that when no keys are selected user can click on "Close" control for right table and see key list in full screen', async t => {
-        // Verify that user sees two panels(key list and empty details panel) opening Browser page for the first time
-        await t.expect(browserPage.noKeysToDisplayText.visible).ok('No keys selected panel');
-        // Save key table size before switching to full screen
-        const widthKeysBeforeFullScreen = await browserPage.keyListTable.clientWidth;
-        // Close right panel with key details
-        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('Key Details Table');
-        await t.click(browserPage.closeRightPanel);
-        // Check that table is in full screen
-        const widthTableAfterFullScreen = await browserPage.keyListTable.clientWidth;
-        await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen');
-    });
+test('Verify that when no keys are selected user can click on "Close" control for right table and see key list in full screen', async t => {
+    // Verify that user sees two panels(key list and empty details panel) opening Browser page for the first time
+    await t.expect(browserPage.noKeysToDisplayText.visible).ok('No keys selected panel not displayed');
+    // Save key table size before switching to full screen
+    const widthKeysBeforeFullScreen = await browserPage.keyListTable.clientWidth;
+    // Close right panel with key details
+    await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('Key Details Table not displayed');
+    await t.click(browserPage.closeRightPanel);
+    // Check that table is in full screen
+    const widthTableAfterFullScreen = await browserPage.keyListTable.clientWidth;
+    await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen not greater then before');
+});
 test
     .before(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
@@ -68,8 +66,7 @@ test
     .after(async() => {
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    .meta({ rte: rte.standalone })('Verify that when user closes key details in full screen mode the list of keys displayed in full screen', async t => {
+    })('Verify that when user closes key details in full screen mode the list of keys displayed in full screen', async t => {
         // Save keys table size before switching to full screen
         const widthKeysBeforeFullScreen = await browserPage.keyListTable.clientWidth;
         // Open full mode for key details
@@ -78,13 +75,13 @@ test
         await t.click(browserPage.closeKeyButton);
         // Check that key list is opened in full screen
         const widthTableAfterFullScreen = await browserPage.keyListTable.clientWidth;
-        await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen');
+        await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen not greater then before');
         // Verify that when user selects the key while key list is in full screen, key details is opened on the right side panel
         const widthKeysBeforeExitFullScreen = await browserPage.keyListTable.clientWidth;
         await browserPage.openKeyDetails(keyName);
         const widthKeysAfterExitFullScreen = await browserPage.keyListTable.clientWidth;
-        await t.expect(widthKeysAfterExitFullScreen).lt(widthKeysBeforeExitFullScreen, 'Width after switching from full screen');
-        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('Key details opened');
+        await t.expect(widthKeysAfterExitFullScreen).lt(widthKeysBeforeExitFullScreen, 'Width after switching from full screen not less then before');
+        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).ok('Key details not opened');
     });
 test
     .before(async() => {
@@ -95,15 +92,14 @@ test
     .after(async() => {
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    .meta({ rte: rte.standalone })('Verify that when users close key details not in full mode, they can see full key list screen', async t => {
+    })('Verify that when users close key details not in full mode, they can see full key list screen', async t => {
         // Save key list table size before switching to full screen
         const widthKeysBeforeFullScreen = await browserPage.keyListTable.clientWidth;
         // Close key details
         await t.click(browserPage.closeKeyButton);
         // Check that key list is opened in full screen
         const widthTableAfterFullScreen = await browserPage.keyListTable.clientWidth;
-        await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen');
+        await t.expect(widthTableAfterFullScreen).gt(widthKeysBeforeFullScreen, 'Width after switching to full screen not greater then before');
         // Verify that user can not see key details
-        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('Key details opened');
+        await t.expect(browserPage.keyNameFormDetails.withExactText(keyName).exists).notOk('Key details not opened');
     });

--- a/tests/e2e/tests/regression/browser/handle-dbsize-permissions.e2e.ts
+++ b/tests/e2e/tests/regression/browser/handle-dbsize-permissions.e2e.ts
@@ -1,5 +1,4 @@
 import { t } from 'testcafe';
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage, CliPage, MyRedisDatabasePage, DatabaseOverviewPage, BulkActionsPage } from '../../../pageObjects';
@@ -12,15 +11,14 @@ import { addNewStandaloneDatabaseApi, deleteStandaloneDatabaseApi } from '../../
 import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
 const cliPage = new CliPage();
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const databaseOverviewPage = new DatabaseOverviewPage();
 const bulkActionsPage = new BulkActionsPage();
 const common = new Common();
 const createUserCommand = 'acl setuser noperm nopass on +@all ~* -dbsize';
-const keyName = chance.word({ length: 20 });
-const createKeyCommand = `set ${keyName} ${chance.word({ length: 20 })}`;
+const keyName = common.generateWord(20);
+const createKeyCommand = `set ${keyName} ${common.generateWord(20)}`;
 
 fixture `Handle user permissions`
     .meta({ type: 'regression', rte: rte.standalone })
@@ -29,7 +27,6 @@ fixture `Handle user permissions`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
         await cliPage.sendCommandInCli(createUserCommand);
         ossStandaloneNoPermissionsConfig.host = process.env.OSS_STANDALONE_BIG_HOST || 'oss-standalone-big';
-        // await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
         await t.click(myRedisDatabasePage.myRedisDBButton);
         await addNewStandaloneDatabaseApi(ossStandaloneNoPermissionsConfig);
         await common.reloadPage();
@@ -46,15 +43,15 @@ test('Verify that user without dbsize permissions can connect to DB', async t =>
     // Connect to DB
     await myRedisDatabasePage.clickOnDBByName(ossStandaloneNoPermissionsConfig.databaseName);
     // Check that user can see total number of key is overview
-    await t.expect(databaseOverviewPage.overviewTotalKeys.find('div').withExactText('18 M').exists).ok('Total keys are displayed');
+    await t.expect(databaseOverviewPage.overviewTotalKeys.find('div').withExactText('18 M').exists).ok('Total keys are not displayed');
     // Check that user can see total number of keys in browser
-    await t.expect(browserPage.keysSummary.find('b').withText('18 00').exists).ok('Total number is displayed');
+    await t.expect(browserPage.keysSummary.find('b').withText('18 00').exists).ok('Total number is not displayed');
     // Check that user can search per key
     await cliPage.sendCommandInCli(createKeyCommand);
     await browserPage.searchByKeyName(keyName);
-    await t.expect(browserPage.keysNumberOfResults.textContent).eql('1', 'Found keys number');
-    await t.expect(browserPage.scannedValue.textContent).contains('18 000', 'Number of scanned');
-    await t.expect(browserPage.keysTotalNumber.textContent).contains('18 000', 'Number of total keys');
+    await t.expect(browserPage.keysNumberOfResults.textContent).eql('1', 'Found keys number not correct');
+    await t.expect(browserPage.scannedValue.textContent).contains('18 000', 'Number of scanned not correct');
+    await t.expect(browserPage.keysTotalNumber.textContent).contains('18 000', 'Number of total keys not correct');
     // Check bulk delete
     await cliPage.sendCommandInCli(createKeyCommand);
     await browserPage.searchByKeyName(keyName);

--- a/tests/e2e/tests/regression/browser/hash-field.e2e.ts
+++ b/tests/e2e/tests/regression/browser/hash-field.e2e.ts
@@ -15,28 +15,27 @@ const fieldForSearch = `SearchField-${common.generateWord(5)}`;
 const keyToAddParameters = { fieldsCount: 500000, keyName, fieldStartWith: 'hashField', fieldValueStartWith: 'hashValue' };
 
 fixture `Hash Key fields verification`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         await browserPage.addHashKey(keyName, '2147476121', 'field', 'value');
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can search per exact field name in Hash in DB with 1 million of fields', async t => {
-        // Add 1000000 fields to the hash key
-        await populateHashWithFields(dbParameters.host, dbParameters.port, keyToAddParameters);
-        await populateHashWithFields(dbParameters.host, dbParameters.port, keyToAddParameters);
-        //Add custom field to the hash key
-        await browserPage.openKeyDetails(keyName);
-        await browserPage.addFieldToHash(fieldForSearch, 'testHashValue');
-        //Search by full field name
-        await browserPage.searchByTheValueInKeyDetails(fieldForSearch);
-        //Check the search result
-        const result = await browserPage.hashFieldsList.nth(0).textContent;
-        await t.expect(result).eql(fieldForSearch, 'Hash field not found');
-    });
+test('Verify that user can search per exact field name in Hash in DB with 1 million of fields', async t => {
+    // Add 1000000 fields to the hash key
+    await populateHashWithFields(dbParameters.host, dbParameters.port, keyToAddParameters);
+    await populateHashWithFields(dbParameters.host, dbParameters.port, keyToAddParameters);
+    // Add custom field to the hash key
+    await browserPage.openKeyDetails(keyName);
+    await browserPage.addFieldToHash(fieldForSearch, 'testHashValue');
+    // Search by full field name
+    await browserPage.searchByTheValueInKeyDetails(fieldForSearch);
+    // Check the search result
+    const result = await browserPage.hashFieldsList.nth(0).textContent;
+    await t.expect(result).eql(fieldForSearch, 'Hash field not found');
+});

--- a/tests/e2e/tests/regression/browser/key-messages.e2e.ts
+++ b/tests/e2e/tests/regression/browser/key-messages.e2e.ts
@@ -16,10 +16,6 @@ const dataTypes: string[] = [
     'RedisTimeSeries',
     'RedisGraph'
 ];
-const commands: string[] = [
-    `TS.CREATE ${keyName}`,
-    `GRAPH.QUERY ${keyName} "CREATE ()"`
-];
 
 fixture `Key messages`
     .meta({ type: 'regression', rte: rte.standalone })
@@ -33,6 +29,10 @@ fixture `Key messages`
 test('Verify that user can see updated message in Browser for TimeSeries and Graph data types', async t => {
     for(let i = 0; i < dataTypes.length; i++) {
         keyName = common.generateWord(10);
+        const commands: string[] = [
+            `TS.CREATE ${keyName}`,
+            `GRAPH.QUERY ${keyName} "CREATE ()"`
+        ];
         const messages: string[] = [
             `This is a ${dataTypes[i]} key`,
             'Use Redis commands in the ',
@@ -53,6 +53,11 @@ test('Verify that user can see updated message in Browser for TimeSeries and Gra
 test('Verify that user can see link to Workbench under word “Workbench” in the RedisTimeSeries and Graph key details', async t => {
     for(let i = 0; i < dataTypes.length; i++) {
         keyName = common.generateWord(10);
+        const commands: string[] = [
+            `TS.CREATE ${keyName}`,
+            `GRAPH.QUERY ${keyName} "CREATE ()"`
+        ];
+
         // Add key and verify Workbench link
         await cliPage.sendCommandInCli(commands[i]);
         await browserPage.searchByKeyName(keyName);

--- a/tests/e2e/tests/regression/browser/keys-all-databases.e2e.ts
+++ b/tests/e2e/tests/regression/browser/keys-all-databases.e2e.ts
@@ -24,15 +24,15 @@ const common = new Common();
 let keyName = common.generateWord(10);
 const verifyKeysAdded = async(): Promise<void> => {
     keyName = common.generateWord(10);
-    //add Hash key
+    // Add Hash key
     await browserPage.addHashKey(keyName);
-    //check the notification message
+    // Check the notification message
     const notification = await browserPage.getMessageText();
-    await t.expect(notification).contains('Key has been added', 'The notification');
-    //check that new key is displayed in the list
+    await t.expect(notification).contains('Key has been added', 'The notification not correct');
+    // Check that new key is displayed in the list
     await browserPage.searchByKeyName(keyName);
     const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-    await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
+    await t.expect(isKeyIsDisplayedInTheList).ok('The key is not added');
 };
 
 fixture `Work with keys in all types of databases`
@@ -44,7 +44,7 @@ test
         await acceptLicenseTermsAndAddREClusterDatabase(redisEnterpriseClusterConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(redisEnterpriseClusterConfig.databaseName);
     })('Verify that user can add Key in RE Cluster DB', async() => {
@@ -56,7 +56,7 @@ test
         await acceptLicenseTermsAndAddRECloudDatabase(cloudDatabaseConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(cloudDatabaseConfig.databaseName);
     })('Verify that user can add Key in RE Cloud DB', async() => {
@@ -68,7 +68,7 @@ test
         await acceptLicenseTermsAndAddOSSClusterDatabase(ossClusterConfig, ossClusterConfig.ossClusterDatabaseName);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })('Verify that user can add Key in OSS Cluster DB', async() => {
@@ -80,7 +80,7 @@ test
         await acceptLicenseTermsAndAddSentinelDatabaseApi(ossSentinelConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteAllSentinelDatabasesApi(ossSentinelConfig);
     })('Verify that user can add Key in Sentinel Primary Group', async() => {

--- a/tests/e2e/tests/regression/browser/large-key-details-values.e2e.ts
+++ b/tests/e2e/tests/regression/browser/large-key-details-values.e2e.ts
@@ -18,11 +18,11 @@ const keyTTL = '2147476121';
 fixture `Expand/Collapse large values in key details`
     .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async t => {
-        //Clear and delete database
+        // Clear and delete database
         if (await browserPage.closeKeyButton.visible) {
             await t.click(browserPage.closeKeyButton);
         }
@@ -35,7 +35,7 @@ test('Verify that user can click on a row to expand it if any of its cells conta
     // Create stream key
     await cliPage.sendCommandInCli(`XADD ${keyName} * '${field}' '${value}'`);
     await cliPage.sendCommandInCli(`XADD ${keyName} * '${field}' '${value1}'`);
-    //Open key details
+    // Open key details
     await browserPage.openKeyDetails(keyName);
     // Remember height of the cells
     const startLongCellHeight = await entryFieldLong.clientHeight;

--- a/tests/e2e/tests/regression/browser/last-refresh.e2e.ts
+++ b/tests/e2e/tests/regression/browser/last-refresh.e2e.ts
@@ -2,79 +2,44 @@ import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Last refresh`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can see the date and time of the last update of my Keys in the tooltip', async t => {
-        //Hover on the refresh icon
-        await t.hover(browserPage.refreshKeysButton);
-        //Verify the last update info
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see my timer updated when I refresh the list of Keys of the list of values', async t => {
-        keyName = chance.word({ length: 10 });
-        //Add key
-        await browserPage.addStringKey(keyName);
-        await browserPage.openKeyDetails(keyName);
-        //Wait for 2 min
-        await t.wait(120000);
-        //Hover on the refresh icon
-        await t.hover(browserPage.refreshKeyButton);
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\n2 min', 'tooltip text');
-        //Click on Refresh and check last refresh
-        await t.click(browserPage.refreshKeyButton);
-        await t.hover(browserPage.refreshKeyButton);
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the date and time of the last update of my Key values in the tooltip', async t => {
-        keyName = chance.word({ length: 10 });
-        //Add key
-        await browserPage.addStringKey(keyName);
-        await browserPage.openKeyDetails(keyName);
-        //Hover on the refresh icon
-        await t.hover(browserPage.refreshKeyButton);
-        //Verify the last update info
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see my last refresh updated each time I hover over the Refresh icon', async t => {
-        keyName = chance.word({ length: 10 });
-        //Add key
-        await browserPage.addStringKey(keyName);
-        await browserPage.openKeyDetails(keyName);
-        //Hover on the keys refresh icon
-        await t.hover(browserPage.refreshKeysButton);
-        //Verify the last update info
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text');
-        //Hover on the key in details refresh icon
-        await t.hover(browserPage.refreshKeyButton);
-        //Verify the last update info
-        await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text');
-    });
+test('Verify that user can see my timer updated when I refresh the list of Keys of the list of values', async t => {
+    keyName = common.generateWord(10);
+    // Hover on the refresh icon
+    await t.hover(browserPage.refreshKeysButton);
+    // Verify that user can see the date and time of the last update of my Keys in the tooltip
+    await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text not correct');
+
+    // Add key
+    await browserPage.addStringKey(keyName);
+    await browserPage.openKeyDetails(keyName);
+    // Wait for 1 min
+    await t.wait(60000);
+    // Hover on the refresh icon
+    await t.hover(browserPage.refreshKeyButton);
+    await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\n1 min', 'tooltip text not correct');
+    // Click on Refresh and check last refresh
+    await t.click(browserPage.refreshKeyButton);
+    await t.hover(browserPage.refreshKeyButton);
+    // Verify that user can see the date and time of the last update of my Key values in the tooltip
+    // Verify that user can see my last refresh updated each time I hover over the Refresh icon
+    await t.expect(browserPage.tooltip.innerText).contains('Last Refresh\nnow', 'tooltip text not correct');
+});

--- a/tests/e2e/tests/regression/browser/list-key.e2e.ts
+++ b/tests/e2e/tests/regression/browser/list-key.e2e.ts
@@ -22,7 +22,7 @@ fixture `List Key verification`
         await browserPage.addListKey(keyName, '2147476121', 'testElement');
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
@@ -31,12 +31,12 @@ test
         // Add 1000000 elements to the list key
         await populateListWithElements(dbParameters.host, dbParameters.port, keyToAddParameters);
         await populateListWithElements(dbParameters.host, dbParameters.port, keyToAddParameters);
-        //Add custom element to the list key
+        // Add custom element to the list key
         await browserPage.openKeyDetails(keyName);
         await browserPage.addElementToList(elementForSearch);
-        //Search by element index
+        // Search by element index
         await browserPage.searchByTheValueInKeyDetails('1000001');
-        //Check the search result
+        // Check the search result
         const result = await browserPage.listElementsList.nth(0).textContent;
         await t.expect(result).eql(elementForSearch, 'List element not found');
     });

--- a/tests/e2e/tests/regression/browser/scan-keys.e2e.ts
+++ b/tests/e2e/tests/regression/browser/scan-keys.e2e.ts
@@ -15,19 +15,18 @@ const explicitErrorHandler = (): void => {
 };
 
 fixture `Browser - Specify Keys to Scan`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.none})
     .page(commonUrl)
     .clientScripts({ content: `(${explicitErrorHandler.toString()})()` })
     .beforeEach(async() => {
         await acceptLicenseTerms();
     });
-test
-    .meta({ rte: rte.none })('Verify that the user not enter the value less than 500 - the system automatically applies min value if user enters less than min', async t => {
-        //Go to Settings page
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Specify keys to scan less than 500
-        await t.click(settingsPage.accordionAdvancedSettings);
-        await settingsPage.changeKeysToScanValue('100');
-        //Verify the applied scan value
-        await t.expect(await settingsPage.keysToScanValue.textContent).eql('500', 'The system automatically applies min value 500');
-    });
+test('Verify that the user not enter the value less than 500 - the system automatically applies min value if user enters less than min', async t => {
+    // Go to Settings page
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Specify keys to scan less than 500
+    await t.click(settingsPage.accordionAdvancedSettings);
+    await settingsPage.changeKeysToScanValue('100');
+    // Verify the applied scan value
+    await t.expect(await settingsPage.keysToScanValue.textContent).eql('500', 'The system automatically not applies min value 500');
+});

--- a/tests/e2e/tests/regression/browser/set-key.e2e.ts
+++ b/tests/e2e/tests/regression/browser/set-key.e2e.ts
@@ -15,28 +15,27 @@ const memberForSearch = `SearchField-${common.generateWord(5)}`;
 const keyToAddParameters = { membersCount: 500000, keyName, memberStartWith: 'setMember' };
 
 fixture `Set Key verification`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         await browserPage.addSetKey(keyName, '2147476121', 'testMember');
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can search per exact member name in Set key in DB with 1 million of members', async t => {
-        // Add 1000000 members to the set key
-        await populateSetWithMembers(dbParameters.host, dbParameters.port, keyToAddParameters);
-        await populateSetWithMembers(dbParameters.host, dbParameters.port, keyToAddParameters);
-        //Add custom member to the set key
-        await browserPage.openKeyDetails(keyName);
-        await browserPage.addMemberToSet(memberForSearch);
-        //Search by full member name
-        await browserPage.searchByTheValueInSetKey(memberForSearch);
-        //Check the search result
-        const result = await browserPage.setMembersList.nth(0).textContent;
-        await t.expect(result).eql(memberForSearch, 'Set member not found');
-    });
+test('Verify that user can search per exact member name in Set key in DB with 1 million of members', async t => {
+    // Add 1000000 members to the set key
+    await populateSetWithMembers(dbParameters.host, dbParameters.port, keyToAddParameters);
+    await populateSetWithMembers(dbParameters.host, dbParameters.port, keyToAddParameters);
+    // Add custom member to the set key
+    await browserPage.openKeyDetails(keyName);
+    await browserPage.addMemberToSet(memberForSearch);
+    // Search by full member name
+    await browserPage.searchByTheValueInSetKey(memberForSearch);
+    // Check the search result
+    const result = await browserPage.setMembersList.nth(0).textContent;
+    await t.expect(result).eql(memberForSearch, 'Set member not found');
+});

--- a/tests/e2e/tests/regression/browser/stream-key.e2e.ts
+++ b/tests/e2e/tests/regression/browser/stream-key.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { rte } from '../../../helpers/constants';
 import { BrowserPage, CliPage } from '../../../pageObjects';
@@ -8,12 +7,11 @@ import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
 const common = new Common();
 
-const value = chance.word({length: 5});
-let field = chance.word({length: 5});
-let keyName = chance.word({length: 20});
+const value = common.generateWord(5);
+let field = common.generateWord(5);
+let keyName = common.generateWord(20);
 
 fixture `Stream key`
     .meta({
@@ -33,45 +31,47 @@ test('Verify that user can see a Stream in a table format', async t => {
         'Entry ID',
         field
     ];
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const command = `XADD ${keyName} * '${field}' '${value}'`;
-    //Add new Stream key with 5 EntryIds
+
+    // Add new Stream key with 5 EntryIds
     for(let i = 0; i < 5; i++){
         await cliPage.sendCommandInCli(command);
     }
-    //Open key details and check Steam format
+    // Open key details and check Steam format
     await browserPage.openKeyDetails(keyName);
-    await t.expect(browserPage.virtualTableContainer.visible).ok('The Stream is displayed in a table format');
+    await t.expect(browserPage.virtualTableContainer.visible).ok('The Stream is not displayed in a table format');
     for(const field of streamFields){
-        await t.expect(browserPage.streamEntriesContainer.textContent).contains(field, 'The Stream fields are in the table');
+        await t.expect(browserPage.streamEntriesContainer.textContent).contains(field, 'The Stream fields are not displayed in the table');
     }
-    await t.expect(browserPage.streamFieldsValues.textContent).contains(value, 'The Stream field value is in the table');
+    await t.expect(browserPage.streamFieldsValues.textContent).contains(value, 'The Stream field value is not displayed in the table');
 });
 test('Verify that user can sort ASC/DESC by Entry ID', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const command = `XADD ${keyName} * '${field}' '${value}'`;
-    //Add new Stream key with 5 EntryIds
+
+    // Add new Stream key with 5 EntryIds
     for(let i = 0; i < 5; i++){
         await cliPage.sendCommandInCli(command);
     }
-    //Open key details and check Entry ID ASC sorting
+    // Open key details and check Entry ID ASC sorting
     await browserPage.openKeyDetails(keyName);
     const entryCount = await browserPage.streamEntryDate.count;
     for(let i = 0; i < entryCount - 1; i++){
         const entryDateFirstAsc = Date.parse(await browserPage.streamEntryDate.nth(i).textContent);
         const entryDateSecondAsc = Date.parse(await browserPage.streamEntryDate.nth(i + 1).textContent);
-        await t.expect(entryDateFirstAsc).gt(entryDateSecondAsc, 'By default the table is sorted by Entry ID');
+        await t.expect(entryDateFirstAsc).gt(entryDateSecondAsc, 'By default the table is not sorted by Entry ID');
     }
-    //Check the DESC sorting
+    // Check the DESC sorting
     await t.click(browserPage.sortingButton);
     for(let i = 0; i < entryCount - 1; i++){
         const entryDateFirstDesc = Date.parse(await browserPage.streamEntryDate.nth(i).textContent);
         const entryDateSecondDesc = Date.parse(await browserPage.streamEntryDate.nth(i + 1).textContent);
-        await t.expect(entryDateFirstDesc).lt(entryDateSecondDesc, 'The Stream fields are sorted DESC by Entry ID');
+        await t.expect(entryDateFirstDesc).lt(entryDateSecondDesc, 'The Stream fields are not sorted DESC by Entry ID');
     }
 });
 test('Verify that user can see all the columns are displayed by default for Stream', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const fields = [
         'Pressure',
         'Humidity',
@@ -82,58 +82,62 @@ test('Verify that user can see all the columns are displayed by default for Stre
         '78',
         '27'
     ];
-    //Add new Stream key with 3 fields
+
+    // Add new Stream key with 3 fields
     for(let i = 0; i < fields.length; i++){
         await cliPage.sendCommandInCli(`XADD ${keyName} * ${fields[i]} ${values[i]}`);
     }
-    //Open key details and check fields
+    // Open key details and check fields
     await browserPage.openKeyDetails(keyName);
     await t.click(browserPage.fullScreenModeButton);
     for(let i = fields.length - 1; i <= 0; i--){
         const fieldName = await browserPage.streamFields.nth(i).textContent;
-        await t.expect(fieldName).eql(fields[i], 'All the columns are displayed by default for Stream');
+        await t.expect(fieldName).eql(fields[i], 'All the columns are not displayed by default for Stream');
     }
     await t.click(browserPage.fullScreenModeButton);
 });
 test('Verify that the multi-line cell value tooltip is available on hover as per standard key details behavior', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     const fields = [
         'Pressure',
         'Humidity'
     ];
-    const entryValue = chance.sentence({words: 5});
-    //Add new Stream key with multi-line cell value
+    const entryValue = common.generateSentence(5);
+
+    // Add new Stream key with multi-line cell value
     for(let i = 0; i < fields.length; i++){
         await cliPage.sendCommandInCli(`XADD ${keyName} * '${fields[i]}' '${entryValue}'`);
     }
-    //Open key details and check tooltip
+    // Open key details and check tooltip
     await browserPage.openKeyDetails(keyName);
     await t.hover(browserPage.streamEntryFields);
-    await t.expect(browserPage.tooltip.textContent).contains(entryValue, 'The multi-line cell value tooltip is available');
+    await t.expect(browserPage.tooltip.textContent).contains(entryValue, 'The multi-line cell value tooltip is not available');
 });
 test('Verify that user can see a confirmation message when request to delete an entry in the Stream', async t => {
-    keyName = chance.word({length: 20});
+    keyName = common.generateWord(20);
     field = 'fieldForRemoving';
     const confirmationMessage = `will be removed from ${keyName}`;
-    //Add new Stream key with 1 field
+
+    // Add new Stream key with 1 field
     await cliPage.sendCommandInCli(`XADD ${keyName} * ${field} ${value}`);
-    //Open key details and click on delete entry
+    // Open key details and click on delete entry
     await browserPage.openKeyDetails(keyName);
     const entryId = await browserPage.streamEntryIdValue.textContent;
     await t.click(browserPage.removeEntryButton);
-    //Check the confirmation message
-    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(confirmationMessage, `The confirmation message ${keyName}`);
-    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(entryId, 'The confirmation message for removing Entry');
+    // Check the confirmation message
+    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(confirmationMessage, `The confirmation message ${keyName} not displayed`);
+    await t.expect(browserPage.confirmationMessagePopover.textContent).contains(entryId, 'The confirmation message for removing Entry not displayed');
 });
 test('Verify that the Entry ID field, Delete button are always displayed while scrolling for Stream data', async t => {
-    keyName = chance.word({ length: 20 });
+    keyName = common.generateWord(20);
     const fields = common.createArrayWithKeys(9);
     const values = common.createArrayWithKeys(9);
-    //Add new Stream key with 3 fields
+
+    // Add new Stream key with 3 fields
     for (let i = 0; i < fields.length; i++) {
         await cliPage.sendCommandInCli(`XADD ${keyName} * ${fields[i]} ${values[i]}`);
     }
-    //Open key details
+    // Open key details
     await browserPage.openKeyDetails(keyName);
     // Scroll right
     await t.pressKey('shift').scroll(browserPage.streamVirtualContainer, 'right');

--- a/tests/e2e/tests/regression/browser/stream-pending-messages.e2e.ts
+++ b/tests/e2e/tests/regression/browser/stream-pending-messages.e2e.ts
@@ -14,13 +14,6 @@ const common = new Common();
 
 let keyName = common.generateWord(20);
 let consumerGroupName = common.generateWord(20);
-const cliCommands = [
-    `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
-    `XADD ${keyName} * message apple`,
-    `XADD ${keyName} * message orange`,
-    `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`,
-    `XREADGROUP GROUP ${consumerGroupName} Bob COUNT 1 STREAMS ${keyName} >`
-];
 
 fixture `Pending messages`
     .meta({ type: 'regression', rte: rte.standalone })
@@ -65,6 +58,13 @@ test('Verify that user can\'t select currently selected Consumer to Claim messag
 test('Verify that the message is claimed only if its idle time is greater than the Min Idle Time', async t => {
     keyName = common.generateWord(20);
     consumerGroupName = common.generateWord(20);
+    const cliCommands = [
+        `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
+        `XADD ${keyName} * message apple`,
+        `XADD ${keyName} * message orange`,
+        `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`,
+        `XREADGROUP GROUP ${consumerGroupName} Bob COUNT 1 STREAMS ${keyName} >`
+    ];
 
     // Add New Stream Key with pending message
     for(const command of cliCommands){
@@ -83,6 +83,13 @@ test('Verify that the message is claimed only if its idle time is greater than t
 test('Verify that when user toggle optional parameters on, he can see optional fields', async t => {
     keyName = common.generateWord(20);
     consumerGroupName = common.generateWord(20);
+    const cliCommands = [
+        `XGROUP CREATE ${keyName} ${consumerGroupName} $ MKSTREAM`,
+        `XADD ${keyName} * message apple`,
+        `XADD ${keyName} * message orange`,
+        `XREADGROUP GROUP ${consumerGroupName} Alice COUNT 1 STREAMS ${keyName} >`,
+        `XREADGROUP GROUP ${consumerGroupName} Bob COUNT 1 STREAMS ${keyName} >`
+    ];
 
     // Add New Stream Key with pending message
     for(const command of cliCommands){

--- a/tests/e2e/tests/regression/browser/ttl-format.e2e.ts
+++ b/tests/e2e/tests/regression/browser/ttl-format.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { Selector } from 'testcafe';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { keyTypes } from '../../../helpers/keys';
@@ -6,17 +5,18 @@ import { rte, COMMANDS_TO_CREATE_KEY, keyLength } from '../../../helpers/constan
 import { BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-const keyName = chance.word({ length: 20 });
+const keyName = common.generateWord(20);
 const keysData = keyTypes.map(object => ({ ...object })).slice(0, 6);
 for (const key of keysData) {
-    key.keyName = `${key.keyName}` + '-' + `${chance.word({ length: keyLength })}`;
+    key.keyName = `${key.keyName}` + '-' + `${common.generateWord(keyLength)}`;
 }
-//Arrays with TTL in seconds, min, hours, days, months, years and their values in Browser Page
+// Arrays with TTL in seconds, min, hours, days, months, years and their values in Browser Page
 const ttlForSet = [59, 800, 20000, 2000000, 31000000, 2147483647];
 const ttlValues = ['s', '13 min', '5 h', '23 d', '11 mo', '68 yr'];
 
@@ -30,28 +30,28 @@ fixture `TTL values in Keys Table`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         for (let i = 0; i < keysData.length; i++) {
             await browserPage.deleteKey();
         }
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can see TTL in the list of keys rounded down to the nearest unit', async t => {
-    //Create new keys with TTL
+    // Create new keys with TTL
     await t.click(cliPage.cliExpandButton);
     for (let i = 0; i < keysData.length; i++) {
-        await t.typeText(cliPage.cliCommandInput, COMMANDS_TO_CREATE_KEY[keysData[i].textType](keysData[i].keyName), {paste: true});
-        await t.pressKey('enter');
-        await t.typeText(cliPage.cliCommandInput, `EXPIRE ${keysData[i].keyName} ${ttlForSet[i]}`, {paste: true});
-        await t.pressKey('enter');
+        await t.typeText(cliPage.cliCommandInput, COMMANDS_TO_CREATE_KEY[keysData[i].textType](keysData[i].keyName), {paste: true})
+            .pressKey('enter')
+            .typeText(cliPage.cliCommandInput, `EXPIRE ${keysData[i].keyName} ${ttlForSet[i]}`, {paste: true})
+            .pressKey('enter');
     }
     await t.click(cliPage.cliCollapseButton);
-    //Refresh Keys in Browser
+    // Refresh Keys in Browser
     await t.click(browserPage.refreshKeysButton);
-    //Check that Keys has correct TTL value in keys table
+    // Check that Keys has correct TTL value in keys table
     for (let i = 0; i < keysData.length; i++) {
         const ttlValueElement = Selector(`[data-testid="ttl-${keysData[i].keyName}"]`);
-        await t.expect(ttlValueElement.textContent).contains(ttlValues[i], `TTL value in keys table is ${ttlValues[i]}`);
+        await t.expect(ttlValueElement.textContent).contains(ttlValues[i], `TTL value in keys table is not ${ttlValues[i]}`);
     }
 });
 test
@@ -63,7 +63,7 @@ test
         let ttlToCompare = TTL;
         await browserPage.addStringKey(keyName, 'test', TTL.toString());
         await t.click(browserPage.refreshKeysButton);
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Added key');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('Key not added');
         // Specify selector with TTL
         const ttlValueElement = Selector(`[data-testid="ttl-${keyName}"]`);
         // Check that TTL reduces every page refresh
@@ -75,5 +75,5 @@ test
         }
         // Check that key with finished TTL is deleted
         await t.click(browserPage.refreshKeysButton);
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).notOk('Not displayed key');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).notOk('Key is still displayed');
     });

--- a/tests/e2e/tests/regression/cli/cli-command-helper.e2e.ts
+++ b/tests/e2e/tests/regression/cli/cli-command-helper.e2e.ts
@@ -22,129 +22,126 @@ let externalPageLink = '';
 let externalPageLinks: string[] = [];
 
 fixture `CLI Command helper`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
+test('Verify that user can open/close CLI separately from Command Helper', async t => {
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Verify that CLI is opened separately
+    await t.expect(cliPage.commandHelperArea.visible).notOk('Command Helper is not closed');
+    await t.expect(cliPage.cliCollapseButton.visible).ok('CLI is not opended');
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Verify that user can close CLI separately
+    await t.click(cliPage.cliCollapseButton);
+    await t.expect(cliPage.commandHelperArea.visible).ok('Command Helper is not displayed');
+    await t.expect(cliPage.cliCollapseButton.visible).notOk('CLI is not closed');
+
+    // Verify that user can open/close Command Helper separately from CLI
+    await t.expect(cliPage.commandHelperArea.visible).ok('Command Helper is not opened');
+    await t.expect(cliPage.cliCollapseButton.visible).notOk('CLI is not closed');
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Verify that Command Helper is closed separately
+    await t.click(cliPage.closeCommandHelperButton);
+    await t.expect(cliPage.commandHelperArea.visible).notOk('Command Helper is not closed');
+    await t.expect(cliPage.cliCollapseButton.visible).ok('CLI is not opended');
+});
+test('Verify that user can see that Command Helper is minimized when he clicks the "minimize" button', async t => {
+    const helperColourBefore = await common.getBackgroundColour(cliPage.commandHelperBadge);
+    // Open Command Helper and minimize
+    await t.click(cliPage.expandCommandHelperButton);
+    await t.click(cliPage.minimizeCommandHelperButton);
+    // Verify Command helper is minimized
+    const helperColourAfter = await common.getBackgroundColour(cliPage.commandHelperBadge);
+    await t.expect(helperColourAfter).notEql(helperColourBefore, 'Command helper badge colour is not changed');
+    await t.expect(cliPage.minimizeCliButton.visible).eql(false, 'Command helper is not mimized');
+});
+test('Verify that user can see that Command Helper displays the previous information when he re-opens it', async t => {
+    filteringGroup = 'Search';
+    commandToCheck = 'FT.EXPLAIN';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Select one command from the list
+    await cliPage.selectFilterGroupType(filteringGroup);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
+    // Minimize and re-open Command Helper
+    await t.click(cliPage.minimizeCommandHelperButton);
+    await t.click(cliPage.expandCommandHelperButton);
+    // Verify Command helper information
+    await t.expect(cliPage.cliHelperTitleArgs.textContent).contains(commandToCheck, 'Command Helper information not persists after reopening');
+});
 test
-    .meta({ rte: rte.standalone })('Verify that user can open/close CLI separately from Command Helper', async t => {
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Verify that CLI is opened separately
-        await t.expect(cliPage.commandHelperArea.visible).notOk('Command Helper is closed');
-        await t.expect(cliPage.cliCollapseButton.visible).ok('CLI is opended');
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Verify that user can close CLI separately
-        await t.click(cliPage.cliCollapseButton);
-        await t.expect(cliPage.commandHelperArea.visible).ok('Command Helper is displayed');
-        await t.expect(cliPage.cliCollapseButton.visible).notOk('CLI is closed');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can open/close Command Helper separately from CLI', async t => {
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Verify that Command Helper is opened separately
-        await t.expect(cliPage.commandHelperArea.visible).ok('Command Helper is opened');
-        await t.expect(cliPage.cliCollapseButton.visible).notOk('CLI is closed');
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Verify that Command Helper is closed separately
-        await t.click(cliPage.closeCommandHelperButton);
-        await t.expect(cliPage.commandHelperArea.visible).notOk('Command Helper is closed');
-        await t.expect(cliPage.cliCollapseButton.visible).ok('CLI is opended');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see that Command Helper is minimized when he clicks the "minimize" button', async t => {
-        const helperColourBefore = await common.getBackgroundColour(cliPage.commandHelperBadge);
-        //Open Command Helper and minimize
-        await t.click(cliPage.expandCommandHelperButton);
-        await t.click(cliPage.minimizeCommandHelperButton);
-        //Verify Command helper is minimized
-        const helperColourAfter = await common.getBackgroundColour(cliPage.commandHelperBadge);
-        await t.expect(helperColourAfter).notEql(helperColourBefore, 'Command helper badge colour is changed');
-        await t.expect(cliPage.minimizeCliButton.visible).eql(false, 'Command helper is mimized');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see that Command Helper displays the previous information when he re-opens it', async t => {
-        filteringGroup = 'Search';
-        commandToCheck = 'FT.EXPLAIN';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from the list
-        await cliPage.selectFilterGroupType(filteringGroup);
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        //Minimize and re-open Command Helper
-        await t.click(cliPage.minimizeCommandHelperButton);
-        await t.click(cliPage.expandCommandHelperButton);
-        //Verify Command helper information
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).contains(commandToCheck, 'Command Helper information persists after reopening');
-    });
-test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can see in Command helper and click on new group "JSON", can choose it and see list of commands in the group', async t => {
+    .meta({ env: env.web })('Verify that user can see in Command helper and click on new group "JSON", can choose it and see list of commands in the group', async t => {
         filteringGroup = 'JSON';
         commandToCheck = 'JSON.SET';
         commandArgumentsToCheck = 'JSON.SET key path value [condition]';
         externalPageLink = 'https://redis.io/commands/json.set/';
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from the list
+        // Select one command from the list
         await cliPage.selectFilterGroupType(filteringGroup);
         await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        //Verify results of opened command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title');
-        //Click on Read More link for selected command
+        // Verify results of opened command
+        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title not correct');
+        // Click on Read More link for selected command
         await t.click(cliPage.readMoreButton);
-        //Check new opened window page with the correct URL
+        // Check new opened window page with the correct URL
         await common.checkURL(externalPageLink);
         await t.switchToParentWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can see in Command helper and click on new group "Search", can choose it and see list of commands in the group', async t => {
+    .meta({ env: env.web })('Verify that user can see in Command helper and click on new group "Search", can choose it and see list of commands in the group', async t => {
         filteringGroup = 'Search';
         commandToCheck = 'FT.EXPLAIN';
         commandArgumentsToCheck = 'FT.EXPLAIN index query [dialect]';
         externalPageLink = 'https://redis.io/commands/ft.explain/';
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from the list
+        // Select one command from the list
         await cliPage.selectFilterGroupType(filteringGroup);
         await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        //Verify results of opened command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title');
-        //Click on Read More link for selected command
+        // Verify results of opened command
+        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title not correct');
+        // Click on Read More link for selected command
         await t.click(cliPage.readMoreButton);
-        //Check new opened window page with the correct URL
+        // Check new opened window page with the correct URL
         await common.checkURL(externalPageLink);
         await t.switchToParentWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can see HyperLogLog title in Command Helper for this command group', async t => {
+    .meta({ env: env.web })('Verify that user can see HyperLogLog title in Command Helper for this command group', async t => {
         filteringGroup = 'HyperLogLog';
         commandToCheck = 'PFCOUNT';
         commandArgumentsToCheck = 'PFCOUNT key [key ...]';
         externalPageLink = 'https://redis.io/commands/pfcount/';
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from the list
+        // Select one command from the list
         await cliPage.selectFilterGroupType(filteringGroup);
         await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        //Verify results of opened command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title');
-        //Click on Read More link for selected command
+        // Verify results of opened command
+        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title not correct');
+        // Click on Read More link for selected command
         await t.click(cliPage.readMoreButton);
-        //Check new opened window page with the correct URL
+        // Check new opened window page with the correct URL
         await common.checkURL(externalPageLink);
         // await t.expect(getPageUrl()).eql(externalPageLink, 'The opened page');
         await t.switchToParentWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can see all separated groups for AI json file (model, tensor, inference, script)', async t => {
+    .meta({ env: env.web })('Verify that user can see all separated groups for AI json file (model, tensor, inference, script)', async t => {
         filteringGroups = ['Model', 'Script', 'Inference', 'Tensor'];
         commandsToCheck = [
             'AI.MODELDEL',
@@ -164,48 +161,50 @@ test
             'https://redis.io/commands/ai.scriptexecute',
             'https://redis.io/commands/ai.tensorset'
         ];
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
         let i = 0;
         while (i < filteringGroups.length) {
-            //Select one group from the list
+            // Select one group from the list
             await cliPage.selectFilterGroupType(filteringGroups[i]);
-            //Click on the group
+            // Click on the group
             await t.click(cliPage.cliHelperOutputTitles.withExactText(commandsToCheck[i]));
-            //Verify results of opened command
-            await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandsArgumentsToCheck[i], 'Selected command title');
-            //Click on Read More link for selected command
+            // Verify results of opened command
+            await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandsArgumentsToCheck[i], 'Selected command title not correct');
+            // Click on Read More link for selected command
             await t.click(cliPage.readMoreButton);
-            //Check new opened window page with the correct URL
+            // Check new opened window page with the correct URL
             await common.checkURL(externalPageLinks[i]);
-            //Close the window with external link to switch to the application window
+            // Close the window with external link to switch to the application window
             await t.closeWindow();
             i++;
         }
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can work with Gears group in Command Helper (RedisGears module)', async t => {
+    .meta({ env: env.web })('Verify that user can work with Gears group in Command Helper (RedisGears module)', async t => {
         filteringGroup = 'Gears';
         commandToCheck = 'RG.GETEXECUTION';
         commandArgumentsToCheck = 'RG.GETEXECUTION id [SHARD|CLUSTER]';
         externalPageLink = 'https://redis.io/commands/rg.getexecution';
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
-        //Verify that user can see Gears group in Command Helper (RedisGears module)
+        // Verify that user can see Gears group in Command Helper (RedisGears module)
         await cliPage.selectFilterGroupType(filteringGroup);
-        //Select one command from the Gears list
+        // Select one command from the Gears list
         await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        //Verify results of opened command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title');
-        //Verify that user can use Read More link for Gears group in Command Helper (RedisGears module)
+        // Verify results of opened command
+        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandArgumentsToCheck, 'Selected command title not correct');
+        // Verify that user can use Read More link for Gears group in Command Helper (RedisGears module)
         await t.click(cliPage.readMoreButton);
-        //Check new opened window page with the correct URL
+        // Check new opened window page with the correct URL
         await common.checkURL(externalPageLink);
-        //Close the window with external link to switch to the application window
+        // Close the window with external link to switch to the application window
         await t.closeWindow();
     });
 test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can work with Bloom groups in Command Helper (RedisBloom module)', async t => {
+    .meta({ env: env.web })('Verify that user can work with Bloom groups in Command Helper (RedisBloom module)', async t => {
         filteringGroups = ['Bloom Filter', 'CMS', 'TDigest', 'TopK', 'Cuckoo Filter'];
         commandsToCheck = [
             'BF.MEXISTS',
@@ -228,46 +227,47 @@ test
             'https://redis.io/commands/topk.list/',
             'https://redis.io/commands/cf.add/'
         ];
-        //Open Command Helper
+
+        // Open Command Helper
         await t.click(cliPage.expandCommandHelperButton);
         let i = 0;
         while (i < filteringGroup.length) {
-            //Verify that user can see Bloom, Cuckoo, CMS, TDigest, TopK groups in Command Helper (RedisBloom module)
+            // Verify that user can see Bloom, Cuckoo, CMS, TDigest, TopK groups in Command Helper (RedisBloom module)
             await cliPage.selectFilterGroupType(filteringGroups[i]);
-            //Click on the command
+            // Click on the command
             await t.click(cliPage.cliHelperOutputTitles.withExactText(commandsToCheck[i]));
-            //Verify results of opened command
-            await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandsArgumentsToCheck[i], 'Selected command title');
-            //Verify that user can use Read More link for Bloom, Cuckoo, CMS, TDigest, TopK groups in Command Helper (RedisBloom module).
+            // Verify results of opened command
+            await t.expect(cliPage.cliHelperTitleArgs.textContent).eql(commandsArgumentsToCheck[i], 'Selected command title not correct');
+            // Verify that user can use Read More link for Bloom, Cuckoo, CMS, TDigest, TopK groups in Command Helper (RedisBloom module).
             await t.click(cliPage.readMoreButton);
-            //Check new opened window page with the correct URL
+            // Check new opened window page with the correct URL
             await common.checkURL(externalPageLinks[i]);
-            //Close the window with external link to switch to the application window
+            // Close the window with external link to switch to the application window
             await t.closeWindow();
             i++;
         }
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can go back to list of commands for group in Command Helper', async t => {
-        filteringGroup = 'Search';
-        commandToCheck = 'FT.EXPLAIN';
-        const commandForSearch = 'EXPLAIN';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from the list
-        await t.typeText(cliPage.cliHelperSearch, commandForSearch);
-        await cliPage.selectFilterGroupType(filteringGroup);
-        // Remember found commands
-        const commandsFilterCount = await cliPage.cliHelperOutputTitles.count;
-        const filteredCommands: string[] = [];
-        for (let i = 0; i < commandsFilterCount; i++) {
-            filteredCommands.push(await cliPage.cliHelperOutputTitles.nth(i).textContent);
-        }
-        // Select command
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
-        // Click return button
-        await t.click(cliPage.returnToList);
-        // Check that user returned to list with filter and search applied
-        await cliActions.checkCommandsInCommandHelper(filteredCommands);
-        await t.expect(cliPage.returnToList.exists).notOk('Return to list button still displayed');
-    });
+test('Verify that user can go back to list of commands for group in Command Helper', async t => {
+    filteringGroup = 'Search';
+    commandToCheck = 'FT.EXPLAIN';
+    const commandForSearch = 'EXPLAIN';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Select one command from the list
+    await t.typeText(cliPage.cliHelperSearch, commandForSearch);
+    await cliPage.selectFilterGroupType(filteringGroup);
+    // Remember found commands
+    const commandsFilterCount = await cliPage.cliHelperOutputTitles.count;
+    const filteredCommands: string[] = [];
+    for (let i = 0; i < commandsFilterCount; i++) {
+        filteredCommands.push(await cliPage.cliHelperOutputTitles.nth(i).textContent);
+    }
+    // Select command
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(commandToCheck));
+    // Click return button
+    await t.click(cliPage.returnToList);
+    // Check that user returned to list with filter and search applied
+    await cliActions.checkCommandsInCommandHelper(filteredCommands);
+    await t.expect(cliPage.returnToList.exists).notOk('Return to list button still displayed');
+});

--- a/tests/e2e/tests/regression/cli/cli-logical-db.e2e.ts
+++ b/tests/e2e/tests/regression/cli/cli-logical-db.e2e.ts
@@ -21,95 +21,76 @@ const cliMessage = [
 ];
 
 fixture `CLI logical database`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
     })
-    .afterEach(async () => {
-        //Delete database
-        await deleteDatabase(ossStandaloneConfig.databaseName + ` [${index}]`);
-    })
+    .afterEach(async() => {
+        // Delete database
+        await deleteDatabase(`${ossStandaloneConfig.databaseName  } [${index}]`);
+    });
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Delete database
+    .after(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that working with logical DBs, user can not see 0 DB index in CLI', async t => {
+    })('Verify that working with logical DBs, user can not see 0 DB index in CLI', async t => {
         await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Open CLI
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Verify that user can not see 0 DB index in CLI
-        for ( const text of cliMessage ) {
-            await t.expect(cliPage.cliArea.textContent).contains(text, 'No DB index is displayed in the CLI message');
+        // Verify that user can not see 0 DB index in CLI
+        for (const text of cliMessage) {
+            await t.expect(cliPage.cliArea.textContent).contains(text, 'No DB index is not displayed in the CLI message');
         }
-        await t.expect(cliPage.cliDbIndex.visible).eql(false, 'No DB index before the > character in CLI is displayed');
+        await t.expect(cliPage.cliDbIndex.visible).eql(false, 'No DB index before the > character in CLI is not displayed');
         await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, 'Database index 0 is not displayed in the CLI endpoint');
-});
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that working with logical DBs, user can see N DB index in CLI', async t => {
-        index = '1';
-        databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
-        await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName + ` [${index}]`);
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Verify that user can see DB index in CLI
-        for ( const text of cliMessage ) {
-            await t.expect(cliPage.cliArea.textContent).contains(text, 'DB index is displayed in the CLI message');
-        }
-        await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'DB index before the > character in CLI is displayed');
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, 'Database index is displayed in the CLI endpoint');
-});
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user re-creates client in CLI the new client is connected to the DB index selected for the DB by default', async t => {
-        index = '2';
-        databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
-        await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName + ` [${index}]`);
-        //Open CLI and verify that user can see DB index in CLI
-        await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'DB index before the > character in CLI is displayed');
-        //Re-creates client in CLI
-        await t.click(cliPage.cliCollapseButton);
-        await t.click(cliPage.cliExpandButton);
-        //Verify that the new client is connected to the DB index selected for the DB by default
-        await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'The new client is connected to the DB index selected for the DB by default');
-});
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see DB index in the endpoint in CLI header is automatically changed when switched to another logical DB', async t => {
-        index = '2';
-        const indexAfter = '3';
-        databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
-        const databaseEndpointAfter = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${indexAfter}]`;
-        await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName + ` [${index}]`);
-        //Open CLI and verify the database index in the endpoint
-        await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header contains ${index} index`);
-        //Switch to another logical database and check endpoint
-        await t.typeText(cliPage.cliCommandInput, `Select ${indexAfter}`, { paste: true });
-        await t.pressKey('enter');
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpointAfter, `The endpoint in CLI header is automatically changed to the new ${indexAfter}`);
-});
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can work with selected logical DB in CLI when he minimazes and then maximizes the CLI', async t => {
-        index = '2';
-        databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
-        await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName + ` [${index}]`);
-        //Open CLI and verify the database index in the endpoint
-        await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header contains ${index} index`);
-        //Minimize and maximize CLI and verify endpoint
-        await t.click(cliPage.minimizeCliButton);
-        await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header contains ${index} index after minimize`);
-});
+    });
+test('Verify that working with logical DBs, user can see N DB index in CLI', async t => {
+    index = '1';
+    databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
 
+    await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
+    await myRedisDatabasePage.clickOnDBByName(`${ossStandaloneConfig.databaseName  } [${index}]`);
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Verify that user can see DB index in CLI
+    for (const text of cliMessage) {
+        await t.expect(cliPage.cliArea.textContent).contains(text, 'DB index is not displayed in the CLI message');
+    }
+    await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'DB index before the > character in CLI is not displayed');
+    await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, 'Database index is not displayed in the CLI endpoint');
+});
+test('Verify that user can see DB index in the endpoint in CLI header is automatically changed when switched to another logical DB', async t => {
+    index = '2';
+    const indexAfter = '3';
+    databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${index}]`;
+    const databaseEndpointAfter = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}[${indexAfter}]`;
+
+    await addRedisDatabasePage.addLogicalRedisDatabase(ossStandaloneConfig, index);
+    await myRedisDatabasePage.clickOnDBByName(`${ossStandaloneConfig.databaseName  } [${index}]`);
+
+    // Open CLI and verify that user can see DB index in CLI
+    await t.click(cliPage.cliExpandButton);
+    await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'DB index before the > character in CLI is not displayed');
+    // Re-creates client in CLI
+    await t.click(cliPage.cliCollapseButton);
+    await t.click(cliPage.cliExpandButton);
+    // Verify that when user re-creates client in CLI the new client is connected to the DB index selected for the DB by default
+    await t.expect(cliPage.cliDbIndex.textContent).eql(`[${index}] `, 'The new client is not connected to the DB index selected for the DB by default');
+
+    // Open CLI and verify the database index in the endpoint
+    await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header not contains ${index} index`);
+    // Minimize and maximize CLI
+    await t.click(cliPage.minimizeCliButton);
+    await t.click(cliPage.cliExpandButton);
+    // Verify that user can work with selected logical DB in CLI when he minimazes and then maximizes the CLI
+    await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header not contains ${index} index after minimize`);
+
+    // Open CLI and verify the database index in the endpoint
+    await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, `The endpoint in CLI header not contains ${index} index`);
+    // Switch to another logical database and check endpoint
+    await t.typeText(cliPage.cliCommandInput, `Select ${indexAfter}`, { paste: true });
+    await t.pressKey('enter');
+    await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpointAfter, `The endpoint in CLI header is not automatically changed to the new ${indexAfter}`);
+});

--- a/tests/e2e/tests/regression/cli/cli-promote-workbench.ts
+++ b/tests/e2e/tests/regression/cli/cli-promote-workbench.ts
@@ -12,7 +12,7 @@ const workbenchPage = new WorkbenchPage();
 const myRedisDatabasePage = new MyRedisDatabasePage();
 
 fixture `Promote workbench in CLI`
-    .meta({ rte: rte.standalone, type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
@@ -21,16 +21,16 @@ fixture `Promote workbench in CLI`
         // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-test('Verify that users can see workbench promotion message when they open CLI', async t => {
-    // Open CLI
-    await t.click(cliPage.cliExpandButton);
-    await t.expect(cliPage.workbenchLink.parent().textContent).eql('Try Workbench, our advanced CLI. Check out our Quick Guides to learn more about Redis capabilities.');
-    // Verify that user is redirected to Workbench page clicking on workbench link in CLI
-    await t.click(cliPage.workbenchLink);
-    await t.expect(workbenchPage.expandArea.exists).ok('Workbench page is opened');
-    // Verify that CLI panel is minimized after redirection to workbench from CLI
-    await t.expect(cliPage.cliPanel.visible).notOk('Closed CLI');
-});
+// test('Verify that users can see workbench promotion message when they open CLI', async t => {
+//     // Open CLI
+//     await t.click(cliPage.cliExpandButton);
+//     await t.expect(cliPage.workbenchLink.parent().textContent).eql('Try Workbench, our advanced CLI. Check out our Quick Guides to learn more about Redis capabilities.', 'Wrong promotion message');
+//     // Verify that user is redirected to Workbench page clicking on workbench link in CLI
+//     await t.click(cliPage.workbenchLink);
+//     await t.expect(workbenchPage.expandArea.exists).ok('Workbench page is not opened');
+//     // Verify that CLI panel is minimized after redirection to workbench from CLI
+//     await t.expect(cliPage.cliPanel.visible).notOk('Closed CLI');
+// });
 test('Verify that user can see saved workbench context after redirection from CLI to workbench', async t => {
     // Open Workbench
     await t.click(myRedisDatabasePage.workbenchButton);
@@ -40,11 +40,17 @@ test('Verify that user can see saved workbench context after redirection from CL
     await t.click(workbenchPage.collapsePreselectAreaButton);
     // Turn to Browser page
     await t.click(myRedisDatabasePage.browserButton);
-    // Open CLI
+    // Verify that users can see workbench promotion message when they open CLI
     await t.click(cliPage.cliExpandButton);
+    await t.expect(cliPage.workbenchLink.parent().textContent).eql('Try Workbench, our advanced CLI. Check out our Quick Guides to learn more about Redis capabilities.', 'Wrong promotion message');
+    // Verify that user is redirected to Workbench page clicking on workbench link in CLI
     await t.click(cliPage.workbenchLink);
+    await t.expect(workbenchPage.expandArea.exists).ok('Workbench page is not opened');
+    // Verify that CLI panel is minimized after redirection to workbench from CLI
+    await t.expect(cliPage.cliPanel.visible).notOk('Closed CLI');
+
     // Check content in Workbench area
-    await t.expect(workbenchPage.expandPreselectAreaButton.visible).ok('Enablement area is folded');
+    await t.expect(workbenchPage.expandPreselectAreaButton.visible).ok('Enablement area is not folded');
     // Check editor
-    await t.expect(workbenchPage.mainEditorArea.find('span').withExactText(command).visible).ok('Command is saved in editor');
+    await t.expect(workbenchPage.mainEditorArea.find('span').withExactText(command).visible).ok('Command is not saved in editor');
 });

--- a/tests/e2e/tests/regression/cli/cli-promote-workbench.ts
+++ b/tests/e2e/tests/regression/cli/cli-promote-workbench.ts
@@ -21,16 +21,6 @@ fixture `Promote workbench in CLI`
         // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
-// test('Verify that users can see workbench promotion message when they open CLI', async t => {
-//     // Open CLI
-//     await t.click(cliPage.cliExpandButton);
-//     await t.expect(cliPage.workbenchLink.parent().textContent).eql('Try Workbench, our advanced CLI. Check out our Quick Guides to learn more about Redis capabilities.', 'Wrong promotion message');
-//     // Verify that user is redirected to Workbench page clicking on workbench link in CLI
-//     await t.click(cliPage.workbenchLink);
-//     await t.expect(workbenchPage.expandArea.exists).ok('Workbench page is not opened');
-//     // Verify that CLI panel is minimized after redirection to workbench from CLI
-//     await t.expect(cliPage.cliPanel.visible).notOk('Closed CLI');
-// });
 test('Verify that user can see saved workbench context after redirection from CLI to workbench', async t => {
     // Open Workbench
     await t.click(myRedisDatabasePage.workbenchButton);

--- a/tests/e2e/tests/regression/cli/cli-re-cluster.e2e.ts
+++ b/tests/e2e/tests/regression/cli/cli-re-cluster.e2e.ts
@@ -22,14 +22,14 @@ const cliPage = new CliPage();
 const common = new Common();
 
 let keyName = common.generateWord(10);
-const verifyCommandsInCli = async() => {
+const verifyCommandsInCli = async(): Promise<void> => {
     keyName = common.generateWord(10);
-    //Open CLI
+    // Open CLI
     await t.click(cliPage.cliExpandButton);
-    //Add key from CLI
+    // Add key from CLI
     await t.typeText(cliPage.cliCommandInput, `SADD ${keyName} "chinese" "japanese" "german"`);
     await t.pressKey('enter');
-    //Check that the key is added
+    // Check that the key is added
     await browserPage.searchByKeyName(keyName);
     const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
     await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
@@ -44,7 +44,7 @@ test
         await acceptLicenseTermsAndAddREClusterDatabase(redisEnterpriseClusterConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(redisEnterpriseClusterConfig.databaseName);
     })('Verify that user can add data via CLI in RE Cluster DB', async() => {
@@ -56,7 +56,7 @@ test
         await acceptLicenseTermsAndAddRECloudDatabase(cloudDatabaseConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(cloudDatabaseConfig.databaseName);
     })('Verify that user can add data via CLI in RE Cloud DB', async() => {
@@ -68,7 +68,7 @@ test
         await acceptLicenseTermsAndAddOSSClusterDatabase(ossClusterConfig, ossClusterConfig.ossClusterDatabaseName);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })('Verify that user can add data via CLI in OSS Cluster DB', async() => {
@@ -80,7 +80,7 @@ test
         await acceptLicenseTermsAndAddSentinelDatabaseApi(ossSentinelConfig);
     })
     .after(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteAllSentinelDatabasesApi(ossSentinelConfig);
     })('Verify that user can add data via CLI in Sentinel Primary Group', async() => {

--- a/tests/e2e/tests/regression/cli/cli.e2e.ts
+++ b/tests/e2e/tests/regression/cli/cli.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { Common } from '../../../helpers/common';
 import { BrowserPage, CliPage } from '../../../pageObjects';
@@ -11,128 +10,84 @@ import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 
 const cliPage = new CliPage();
 const common = new Common();
-const chance = new Chance();
 const browserPage = new BrowserPage();
 
-let keyName = chance.word({ length: 20 });
+let keyName = common.generateWord(20);
 const keyTTL = '2147476121';
 const jsonValue = '{"name":"xyz"}';
 const cliCommands = ['get test', 'acl help', 'client list'];
 
 fixture `CLI`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see CLI is minimized when he clicks the "minimize" button', async t => {
-        const cliColourBefore = await common.getBackgroundColour(cliPage.cliBadge);
-        //Open CLI and minimize
-        await t.click(cliPage.cliExpandButton);
-        await t.click(cliPage.minimizeCliButton);
-        //Verify cli is minimized
-        const cliColourAfter = await common.getBackgroundColour(cliPage.cliBadge);
-        await t.expect(cliColourAfter).notEql(cliColourBefore, 'CLI badge colour is changed');
-        await t.expect(cliPage.minimizeCliButton.visible).eql(false, 'CLI is mimized');
     });
+test('Verify that user can see CLI is minimized when he clicks the "minimize" button', async t => {
+    const cliColourBefore = await common.getBackgroundColour(cliPage.cliBadge);
+
+    // Open CLI and minimize
+    await t.click(cliPage.cliExpandButton);
+    await t.click(cliPage.minimizeCliButton);
+    // Verify cli is minimized
+    const cliColourAfter = await common.getBackgroundColour(cliPage.cliBadge);
+    await t.expect(cliColourAfter).notEql(cliColourBefore, 'CLI badge colour is not changed');
+    await t.expect(cliPage.minimizeCliButton.visible).eql(false, 'CLI is not mimized');
+});
+test('Verify that user can see results history when he re-opens CLI after minimizing', async t => {
+    const command = 'SET key';
+
+    // Open CLI and run commands
+    await t.click(cliPage.cliExpandButton);
+    await t.typeText(cliPage.cliCommandInput, command);
+    await t.pressKey('enter');
+    // Minimize and re-open cli
+    await t.click(cliPage.minimizeCliButton);
+    await t.click(cliPage.cliExpandButton);
+    // Verify cli results history
+    await t.expect(cliPage.cliCommandExecuted.textContent).eql(command, 'CLI results history not persists after reopening');
+});
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see results history when he re-opens CLI after minimizing', async t => {
-        const command = 'SET key';
-        //Open CLI and run commands
-        await t.click(cliPage.cliExpandButton);
-        await t.typeText(cliPage.cliCommandInput, command);
-        await t.pressKey('enter');
-        //Minimize and re-open cli
-        await t.click(cliPage.minimizeCliButton);
-        await t.click(cliPage.cliExpandButton);
-        //Verify cli results history
-        await t.expect(cliPage.cliCommandExecuted.textContent).eql(command, 'CLI results history persists after reopening');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see CLI is minimized when he clicks the "minimize" button', async t => {
-        const cliColourBefore = await common.getBackgroundColour(cliPage.cliBadge);
-        //Open CLI and minimize
-        await t.click(cliPage.cliExpandButton);
-        await t.click(cliPage.minimizeCliButton);
-        //Verify cli is minimized
-        const cliColourAfter = await common.getBackgroundColour(cliPage.cliBadge);
-        await t.expect(cliColourAfter).notEql(cliColourBefore, 'CLI badge colour is changed');
-        await t.expect(cliPage.minimizeCliButton.visible).eql(false, 'CLI is mimized');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see results history when he re-opens CLI after minimizing', async t => {
-        const command = 'SET key';
-        //Open CLI and run commands
-        await t.click(cliPage.cliExpandButton);
-        await t.typeText(cliPage.cliCommandInput, command);
-        await t.pressKey('enter');
-        //Minimize and re-open cli
-        await t.click(cliPage.minimizeCliButton);
-        await t.click(cliPage.cliExpandButton);
-        //Verify cli results history
-        await t.expect(cliPage.cliCommandExecuted.textContent).eql(command, 'CLI results history persists after reopening');
-    });
-test
-    .meta({ rte: rte.standalone })
     .after(async() => {
-        //Clear database and delete
+        // Clear database and delete
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can repeat commands by entering a number of repeats before the Redis command in CLI', async t => {
-        keyName = chance.word({ length: 20 });
+    })('Verify that user can repeat commands by entering a number of repeats before the Redis command in CLI', async t => {
+        keyName = common.generateWord(20);
         const command = `SET ${keyName} a`;
         const repeats = 10;
-        //Open CLI and run command with repeats
+
+        // Open CLI and run command with repeats
         await t.click(cliPage.cliExpandButton);
         await t.typeText(cliPage.cliCommandInput, `${repeats} ${command}`);
         await t.pressKey('enter');
-        //Verify result
-        await t.expect(cliPage.cliOutputResponseSuccess.count).eql(repeats, `CLI contains ${repeats} results`);
-});
+        // Verify result
+        await t.expect(cliPage.cliOutputResponseSuccess.count).eql(repeats, `CLI not contains ${repeats} results`);
+    });
 test
-    .meta({ rte: rte.standalone })
     .after(async() => {
-        //Clear database and delete
+        // Clear database and delete
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can run command json.get and see JSON object with escaped quotes (\" instead of ")', async t => {
-        keyName = chance.word({ length: 20 });
+    })('Verify that user can run command json.get and see JSON object with escaped quotes (\" instead of ")', async t => {
+        keyName = common.generateWord(20);
         const jsonValueCli = '"{\\"name\\":\\"xyz\\"}"';
-        //Add Json key with json object
+
+        // Add Json key with json object
         await browserPage.addJsonKey(keyName, jsonValue, keyTTL);
         const command = `JSON.GET ${keyName}`;
-        //Open CLI and run command
+        // Open CLI and run command
         await t.click(cliPage.cliExpandButton);
         await t.typeText(cliPage.cliCommandInput, command, { paste: true });
         await t.pressKey('enter');
-        //Verify result
-        await t.expect(cliPage.cliOutputResponseSuccess.innerText).eql(jsonValueCli, 'The user can see JSON object with escaped quotes');
-});
-test
-    .meta({ rte: rte.standalone })
-    .after(async() => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can see DB endpoint in the header of CLI', async t => {
-        const databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}`;
-        //Open CLI and check endpoint
-        await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, 'The user can see DB endpoint in the header of CLI');
+        // Verify result
+        await t.expect(cliPage.cliOutputResponseSuccess.innerText).eql(jsonValueCli, 'The user can not see JSON object with escaped quotes');
     });
 test
-    .meta({rte: rte.standalone})
     .before(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         for (const command of cliCommands) {
@@ -140,11 +95,15 @@ test
         }
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can use "Up" and "Down" keys to view previous commands in CLI in the application', async t => {
+    })('Verify that user can use "Up" and "Down" keys to view previous commands in CLI in the application', async t => {
+        const databaseEndpoint = `${ossStandaloneConfig.host}:${ossStandaloneConfig.port}`;
+
         await t.click(cliPage.cliExpandButton);
+        // Verify that user can see DB endpoint in the header of CLI
+        await t.expect(cliPage.cliEndpoint.textContent).eql(databaseEndpoint, 'The user can not see DB endpoint in the header of CLI');
+
         await t.expect(cliPage.cliCommandInput.innerText).eql('');
         for (let i = cliCommands.length - 1; i >= 0; i--) {
             await t.pressKey('up');

--- a/tests/e2e/tests/regression/database/database-list-search.e2e.ts
+++ b/tests/e2e/tests/regression/database/database-list-search.e2e.ts
@@ -3,9 +3,9 @@ import {
     addNewStandaloneDatabasesApi,
     deleteStandaloneDatabasesApi,
     discoverSentinelDatabaseApi,
-    deleteAllSentinelDatabasesApi,
     addNewOSSClusterDatabaseApi,
-    deleteOSSClusterDatabaseApi
+    deleteOSSClusterDatabaseApi,
+    deleteAllDatabasesByConnectionTypeApi
 } from '../../../helpers/api/api-database';
 import { MyRedisDatabasePage } from '../../../pageObjects';
 import { rte } from '../../../helpers/constants';
@@ -35,76 +35,72 @@ fixture `Database list search`
         await acceptLicenseTerms();
         await addNewStandaloneDatabasesApi(databasesForAdding);
         await addNewOSSClusterDatabaseApi(ossClusterConfig);
-        await discoverSentinelDatabaseApi(ossSentinelConfig);
+        await discoverSentinelDatabaseApi(ossSentinelConfig, 1);
         // Reload Page
         await common.reloadPage();
     })
     .afterEach(async() => {
-        //Clear and delete databases
+        // Clear and delete databases
         await deleteStandaloneDatabasesApi(databasesForAdding);
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
-        await deleteAllSentinelDatabasesApi(ossSentinelConfig);
+        await deleteAllDatabasesByConnectionTypeApi('SENTINEL');
     });
-test('Verify that user can search DB by database name on the List of databases', async t => {
-    //Search for DB by name
+test('Verify DB list search', async t => {
+    const searchedDBHostInvalid = 'invalid';
     const searchedDBName = 'Search';
-    await t.typeText(myRedisDatabasePage.searchInput, searchedDBName, { replace: true });
-    //Verify that database found on the list search by name
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).ok('The database with alias not found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).ok('The database with alias not found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[2].databaseName).exists).notOk('The database with other alias is found', { timeout: 10000 });
-});
-test('Verify that user can search DB by host on the List of databases', async t => {
-    //Search for DB by host
     const searchedDBHost = ossStandaloneConfig.host;
-    await t.typeText(myRedisDatabasePage.searchInput, searchedDBHost, { replace: true });
-    //Verify that database found on the list search by host
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).ok('The database with host not found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).ok('The database with host not found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossSentinelConfig.name[1]).exists).notOk('The database with other host is found', { timeout: 10000 });
-});
-test('Verify that user can search DB by port on the List of databases', async t => {
-    //Search for DB by port
     const searchedDBPort = ossSentinelConfig.sentinelPort;
-    await t.typeText(myRedisDatabasePage.searchInput, searchedDBPort, { replace: true });
-    //Verify that database found on the list search by port
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).notOk('The database with port is found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).notOk('The database with port is found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossSentinelConfig.name[1]).exists).ok('The database with other port is not found', { timeout: 10000 });
-});
-// Unskip after fixing https://redislabs.atlassian.net/browse/RI-3300
-test.skip('Verify that user can search DB by Connection Type on the List of databases', async t => {
-    //Search for DB by connection type
     const searchedDBConType = 'OSS Cluster';
-    await t.typeText(myRedisDatabasePage.searchInput, searchedDBConType, { replace: true });
-    //Verify that database found on the list search by connection type
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossClusterConfig.ossClusterDatabaseName).exists).ok('The database with connection type not found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).notOk('The database with other connection type found', { timeout: 10000 });
-    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).notOk('The database with other connection type found', { timeout: 10000 });
-});
-test('Verify that user can search DB by Last Connection on the List of databases', async t => {
     const searchedDBFirst = 'less than a minute ago';
     const searchedDBSecond = '1 minute ago';
     const searchTimeout = 60 * 1000; // 60 sec to wait for changing Last Connection time
     const dbSelector = myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[2].databaseName);
     const startTime = Date.now();
-    //Search for DB by Last Connection
+
+    // Search for DB by Invalid search
+    await t.typeText(myRedisDatabasePage.searchInput, searchedDBHostInvalid, { replace: true });
+    // Verify that user sees "No results found" message when pattern doesn`t match any database
+    await t.expect(myRedisDatabasePage.noResultsFoundMessage.exists).ok('"No results found message" not displayed');
+    await t.expect(myRedisDatabasePage.noResultsFoundText.exists).ok('"No databases matched your search" message not displayed');
+
+    // Search for DB by name
+    await t.typeText(myRedisDatabasePage.searchInput, searchedDBName, { replace: true });
+    // Verify that user can search DB by database name on the List of databases
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).ok('The database with alias not found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).ok('The database with alias not found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[2].databaseName).exists).notOk('The database with other alias is found', { timeout: 10000 });
+
+    // Search for DB by host
+    await t.typeText(myRedisDatabasePage.searchInput, searchedDBHost, { replace: true });
+    // Verify that user can search DB by host on the List of databases
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).ok('The database with host not found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).ok('The database with host not found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossSentinelConfig.name[0]).exists).notOk('The database with other host is found', { timeout: 10000 });
+
+    // Search for DB by port
+    await t.typeText(myRedisDatabasePage.searchInput, searchedDBPort, { replace: true });
+    // Verify that user can search DB by port on the List of databases
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).notOk('The database with port is found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).notOk('The database with port is found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossSentinelConfig.name[0]).exists).ok('The database with other port is not found', { timeout: 10000 });
+
+    // Search for DB by connection type
+    await t.typeText(myRedisDatabasePage.searchInput, searchedDBConType, { replace: true });
+    // Verify that user can search DB by Connection Type on the List of databases
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossClusterConfig.ossClusterDatabaseName).exists).ok('The database with connection type not found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[0].databaseName).exists).notOk('The database with other connection type found', { timeout: 10000 });
+    await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).notOk('The database with other connection type found', { timeout: 10000 });
+
+    // Search for DB by Last Connection
     await t.typeText(myRedisDatabasePage.searchInput, searchedDBFirst, { replace: true });
-    //Verify that database added < 1min ago found on the list search by Last Connection
+    // Verify that database added < 1min ago found on the list search by Last Connection
     await t.expect(myRedisDatabasePage.dbNameList.withExactText(databasesForSearch[1].databaseName).exists).ok('The database with Last Connection not found', { timeout: 10000 });
-    //Verify that database added > 1min ago found on the list search by Last Connection
+    // Verify that database added > 1min ago found on the list search by Last Connection
     do {
         await common.reloadPage();
         await t.typeText(myRedisDatabasePage.searchInput, searchedDBSecond, { replace: true });
     }
     while (!(await dbSelector.exists) && Date.now() - startTime < searchTimeout);
+    // Verify that user can search DB by Last Connection on the List of databases
     await t.expect(dbSelector.exists).ok('The database with Last Connection not found', { timeout: 10000 });
-});
-test('Verify that user sees "No results found" message when pattern doesn`t match any database', async t => {
-    //Search for DB by Invalid search
-    const searchedDBHost = 'invalid';
-    await t.typeText(myRedisDatabasePage.searchInput, searchedDBHost, { replace: true });
-    //Verify that "No results found" message is displayed in case of invalid search
-    await t.expect(myRedisDatabasePage.noResultsFoundMessage.exists).ok('"No results found message" not displayed');
-    await t.expect(myRedisDatabasePage.noResultsFoundText.exists).ok('"No databases matched your search" message not displayed');
 });

--- a/tests/e2e/tests/regression/database/edit-db.e2e.ts
+++ b/tests/e2e/tests/regression/database/edit-db.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi, deleteDatabase } from '../../../helpers/database';
 import { MyRedisDatabasePage } from '../../../pageObjects';
 import {
@@ -6,37 +5,35 @@ import {
     ossStandaloneConfig
 } from '../../../helpers/conf';
 import { rte } from '../../../helpers/constants';
+import { Common } from '../../../helpers/common';
 
-const chance = new Chance();
+const common = new Common();
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const database = Object.assign({}, ossStandaloneConfig);
 
-const previousDatabaseName = chance.word({ length: 20 });
-const newDatabaseName = chance.word({ length: 20 });
+const previousDatabaseName = common.generateWord(20);
+const newDatabaseName = common.generateWord(20);
 database.databaseName = previousDatabaseName;
 
 fixture `List of Databases`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(database, database.databaseName);
-        console.log(`Newly added database name is ${database.databaseName}`);
     });
 test
-    .meta({ rte: rte.standalone })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(newDatabaseName);
     })('Verify that user can edit DB alias of Standalone DB', async t => {
         await t.click(myRedisDatabasePage.myRedisDBButton);
-        //Edit alias of added database
+        // Edit alias of added database
         await myRedisDatabasePage.clickOnEditDBByName(database.databaseName);
         await t.click(myRedisDatabasePage.editAliasButton);
         await t.typeText(myRedisDatabasePage.aliasInput, newDatabaseName, { replace: true });
         await t.click(myRedisDatabasePage.applyButton);
         await t.click(myRedisDatabasePage.submitChangesButton);
-        console.log(`New database name is ${database.databaseName}`);
-        //Verify that database has new alias
-        await t.expect(myRedisDatabasePage.dbNameList.withExactText(newDatabaseName).exists).ok('The database with new alias is in the list', { timeout: 10000 });
-        await t.expect(myRedisDatabasePage.dbNameList.withExactText(previousDatabaseName).exists).notOk('The database with previous alias is not in the list', { timeout: 10000 });
+        // Verify that database has new alias
+        await t.expect(myRedisDatabasePage.dbNameList.withExactText(newDatabaseName).exists).ok('The database with new alias is in not the list', { timeout: 10000 });
+        await t.expect(myRedisDatabasePage.dbNameList.withExactText(previousDatabaseName).exists).notOk('The database with previous alias is still in the list', { timeout: 10000 });
     });

--- a/tests/e2e/tests/regression/database/github.e2e.ts
+++ b/tests/e2e/tests/regression/database/github.e2e.ts
@@ -13,29 +13,28 @@ const getPageUrl = ClientFunction(() => window.location.href);
 fixture `Github functionality`
     .meta({ type: 'regression' })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
         await addNewStandaloneDatabaseApi(ossStandaloneConfig);
         // Reload Page
         await common.reloadPage();
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
+    });
 test
-    .meta({ rte: rte.standalone, env: env.web })
-    ('Verify that user can work with Github link in the application', async t => {
-        //Verify that user can see the icon for GitHub reference at the bottom of the left side bar in the List of DBs
-        await t.expect(myRedisDatabasePage.githubButton.visible).ok('Github button');
+    .meta({ rte: rte.standalone, env: env.web })('Verify that user can work with Github link in the application', async t => {
+        // Verify that user can see the icon for GitHub reference at the bottom of the left side bar in the List of DBs
+        await t.expect(myRedisDatabasePage.githubButton.visible).ok('Github button not found');
         //Verify that user can see the icon for GitHub reference at the bottom of the left side bar on the Browser page
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.expect(myRedisDatabasePage.githubButton.visible).ok('Github button');
-        //Verify that user can see the icon for GitHub reference at the bottom of the left side bar on the Workbench page
+        await t.expect(myRedisDatabasePage.githubButton.visible).ok('Github button not found');
+        // Verify that user can see the icon for GitHub reference at the bottom of the left side bar on the Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
         await t.expect(myRedisDatabasePage.githubButton.visible).ok('Github button');
-        //Verify that when user clicks on Github icon he redirects to the URL: https://github.com/RedisInsight/RedisInsight
+        // Verify that when user clicks on Github icon he redirects to the URL: https://github.com/RedisInsight/RedisInsight
         await t.click(myRedisDatabasePage.githubButton);
-        await t.expect(getPageUrl()).contains('https://github.com/RedisInsight/RedisInsight');
+        await t.expect(getPageUrl()).contains('https://github.com/RedisInsight/RedisInsight', 'Link is not correct');
         await t.switchToParentWindow();
     });

--- a/tests/e2e/tests/regression/database/logical-databases.e2e.ts
+++ b/tests/e2e/tests/regression/database/logical-databases.e2e.ts
@@ -9,29 +9,28 @@ const addRedisDatabasePage = new AddRedisDatabasePage();
 const myRedisDatabasePage = new MyRedisDatabasePage();
 
 fixture `Logical databases`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async t => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that if user enters any index of the logical database that does not exist in the database, he can see Redis error "ERR DB index is out of range" and cannot proceed', async t => {
-        const index = '0';
-        //Add database with logical index
-        await addRedisDatabasePage.addRedisDataBase(ossStandaloneConfig);
-        await t.click(addRedisDatabasePage.databaseIndexCheckbox);
-        await t.typeText(addRedisDatabasePage.databaseIndexInput, index, { paste: true });
-        await t.click(addRedisDatabasePage.addRedisDatabaseButton);
-        //Open database and run command with non-existing index
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.click(cliPage.cliExpandButton);
-        await t.typeText(cliPage.cliCommandInput, 'Select 19', { paste: true });
-        await t.pressKey('enter');
-        //Verify the error
-        await t.expect(cliPage.cliOutputResponseFail.textContent).eql('"ERR DB index is out of range"', 'Error is dispalyed in CLI');
     });
+test('Verify that if user enters any index of the logical database that does not exist in the database, he can see Redis error "ERR DB index is out of range" and cannot proceed', async t => {
+    const index = '0';
+
+    // Add database with logical index
+    await addRedisDatabasePage.addRedisDataBase(ossStandaloneConfig);
+    await t.click(addRedisDatabasePage.databaseIndexCheckbox);
+    await t.typeText(addRedisDatabasePage.databaseIndexInput, index, { paste: true });
+    await t.click(addRedisDatabasePage.addRedisDatabaseButton);
+    // Open database and run command with non-existing index
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    await t.click(cliPage.cliExpandButton);
+    await t.typeText(cliPage.cliCommandInput, 'Select 19', { paste: true });
+    await t.pressKey('enter');
+    // Verify the error
+    await t.expect(cliPage.cliOutputResponseFail.textContent).eql('"ERR DB index is out of range"', 'Error is not dispalyed in CLI');
+});

--- a/tests/e2e/tests/regression/database/overview.e2e.ts
+++ b/tests/e2e/tests/regression/database/overview.e2e.ts
@@ -7,25 +7,24 @@ const browserPage = new BrowserPage();
 const databaseOverviewPage = new DatabaseOverviewPage();
 
 fixture `Overview`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.reCloud })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddRECloudDatabase(cloudDatabaseConfig);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(cloudDatabaseConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can see not available metrics from Overview in tooltip with the text "<Metric_name> is/are not available"', async t => {
-        //Verify that CPU parameter is not displayed in Overview
-        await t.expect(browserPage.overviewCpu.visible).notOk('Not available CPU');
-        //Click on More Info icon
-        await t.click(databaseOverviewPage.overviewMoreInfo);
-        //Check that tooltip was opened
-        await t.expect(databaseOverviewPage.overviewTooltip.visible).ok('Overview tooltip');
-        //Verify that Database statistics title is displayed in tooltip
-        await t.expect(databaseOverviewPage.overviewTooltipStatTitle.visible).ok('Statistics title');
-        //Verify that CPU parameter is displayed in tooltip
-        await t.expect(browserPage.overviewCpu.find('i').textContent).eql('CPU is not available');
-    });
+test('Verify that user can see not available metrics from Overview in tooltip with the text "<Metric_name> is/are not available"', async t => {
+    // Verify that CPU parameter is not displayed in Overview
+    await t.expect(browserPage.overviewCpu.visible).notOk('Not available CPU is displayed');
+    // Click on More Info icon
+    await t.click(databaseOverviewPage.overviewMoreInfo);
+    // Check that tooltip was opened
+    await t.expect(databaseOverviewPage.overviewTooltip.visible).ok('Overview tooltip not displayed');
+    // Verify that Database statistics title is displayed in tooltip
+    await t.expect(databaseOverviewPage.overviewTooltipStatTitle.visible).ok('Statistics title not displayed');
+    // Verify that CPU parameter is displayed in tooltip
+    await t.expect(browserPage.overviewCpu.find('i').textContent).eql('CPU is not available');
+});

--- a/tests/e2e/tests/regression/database/redisstack.e2e.ts
+++ b/tests/e2e/tests/regression/database/redisstack.e2e.ts
@@ -1,8 +1,8 @@
 import { rte } from '../../../helpers/constants';
-import { acceptLicenseTerms } from '../../../helpers/database';
+import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, DatabaseOverviewPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { addNewStandaloneDatabaseApi, deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
@@ -11,55 +11,48 @@ const common = new Common();
 const moduleNameList = ['RediSearch', 'RedisGraph', 'RedisBloom', 'RedisJSON', 'RedisTimeSeries'];
 
 fixture `Redis Stack`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         // Add new databases using API
-        await acceptLicenseTerms();
-        await addNewStandaloneDatabaseApi(ossStandaloneConfig);
+        await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         // Reload Page
         await common.reloadPage();
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({rte: rte.standalone})
-    ('Verify that user can see module list Redis Stack icon hovering (without Redis Stack text)', async t => {
-        //Verify that user can see Redis Stack icon when Redis Stack DB is added in the application
-        await t.expect(myRedisDatabasePage.redisStackIcon.visible).ok('Redis Stack icon');
-        //Hover over redis stack icon
-        await t.hover(myRedisDatabasePage.redisStackIcon);
-        await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Tooltip with modules');
-        //Verify that user can see the Redis Stack logo is placed in the module list tooltip in the list of DBs
-        await t.expect(myRedisDatabasePage.tooltipRedisStackLogo.visible).ok('Redis Stack logo');
-        //Check all Redis Stack modules inside
-        await myRedisDatabasePage.checkModulesInTooltip(moduleNameList);
     });
-test
-    .meta({rte: rte.standalone})
-    ('Verify that user can see Redis Stack icon in Edit mode near the DB name', async t => {
-        //Open Edit mode
-        await t.click(myRedisDatabasePage.editDatabaseButton);
-        //Check redis stack icon near the db name
-        await t.expect(myRedisDatabasePage.redisStackIcon.visible).ok('Redis Stack icon');
-        //Verify that user can see the Redis Stack logo is placed in the DB edit form when hover over the RedisStack logo
-        await t.hover(myRedisDatabasePage.redisStackIcon);
-        await t.expect(myRedisDatabasePage.tooltipRedisStackLogo.visible).ok('Redis Stack logo');
-        const databaseName = await myRedisDatabasePage.redisStackIcon.parent().nextSibling();
-        await t.expect(databaseName.withAttribute('data-testid', 'edit-alias-btn').exists).ok();
-    });
-test
-    .meta({rte: rte.standalone})
-    ('Verify that user can see Redis Stack icon and logo in Browser page in Overview.', async t => {
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.expect(databaseOverviewPage.overviewRedisStackLogo.visible).ok('Redis Stack logo');
-        //Open Workbench page
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(databaseOverviewPage.overviewRedisStackLogo.visible).ok('Redis Stack logo');
-        //Check modules inside of the tooltip
-        await t.hover(databaseOverviewPage.overviewRedisStackLogo);
-        await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Tooltip with modules');
-        await myRedisDatabasePage.checkModulesInTooltip(moduleNameList);
-    });
+test('Verify that user can see module list Redis Stack icon hovering (without Redis Stack text)', async t => {
+    // Verify that user can see Redis Stack icon when Redis Stack DB is added in the application
+    await t.expect(myRedisDatabasePage.redisStackIcon.visible).ok('Redis Stack icon not found');
+    // Hover over redis stack icon
+    await t.hover(myRedisDatabasePage.redisStackIcon);
+    await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Tooltip with modules not found');
+    // Verify that user can see the Redis Stack logo is placed in the module list tooltip in the list of DBs
+    await t.expect(myRedisDatabasePage.tooltipRedisStackLogo.visible).ok('Redis Stack logo not found');
+    // Check all Redis Stack modules inside
+    await myRedisDatabasePage.checkModulesInTooltip(moduleNameList);
+});
+test('Verify that user can see Redis Stack icon in Edit mode near the DB name', async t => {
+    // Open Edit mode
+    await t.click(myRedisDatabasePage.editDatabaseButton);
+    // Check redis stack icon near the db name
+    await t.expect(myRedisDatabasePage.redisStackIcon.visible).ok('Redis Stack icon not found');
+    // Verify that user can see the Redis Stack logo is placed in the DB edit form when hover over the RedisStack logo
+    await t.hover(myRedisDatabasePage.redisStackIcon);
+    await t.expect(myRedisDatabasePage.tooltipRedisStackLogo.visible).ok('Redis Stack logo not found');
+    const databaseName = await myRedisDatabasePage.redisStackIcon.parent().nextSibling();
+    await t.expect(databaseName.withAttribute('data-testid', 'edit-alias-btn').exists).ok('Edit button not found');
+});
+test('Verify that user can see Redis Stack icon and logo in Browser page in Overview.', async t => {
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    await t.expect(databaseOverviewPage.overviewRedisStackLogo.visible).ok('Redis Stack logo not found');
+    // Open Workbench page
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(databaseOverviewPage.overviewRedisStackLogo.visible).ok('Redis Stack logo not found');
+    // Check modules inside of the tooltip
+    await t.hover(databaseOverviewPage.overviewRedisStackLogo);
+    await t.expect(myRedisDatabasePage.moduleTooltip.visible).ok('Tooltip with modules not found');
+    await myRedisDatabasePage.checkModulesInTooltip(moduleNameList);
+});

--- a/tests/e2e/tests/regression/database/redisstack.e2e.ts
+++ b/tests/e2e/tests/regression/database/redisstack.e2e.ts
@@ -1,5 +1,5 @@
 import { rte } from '../../../helpers/constants';
-import { acceptLicenseTerms, acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
+import { acceptLicenseTerms } from '../../../helpers/database';
 import { MyRedisDatabasePage, DatabaseOverviewPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { addNewStandaloneDatabaseApi, deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';

--- a/tests/e2e/tests/regression/database/redisstack.e2e.ts
+++ b/tests/e2e/tests/regression/database/redisstack.e2e.ts
@@ -1,8 +1,8 @@
 import { rte } from '../../../helpers/constants';
-import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
+import { acceptLicenseTerms, acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, DatabaseOverviewPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { addNewStandaloneDatabaseApi, deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
 import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
@@ -15,7 +15,8 @@ fixture `Redis Stack`
     .page(commonUrl)
     .beforeEach(async() => {
         // Add new databases using API
-        await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
+        await acceptLicenseTerms();
+        await addNewStandaloneDatabaseApi(ossStandaloneConfig);
         // Reload Page
         await common.reloadPage();
     })

--- a/tests/e2e/tests/regression/monitor/monitor.e2e.ts
+++ b/tests/e2e/tests/regression/monitor/monitor.e2e.ts
@@ -26,72 +26,68 @@ const chance = new Chance();
 const common = new Common();
 
 fixture `Monitor`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
+test('Verify Monitor refresh/stop', async t => {
+    // Run monitor
+    await monitorPage.startMonitor();
+    // Close Monitor
+    await t.click(monitorPage.closeMonitor);
+    // Verify that monitor is not displayed
+    await t.expect(monitorPage.monitorArea.visible).notOk('Profiler area not found');
+    // Verify that user open monitor again
+    await t.click(monitorPage.expandMonitor);
+    // Verify that when user closes the Monitor by clicking on "Close Monitor" button Monitor stopped
+    await t.expect(monitorPage.startMonitorButton.visible).ok('Start profiler button not found');
+
+    // Run monitor
+    await t.click(monitorPage.startMonitorButton);
+    await monitorPage.checkCommandInMonitorResults('info');
+    // Click on Stop Monitor button
+    await t.click(monitorPage.runMonitorToggle);
+    // Check that Monitor is stopped
+    await t.expect(monitorPage.resetProfilerButton.visible).ok('Reset profiler button not appeared');
+    // Get the last log line
+    const lastTimestamp = await monitorPage.monitorCommandLineTimestamp.nth(-1).textContent;
+    // Click on refresh keys to get new logs
+    await t.click(browserPage.refreshKeysButton);
+    // Verify that Monitor is stopped when user clicks on "Stop" button
+    await t.expect(monitorPage.monitorCommandLineTimestamp.nth(-1).textContent).eql(lastTimestamp, 'The last line of monitor logs not correct');
+
+    // Run monitor
+    await t.click(monitorPage.resetProfilerButton);
+    await t.click(monitorPage.startMonitorButton);
+    await monitorPage.checkCommandInMonitorResults('info');
+    // Refresh the page
+    await common.reloadPage();
+    // Check that monitor is closed
+    await t.expect(monitorPage.monitorArea.exists).notOk('Monitor area not found');
+    // Verify that when user refreshes the page the list of results in Monitor is not saved
+    await t.click(monitorPage.expandMonitor);
+    await t.expect(monitorPage.monitorWarningMessage.exists).ok('Warning message in monitor not found');
+
+    // Run monitor
+    await t.click(monitorPage.startMonitorButton);
+    await monitorPage.checkCommandInMonitorResults('info');
+    // Click on refresh keys to get new logs
+    await t.click(browserPage.refreshKeysButton);
+    // Get last timestamp
+    const lastTimestampSelector = await monitorPage.monitorCommandLineTimestamp.nth(-1);
+    // Stop Monitor
+    await monitorPage.stopMonitor();
+    // Click on Clear button
+    await t.click(monitorPage.clearMonitorButton);
+    // Verify that when user clicks on "Clear" button in Monitor, all commands history is removed
+    await t.expect(lastTimestampSelector.exists).notOk('Cleared last line not found');
+});
 test
-    .meta({ rte: rte.standalone })('Verify that when user closes the Monitor by clicking on "Close Monitor" button Monitor stopped', async t => {
-        //Run monitor
-        await monitorPage.startMonitor();
-        //Close Monitor
-        await t.click(monitorPage.closeMonitor);
-        //Verify that monitor is not displayed
-        await t.expect(monitorPage.monitorArea.visible).notOk('Profiler area');
-        //Verify that user open monitor again
-        await t.click(monitorPage.expandMonitor);
-        //Verify that when user reopens Monitor history is not displayed
-        await t.expect(monitorPage.startMonitorButton.visible).ok('Start profiler button');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that Monitor is stopped when user clicks on "Stop" button', async t => {
-        //Run monitor
-        await monitorPage.startMonitor();
-        //Click on Stop Monitor button
-        await t.click(monitorPage.runMonitorToggle);
-        //Check that Monitor is stopped
-        await t.expect(monitorPage.resetProfilerButton.visible).ok('Reset profiler button appeared');
-        //Get the last log line
-        const lastTimestamp = await monitorPage.monitorCommandLineTimestamp.nth(-1).textContent;
-        //Click on refresh keys to get new logs
-        await t.click(browserPage.refreshKeysButton);
-        //Check that no commands are displayed after monitor paused
-        await t.expect(monitorPage.monitorCommandLineTimestamp.nth(-1).textContent).eql(lastTimestamp, 'The last line of monitor logs');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user refreshes the page the list of results in Monitor is not saved', async t => {
-        //Run monitor
-        await monitorPage.startMonitor();
-        //Refresh the page
-        await common.reloadPage();
-        //Check that monitor is closed
-        await t.expect(monitorPage.monitorArea.exists).notOk('Monitor area');
-        //Check that monitor area doesn't have any saved results
-        await t.click(monitorPage.expandMonitor);
-        await t.expect(monitorPage.monitorWarningMessage.exists).ok('Warning message in monitor');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that when user clicks on "Clear" button in Monitor, all commands history is removed', async t => {
-        //Run monitor
-        await monitorPage.startMonitor();
-        //Click on refresh keys to get new logs
-        await t.click(browserPage.refreshKeysButton);
-        //Get last timestamp
-        const lastTimestamp = await monitorPage.monitorCommandLineTimestamp.nth(-1);
-        //Stop Monitor
-        await monitorPage.stopMonitor();
-        //Click on Clear button
-        await t.click(monitorPage.clearMonitorButton);
-        //Check that monitor screen is cleared
-        await t.expect(lastTimestamp.exists).notOk('Cleared last line');
-    });
-test
-    .meta({ rte: rte.standalone })
     .before(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
         await t.click(myRedisDatabasePage.settingsButton);
@@ -104,29 +100,28 @@ test
         await t.click(myRedisDatabasePage.settingsButton);
         await t.click(settingsPage.accordionAdvancedSettings);
         await settingsPage.changeKeysToScanValue('10000');
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     })('Verify that user can see monitor results in high DB load', async t => {
-        //Run monitor
+        // Run monitor
         await monitorPage.startMonitor();
-        //Search by not existed key pattern
+        // Search by not existed key pattern
         await browserPage.searchByKeyName(`${chance.string({ length: 10 })}*`);
-        //Check that the last child is updated
+        // Check that the last child is updated
         for (let i = 0; i <= 10; i++) {
             const previousTimestamp = await monitorPage.monitorCommandLineTimestamp.nth(-1).textContent;
             await t.wait(5500);
             const nextTimestamp = await monitorPage.monitorCommandLineTimestamp.nth(-1).textContent;
-            await t.expect(previousTimestamp).notEql(nextTimestamp);
+            await t.expect(previousTimestamp).notEql(nextTimestamp, 'Monitor results not correct');
         }
     });
 test
-    .meta({ rte: rte.standalone })
     .before(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         await cliPage.sendCommandInCli('acl setuser noperm nopass on +@all ~* -monitor');
-        //Check command result in CLI
+        // Check command result in CLI
         await t.click(cliPage.cliExpandButton);
-        await t.expect(cliPage.cliOutputResponseSuccess.textContent).eql('"OK"', 'Command from autocomplete was found & executed');
+        await t.expect(cliPage.cliOutputResponseSuccess.textContent).eql('"OK"', 'Command from autocomplete was not found & executed');
         await t.click(cliPage.cliCollapseButton);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
         await t.click(myRedisDatabasePage.myRedisDBButton);
@@ -135,19 +130,19 @@ test
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneNoPermissionsConfig.databaseName);
     })
     .after(async() => {
-        //Delete created user
+        // Delete created user
         await cliPage.sendCommandInCli('acl DELUSER noperm');
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneNoPermissionsConfig);
     })('Verify that if user doesn\'t have permissions to run monitor, user can see error message', async t => {
-        //Expand the Profiler
+        // Expand the Profiler
         await t.click(monitorPage.expandMonitor);
-        //Click on run monitor button
+        // Click on run monitor button
         await t.click(monitorPage.startMonitorButton);
-        //Check that error message is displayed
-        await t.expect(monitorPage.monitorNoPermissionsMessage.visible).ok('Error message');
-        //Check the error message text
-        await t.expect(monitorPage.monitorNoPermissionsMessage.innerText).eql('The Profiler cannot be started. This user has no permissions to run the \'monitor\' command');
-        //Verify that if user doesn't have permissions to run monitor, run monitor button is not available
-        await t.expect(monitorPage.runMonitorToggle.withAttribute('disabled').exists).ok('No permissions run icon');
+        // Check that error message is displayed
+        await t.expect(monitorPage.monitorNoPermissionsMessage.visible).ok('Error message not found');
+        // Check the error message text
+        await t.expect(monitorPage.monitorNoPermissionsMessage.innerText).eql('The Profiler cannot be started. This user has no permissions to run the \'monitor\' command', 'No Permissions message not found');
+        // Verify that if user doesn't have permissions to run monitor, run monitor button is not available
+        await t.expect(monitorPage.runMonitorToggle.withAttribute('disabled').exists).ok('No permissions run icon not found');
     });

--- a/tests/e2e/tests/regression/monitor/save-commands.e2e.ts
+++ b/tests/e2e/tests/regression/monitor/save-commands.e2e.ts
@@ -19,39 +19,39 @@ fixture `Save commands`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that when clicks on “Reset Profiler” button he brought back to Profiler home screen', async t => {
-    //Start Monitor without Save logs
+    // Start Monitor without Save logs
     await monitorPage.startMonitor();
-    //Remember the number of files in Temp
+    // Remember the number of files in Temp
     const numberOfTempFiles = fs.readdirSync(tempDir).length;
-    //Reset profiler
+    // Reset profiler
     await monitorPage.resetProfiler();
     //Check the screen
-    await t.expect(monitorPage.monitorNotStartedElement.visible).ok('The Profiler home screen appears');
+    await t.expect(monitorPage.monitorNotStartedElement.visible).ok('The Profiler home screen not appeared');
     await t.click(monitorPage.closeMonitor);
-    //Start Monitor with Save logs
+    // Start Monitor with Save logs
     await monitorPage.startMonitorWithSaveLog();
-    //Reset profiler
+    // Reset profiler
     await monitorPage.resetProfiler();
-    //Check the screen
-    await t.expect(monitorPage.monitorNotStartedElement.visible).ok('The Profiler home screen appears');
-    await t.expect(monitorPage.monitorIsStartedText.visible).notOk('The current Profiler session is closed');
-    //temporary Log file is deleted
-    await t.expect(numberOfTempFiles).eql(fs.readdirSync(tempDir).length, 'The temporary Log file is deleted');
+    // Check the screen
+    await t.expect(monitorPage.monitorNotStartedElement.visible).ok('The Profiler home screen not appeared');
+    await t.expect(monitorPage.monitorIsStartedText.visible).notOk('The current Profiler session is not closed');
+    // temporary Log file is deleted
+    await t.expect(numberOfTempFiles).eql(fs.readdirSync(tempDir).length, 'The temporary Log file is not deleted');
 });
 test('Verify that when user clears the Profiler he doesn\'t brought back to Profiler home screen', async t => {
-    //Start Monitor
+    // Start Monitor
     await monitorPage.startMonitor();
-    //Clear monitor and check the view
+    // Clear monitor and check the view
     await t.click(monitorPage.clearMonitorButton);
-    await t.expect(monitorPage.monitorNotStartedElement.visible).notOk('Profiler home screen is not opened after Clear');
+    await t.expect(monitorPage.monitorNotStartedElement.visible).notOk('Profiler home screen is still opened after Clear');
     await t.click(monitorPage.closeMonitor);
-    //Start Monitor with Save logs
+    // Start Monitor with Save logs
     await monitorPage.startMonitorWithSaveLog();
-    //Clear monitor and check the view
+    // Clear monitor and check the view
     await t.click(monitorPage.clearMonitorButton);
-    await t.expect(monitorPage.monitorNotStartedElement.visible).notOk('Profiler home screen is not opened after Clear');
+    await t.expect(monitorPage.monitorNotStartedElement.visible).notOk('Profiler home screen is still opened after Clear');
 });

--- a/tests/e2e/tests/regression/pub-sub/debug-mode.e2e.ts
+++ b/tests/e2e/tests/regression/pub-sub/debug-mode.e2e.ts
@@ -10,14 +10,14 @@ const pubSubPage = new PubSubPage();
 const cliPage = new CliPage();
 
 fixture `PubSub debug mode`
-    .meta({ env: env.web, rte: rte.standalone, type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to PubSub page and subscribe to channel
+        // Go to PubSub page and subscribe to channel
         await t.click(myRedisDatabasePage.pubSubButton);
         await t.click(pubSubPage.subscribeButton);
-        //Publish different messages
+        // Publish different messages
         await cliPage.sendCommandInCli('10 publish channel first');
         await cliPage.sendCommandInCli('10 publish channel second');
         await cliPage.sendCommandInCli('10 publish channel third');
@@ -26,37 +26,40 @@ fixture `PubSub debug mode`
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 
-test('Verify that when user navigating away and back to pubsub window the debug mode state will be reset to default auto-scroll', async t => {
-    //Scroll to the first messages
-    await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
-    //Verify that new messages keep arriving in the background and user can always see up to date count of total messages received.
-    await pubSubPage.publishMessage('test', 'message sent in the background');
-    await t.expect(pubSubPage.totalMessagesCount.textContent).contains('31', 'Total counter value is incorrect');
-    //Verify that when user scroll away from the newest message the auto-scroll is stopped
-    await cliPage.sendCommandInCli('30 publish channel additionalMessages');
-    await pubSubPage.publishMessage('test', 'new message with no scroll');
-    await verifyMessageDisplayingInPubSub('new message with no scroll', false);
-    //Go to Browser Page
-    await t.click(myRedisDatabasePage.myRedisDBButton);
-    //Go to PubSub page
-    await t.click(myRedisDatabasePage.pubSubButton);
-    //Verify that the debug mode state is reset to default auto-scroll
-    await verifyMessageDisplayingInPubSub('new message with no scroll', true);
-});
-test('Verify that when user scroll all the way to the newest available message (down), auto-scroll resumes automatically.', async t => {
-    //Scroll to the first messages
-    await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
-    await pubSubPage.publishMessage('test', 'message to scroll');
-    await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('message to scroll'));
-    await cliPage.sendCommandInCli('20 publish channel fourth');
-    //Verify auto-scroll resumes automatically
-    await verifyMessageDisplayingInPubSub('fourth', true);
-});
-test('Verify that user can get to the newest message in one click', async t => {
-    //Scroll to the first messages
-    await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
-    await pubSubPage.publishMessage('test', 'new message');
-    await t.click(pubSubPage.scrollDownButton);
-    //Verify the user scrolled to the newest message
-    await verifyMessageDisplayingInPubSub('new message', true);
-});
+test
+    .meta({ env: env.web })('Verify that when user navigating away and back to pubsub window the debug mode state will be reset to default auto-scroll', async t => {
+    // Scroll to the first messages
+        await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
+        // Verify that new messages keep arriving in the background and user can always see up to date count of total messages received.
+        await pubSubPage.publishMessage('test', 'message sent in the background');
+        await t.expect(pubSubPage.totalMessagesCount.textContent).contains('31', 'Total counter value is incorrect');
+        // Verify that when user scroll away from the newest message the auto-scroll is stopped
+        await cliPage.sendCommandInCli('30 publish channel additionalMessages');
+        await pubSubPage.publishMessage('test', 'new message with no scroll');
+        await verifyMessageDisplayingInPubSub('new message with no scroll', false);
+        // Go to Browser Page
+        await t.click(myRedisDatabasePage.myRedisDBButton);
+        // Go to PubSub page
+        await t.click(myRedisDatabasePage.pubSubButton);
+        // Verify that the debug mode state is reset to default auto-scroll
+        await verifyMessageDisplayingInPubSub('new message with no scroll', true);
+    });
+test
+    .meta({ env: env.web })('Verify that when user scroll all the way to the newest available message (down), auto-scroll resumes automatically.', async t => {
+    // Scroll to the first messages
+        await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
+        await pubSubPage.publishMessage('test', 'message to scroll');
+        await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('message to scroll'));
+        await cliPage.sendCommandInCli('20 publish channel fourth');
+        // Verify auto-scroll resumes automatically
+        await verifyMessageDisplayingInPubSub('fourth', true);
+    });
+test
+    .meta({ env: env.web })('Verify that user can get to the newest message in one click', async t => {
+    // Scroll to the first messages
+        await t.scrollIntoView(pubSubPage.pubSubPageContainer.find(pubSubPage.cssSelectorMessage).withText('first'));
+        await pubSubPage.publishMessage('test', 'new message');
+        await t.click(pubSubPage.scrollDownButton);
+        // Verify the user scrolled to the newest message
+        await verifyMessageDisplayingInPubSub('new message', true);
+    });

--- a/tests/e2e/tests/regression/pub-sub/pub-sub-oss-cluster-7.ts
+++ b/tests/e2e/tests/regression/pub-sub/pub-sub-oss-cluster-7.ts
@@ -32,10 +32,10 @@ test
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })
     .meta({ rte: rte.ossCluster })('Verify that SPUBLISH message is displayed for OSS Cluster 7 database', async t => {
-        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).ok('SPUBLISH message');
+        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).ok('SPUBLISH message nit displayed');
         // Verify that user can see published messages for OSS Cluster 7
         await t.click(pubSubPage.subscribeButton);
-        //Publish different messages
+        // Publish different messages
         await cliPage.sendCommandInCli('50 publish channel oss_cluster_message');
         await verifyMessageDisplayingInPubSub('oss_cluster_message', true);
         // Verify that SPUBLISHED messages are not displayed for OSS Cluster 7
@@ -54,7 +54,7 @@ test
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })
     .meta({ rte: rte.standalone })('Verify that SPUBLISH message is not displayed for other databases expect OSS Cluster 7', async t => {
-        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).notOk('No SPUBLISH message');
+        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).notOk('No SPUBLISH message still displayed');
         // Verify that user can't see published messages for Standalone DB
         await t.click(pubSubPage.subscribeButton);
         await cliPage.sendCommandInCli('10 spublish channel oss_cluster_message_spublish');

--- a/tests/e2e/tests/regression/pub-sub/pub-sub-oss-cluster-7.ts
+++ b/tests/e2e/tests/regression/pub-sub/pub-sub-oss-cluster-7.ts
@@ -32,7 +32,7 @@ test
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })
     .meta({ rte: rte.ossCluster })('Verify that SPUBLISH message is displayed for OSS Cluster 7 database', async t => {
-        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).ok('SPUBLISH message nit displayed');
+        await t.expect(pubSubPage.ossClusterEmptyMessage.exists).ok('SPUBLISH message not displayed');
         // Verify that user can see published messages for OSS Cluster 7
         await t.click(pubSubPage.subscribeButton);
         // Publish different messages

--- a/tests/e2e/tests/regression/shortcuts/shortcuts.e2e.ts
+++ b/tests/e2e/tests/regression/shortcuts/shortcuts.e2e.ts
@@ -1,8 +1,8 @@
+import { ClientFunction } from 'testcafe';
 import { rte, env } from '../../../helpers/constants';
 import { acceptLicenseTerms } from '../../../helpers/database';
 import { MyRedisDatabasePage, HelpCenterPage, ShortcutsPage } from '../../../pageObjects';
 import { commonUrl } from '../../../helpers/conf';
-import { ClientFunction } from 'testcafe';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const helpCenterPage = new HelpCenterPage();
@@ -10,85 +10,74 @@ const shortcutsPage = new ShortcutsPage();
 const getPageUrl = ClientFunction(() => window.location.href);
 
 fixture `Shortcuts`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.none })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTerms();
-    })
+    });
 test
-    .meta({ env: env.web, rte: rte.none })
-    ('Verify that user can see a summary of Shortcuts by clicking "Keyboard Shortcuts" button in Help Center', async t => {
+    .meta({ env: env.web })('Verify that user can see a summary of Shortcuts by clicking "Keyboard Shortcuts" button in Help Center', async t => {
         // Click on help center icon and verify panel
         await t.click(myRedisDatabasePage.helpCenterButton);
-        await t.expect(helpCenterPage.helpCenterPanel.exists).ok('Help Center panel is opened');
+        await t.expect(helpCenterPage.helpCenterPanel.exists).ok('Help Center panel is not opened');
         // Click on Shortcuts option and verify panel
         await t.click(helpCenterPage.helpCenterShortcutButton);
-        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is opened');
+        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is not opened');
         // Validate Title and sections of Shortcuts
-        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is opened');
-        await t.expect(shortcutsPage.shortcutsTitle.exists).ok('shortcutsTitle is opened');
-        await t.expect(shortcutsPage.shortcutsCLISection.exists).ok('shortcutsCLISection is displayed');
-        await t.expect(shortcutsPage.shortcutsWorkbenchSection.exists).ok('shortcutsWorkbenchSection is displayed');
+        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is not opened');
+        await t.expect(shortcutsPage.shortcutsTitle.exists).ok('shortcutsTitle is not opened');
+        await t.expect(shortcutsPage.shortcutsCLISection.exists).ok('shortcutsCLISection is not displayed');
+        await t.expect(shortcutsPage.shortcutsWorkbenchSection.exists).ok('shortcutsWorkbenchSection is not displayed');
         // Verify that user can close the Shortcuts
         await t.click(shortcutsPage.shortcutsCloseButton);
         await t.expect(shortcutsPage.shortcutsPanel.exists).notOk('Shortcuts panel is not displayed');
-    })
-test
-    .meta({ env: env.desktop, rte: rte.none })
-    ('Verify that user can see a summary of Shortcuts by clicking "Keyboard Shortcuts" button in Help Center for desktop', async t => {
-        // Click on help center icon and verify panel
-        await t.click(myRedisDatabasePage.helpCenterButton);
-        await t.expect(helpCenterPage.helpCenterPanel.exists).ok('Help Center panel is opened');
-        // Click on Shortcuts option and verify panel
-        await t.click(helpCenterPage.helpCenterShortcutButton);
-        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is opened');
-        // Validate Title and sections of Shortcuts
-        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is opened');
-        await t.expect(shortcutsPage.shortcutsTitle.exists).ok('shortcutsTitle is opened');
-        await t.expect(shortcutsPage.shortcutsDesktopApplicationSection.exists).ok('shortcutsDesktopApplicationSection is opened');
-        await t.expect(shortcutsPage.shortcutsCLISection.exists).ok('shortcutsCLISection is displayed');
-        await t.expect(shortcutsPage.shortcutsWorkbenchSection.exists).ok('shortcutsWorkbenchSection is displayed');
-        // Verify that user can close the Shortcuts
-        await t.click(shortcutsPage.shortcutsCloseButton);
-        await t.expect(shortcutsPage.shortcutsPanel.exists).notOk('Shortcuts panel is not displayed');
-    })
-test
-    .meta({ rte: rte.none })
-    ('Verify that user can see description of the “up” shortcut in the Help Center > Keyboard Shortcuts > Workbench table', async t => {
-        const description = [
-            'Quick-access to command history',
-            'Up Arrow'
-        ];
-        //Open Shortcuts
-        await t.click(myRedisDatabasePage.helpCenterButton);
-        await t.click(helpCenterPage.helpCenterShortcutButton);
-        // Verify that user can see description of the “up” shortcut
-        for(const element of description) {
-            await t.expect(shortcutsPage.shortcutsPanel.textContent).contains(element, 'The user can see description of the “up” shortcut');
-        }
-    })
-test
-    .meta({ rte: rte.none })
-    ('Verify that user can see the description of the “Shift+Space” keyboard shortcut in the Keyboard Shortcuts', async t => {
-        const description = [
-            'Use Non-Redis Editor',
-            'Shift+Space'
-        ];
-        //Open Shortcuts
-        await t.click(myRedisDatabasePage.helpCenterButton);
-        await t.click(helpCenterPage.helpCenterShortcutButton);
-        // Verify that user can see description of the “Shift+Space” shortcut
-        for(const element of description) {
-            await t.expect(shortcutsPage.shortcutsPanel.textContent).contains(element, 'The user can see description of the “Shift+Space” shortcut');
-        }
-    })
-test
-    .meta({ env: env.web, rte: rte.none })
-    ('Verify redirected link opening Release Notes in Help Center', async t => {
+
         const link = 'https://github.com/RedisInsight/RedisInsight/releases';
-        //Click on the Release Notes in Help Center
+        // Click on the Release Notes in Help Center
         await t.click(myRedisDatabasePage.helpCenterButton);
         await t.click(helpCenterPage.helpCenterReleaseNotesButton);
-        //Verify the opened link
-        await t.expect(getPageUrl()).eql(link, 'The Release Notes link');
-    })
+        // Verify redirected link opening Release Notes in Help Center
+        await t.expect(getPageUrl()).eql(link, 'The Release Notes link not correct');
+    });
+test
+    .meta({ env: env.desktop })('Verify that user can see a summary of Shortcuts by clicking "Keyboard Shortcuts" button in Help Center for desktop', async t => {
+        // Click on help center icon and verify panel
+        await t.click(myRedisDatabasePage.helpCenterButton);
+        await t.expect(helpCenterPage.helpCenterPanel.exists).ok('Help Center panel is not opened');
+        // Click on Shortcuts option and verify panel
+        await t.click(helpCenterPage.helpCenterShortcutButton);
+        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is not opened');
+        // Validate Title and sections of Shortcuts
+        await t.expect(shortcutsPage.shortcutsPanel.exists).ok('Shortcuts panel is not opened');
+        await t.expect(shortcutsPage.shortcutsTitle.exists).ok('shortcutsTitle is not opened');
+        await t.expect(shortcutsPage.shortcutsDesktopApplicationSection.exists).ok('shortcutsDesktopApplicationSection is not opened');
+        await t.expect(shortcutsPage.shortcutsCLISection.exists).ok('shortcutsCLISection is not displayed');
+        await t.expect(shortcutsPage.shortcutsWorkbenchSection.exists).ok('shortcutsWorkbenchSection is not displayed');
+        // Verify that user can close the Shortcuts
+        await t.click(shortcutsPage.shortcutsCloseButton);
+        await t.expect(shortcutsPage.shortcutsPanel.exists).notOk('Shortcuts panel is not displayed');
+    });
+test('Verify that user can see description of the “up” shortcut in the Help Center > Keyboard Shortcuts > Workbench table', async t => {
+    const description = [
+        'Quick-access to command history',
+        'Up Arrow'
+    ];
+    const description2 = [
+        'Use Non-Redis Editor',
+        'Shift+Space'
+    ];
+
+    // Open Shortcuts
+    await t.click(myRedisDatabasePage.helpCenterButton);
+    await t.click(helpCenterPage.helpCenterShortcutButton);
+
+    // Verify that user can see the description of the “Shift+Space” keyboard shortcut in the Keyboard Shortcuts
+    for (const element of description2) {
+        await t.expect(shortcutsPage.shortcutsPanel.textContent).contains(element, 'The user can not see description of the “Shift+Space” shortcut');
+    }
+
+    // Verify that user can see description of the “up” shortcut
+    for (const element of description) {
+        await t.expect(shortcutsPage.shortcutsPanel.textContent).contains(element, 'The user can not see description of the “up” shortcut');
+    }
+});

--- a/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
+++ b/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
@@ -18,7 +18,7 @@ fixture `Tree view verifications`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneBigConfig, ossStandaloneBigConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneBigConfig);
     });
 test
@@ -26,47 +26,47 @@ test
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that user can see message "No keys to display." when there are no keys in the database', async t => {
-        const message = 'No keys to display.Use Workbench Guides and Tutorials to quickly load the data.'
-        //Verify the message
+        const message = 'No keys to display.Use Workbench Guides and Tutorials to quickly load the data.';
+
+        // Verify the message
         await t.click(browserPage.treeViewButton);
-        await t.expect(browserPage.keyListMessage.textContent).contains(message, 'The message is displayed');
+        await t.expect(browserPage.keyListMessage.textContent).contains(message, 'The message is not displayed');
+
+        // Verify the default separator
+        await t.expect(browserPage.treeViewSeparator.textContent).eql(':', 'The “:” (colon) not used as a default separator for namespaces');
+        // Verify that user can see that “:” (colon) used as a default separator for namespaces and see the number of keys found per each namespace
+        await t.expect(browserPage.treeViewKeysNumber.visible).ok('The user can not see the number of keys');
+
         // Verify that workbench opened by clicking on "Use Workbench Guides and Tutorials" link
         await t.click(browserPage.workbenchLinkButton);
         await t.expect(workbenchPage.expandArea.visible).ok('Workbench page is not opened');
     });
 test('Verify that user can see the total number of keys, the number of keys scanned, the “Scan more” control displayed at the top of Tree view and Browser view', async t => {
-        await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
-        //Verify the controls on the Browser view
-        await t.expect(browserPage.totalKeysNumber.visible).ok('The total number of keys is displayed on the Browser view');
-        await t.expect(browserPage.scannedValue.visible).ok('The number of keys scanned is displayed on the Browser view');
-        await t.expect(browserPage.scanMoreButton.visible).ok('The scan more button is displayed on the Browser view');
-        //Verify the controls on the Tree view
-        await t.click(browserPage.treeViewButton);
-        await t.expect(browserPage.totalKeysNumber.visible).ok('The total number of keys is displayed on the Tree view');
-        await t.expect(browserPage.scannedValue.visible).ok('The number of keys scanned is displayed on the Tree view');
-        await t.expect(browserPage.scanMoreButton.visible).ok('The scan more button is displayed on the Tree view');
-    });
+    await browserPage.selectFilterGroupType(KeyTypesTexts.Hash);
+    // Verify the controls on the Browser view
+    await t.expect(browserPage.totalKeysNumber.visible).ok('The total number of keys is not displayed on the Browser view');
+    await t.expect(browserPage.scannedValue.visible).ok('The number of keys scanned is not displayed on the Browser view');
+    await t.expect(browserPage.scanMoreButton.visible).ok('The scan more button is not displayed on the Browser view');
+    // Verify the controls on the Tree view
+    await t.click(browserPage.treeViewButton);
+    await t.expect(browserPage.totalKeysNumber.visible).ok('The total number of keys is not displayed on the Tree view');
+    await t.expect(browserPage.scannedValue.visible).ok('The number of keys scanned is not displayed on the Tree view');
+    await t.expect(browserPage.scanMoreButton.visible).ok('The scan more button is not displayed on the Tree view');
+});
 test('Verify that when user deletes the key he can see the key is removed from the folder, the number of keys is reduced, the percentage is recalculated', async t => {
-        //Open the first key in the tree view and remove
-        await t.click(browserPage.treeViewButton);
-        await t.expect(browserPage.treeViewDeviceFolder.visible).ok('The key folder is displayed', { timeout: 30000 });
-        await t.click(browserPage.treeViewDeviceFolder);
-        const numberOfKeys = await browserPage.treeViewDeviceKyesCount.textContent;
-        const keyFolder = await browserPage.treeViewDeviceFolder.nth(2).textContent;
-        await t.click(browserPage.treeViewDeviceFolder.nth(2));
-        await t.click(browserPage.treeViewDeviceFolder.nth(5));
-        await browserPage.deleteKey();
-        //Verify the results
-        await t.expect(browserPage.treeViewDeviceFolder.nth(2).textContent).notEql(keyFolder, 'The key folder is removed from the tree view');
-        await t.expect(browserPage.treeViewDeviceKyesCount.textContent).notEql(numberOfKeys, 'The number of keys is recalculated');
-    });
-test('Verify that user can see that “:” (colon) used as a default separator for namespaces and see the number of keys found per each namespace', async t => {
-        await t.click(browserPage.treeViewButton);
-        //Verify the default separator
-        await t.expect(browserPage.treeViewSeparator.textContent).eql(':', 'The “:” (colon) used as a default separator for namespaces');
-        //Verify the number of keys found
-        await t.expect(browserPage.treeViewKeysNumber.visible).ok('The user can see the number of keys');
-    });
+    // Open the first key in the tree view and remove
+    await t.click(browserPage.treeViewButton);
+    await t.expect(browserPage.treeViewDeviceFolder.visible).ok('The key folder is not displayed', { timeout: 30000 });
+    await t.click(browserPage.treeViewDeviceFolder);
+    const numberOfKeys = await browserPage.treeViewDeviceKyesCount.textContent;
+    const keyFolder = await browserPage.treeViewDeviceFolder.nth(2).textContent;
+    await t.click(browserPage.treeViewDeviceFolder.nth(2));
+    await t.click(browserPage.treeViewDeviceFolder.nth(5));
+    await browserPage.deleteKey();
+    // Verify the results
+    await t.expect(browserPage.treeViewDeviceFolder.nth(2).textContent).notEql(keyFolder, 'The key folder is not removed from the tree view');
+    await t.expect(browserPage.treeViewDeviceKyesCount.textContent).notEql(numberOfKeys, 'The number of keys is not recalculated');
+});

--- a/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
+++ b/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
@@ -3,7 +3,7 @@ import { BrowserPage, WorkbenchPage } from '../../../pageObjects';
 import {
     commonUrl,
     ossStandaloneBigConfig,
-    ossStandaloneConfig
+    ossStandaloneRedisearch
 } from '../../../helpers/conf';
 import { KeyTypesTexts, rte } from '../../../helpers/constants';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
@@ -23,11 +23,11 @@ fixture `Tree view verifications`
     });
 test
     .before(async() => {
-        await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
+        await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
     })
     .after(async() => {
         // Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
+        await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     })('Verify that user can see message "No keys to display." when there are no keys in the database', async t => {
         const message = 'No keys to display.Use Workbench Guides and Tutorials to quickly load the data.';
 

--- a/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
+++ b/tests/e2e/tests/regression/tree-view/tree-view.e2e.ts
@@ -35,11 +35,6 @@ test
         await t.click(browserPage.treeViewButton);
         await t.expect(browserPage.keyListMessage.textContent).contains(message, 'The message is not displayed');
 
-        // Verify the default separator
-        await t.expect(browserPage.treeViewSeparator.textContent).eql(':', 'The “:” (colon) not used as a default separator for namespaces');
-        // Verify that user can see that “:” (colon) used as a default separator for namespaces and see the number of keys found per each namespace
-        await t.expect(browserPage.treeViewKeysNumber.visible).ok('The user can not see the number of keys');
-
         // Verify that workbench opened by clicking on "Use Workbench Guides and Tutorials" link
         await t.click(browserPage.workbenchLinkButton);
         await t.expect(workbenchPage.expandArea.visible).ok('Workbench page is not opened');
@@ -59,6 +54,12 @@ test('Verify that user can see the total number of keys, the number of keys scan
 test('Verify that when user deletes the key he can see the key is removed from the folder, the number of keys is reduced, the percentage is recalculated', async t => {
     // Open the first key in the tree view and remove
     await t.click(browserPage.treeViewButton);
+
+    // Verify the default separator
+    await t.expect(browserPage.treeViewSeparator.textContent).eql(':', 'The “:” (colon) not used as a default separator for namespaces');
+    // Verify that user can see that “:” (colon) used as a default separator for namespaces and see the number of keys found per each namespace
+    await t.expect(browserPage.treeViewKeysNumber.visible).ok('The user can not see the number of keys');
+
     await t.expect(browserPage.treeViewDeviceFolder.visible).ok('The key folder is not displayed', { timeout: 30000 });
     await t.click(browserPage.treeViewDeviceFolder);
     const numberOfKeys = await browserPage.treeViewDeviceKyesCount.textContent;

--- a/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
@@ -8,84 +8,87 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 
 fixture `Autocomplete for entered commands`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can open the "read more" about the command by clicking on the ">" icon or "ctrl+space"', async t => {
-        const command = 'HSET'
-        const commandDetails = [
+    });
+test('Verify that user can open the "read more" about the command by clicking on the ">" icon or "ctrl+space"', async t => {
+    const command = 'HSET';
+    const commandDetails = [
         'HSET key field_value [field_value ...]',
         'Set the string value of a hash field',
         'Arguments:',
         'required key',
         'multiple field_value'
-        ];
-        //Type command
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        //Open the read more by clicking on the "ctrl+space" and check
-        await t.pressKey('ctrl+space');
-        await t.expect(await workbenchPage.monacoCommandDetails.exists).ok('The "read more" about the command is opened');
-        for(const detail of commandDetails) {
-            await t.expect(await workbenchPage.monacoCommandDetails.textContent).contains(detail, `The ${detail} command detail is displayed`)
-        }
-        //Close the command details
-        await t.pressKey('ctrl+space');
-        await t.expect(await workbenchPage.monacoCommandDetails.exists).notOk('The "read more" about the command is closed');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see static list of arguments is displayed when he enters the command in Editor in Workbench', async t => {
-        const command = 'AI.SCRIPTEXECUTE'
-        //Type the command in Editing area
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        //Check that no hints are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed yet')
-        //Add space after the printed command
-        await t.typeText(workbenchPage.queryInput, `${command} `, { replace: true })
-        //Check that hint with arguments are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can close the static list of arguments by pressing “ESC”', async t => {
-        const command = 'TS.DELETERULE '
-        await t.typeText(workbenchPage.queryInput, command, { replace: true })
-        //Check that hint with arguments are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
-        //Remove hints with arguments
-        await t.pressKey('esc');
-        //Check no hints are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed')
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the static list of arguments when he uses “Ctrl+Shift+Space” combination for already entered command for Windows', async t => {
-        const command = 'JSON.ARRAPPEND'
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        //Verify that the list with auto-suggestions is displayed
-        await t.expect(await workbenchPage.monacoSuggestion.exists).ok('Auto-suggestions are displayed');
-        //Select the command from suggestion list
-        await t.pressKey('enter');
-        //Check that the command is displayed in Editing area after selecting
-        const script = await workbenchPage.queryInputScriptArea.textContent;
-        await t.expect(script.replace(/\s/g, ' ')).eql('JSON.ARRAPPEND key value ', 'Result of sent command exists');
-        //Check that hint with arguments are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
-        //Remove hints with arguments
-        await t.pressKey('esc');
-        //Check no hints are displayed
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are not displayed')
-        //Check that using shortcut “Ctrl+Shift+Space” hints are displayed
-        await t.pressKey('ctrl+shift+space');
-        await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are displayed')
-    });
+    ];
+
+    // Type command
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    // Open the read more by clicking on the "ctrl+space" and check
+    await t.pressKey('ctrl+space');
+    await t.expect(await workbenchPage.monacoCommandDetails.exists).ok('The "read more" about the command is not opened');
+    for(const detail of commandDetails) {
+        await t.expect(await workbenchPage.monacoCommandDetails.textContent).contains(detail, `The ${detail} command detail is not displayed`);
+    }
+    // Close the command details
+    await t.pressKey('ctrl+space');
+    await t.expect(await workbenchPage.monacoCommandDetails.exists).notOk('The "read more" about the command is not closed');
+});
+test('Verify that user can see static list of arguments is displayed when he enters the command in Editor in Workbench', async t => {
+    const command = 'AI.SCRIPTEXECUTE';
+    const command2 = 'TS.DELETERULE ';
+
+    // Type the command in Editing area
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    // Check that no hints are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed');
+    // Add space after the printed command
+    await t.typeText(workbenchPage.queryInput, `${command} `, { replace: true });
+    // Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed');
+
+    await t.typeText(workbenchPage.queryInput, command2, { replace: true });
+    // Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed');
+    // Remove hints with arguments
+    await t.pressKey('esc');
+    // Verify that user can close the static list of arguments by pressing “ESC”
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed');
+});
+// test('Verify that user can close the static list of arguments by pressing “ESC”', async t => {
+//         const command = 'TS.DELETERULE '
+//         await t.typeText(workbenchPage.queryInput, command, { replace: true })
+//         //Check that hint with arguments are displayed
+//         await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed')
+//         //Remove hints with arguments
+//         await t.pressKey('esc');
+//         //Check no hints are displayed
+//         await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed')
+//     });
+test('Verify that user can see the static list of arguments when he uses “Ctrl+Shift+Space” combination for already entered command for Windows', async t => {
+    const command = 'JSON.ARRAPPEND';
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    // Verify that the list with auto-suggestions is displayed
+    await t.expect(await workbenchPage.monacoSuggestion.exists).ok('Auto-suggestions are not displayed');
+    // Select the command from suggestion list
+    await t.pressKey('enter');
+    // Check that the command is displayed in Editing area after selecting
+    const script = await workbenchPage.queryInputScriptArea.textContent;
+    await t.expect(script.replace(/\s/g, ' ')).eql('JSON.ARRAPPEND key value ', 'Result of sent command not exists');
+    // Check that hint with arguments are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed');
+    // Remove hints with arguments
+    await t.pressKey('esc');
+    // Check no hints are displayed
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed');
+    // Check that using shortcut “Ctrl+Shift+Space” hints are displayed
+    await t.pressKey('ctrl+shift+space');
+    await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed');
+});

--- a/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/autocomplete.e2e.ts
@@ -62,16 +62,6 @@ test('Verify that user can see static list of arguments is displayed when he ent
     // Verify that user can close the static list of arguments by pressing “ESC”
     await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed');
 });
-// test('Verify that user can close the static list of arguments by pressing “ESC”', async t => {
-//         const command = 'TS.DELETERULE '
-//         await t.typeText(workbenchPage.queryInput, command, { replace: true })
-//         //Check that hint with arguments are displayed
-//         await t.expect(workbenchPage.monacoHintWithArguments.visible).ok('Hints with arguments are not displayed')
-//         //Remove hints with arguments
-//         await t.pressKey('esc');
-//         //Check no hints are displayed
-//         await t.expect(workbenchPage.monacoHintWithArguments.visible).notOk('Hints with arguments are still displayed')
-//     });
 test('Verify that user can see the static list of arguments when he uses “Ctrl+Shift+Space” combination for already entered command for Windows', async t => {
     const command = 'JSON.ARRAPPEND';
     await t.typeText(workbenchPage.queryInput, command, { replace: true });

--- a/tests/e2e/tests/regression/workbench/command-results.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/command-results.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { WorkbenchPage } from '../../../pageObjects/workbench-page';
 import { MyRedisDatabasePage } from '../../../pageObjects';
@@ -8,12 +7,13 @@ import {
 } from '../../../helpers/conf';
 import { env, rte } from '../../../helpers/constants';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
-const indexName = chance.word({ length: 5 });
+const indexName = common.generateWord(5);
 const commandsForIndex = [
     `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA price NUMERIC SORTABLE`,
     'HMSET product:1 price 20',
@@ -26,25 +26,25 @@ fixture.skip `Command results at Workbench`
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
-        //Add index and data
+        // Add index and data
         await t.click(myRedisDatabasePage.workbenchButton);
         await workbenchPage.sendCommandsArrayInWorkbench(commandsForIndex);
     })
     .afterEach(async t => {
-        //Drop index and database
+        // Drop index and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
     });
 test
     .meta({ env: env.web })('Verify that user can switches between Table and Text for FT.INFO and see results corresponding to their views', async t => {
-        // indexName = chance.word({ length: 5 });
         const infoCommand = `FT.INFO ${indexName}`;
-        //Send FT.INFO and switch to Text view
+
+        // Send FT.INFO and switch to Text view
         await workbenchPage.sendCommandInWorkbench(infoCommand);
         await workbenchPage.selectViewTypeText();
         await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).exists).ok('The text view is not switched for command FT.INFO');
-        //Switch to Table view and check result
+        // Switch to Table view and check result
         await workbenchPage.selectViewTypeTable();
         await t.switchToIframe(workbenchPage.iframe);
         await t.expect(await workbenchPage.queryTableResult.exists).ok('The table view is not switched for command FT.INFO');
@@ -52,11 +52,12 @@ test
 test
     .meta({ env: env.web })('Verify that user can switches between Table and Text for FT.SEARCH and see results corresponding to their views', async t => {
         const searchCommand = `FT.SEARCH ${indexName} *`;
-        //Send FT.SEARCH and switch to Text view
+
+        // Send FT.SEARCH and switch to Text view
         await workbenchPage.sendCommandInWorkbench(searchCommand);
         await workbenchPage.selectViewTypeText();
         await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The text view is not switched for command FT.SEARCH');
-        //Switch to Table view and check result
+        // Switch to Table view and check result
         await workbenchPage.selectViewTypeTable();
         await t.switchToIframe(workbenchPage.iframe);
         await t.expect(await workbenchPage.queryTableResult.exists).ok('The table view is not switched for command FT.SEARCH');
@@ -64,11 +65,12 @@ test
 test
     .meta({ env: env.web })('Verify that user can switches between Table and Text for FT.AGGREGATE and see results corresponding to their views', async t => {
         const aggregateCommand = `FT.Aggregate ${indexName} * GROUPBY 0 REDUCE MAX 1 @price AS max_price`;
-        //Send FT.AGGREGATE and switch to Text view
+
+        // Send FT.AGGREGATE and switch to Text view
         await workbenchPage.sendCommandInWorkbench(aggregateCommand);
         await workbenchPage.selectViewTypeText();
         await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The text view is not switched for command FT.AGGREGATE');
-        //Switch to Table view and check result
+        // Switch to Table view and check result
         await workbenchPage.selectViewTypeTable();
         await t.switchToIframe(workbenchPage.iframe);
         await t.expect(await workbenchPage.queryTableResult.exists).ok('The table view is not switched for command FT.AGGREGATE');
@@ -77,14 +79,15 @@ test
 test.skip
     .meta({ env: env.web })('Verify that user can switches between views and see results according to this view in full mode in Workbench', async t => {
         const command = 'CLIENT LIST';
-        //Send command and check table view is default in full mode
+
+        // Send command and check table view is default in full mode
         await workbenchPage.sendCommandInWorkbench(command);
         await t.click(workbenchPage.fullScreenButton);
         await t.switchToIframe(workbenchPage.iframe);
         await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTableResult).visible).ok('The search results are displayed in Table view by default');
-        //Select Text view from dropdown
+        // Select Text view from dropdown
         await t.switchToMainWindow();
         await workbenchPage.selectViewTypeText();
-        //Verify that search results are displayed in Text view
+        // Verify that search results are displayed in Text view
         await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).visible).ok('The result is displayed in Text view');
     });

--- a/tests/e2e/tests/regression/workbench/context.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/context.e2e.ts
@@ -13,70 +13,62 @@ const common = new Common();
 const speed = 0.4;
 
 fixture `Workbench Context`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved CLI state when navigates away to any other page', async t => {
-        //Expand CLI and navigte to Browser
-        await t.click(cliPage.cliExpandButton);
-        await t.click(myRedisDatabasePage.browserButton);
-        //Return back to Workbench and check CLI
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(await cliPage.cliCollapseButton.exists).ok('CLI is still expanded');
     });
+test('Verify that user can see saved CLI state when navigates away to any other page', async t => {
+    // Expand CLI and navigte to Browser
+    await t.click(cliPage.cliExpandButton);
+    await t.click(myRedisDatabasePage.browserButton);
+    // Return back to Workbench and check CLI
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(await cliPage.cliCollapseButton.exists).ok('CLI is not expanded');
+});
 // Update after resolving https://redislabs.atlassian.net/browse/RI-3299
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved CLI size when navigates away to any other page', async t => {
-        const offsetY = 200;
+test('Verify that user can see saved CLI size when navigates away to any other page', async t => {
+    const offsetY = 200;
 
-        await t.click(cliPage.cliExpandButton);
-        const cliAreaHeight = await cliPage.cliArea.clientHeight;
-        const cliAreaHeightEnd = cliAreaHeight + 150;
-        const cliResizeButton = await cliPage.cliResizeButton;
-        await t.hover(cliResizeButton);
-        //Resize CLI 50px up and navigate to the My Redis databases page
-        await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.01 });
-        await t.click(myRedisDatabasePage.myRedisDBButton);
-        //Navigate back to the database Workbench and check CLI size
-        await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.expect(await cliPage.cliArea.clientHeight > cliAreaHeightEnd).ok('Saved context for resizable cli is incorrect');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see all the information removed when reloads the page', async t => {
-        const command = 'FT._LIST';
-        //Create context modificaions and navigate to Browser
-        await t.typeText(workbenchPage.queryInput, command, { replace: true, speed: speed});
-        await t.click(cliPage.cliExpandButton);
-        await t.click(myRedisDatabasePage.browserButton);
-        //Open Workbench page and verify context
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(await cliPage.cliCollapseButton.exists).ok('CLI is still expanded');
-        await t.expect(await workbenchPage.queryInputScriptArea.textContent).eql(command, 'Input in Editor is saved');
-        //Reload the window and chek context
-        await common.reloadPage();
-        await t.expect(await cliPage.cliCollapseButton.exists).notOk('CLI is collapsed');
-        await t.expect(await workbenchPage.queryInputScriptArea.textContent).eql('', 'Input in Editor is removed');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved state of the Enablement area when navigates back to the Workbench from other page', async t => {
-        //Collapse the Enablement area and open Settings
-        await t.hover(workbenchPage.preselectArea);
-        await t.click(workbenchPage.collapsePreselectAreaButton);
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Navigate back to Workbench and Verify the context
-        await t.click(myRedisDatabasePage.workbenchButton);
-        await t.expect(workbenchPage.enablementAreaTreeView.visible).notOk('The Enablement area is still collapsed');
-    });
+    await t.click(cliPage.cliExpandButton);
+    const cliAreaHeight = await cliPage.cliArea.clientHeight;
+    const cliAreaHeightEnd = cliAreaHeight + 150;
+    const cliResizeButton = await cliPage.cliResizeButton;
+    await t.hover(cliResizeButton);
+    // Resize CLI 50px up and navigate to the My Redis databases page
+    await t.drag(cliResizeButton, 0, -offsetY, { speed: 0.01 });
+    await t.click(myRedisDatabasePage.myRedisDBButton);
+    // Navigate back to the database Workbench and check CLI size
+    await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
+    await t.expect(await cliPage.cliArea.clientHeight > cliAreaHeightEnd).ok('Saved context for resizable cli is incorrect');
+});
+test('Verify that user can see all the information removed when reloads the page', async t => {
+    const command = 'FT._LIST';
+    // Create context modificaions and navigate to Browser
+    await t.typeText(workbenchPage.queryInput, command, { replace: true, speed: speed});
+    await t.click(cliPage.cliExpandButton);
+    await t.click(myRedisDatabasePage.browserButton);
+    // Open Workbench page and verify context
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(await cliPage.cliCollapseButton.exists).ok('CLI is not expanded');
+    await t.expect(await workbenchPage.queryInputScriptArea.textContent).eql(command, 'Input in Editor is not saved');
+    // Reload the window and chek context
+    await common.reloadPage();
+    await t.expect(await cliPage.cliCollapseButton.exists).notOk('CLI is not collapsed');
+    await t.expect(await workbenchPage.queryInputScriptArea.textContent).eql('', 'Input in Editor is not removed');
+});
+test('Verify that user can see saved state of the Enablement area when navigates back to the Workbench from other page', async t => {
+    // Collapse the Enablement area and open Settings
+    await t.hover(workbenchPage.preselectArea);
+    await t.click(workbenchPage.collapsePreselectAreaButton);
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Navigate back to Workbench and Verify the context
+    await t.click(myRedisDatabasePage.workbenchButton);
+    await t.expect(workbenchPage.enablementAreaTreeView.visible).notOk('The Enablement area is not collapsed');
+});

--- a/tests/e2e/tests/regression/workbench/cypher.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/cypher.e2e.ts
@@ -10,110 +10,100 @@ const workbenchPage = new WorkbenchPage();
 const command = 'GRAPH.QUERY graph';
 
 fixture `Cypher syntax at Workbench`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Drop database
+        // Drop database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see popover “Use Cypher Syntax” when cursor is inside the query argument double/single quotes in the GRAPH command', async t => {
-        //Type command and put the cursor inside
-        await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
-        await t.pressKey('left');
-        //Check that user can see popover
-        await t.expect(await workbenchPage.monacoWidget.textContent).contains('Use Cypher Editor', 'The user can see popover Use Cypher Syntax');
-        await t.expect(await workbenchPage.monacoWidget.textContent).contains('Shift+Space', 'The user can see shortcut for Cypher Syntax');
-        //Verify the popover with single quotes
-        await t.typeText(workbenchPage.queryInput, `${command} ''`, { replace: true });
-        await t.pressKey('left');
-        await t.expect(await workbenchPage.monacoWidget.textContent).contains('Use Cypher Editor', 'The user can see popover Use Cypher Syntax');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user clicks on the “X” control or use shortcut “ESC” popover Editor is closed and changes are not saved', async t => {
-        const cypherCommand = `${command} "query"`;
-        //Type command and open the popover editor
-        await t.typeText(workbenchPage.queryInput, cypherCommand, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Do some changes in the Editor and close by “X” control
-        await t.typeText(workbenchPage.queryInput.nth(1), 'test', { replace: true });
-        await t.click(workbenchPage.cancelButton);
-        //Verify that editor is closed and changes are not saved
-        let commandAfter = await workbenchPage.scriptsLines.textContent;
-        await t.expect(workbenchPage.queryInput.nth(1).exists).notOk('The popover Editor is closed');
-        await t.expect(commandAfter.replace(/\s/g, ' ')).eql(cypherCommand, 'The changes are not saved from the Editor');
-        //Re-open the Editor and do some changes and close by shortcut “ESC”
-        await t.click(workbenchPage.monacoWidget);
-        await t.typeText(workbenchPage.queryInput.nth(1), 'test', { replace: true });
-        await t.pressKey('esc');
-        //Verify that editor is closed and changes are not saved
-        commandAfter = await workbenchPage.scriptsLines.textContent;
-        await t.expect(commandAfter.replace(/\s/g, ' ')).eql(cypherCommand, 'The changes are not saved from the Editor');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user use shortcut “CTRL+ENTER” or clicks on the “V” control popover Editor is closed and changes are saved', async t => {
-        let script = 'query';
-        //Type command and open the popover editor
-        await t.typeText(workbenchPage.queryInput, `${command} "${script}`, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Do some changes in the Editor and click on the “V” control
-        script = 'test';
-        await t.pressKey('ctrl+a');
-        await t.typeText(workbenchPage.queryInput.nth(1), script, { replace: true });
-        await t.click(workbenchPage.applyButton);
-        //Verify that editor is closed and changes are saved
-        let commandAfter = await workbenchPage.scriptsLines.textContent;
-        await t.expect(workbenchPage.queryInput.nth(1).exists).notOk('The popover Editor is closed');
-        await t.expect(commandAfter.replace(/\s/g, ' ')).eql(`${command} "${script}"`, 'The changes are not saved from the Editor');
-        //Re-open the Editor and do some changes and use keyboard shortcut “CTRL+ENTER”
-        await t.click(workbenchPage.monacoWidget);
-        script = 'test2';
-        await t.pressKey('ctrl+a');
-        await t.typeText(workbenchPage.queryInput.nth(1), 'test2', { paste: true, replace: true });
-        await t.pressKey('ctrl+enter');
-        //Verify that editor is closed and changes are not saved
-        commandAfter = await workbenchPage.scriptsLines.textContent;
-        await t.expect(commandAfter.replace(/\s/g, ' ')).eql(`${command} "${script}"`, 'The changes are not saved from the Editor');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the opacity of main Editor is 80%, Run button is disabled when the non-Redis editor is opened', async t => {
-        //Type command and open Cypher editor
-        await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Check the main Editor and Run button
-        await t.expect(workbenchPage.mainEditorArea.getStyleProperty('opacity')).eql('0.8', 'The opacity of main Editor');
-        await t.click(workbenchPage.submitCommandButton);
-        await t.expect(workbenchPage.noCommandHistorySection.visible).ok('The Run button in main Editor is disabled');
-        await t.hover(workbenchPage.submitCommandButton);
-        await t.expect(workbenchPage.runButtonToolTip.visible).notOk('The Run button in main Editor do not react on hover');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can resize non-Redis editor only by the top and bottom borders', async t => {
-        const offsetY = 50;
-        await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY * 10, { speed: 0.4 });
-        //Type command and open Cypher editor
-        await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
-        await t.pressKey('left');
-        await t.click(workbenchPage.monacoWidget);
-        //Check that user can resize editor by top border
-        let editorHeight = await workbenchPage.queryInput.nth(1).clientHeight;
-        await t.drag(workbenchPage.nonRedisEditorResizeTop, 0, -offsetY, { speed: 0.4 });
-        await t.expect(workbenchPage.queryInput.nth(1).clientHeight).eql(editorHeight + offsetY, 'The non-Redis editor is resized by the top border');
-        //Check that user can resize editor by bottom border
-        editorHeight = await workbenchPage.queryInput.nth(1).clientHeight;
-        await t.drag(workbenchPage.nonRedisEditorResizeBottom, 0, -offsetY, { speed: 0.4 });
-        await t.expect(workbenchPage.queryInput.nth(1).clientHeight).eql(editorHeight - offsetY, 'The non-Redis editor is resized by the bottom border');
-    });
+test('Verify that user can see popover “Use Cypher Syntax” when cursor is inside the query argument double/single quotes in the GRAPH command', async t => {
+    // Type command and put the cursor inside
+    await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
+    await t.pressKey('left');
+    // Check that user can see popover
+    await t.expect(await workbenchPage.monacoWidget.textContent).contains('Use Cypher Editor', 'The user can not see popover Use Cypher Syntax');
+    await t.expect(await workbenchPage.monacoWidget.textContent).contains('Shift+Space', 'The user can not see shortcut for Cypher Syntax');
+    // Verify the popover with single quotes
+    await t.typeText(workbenchPage.queryInput, `${command} ''`, { replace: true });
+    await t.pressKey('left');
+    await t.expect(await workbenchPage.monacoWidget.textContent).contains('Use Cypher Editor', 'The user can not see popover Use Cypher Syntax');
+});
+test('Verify that when user clicks on the “X” control or use shortcut “ESC” popover Editor is closed and changes are not saved', async t => {
+    const cypherCommand = `${command} "query"`;
+    // Type command and open the popover editor
+    await t.typeText(workbenchPage.queryInput, cypherCommand, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Do some changes in the Editor and close by “X” control
+    await t.typeText(workbenchPage.queryInput.nth(1), 'test', { replace: true });
+    await t.click(workbenchPage.cancelButton);
+    // Verify that editor is closed and changes are not saved
+    let commandAfter = await workbenchPage.scriptsLines.textContent;
+    await t.expect(workbenchPage.queryInput.nth(1).exists).notOk('The popover Editor is not closed');
+    await t.expect(commandAfter.replace(/\s/g, ' ')).eql(cypherCommand, 'The changes are still saved from the Editor');
+    // Re-open the Editor and do some changes and close by shortcut “ESC”
+    await t.click(workbenchPage.monacoWidget);
+    await t.typeText(workbenchPage.queryInput.nth(1), 'test', { replace: true });
+    await t.pressKey('esc');
+    // Verify that editor is closed and changes are not saved
+    commandAfter = await workbenchPage.scriptsLines.textContent;
+    await t.expect(commandAfter.replace(/\s/g, ' ')).eql(cypherCommand, 'The changes are still saved from the Editor');
+});
+test('Verify that when user use shortcut “CTRL+ENTER” or clicks on the “V” control popover Editor is closed and changes are saved', async t => {
+    let script = 'query';
+    // Type command and open the popover editor
+    await t.typeText(workbenchPage.queryInput, `${command} "${script}`, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Do some changes in the Editor and click on the “V” control
+    script = 'test';
+    await t.pressKey('ctrl+a');
+    await t.typeText(workbenchPage.queryInput.nth(1), script, { replace: true });
+    await t.click(workbenchPage.applyButton);
+    // Verify that editor is closed and changes are saved
+    let commandAfter = await workbenchPage.scriptsLines.textContent;
+    await t.expect(workbenchPage.queryInput.nth(1).exists).notOk('The popover Editor is not closed');
+    await t.expect(commandAfter.replace(/\s/g, ' ')).eql(`${command} "${script}"`, 'The changes are not saved from the Editor');
+    // Re-open the Editor and do some changes and use keyboard shortcut “CTRL+ENTER”
+    await t.click(workbenchPage.monacoWidget);
+    script = 'test2';
+    await t.pressKey('ctrl+a');
+    await t.typeText(workbenchPage.queryInput.nth(1), 'test2', { paste: true, replace: true });
+    await t.pressKey('ctrl+enter');
+    // Verify that editor is closed and changes are not saved
+    commandAfter = await workbenchPage.scriptsLines.textContent;
+    await t.expect(commandAfter.replace(/\s/g, ' ')).eql(`${command} "${script}"`, 'The changes are still saved from the Editor');
+});
+test('Verify that user can see the opacity of main Editor is 80%, Run button is disabled when the non-Redis editor is opened', async t => {
+    // Type command and open Cypher editor
+    await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Check the main Editor and Run button
+    await t.expect(workbenchPage.mainEditorArea.getStyleProperty('opacity')).eql('0.8', 'The opacity of main Editor is incorrect');
+    await t.click(workbenchPage.submitCommandButton);
+    await t.expect(workbenchPage.noCommandHistorySection.visible).ok('The Run button in main Editor is not disabled');
+    await t.hover(workbenchPage.submitCommandButton);
+    await t.expect(workbenchPage.runButtonToolTip.visible).notOk('The Run button in main Editor still react on hover');
+});
+test('Verify that user can resize non-Redis editor only by the top and bottom borders', async t => {
+    const offsetY = 50;
+    await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, offsetY * 10, { speed: 0.4 });
+    // Type command and open Cypher editor
+    await t.typeText(workbenchPage.queryInput, `${command} "query"`, { replace: true });
+    await t.pressKey('left');
+    await t.click(workbenchPage.monacoWidget);
+    // Check that user can resize editor by top border
+    let editorHeight = await workbenchPage.queryInput.nth(1).clientHeight;
+    await t.drag(workbenchPage.nonRedisEditorResizeTop, 0, -offsetY, { speed: 0.4 });
+    await t.expect(workbenchPage.queryInput.nth(1).clientHeight).eql(editorHeight + offsetY, 'The non-Redis editor is not resized by the top border');
+    // Check that user can resize editor by bottom border
+    editorHeight = await workbenchPage.queryInput.nth(1).clientHeight;
+    await t.drag(workbenchPage.nonRedisEditorResizeBottom, 0, -offsetY, { speed: 0.4 });
+    await t.expect(workbenchPage.queryInput.nth(1).clientHeight).eql(editorHeight - offsetY, 'The non-Redis editor is not resized by the bottom border');
+});

--- a/tests/e2e/tests/regression/workbench/default-scripts-area.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/default-scripts-area.e2e.ts
@@ -8,34 +8,30 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
 
 fixture `Default scripts area at Workbench`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can expand/collapse the enablement area', async t => {
-        //Hover over Enablement area
+test('Verify that user can expand/collapse the enablement area', async t => {
+        // Hover over Enablement area
         await t.hover(workbenchPage.preselectArea);
-        //Collapse the area with default scripts
+        // Collapse the area with default scripts
         await t.click(workbenchPage.collapsePreselectAreaButton);
-        //Validate that Enablement area is not displayed
-        await t.expect(workbenchPage.preselectArea.visible).notOk('Enablement area is collapsed');
-        //Expand Enablement area
+        // Validate that Enablement area is not displayed
+        await t.expect(workbenchPage.preselectArea.visible).notOk('Enablement area is not collapsed');
+        // Expand Enablement area
         await t.click(workbenchPage.expandPreselectAreaButton);
-        //Validate that Enablement area is displayed
-        await t.expect(workbenchPage.preselectArea.visible).ok('Enablement area is expanded');
+        // Validate that Enablement area is displayed
+        await t.expect(workbenchPage.preselectArea.visible).ok('Enablement area is not expanded');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the [Manual] option in the Enablement area', async t => {
+test('Verify that user can see the [Manual] option in the Enablement area', async t => {
         const optionsForCheck = [
             'Manual',
             'List the Indices',
@@ -43,112 +39,88 @@ test
             'Search',
             'Aggregate'
         ];
-        //Remember the options displayed in the area
+
+        // Remember the options displayed in the area
         const countOfOptions = await workbenchPage.preselectButtons.count;
-        const displayedOptions = [];
+        const displayedOptions: string[] = [];
         for(let i = 0; i < countOfOptions; i++) {
             displayedOptions.push(await workbenchPage.preselectButtons.nth(i).textContent);
         }
-        //Verify the options in the area
+        // Verify the options in the area
         for(let i = 0; i < countOfOptions; i++) {
-            await t.expect(displayedOptions[i]).eql(optionsForCheck[i], `Option ${optionsForCheck} is in the Enablement area`);
+            await t.expect(displayedOptions[i]).eql(optionsForCheck[i], `Option ${optionsForCheck} is not in the Enablement area`);
         }
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved article in Enablement area when he leaves Workbench page and goes back again', async t => {
+test('Verify that user can see saved article in Enablement area when he leaves Workbench page and goes back again', async t => {
         await t.click(workbenchPage.documentButtonInQuickGuides);
-        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is visible', { timeout: 5000 });
-        //Open Working with Hashes section
+        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is not visible', { timeout: 5000 });
+        // Open Working with Hashes section
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
-        //Check the button from Hash page is visible
-        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is visible');
-        //Go to Browser page
+        // Check the button from Hash page is visible
+        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is not visible');
+        // Go to Browser page
         await t.click(myRedisDatabasePage.browserButton);
-        //Go back to Workbench page
+        // Go back to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
-        //Verify that the same article is opened in Enablement area
-        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is visible');
-        //Go to list of DBs page
+        // Verify that the same article is opened in Enablement area
+        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is not visible');
+        // Go to list of DBs page
         await t.click(myRedisDatabasePage.myRedisDBButton);
-        //Go back to active DB again
+        // Go back to active DB again
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Check that user is on Workbench page and "Working with Hashes" page is displayed
-        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is visible');
+        // Check that user is on Workbench page and "Working with Hashes" page is displayed
+        await t.expect(workbenchPage.preselectHashCreate.visible).ok('The end of the page is not visible');
     });
 //skipped due the issue RI-2384
-test.skip
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see saved scroll position in Enablement area when he leaves Workbench page and goes back again', async t => {
-        //Open Working with Hashes section
+test.skip('Verify that user can see saved scroll position in Enablement area when he leaves Workbench page and goes back again', async t => {
+        // Open Working with Hashes section
         await t.click(workbenchPage.documentButtonInQuickGuides);
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
-        //Evaluate the last button in Enablement Area
+        // Evaluate the last button in Enablement Area
         const buttonsQuantity = await workbenchPage.preselectButtons.count;
         const lastButton = workbenchPage.preselectButtons.nth(buttonsQuantity - 1);
-        //Scroll to the very bottom of the page
+        // Scroll to the very bottom of the page
         await t.scrollIntoView(lastButton);
-        //Check the scroll position
+        // Check the scroll position
         const scrollPosition = await workbenchPage.scrolledEnablementArea.scrollTop;
-        //Go to Browser page
+        // Go to Browser page
         await t.click(myRedisDatabasePage.browserButton);
-        //Go back to Workbench page
+        // Go back to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
-        //Check that scroll position is saved
-        await t.expect(await workbenchPage.scrolledEnablementArea.scrollTop).eql(scrollPosition, 'The scroll position status');
-        //Go to list of DBs page
+        // Check that scroll position is saved
+        await t.expect(await workbenchPage.scrolledEnablementArea.scrollTop).eql(scrollPosition, 'The scroll position status is incorrect');
+        // Go to list of DBs page
         await t.click(myRedisDatabasePage.myRedisDBButton);
-        //Go back to active DB again
+        // Go back to active DB again
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Check that scroll position is saved
-        await t.expect(await workbenchPage.scrolledEnablementArea.scrollTop).eql(scrollPosition, 'Scroll position is correct');
+        // Check that scroll position is saved
+        await t.expect(await workbenchPage.scrolledEnablementArea.scrollTop).eql(scrollPosition, 'Scroll position is not correct');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the siblings menu by clicking on page counter element between Back and Next buttons', async t => {
+test('Verify that user can see the siblings menu by clicking on page counter element between Back and Next buttons', async t => {
         const popoverButtons = [
             'Introduction',
             'Working with Hashes',
             'Working with JSON',
             'Learn More'
         ]
-        //Open Working with Hashes section and click on the on page counter
+
+        // Open Working with Hashes section and click on the on page counter
         await t.click(workbenchPage.documentButtonInQuickGuides);
-        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is visible', { timeout: 5000 });
+        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is not visible', { timeout: 5000 });
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
+        // Verify that user can see the quick navigation section to navigate between siblings under the scrolling content
+        await t.expect(workbenchPage.enablementAreaPagination.visible).ok('The quick navigation section is not displayed');
+
         await t.click(workbenchPage.enablementAreaPagination);
-        //Verify the siblings menu
-        await t.expect(workbenchPage.enablementAreaPaginationPopover.visible).ok('The siblings menu is displayed');
+        // Verify the siblings menu
+        await t.expect(workbenchPage.enablementAreaPaginationPopover.visible).ok('The siblings menu is not displayed');
         const countOfButtons = await workbenchPage.paginationPopoverButtons.count;
         for (let i = 0; i < countOfButtons; i++) {
             let popoverButton = workbenchPage.paginationPopoverButtons.nth(i);
-            await t.expect(popoverButton.textContent).eql(popoverButtons[i], `The siblings menu button ${popoverButtons[i]} is displayed`);
+            await t.expect(popoverButton.textContent).eql(popoverButtons[i], `The siblings menu button ${popoverButtons[i]} is not displayed`);
         }
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the quick navigation section to navigate between siblings under the scrolling content', async t => {
-        //Open Working with Hashes section
-        await t.click(workbenchPage.documentButtonInQuickGuides);
-        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is visible', { timeout: 5000 });
-        await t.click(workbenchPage.internalLinkWorkingWithHashes);
-        //Verify the quick navigation section
-        await t.expect(workbenchPage.enablementAreaPagination.visible).ok('The quick navigation section is displayed');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see the pagination for redis stack pages in Tutorials', async t => {
-        //Open any redis stack Tutorials
-        await t.click(workbenchPage.redisStackTutorialsButton);
-        await t.click(workbenchPage.vectorSimilitaritySearchButton);
-        //Verify the pagination
-        await t.expect(workbenchPage.enablementAreaPagination.visible).ok('The user can see the pagination for redis stack pages');
-        await t.expect(workbenchPage.nextPageButton.visible).ok('The user can see the next page for redis stack pages');
-        await t.expect(workbenchPage.prevPageButton.visible).ok('The user can see the prev page for redis stack pages');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that the same type of content is supported in the “Tutorials” as in the “Quick Guides”', async t => {
+test('Verify that the same type of content is supported in the “Tutorials” as in the “Quick Guides”', async t => {
         const tutorialsContent = [
             'Working with JSON',
             'Vector Similarity Search',
@@ -157,16 +129,22 @@ test
             'Probabilistic data structures'
         ];
         const command = 'HSET bikes:10000  ';
-        //Verify the redis stack links
+
+        // Verify the redis stack links
         await t.click(workbenchPage.redisStackTutorialsButton);
         const linksCount = await workbenchPage.redisStackLinks.count;
         for(let i = 0; i < linksCount; i++) {
             await t.expect(workbenchPage.redisStackLinks.nth(i).textContent).eql(tutorialsContent[i], `The link ${tutorialsContent[i]} is in the Enablement area`);
         }
-        //Verify the load script to Editor
+        // Verify the load script to Editor
         await t.click(workbenchPage.vectorSimilitaritySearchButton);
-        await t.expect(workbenchPage.queryInputScriptArea.textContent).eql('', 'The editor is empty');
+        // Verify that user can see the pagination for redis stack pages in Tutorials
+        await t.expect(workbenchPage.enablementAreaPagination.visible).ok('The user can not see the pagination for redis stack pages');
+        await t.expect(workbenchPage.nextPageButton.visible).ok('The user can not see the next page for redis stack pages');
+        await t.expect(workbenchPage.prevPageButton.visible).ok('The user can not see the prev page for redis stack pages');
+
+        await t.expect(workbenchPage.queryInputScriptArea.textContent).eql('', 'The editor is not empty');
         await t.click(workbenchPage.hashWithVectorButton);
         const editorContent = (await workbenchPage.queryInputScriptArea.textContent).replace(/\s/g, ' ')
-        await t.expect(editorContent).eql(command, 'The selected command is in the Editor');
+        await t.expect(editorContent).eql(command, 'The selected command is not in the Editor');
     });

--- a/tests/e2e/tests/regression/workbench/empty-command-history.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/empty-command-history.e2e.ts
@@ -13,28 +13,28 @@ fixture `Empty command history in Workbench`
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
+    });
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see placeholder text in Workbench history if no commands have not been run yet', async t => {
-        //Verify that all the elements from empty command history placeholder are displayed
-        await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is visible')
-        await t.expect(workbenchPage.noCommandHistoryIcon.visible).ok('No command history icon is visible')
-        await t.expect(workbenchPage.noCommandHistoryTitle.visible).ok('No command history title is visible')
-        await t.expect(workbenchPage.noCommandHistoryText.visible).ok('No command history text is visible')
-        //Run a command
+    .meta({ rte: rte.standalone })('Verify that user can see placeholder text in Workbench history if no commands have not been run yet', async t => {
         const commandToSend = 'info server';
+
+        // Verify that all the elements from empty command history placeholder are displayed
+        await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is not visible');
+        await t.expect(workbenchPage.noCommandHistoryIcon.visible).ok('No command history icon is not visible');
+        await t.expect(workbenchPage.noCommandHistoryTitle.visible).ok('No command history title is not visible');
+        await t.expect(workbenchPage.noCommandHistoryText.visible).ok('No command history text is not visible');
+        // Run a command
         await workbenchPage.sendCommandInWorkbench(commandToSend);
-        //Verify that empty command history placeholder is not displayed
-        await t.expect(workbenchPage.noCommandHistorySection.visible).notOk('No command history section is not visible')
-        //Delete the command result
+        // Verify that empty command history placeholder is not displayed
+        await t.expect(workbenchPage.noCommandHistorySection.visible).notOk('No command history section is still visible');
+        // Delete the command result
         await t.click(Selector(workbenchPage.cssDeleteCommandButton));
-        //Verify that empty command history placeholder is displayed
-        await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is visible')
+        // Verify that empty command history placeholder is displayed
+        await t.expect(workbenchPage.noCommandHistorySection.visible).ok('No command history section is not visible');
     });

--- a/tests/e2e/tests/regression/workbench/group-mode.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/group-mode.e2e.ts
@@ -15,15 +15,15 @@ const commandsNumber = commands.length;
 const commandsString = commands.join('\n');
 
 fixture `Workbench Group Mode`
-    .meta({ rte: rte.standalone, type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can run the commands from the Editor in the group mode', async t => {

--- a/tests/e2e/tests/regression/workbench/history-of-results.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/history-of-results.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { getRandomParagraph } from '../../../helpers/keys';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage, CliPage } from '../../../pageObjects';
@@ -9,12 +8,11 @@ import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
 const cliPage = new CliPage();
 const common = new Common();
 
 const oneMinuteTimeout = 60000;
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const command = `set ${keyName} test`;
 
 fixture `History of results at Workbench`
@@ -22,54 +20,56 @@ fixture `History of results at Workbench`
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keyName}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test
     .meta({ rte: rte.standalone })('Verify that user can see original date and time of command execution in Workbench history after the page update', async t => {
-        keyName = chance.word({ length: 5 });
-        //Send command and remember the time
+        keyName = common.generateWord(5);
+        // Send command and remember the time
         await workbenchPage.sendCommandInWorkbench(command);
         const dateTime = await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssCommandExecutionDateTime).textContent;
-        //Wait fo 1 minute, refresh page and check results
+        // Wait fo 1 minute, refresh page and check results
         await t.wait(oneMinuteTimeout);
         await common.reloadPage();
-        await t.expect(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssCommandExecutionDateTime).textContent).eql(dateTime, 'The original date and time of command execution is saved after the page update');
+        await t.expect(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssCommandExecutionDateTime).textContent).eql(dateTime, 'The original date and time of command execution is not saved after the page update');
     });
 //skipped due the long time execution and hangs of test
 test.skip
     .meta({ rte: rte.standalone })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     })('Verify that if command result is more than 1 MB and user refreshes the page, the message "Results have been deleted since they exceed 1 MB. Re-run the command to see new results." is displayed', async t => {
         const commandToSend = 'set key';
         const commandToGet = 'get key';
-        //Send command with value that exceed 1MB
         const commandText = getRandomParagraph(10).repeat(100);
+
+        // Send command with value that exceed 1MB
         await workbenchPage.sendCommandInWorkbench(`${commandToSend} "${commandText}"`);
         await workbenchPage.sendCommandInWorkbench(commandToGet);
-        //Refresh the page and check result
+        // Refresh the page and check result
         await common.reloadPage();
         await t.click(workbenchPage.queryCardContainer.withText(commandToGet));
-        await t.expect(workbenchPage.queryTextResult.textContent).eql('"Results have been deleted since they exceed 1 MB. Re-run the command to see new results."', 'The messageis displayed');
+        await t.expect(workbenchPage.queryTextResult.textContent).eql('"Results have been deleted since they exceed 1 MB. Re-run the command to see new results."', 'The message is not displayed');
     });
 test
     .meta({ rte: rte.standalone })('Verify that the first command in workbench history is deleted when user executes 31 command (new the following result replaces the first result)', async t => {
-        keyName = chance.word({ length: 10 });
+        keyName = common.generateWord(10);
         const numberOfCommands = 30;
         const firstCommand = 'FT._LIST';
+
         //Send command the first command
         await workbenchPage.sendCommandInWorkbench(firstCommand);
-        await t.expect(workbenchPage.queryCardContainer.nth(0).textContent).contains(firstCommand, 'The first executed command is in the workbench history');
-        //Send 30 commands and check the results
+        await t.expect(workbenchPage.queryCardContainer.nth(0).textContent).contains(firstCommand, 'The first executed command is not in the workbench history');
+        // Send 30 commands and check the results
         await workbenchPage.sendCommandInWorkbench(`${numberOfCommands} ${command}`);
-        await t.expect(workbenchPage.queryCardCommand.find('span').withExactText(`${firstCommand}`).exists).notOk('The first command is not in the history result');
+        await t.expect(workbenchPage.queryCardCommand.find('span').withExactText(`${firstCommand}`).exists).notOk('The first command is still in the history result');
         await t.expect(workbenchPage.queryCardCommand.count).eql(30, { timeout: 5000 });
     });
 test
@@ -79,11 +79,12 @@ test
             'RANDOMKEY'
         ];
         const commandForCheck = 'SET';
-        //Send commands
+
+        // Send commands
         for(const command of commands) {
             await workbenchPage.sendCommandInWorkbench(command);
         }
-        //Verify the quick access to history works when cursor is at the first character
+        // Verify the quick access to history works when cursor is at the first character
         await t.typeText(workbenchPage.queryInput, commandForCheck);
         await t.pressKey('enter');
         await t.pressKey('up');

--- a/tests/e2e/tests/regression/workbench/raw-mode.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/raw-mode.e2e.ts
@@ -10,7 +10,7 @@ const workbenchPage = new WorkbenchPage();
 const common = new Common();
 const browserPage = new BrowserPage();
 
-let keyName = common.generateWord(10);
+const keyName = common.generateWord(10);
 const indexName = common.generateWord(5);
 const keyValue = '\\xe5\\xb1\\xb1\\xe5\\xa5\\xb3\\xe9\\xa6\\xac / \\xe9\\xa9\\xac\\xe7\\x9b\\xae abc 123';
 const unicodeValue = '山女馬 / 马目 abc 123';
@@ -66,11 +66,11 @@ test
         // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .after(async t => {
+    .after(async() => {
         // Clear and delete database
         await deleteStandaloneDatabasesApi(databasesForAdding);
     })('Save Raw mode state', async t => {
-        //Send command in raw mode
+        // Send command in raw mode
         await t.click(workbenchPage.rawModeBtn);
         await workbenchPage.sendCommandsArrayInWorkbench(commandsForSend);
         // Verify that user can see saved Raw mode state after page refresh
@@ -97,7 +97,7 @@ test
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .after(async t => {
-        //Drop index, documents and database
+        // Drop index, documents and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneRedisearch);
@@ -107,10 +107,10 @@ test
             `HMSET product:1 name "${unicodeValue}"`,
             `FT.SEARCH ${indexName} "${unicodeValue}"`
         ];
-        //Send command in raw mode
+        // Send command in raw mode
         await t.click(workbenchPage.rawModeBtn);
         await workbenchPage.sendCommandsArrayInWorkbench(commandsForSend);
-        //Check the FT.SEARCH result
+        // Check the FT.SEARCH result
         await t.switchToIframe(workbenchPage.iframe);
         const name = workbenchPage.queryTableResult.withText(unicodeValue);
         await t.expect(name.exists).ok('The added key name field is not converted to Unicode');

--- a/tests/e2e/tests/regression/workbench/redis-stack-commands.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/redis-stack-commands.e2e.ts
@@ -13,59 +13,58 @@ const workbenchPage = new WorkbenchPage();
 const keyNameGraph = 'bikes_graph';
 
 fixture `Redis Stack command in Workbench`
-    .meta({type: 'regression'})
+    .meta({type: 'regression', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async() => {
-        //Drop key and database
+        // Drop key and database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`GRAPH.DELETE ${keyNameGraph}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 //skipped due the inaccessibility of the iframe
 test.skip
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can switches between Graph and Text for GRAPH command and see results corresponding to their views', async t => {
-        //Send Graph command
+    .meta({ env: env.desktop })('Verify that user can switches between Graph and Text for GRAPH command and see results corresponding to their views', async t => {
+        // Send Graph command
         await t.click(workbenchPage.redisStackTutorialsButton);
         await t.click(workbenchPage.tutorialsWorkingWithGraphLink);
         await t.click(workbenchPage.createGraphBikeButton);
         await t.click(workbenchPage.submitCommandButton);
-        //Switch to Text view and check result
+        // Switch to Text view and check result
         await workbenchPage.selectViewTypeText();
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).exists).ok('The text view is switched for GRAPH command');
-        //Switch to Graph view and check result
+        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).exists).ok('The text view is not switched for GRAPH command');
+        // Switch to Graph view and check result
         await workbenchPage.selectViewTypeGraph();
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.queryGraphContainer).exists).ok('The Graph view is switched for GRAPH command');
+        await t.expect(await workbenchPage.queryCardContainer.nth(0).find(workbenchPage.queryGraphContainer).exists).ok('The Graph view is not switched for GRAPH command');
     });
 test
-    .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can see "No data to visualize" message for Graph command', async t => {
-        //Send Graph command
+    .meta({ env: env.desktop })('Verify that user can see "No data to visualize" message for Graph command', async t => {
+        // Send Graph command
         await t.click(workbenchPage.redisStackTutorialsButton);
         await t.click(workbenchPage.tutorialsWorkingWithGraphLink);
         await t.click(workbenchPage.preselectModelBikeSalesButton);
         await t.click(workbenchPage.submitCommandButton);
-        //Check result
+        // Check result
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.responseInfo.textContent).eql('No data to visualize. Switch to Text view to see raw information.', 'The info message is displayed for Graph');
-        //Switch to Text view and check result
+        await t.expect(workbenchPage.responseInfo.textContent).eql('No data to visualize. Switch to Text view to see raw information.', 'The info message is not displayed for Graph');
+        // Switch to Text view and check result
         await t.switchToMainWindow();
         await workbenchPage.selectViewTypeText();
-        await t.expect(workbenchPage.queryTextResult.exists).ok('The result in text view is displayed');
+        await t.expect(workbenchPage.queryTextResult.exists).ok('The result in text view is not displayed');
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can switches between Chart and Text for TimeSeries command and see results corresponding to their views', async t => {
-        //Send TimeSeries command
-        await t.click(workbenchPage.redisStackTutorialsButton);
-        await t.click(workbenchPage.timeSeriesLink);
-        await t.click(workbenchPage.showSalesPerRegiomButton);
-        await t.click(workbenchPage.submitCommandButton);
-        //Check result is in chart view
-        await t.expect(workbenchPage.chartViewTypeOptionSelected.visible).ok('The chart view option is selected by default');
-        //Switch to Text view and check result
-        await workbenchPage.selectViewTypeText();
-        await t.expect(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).exists).ok('The result in text view is displayed');
-    });
+test('Verify that user can switches between Chart and Text for TimeSeries command and see results corresponding to their views', async t => {
+    // Send TimeSeries command
+    await t.click(workbenchPage.redisStackTutorialsButton);
+    await t.click(workbenchPage.timeSeriesLink);
+    await t.click(workbenchPage.showSalesPerRegiomButton);
+    await t.click(workbenchPage.submitCommandButton);
+    // Check result is in chart view
+    await t.expect(workbenchPage.chartViewTypeOptionSelected.visible).ok('The chart view option is not selected by default');
+    // Switch to Text view and check result
+    await workbenchPage.selectViewTypeText();
+    await t.expect(workbenchPage.queryCardContainer.nth(0).find(workbenchPage.cssQueryTextResult).exists).ok('The result in text view is not displayed');
+});

--- a/tests/e2e/tests/regression/workbench/redisearch-module-not-available.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/redisearch-module-not-available.e2e.ts
@@ -16,22 +16,23 @@ fixture `Redisearch module not available`
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneV5Config, ossStandaloneV5Config.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async(t) => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteStandaloneDatabaseApi(ossStandaloneV5Config);
-    })
+    });
 test
-    .meta({ env: env.web, rte: rte.standalone })
-    ('Verify that user can see the "Create your free Redis database with RediSearch on Redis Cloud" button and click on it in Workbench when module in not loaded', async t => {
-        //Send command with 'FT.'
+    .meta({ env: env.web, rte: rte.standalone })('Verify that user can see the "Create your free Redis database with RediSearch on Redis Cloud" button and click on it in Workbench when module in not loaded', async t => {
+        const link = 'https://redis.com/try-free/?utm_source=redis&utm_medium=app&utm_campaign=redisinsight_redisearch';
+
+        // Send command with 'FT.'
         await workbenchPage.sendCommandInWorkbench(commandForSend);
-        //Verify the button in the results
-        await t.expect(await workbenchPage.queryCardNoModuleButton.visible).ok('The "Create your free Redis database with RediSearch on Redis Cloud" button is visible');
-        //Click on the button in the results
+        // Verify the button in the results
+        await t.expect(await workbenchPage.queryCardNoModuleButton.visible).ok('The "Create your free Redis database with RediSearch on Redis Cloud" button is not visible');
+        // Click on the button in the results
         await t.click(workbenchPage.queryCardNoModuleButton);
-        await t.expect(getPageUrl()).contains('https://redis.com/try-free/?utm_source=redis&utm_medium=app&utm_campaign=redisinsight_redisearch', 'The Try Redis Enterprise page is opened');
+        await t.expect(getPageUrl()).contains(link, 'The Try Redis Enterprise page is not opened');
         await t.switchToParentWindow();
     });

--- a/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
@@ -1,165 +1,144 @@
-import { Chance } from 'chance';
 import { Selector } from 'testcafe';
 import { rte } from '../../../helpers/constants';
 import { acceptLicenseTermsAndAddDatabaseApi } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage, CliPage, SettingsPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
 import { deleteStandaloneDatabaseApi } from '../../../helpers/api/api-database';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
 const cliPage = new CliPage();
 const settingsPage = new SettingsPage();
+const common = new Common();
 
-const indexName = chance.word({ length: 5 });
-let keyName = chance.word({ length: 10 });
+const indexName = common.generateWord(5);
+let keyName = common.generateWord(5);
 
 fixture `Scripting area at Workbench`
-    .meta({ type: 'regression' })
+    .meta({ type: 'regression', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can run multiple commands written in multiple lines in Workbench page', async t => {
-        const commandsForSend = [
-            'info',
-            `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
-            'HMSET product:1 price 20',
-            'FT._LIST'
-        ]
-        //Go to Settings page
-        await t.click(myRedisDatabasePage.settingsButton);
-        //Specify Commands in pipeline
-        await t.click(settingsPage.accordionWorkbenchSettings);
-        await settingsPage.changeCommandsInPipeline('1');
-        //Go to Workbench page
-        await t.click(myRedisDatabasePage.workbenchButton);
-        //Send commands in multiple lines
-        await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'), 0.5);
-        //Check the result
-        for (let i = 1; i < commandsForSend.length + 1; i++) {
-            const resultCommand = await workbenchPage.queryCardCommand.nth(i - 1).textContent;
-            await t.expect(resultCommand).eql(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is in the result`);
-        }
     });
+test('Verify that user can run multiple commands written in multiple lines in Workbench page', async t => {
+    const commandsForSend = [
+        'info',
+        `FT.CREATE ${indexName} ON HASH PREFIX 1 product: SCHEMA name TEXT`,
+        'HMSET product:1 price 20',
+        'FT._LIST'
+    ];
+
+    // Go to Settings page
+    await t.click(myRedisDatabasePage.settingsButton);
+    // Specify Commands in pipeline
+    await t.click(settingsPage.accordionWorkbenchSettings);
+    await settingsPage.changeCommandsInPipeline('1');
+    // Go to Workbench page
+    await t.click(myRedisDatabasePage.workbenchButton);
+    // Send commands in multiple lines
+    await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'), 0.5);
+    // Check the result
+    for (let i = 1; i < commandsForSend.length + 1; i++) {
+        const resultCommand = await workbenchPage.queryCardCommand.nth(i - 1).textContent;
+        await t.expect(resultCommand).eql(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is in not the result`);
+    }
+});
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keyName}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can use double slashes (//) wrapped in double quotes and these slashes will not comment out any characters', async t => {
-        keyName = chance.word({ length: 10 });
+    })('Verify that user can use double slashes (//) wrapped in double quotes and these slashes will not comment out any characters', async t => {
+        keyName = common.generateWord(10);
         const commandsForSend = [
             `HMSET ${keyName} price 20`,
             'FT._LIST'
         ];
-        //Go to Settings page
+
+        // Go to Settings page
         await t.click(myRedisDatabasePage.settingsButton);
-        //Specify Commands in pipeline
+        // Specify Commands in pipeline
         await t.click(settingsPage.accordionWorkbenchSettings);
         await settingsPage.changeCommandsInPipeline('1');
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
-        //Send commands in multiple lines with double slashes (//) wrapped in double quotes
+        // Send commands in multiple lines with double slashes (//) wrapped in double quotes
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n"//"'), 0.5);
-        //Check that all commands are executed
+        // Check that all commands are executed
         for (let i = 1; i < commandsForSend.length + 1; i++) {
             const resultCommand = await workbenchPage.queryCardCommand.nth(i - 1).textContent;
-            await t.expect(resultCommand).contains(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is in the result`);
+            await t.expect(resultCommand).contains(commandsForSend[commandsForSend.length - i], `The command ${commandsForSend[commandsForSend.length - i]} is not in the result`);
         }
     });
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can see an indication (green triangle) of commands from the left side of the line numbers', async t => {
-        //Open Working with Hashes page
+    })('Verify that user can see an indication (green triangle) of commands from the left side of the line numbers', async t => {
+        // Open Working with Hashes page
         await t.click(workbenchPage.documentButtonInQuickGuides);
-        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is visible', { timeout: 5000 });
+        await t.expect(workbenchPage.internalLinkWorkingWithHashes.visible).ok('The working with hachs link is not visible', { timeout: 5000 });
         await t.click(workbenchPage.internalLinkWorkingWithHashes);
-        //Put Create Hash commands into Editing area
+        // Put Create Hash commands into Editing area
         await t.click(workbenchPage.preselectHashCreate);
-        //Maximize Scripting area to see all the commands
+        // Maximize Scripting area to see all the commands
         await t.drag(workbenchPage.resizeButtonForScriptingAndResults, 0, 300, { speed: 0.4 });
-        //Get number of commands in scripting area
+        // Get number of commands in scripting area
         const numberOfCommands = await Selector('span').withExactText('HSET').count;
-        //Compare number of indicator displayed and expected value
-        await t.expect(workbenchPage.monacoCommandIndicator.count).eql(numberOfCommands, 'Number of command indicator');
+        // Compare number of indicator displayed and expected value
+        await t.expect(workbenchPage.monacoCommandIndicator.count).eql(numberOfCommands, 'Number of command indicator is incorrect');
     });
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await cliPage.sendCommandInCli(`DEL ${keyName}`);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can find (using right click) "Run Commands" custom shortcut option in monaco menu and run a command', async t => {
-        keyName = chance.word({ length: 10 });
+    })('Verify that user can find (using right click) "Run Commands" custom shortcut option in monaco menu and run a command', async t => {
+        keyName = common.generateWord(10);
         const command = `HSET ${keyName} field value`;
-        //Put a command in Editing Area
+
+        // Put a command in Editing Area
         await t.typeText(workbenchPage.queryInput, command);
-        //Right click to get context menu
+        // Right click to get context menu
         await t.rightClick(workbenchPage.queryInput);
-        //Select Command Palette option
+        // Select Command Palette option
         await t.click(workbenchPage.monacoContextMenu.find(workbenchPage.cssMonacoCommandPaletteLine));
-        //Print "Run Commands" shortcut
+        // Print "Run Commands" shortcut
         await t.typeText(workbenchPage.monacoShortcutInput, 'Run Commands');
-        //Select "Run Commands" from menu
+        // Select "Run Commands" from menu
         await t.click(workbenchPage.monacoSuggestionOption);
-        //Check the result with sent command
-        await t.expect(await workbenchPage.queryCardCommand.withExactText(command).exists).ok('The result of sent command');
+        // Check the result with sent command
+        await t.expect(await workbenchPage.queryCardCommand.withExactText(command).exists).ok('The result of sent command is not displayed');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can repeat commands by entering a number of repeats before the Redis command and see separate results per each command in Workbench', async t => {
-        const command = 'FT._LIST';
-        const repeats = 5;
-        //Rum command in Workbench with repeats
-        await workbenchPage.sendCommandInWorkbench(`${repeats} ${command}`);
-        //Verify result
-        for (let i = 0; i < repeats; i++) {
-            await t.expect(workbenchPage.queryCardContainer.nth(i).textContent).contains(command, 'Workbench contains separate results');
-        }
-    });
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can not run "Select" command in Workbench', async t => {
-        const command = 'select 13';
-        const result = '"select is not supported by the Workbench.';
-        //Run Select command in Workbench
-        await workbenchPage.sendCommandInWorkbench(command);
-        //Check the command result
-        await t.expect(workbenchPage.commandExecutionResultFailed.textContent).contains(result, 'The select command unsupported message');
-    });
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Delete database
-        await deleteStandaloneDatabaseApi(ossStandaloneConfig);
-    })
-    ('Verify that user can use Ctrl + Enter to run the query in Workbench', async t => {
-        const command = 'FT._LIST';
-        //Type command and use Ctrl + Enter
-        await t.typeText(workbenchPage.queryInput, command, { replace: true });
-        await t.pressKey('ctrl+enter');
-        //Check that command is in results
-        await t.expect(await workbenchPage.queryCardCommand.withExactText(command).exists).ok('The user can use Ctrl + Enter to run the query');
-    });
+test.only('Verify that user can repeat commands by entering a number of repeats before the Redis command and see separate results per each command in Workbench', async t => {
+    const command = 'FT._LIST';
+    const command2 = 'select 13';
+    const repeats = 5;
+    const result = '"select is not supported by the Workbench.';
+
+    // Run command in Workbench with repeats
+    await workbenchPage.sendCommandInWorkbench(`${repeats} ${command}`);
+    // Verify result
+    for (let i = 0; i < repeats; i++) {
+        await t.expect(workbenchPage.queryCardContainer.nth(i).textContent).contains(command, 'Workbench not contains separate results');
+    }
+
+    // Run Select command in Workbench
+    await workbenchPage.sendCommandInWorkbench(command2);
+    // Verify that user can not run "Select" command in Workbench
+    await t.expect(workbenchPage.commandExecutionResultFailed.textContent).contains(result, 'The select command unsupported message is incorrect');
+
+    // Type command and use Ctrl + Enter
+    await t.typeText(workbenchPage.queryInput, command, { replace: true });
+    await t.pressKey('ctrl+enter');
+    // Verify that user can use Ctrl + Enter to run the query in Workbench
+    await t.expect(await workbenchPage.queryCardCommand.withExactText(command).exists).ok('The user can not use Ctrl + Enter to run the query');
+});

--- a/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/scripting-area.e2e.ts
@@ -118,7 +118,7 @@ test
         // Check the result with sent command
         await t.expect(await workbenchPage.queryCardCommand.withExactText(command).exists).ok('The result of sent command is not displayed');
     });
-test.only('Verify that user can repeat commands by entering a number of repeats before the Redis command and see separate results per each command in Workbench', async t => {
+test('Verify that user can repeat commands by entering a number of repeats before the Redis command and see separate results per each command in Workbench', async t => {
     const command = 'FT._LIST';
     const command2 = 'select 13';
     const repeats = 5;

--- a/tests/e2e/tests/regression/workbench/workbench-re-cluster.e2e.ts
+++ b/tests/e2e/tests/regression/workbench/workbench-re-cluster.e2e.ts
@@ -24,17 +24,18 @@ const verifyCommandsInWorkbench = async(): Promise<void> => {
         'command',
         'FT.SEARCH idx *'
     ];
+
     await t.click(myRedisDatabasePage.workbenchButton);
-    //Send commands
+    // Send commands
     await workbenchPage.sendCommandInWorkbench(commandForSend1);
     await workbenchPage.sendCommandInWorkbench(commandForSend2);
-    //Check that all the previous run commands are saved and displayed
+    // Check that all the previous run commands are saved and displayed
     await common.reloadPage();
     await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend1).exists).ok('The previous run commands are saved');
     await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend2).exists).ok('The previous run commands are saved');
-    //Send multiple commands in one query
+    // Send multiple commands in one query
     await workbenchPage.sendCommandInWorkbench(multipleCommands.join('\n'), 0.75);
-    //Check that the results for all commands are displayed
+    // Check that the results for all commands are displayed
     for (const command of multipleCommands) {
         await t.expect(workbenchPage.queryCardCommand.withExactText(command).exists).ok(`The command ${command} from multiple query is displayed`);
     }
@@ -49,7 +50,7 @@ test
         await acceptLicenseTermsAndAddREClusterDatabase(redisEnterpriseClusterConfig);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(redisEnterpriseClusterConfig.databaseName);
     })('Verify that user can run commands in Workbench in RE Cluster DB', async() => {
         await verifyCommandsInWorkbench();
@@ -60,7 +61,7 @@ test
         await acceptLicenseTermsAndAddRECloudDatabase(cloudDatabaseConfig);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(cloudDatabaseConfig.databaseName);
     })('Verify that user can run commands in Workbench in RE Cloud DB', async() => {
         await verifyCommandsInWorkbench();
@@ -71,7 +72,7 @@ test
         await acceptLicenseTermsAndAddOSSClusterDatabase(ossClusterConfig, ossClusterConfig.ossClusterDatabaseName);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteOSSClusterDatabaseApi(ossClusterConfig);
     })('Verify that user can run commands in Workbench in OSS Cluster DB', async() => {
         await verifyCommandsInWorkbench();
@@ -82,7 +83,7 @@ test
         await acceptLicenseTermsAndAddSentinelDatabaseApi(ossSentinelConfig);
     })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteAllSentinelDatabasesApi(ossSentinelConfig);
     })('Verify that user can run commands in Workbench in Sentinel Primary Group', async() => {
         await verifyCommandsInWorkbench();


### PR DESCRIPTION
Refactoring of e2e regression tests from https://redislabs.atlassian.net/browse/RI-3530
Fixed:
1) Many small tests are merged to save test execution time
2) Comments are reduced to one formatting
3) chance.word() replaced by common.generateWord()
4) Error messages of expects are fixed (previously most of them were incorrect)
5) "rte: rte.standalone" moved from tests meta to fixture meta
6) Different updates for some tests