### PR TITLE
RI-3530 smoke tests refactoring

### DIFF
--- a/tests/e2e/tests/smoke/browser/add-keys.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/add-keys.e2e.ts
@@ -1,108 +1,97 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Add keys`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add Hash Key', async t => {
-        keyName = chance.word({ length: 10 });
-        //add Hash key
-        await browserPage.addHashKey(keyName);
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add Set Key', async t => {
-        keyName = chance.word({ length: 10 });
-        //add Set key
-        await browserPage.addSetKey(keyName);
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add List Key', async t => {
-        keyName = chance.word({ length: 10 });
-        //add List key
-        await browserPage.addListKey(keyName);
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add String Key', async t => {
-        keyName = chance.word({ length: 10 });
-        //add String key
-        await browserPage.addStringKey(keyName);
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add ZSet Key', async t => {
-        keyName = chance.word({ length: 10 });
-        //add ZSet key
-        await browserPage.addZSetKey(keyName, '111');
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can add JSON Key', async t => {
-        keyName = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-        const value = '{"name":"xyz"}';
-        //add JSON key
-        await browserPage.addJsonKey(keyName, value, keyTTL);
-        //check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //check that new key is displayed in the list
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
-    });
+test('Verify that user can add Hash Key', async t => {
+    keyName = common.generateWord(10);
+    // Add Hash key
+    await browserPage.addHashKey(keyName);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The Hash key is not added');
+});
+test('Verify that user can add Set Key', async t => {
+    keyName = common.generateWord(10);
+    // Add Set key
+    await browserPage.addSetKey(keyName);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The Set key is not added');
+});
+test('Verify that user can add List Key', async t => {
+    keyName = common.generateWord(10);
+    // Add List key
+    await browserPage.addListKey(keyName);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The List key is not added');
+});
+test('Verify that user can add String Key', async t => {
+    keyName = common.generateWord(10);
+    // Add String key
+    await browserPage.addStringKey(keyName);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The String key is not added');
+});
+test('Verify that user can add ZSet Key', async t => {
+    keyName = common.generateWord(10);
+    // Add ZSet key
+    await browserPage.addZSetKey(keyName, '111');
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The ZSet key is not added');
+});
+test('Verify that user can add JSON Key', async t => {
+    keyName = common.generateWord(10);
+    const keyTTL = '2147476121';
+    const value = '{"name":"xyz"}';
+
+    // Add JSON key
+    await browserPage.addJsonKey(keyName, value, keyTTL);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not displayed');
+    // Check that new key is displayed in the list
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The JSON key is not added');
+});

--- a/tests/e2e/tests/smoke/browser/edit-key-name.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/edit-key-name.e2e.ts
@@ -1,108 +1,91 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyNameBefore = chance.word({ length: 10 });
-let keyNameAfter = chance.word({ length: 10 });
+let keyNameBefore = common.generateWord(10);
+let keyNameAfter = common.generateWord(10);
+const keyTTL = '2147476121';
 
 fixture `Edit Key names verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyNameAfter);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit String Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-
-        await browserPage.addStringKey(keyNameBefore, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit Set Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
+test('Verify that user can edit String Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
 
-        await browserPage.addSetKey(keyNameBefore, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit Zset Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
+    await browserPage.addStringKey(keyNameBefore, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The String Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The String Key Name not correct after editing');
+});
+test('Verify that user can edit Set Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
 
-        await browserPage.addZSetKey(keyNameBefore, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit Hash Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
+    await browserPage.addSetKey(keyNameBefore, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Set Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Set Key Name not correct after editing');
+});
+test('Verify that user can edit Zset Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
 
-        await browserPage.addHashKey(keyNameBefore, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit List Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
+    await browserPage.addZSetKey(keyNameBefore, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Zset Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Zset Key Name not correct after editing');
+});
+test('Verify that user can edit Hash Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
 
-        await browserPage.addListKey(keyNameBefore, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can edit JSON Key name', async t => {
-        keyNameBefore = chance.word({ length: 10 });
-        keyNameAfter = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-        const keyValue = '{"name":"xyz"}';
+    await browserPage.addHashKey(keyNameBefore, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Hash Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Hash Key Name not correct after editing');
+});
+test('Verify that user can edit List Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
 
-        await browserPage.addJsonKey(keyNameBefore, keyValue, keyTTL);
-        let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The Key Name');
-        await browserPage.editKeyName(keyNameAfter);
-        keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The Key Name');
-    });
+    await browserPage.addListKey(keyNameBefore, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The List Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The List Key Name not correct after editing');
+});
+test('Verify that user can edit JSON Key name', async t => {
+    keyNameBefore = common.generateWord(10);
+    keyNameAfter = common.generateWord(10);
+    const keyValue = '{"name":"xyz"}';
+
+    await browserPage.addJsonKey(keyNameBefore, keyValue, keyTTL);
+    let keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameBefore, 'The JSON Key Name not correct before editing');
+    await browserPage.editKeyName(keyNameAfter);
+    keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyNameAfter, 'The JSON Key Name not correct after editing');
+});

--- a/tests/e2e/tests/smoke/browser/edit-key-value.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/edit-key-value.e2e.ts
@@ -20,76 +20,81 @@ fixture `Edit Key values verification`
         await acceptLicenseTermsAndAddDatabaseApi(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteStandaloneDatabaseApi(ossStandaloneConfig);
     });
 test('Verify that user can edit String value', async t => {
     keyName = common.generateWord(10);
-    //Add string key
+
+    // Add string key
     await browserPage.addStringKey(keyName, keyValueBefore, keyTTL);
-    //Check the key value before edit
+    // Check the key value before edit
     let keyValue = await browserPage.getStringKeyValue();
-    await t.expect(keyValue).contains(keyValueBefore, 'The value is incorrect');
-    //Edit String key value
+    await t.expect(keyValue).contains(keyValueBefore, 'The String value is incorrect');
+    // Edit String key value
     await browserPage.editStringKeyValue(keyValueAfter);
-    //Check the key value after edit
+    // Check the key value after edit
     keyValue = await browserPage.getStringKeyValue();
-    await t.expect(keyValue).contains(keyValueAfter, 'Edited value is incorrect');
+    await t.expect(keyValue).contains(keyValueAfter, 'Edited String value is incorrect');
 });
 test('Verify that user can edit Zset Key member', async t => {
     keyName = common.generateWord(10);
     const scoreBefore = '5';
     const scoreAfter = '10';
-    //Add zset key
+
+    // Add zset key
     await browserPage.addZSetKey(keyName, scoreBefore, keyTTL, keyValueBefore);
-    //Check the key score before edit
+    // Check the key score before edit
     let zsetScore = await browserPage.getZsetKeyScore();
-    await t.expect(zsetScore).eql(scoreBefore, 'Score is incorrect');
-    //Edit Zset key score
+    await t.expect(zsetScore).eql(scoreBefore, 'Zset Score is incorrect');
+    // Edit Zset key score
     await browserPage.editZsetKeyScore(scoreAfter);
-    //Check Zset key score after edit
+    // Check Zset key score after edit
     zsetScore = await browserPage.getZsetKeyScore();
-    await t.expect(zsetScore).contains(scoreAfter, 'Score is not edited');
+    await t.expect(zsetScore).contains(scoreAfter, 'Zset Score is not edited');
 });
 test('Verify that user can edit Hash Key field', async t => {
     const fieldName = 'test';
     keyName = common.generateWord(10);
-    //Add Hash key
+
+    // Add Hash key
     await browserPage.addHashKey(keyName, keyTTL, fieldName, keyValueBefore);
-    //Check the key value before edit
+    // Check the key value before edit
     let keyValue = await browserPage.getHashKeyValue();
-    await t.expect(keyValue).eql(keyValueBefore, 'The value is incorrect');
-    //Edit Hash key value
+    await t.expect(keyValue).eql(keyValueBefore, 'The Hash value is incorrect');
+    // Edit Hash key value
     await browserPage.editHashKeyValue(keyValueAfter);
-    //Check Hash key value after edit
+    // Check Hash key value after edit
     keyValue = await browserPage.getHashKeyValue();
-    await t.expect(keyValue).contains(keyValueAfter, 'Edited value is incorrect');
+    await t.expect(keyValue).contains(keyValueAfter, 'Edited Hash value is incorrect');
 });
 test('Verify that user can edit List Key element', async t => {
     keyName = common.generateWord(10);
-    //Add List key
+
+    // Add List key
     await browserPage.addListKey(keyName, keyTTL, keyValueBefore);
-    //Check the key value before edit
+    // Check the key value before edit
     let keyValue = await browserPage.getListKeyValue();
-    await t.expect(keyValue).eql(keyValueBefore, 'The value is incorrect');
-    //Edit List key value
+    await t.expect(keyValue).eql(keyValueBefore, 'The List value is incorrect');
+    // Edit List key value
     await browserPage.editListKeyValue(keyValueAfter);
-    //Check List key value after edit
+    // Check List key value after edit
     keyValue = await browserPage.getListKeyValue();
-    await t.expect(keyValue).contains(keyValueAfter, 'Edited value is incorrect');
+    await t.expect(keyValue).contains(keyValueAfter, 'Edited List value is incorrect');
 });
 test('Verify that user can edit JSON Key value', async t => {
     const jsonValueBefore = '{"name":"xyz"}';
     const jsonEditedValue = '"xyz test"';
     const jsonValueAfter = '{name:"xyz test"}';
     keyName = common.generateWord(10);
-    //Add JSON key with json object
+
+    // Add JSON key with json object
     await browserPage.addJsonKey(keyName, jsonValueBefore, keyTTL);
-    //Check the key value before edit
-    await t.expect(await browserPage.getJsonKeyValue()).eql('{name:"xyz"}', 'The value is incorrect');
-    //Edit JSON key value
+    // Check the key value before edit
+    await t.expect(await browserPage.getJsonKeyValue()).eql('{name:"xyz"}', 'The JSON value is incorrect');
+    // Edit JSON key value
     await browserPage.editJsonKeyValue(jsonEditedValue);
-    //Check JSON key value after edit
-    await t.expect(await browserPage.getJsonKeyValue()).contains(jsonValueAfter, 'Edited value is incorrect');
+    // Check JSON key value after edit
+    await t.expect(await browserPage.getJsonKeyValue()).contains(jsonValueAfter, 'Edited JSON value is incorrect');
 });

--- a/tests/e2e/tests/smoke/browser/filtering.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/filtering.e2e.ts
@@ -2,83 +2,80 @@ import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = `KeyForSearch*?[]789${chance.word({ length: 10 })}`;
-let keyName2 = chance.word({ length: 10 });
-let randomValue = chance.word({ length: 10 });
+let keyName = `KeyForSearch*?[]789${common.generateWord(10)}`;
+let keyName2 = common.generateWord(10);
+let randomValue = common.generateWord(10);
 const valueWithEscapedSymbols = 'KeyFor[A-G]*(';
 const searchedKeyName = 'KeyForSearch\\*\\?\\[]789';
 const searchedValueWithEscapedSymbols = 'KeyFor\\[A-G\\]\\*\\(';
 
 fixture `Filtering per key name in Browser page`
-    .meta({type: 'smoke'})
+    .meta({type: 'smoke', rte: rte.standalone})
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(`${searchedKeyName}${randomValue}`);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search per full key name', async t => {
-        randomValue = chance.word({ length: 10 });
-        keyName = `KeyForSearch*?[]789${randomValue}`;
-        //Add new key
-        await browserPage.addStringKey(keyName);
-        //Search by key with full name
-        await browserPage.searchByKeyName(`${searchedKeyName}${randomValue}`);
-        //Verify that key was found
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key was found');
     });
+test('Verify that user can search per full key name', async t => {
+    randomValue = common.generateWord(10);
+    keyName = `KeyForSearch*?[]789${randomValue}`;
+
+    // Add new key
+    await browserPage.addStringKey(keyName);
+    // Search by key with full name
+    await browserPage.searchByKeyName(`${searchedKeyName}${randomValue}`);
+    // Verify that key was found
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The key was not found');
+});
+test('Verify that user can filter per exact key without using any patterns', async t => {
+    randomValue = common.generateWord(10);
+    keyName = `KeyForSearch*?[]789${randomValue}`;
+
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Create new key for search
+    await t.typeText(cliPage.cliCommandInput, `APPEND ${keyName} 1`);
+    await t.pressKey('enter');
+    await t.click(cliPage.cliCollapseButton);
+    // Filter per exact key without using any patterns
+    await browserPage.searchByKeyName(`${searchedKeyName}${randomValue}`);
+    // Verify that key was found
+    await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
+});
 test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can filter per exact key without using any patterns', async t => {
-        randomValue = chance.word({ length: 10 });
-        keyName = `KeyForSearch*?[]789${randomValue}`;
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Create new key for search
-        await t.typeText(cliPage.cliCommandInput, `APPEND ${keyName} 1`);
-        await t.pressKey('enter');
-        await t.click(cliPage.cliCollapseButton);
-        //Filter per exact key without using any patterns
-        await browserPage.searchByKeyName(`${searchedKeyName}${randomValue}`);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
-    });
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await browserPage.deleteKeyByName(keyName2);
         await browserPage.deleteKeyByName(searchedValueWithEscapedSymbols);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-    ('Verify that user can filter per combined pattern with ?, *, [xy], [^x], [a-z] and escaped special symbols', async t => {
-        keyName = `KeyForSearch${chance.word({ length: 10 })}`;
-        keyName2 = `KeyForSomething${chance.word({ length: 10 })}`;
-        //Add keys
+    })('Verify that user can filter per combined pattern with ?, *, [xy], [^x], [a-z] and escaped special symbols', async t => {
+        keyName = `KeyForSearch${common.generateWord(10)}`;
+        keyName2 = `KeyForSomething${common.generateWord(10)}`;
+
+        // Add keys
         await browserPage.addStringKey(keyName);
         await browserPage.addHashKey(keyName2);
         await browserPage.addHashKey(valueWithEscapedSymbols);
-        //Filter per pattern with ?, *, [xy], [^x], [a-z]
+        // Filter per pattern with ?, *, [xy], [^x], [a-z]
         const searchedValue = 'Key?[A-z]rS[^o][ae]*';
         await browserPage.searchByKeyName(searchedValue);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was found');
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).notOk('The key wasn\'t found');
-        //Filter with escaped special symbols
+        // Verify that key was found
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName)).ok('The key was not found');
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(keyName2)).notOk('The key is found');
+        // Filter with escaped special symbols
         await browserPage.searchByKeyName(searchedValueWithEscapedSymbols);
-        //Verify that key was found
-        await t.expect(await browserPage.isKeyIsDisplayedInTheList(valueWithEscapedSymbols)).ok('The key was found');
+        // Verify that key was found
+        await t.expect(await browserPage.isKeyIsDisplayedInTheList(valueWithEscapedSymbols)).ok('The key was not found');
     });

--- a/tests/e2e/tests/smoke/browser/hash-field.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/hash-field.e2e.ts
@@ -1,52 +1,43 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyFieldValue = 'hashField11111';
 const keyValue = 'hashValue11111!';
 
 fixture `Hash Key fields verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add field to Hash', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addHashKey(keyName, keyTTL);
-        //Add field to the hash key
-        await browserPage.addFieldToHash(keyFieldValue, keyValue);
-        //Search the added field
-        await browserPage.searchByTheValueInKeyDetails(keyFieldValue);
-        //Check the added field
-        await t.expect(browserPage.hashValuesList.withExactText(keyValue).exists).ok('The existence of the value', { timeout: 10000 });
-        await t.expect(browserPage.hashFieldsList.withExactText(keyFieldValue).exists).ok('The existence of the field', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can remove field from Hash', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addHashKey(keyName, keyTTL);
-        //Add field to the hash key
-        await browserPage.addFieldToHash(keyFieldValue, keyValue);
-        //Search the added field
-        await browserPage.searchByTheValueInKeyDetails(keyFieldValue);
-        //Remove field from Hash
-        await t.click(browserPage.removeHashFieldButton);
-        await t.click(browserPage.confirmRemoveHashFieldButton);
-        //Check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Field has been removed', 'The notification');
-    });
+test('Verify that user can add field to Hash', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addHashKey(keyName, keyTTL);
+    // Add field to the hash key
+    await browserPage.addFieldToHash(keyFieldValue, keyValue);
+    // Search the added field
+    await browserPage.searchByTheValueInKeyDetails(keyFieldValue);
+    // Check the added field
+    await t.expect(browserPage.hashValuesList.withExactText(keyValue).exists).ok('The value is not displayed', { timeout: 10000 });
+    await t.expect(browserPage.hashFieldsList.withExactText(keyFieldValue).exists).ok('The field is not displayed', { timeout: 10000 });
+
+    // Verify that user can remove field from Hash
+    await t.click(browserPage.removeHashFieldButton);
+    await t.click(browserPage.confirmRemoveHashFieldButton);
+    // Check the notification message
+    const notofication = await browserPage.getMessageText();
+    await t.expect(notofication).contains('Field has been removed', 'The notification is not displayed');
+});

--- a/tests/e2e/tests/smoke/browser/json-key.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/json-key.e2e.ts
@@ -1,57 +1,48 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const value = '{"name":"xyz"}';
 const jsonObjectValue = '{name:"xyz"}';
 
 fixture `JSON Key verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can create JSON object', async t => {
-        keyName = chance.word({ length: 10 });
-        //Add Json key with json object
-        await browserPage.addJsonKey(keyName, value, keyTTL);
-        //Check the notification message
-        const notification = await browserPage.getMessageText();
-        await t.expect(notification).contains('Key has been added', 'The notification');
-        //Check the added key contains json object
-        await t.expect(browserPage.addJsonObjectButton.exists).ok('The existence of the add Json object button', { timeout: 10000 });
-        await t.expect(browserPage.jsonKeyValue.textContent).eql(jsonObjectValue, 'The json object value');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add key with value to any level of JSON structure', async t => {
-        keyName = chance.word({ length: 10 });
-        //Add Json key with json object
-        await browserPage.addJsonKey(keyName, value, keyTTL);
-        //Check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        //Add key with value on the same level
-        await browserPage.addJsonKeyOnTheSameLevel('"key1"', '"value1"');
-        //Check the added key contains json object with added key
-        await t.expect(browserPage.addJsonObjectButton.exists).ok('The existence of the add Json object button', { timeout: 10000 });
-        await t.expect(browserPage.jsonKeyValue.textContent).eql('{name:"xyz"key1:"value1"}', 'The json object value');
-        //Add key with value inside the json
-        await browserPage.addJsonKeyOnTheSameLevel('"key2"', '{}');
-        await browserPage.addJsonKeyInsideStructure('"key2222"', '12345');
-        //Check the added key contains json object with added key
-        await t.click(browserPage.expandJsonObject);
-        await t.expect(browserPage.jsonKeyValue.textContent).eql('{name:"xyz"key1:"value1"key2:{key2222:12345}}', 'The json object value');
-    });
+test('Verify that user can add key with value to any level of JSON structure', async t => {
+    keyName = common.generateWord(10);
+    // Add Json key with json object
+    await browserPage.addJsonKey(keyName, value, keyTTL);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not found');
+    // Verify that user can create JSON object
+    await t.expect(browserPage.addJsonObjectButton.exists).ok('The add Json object button not found', { timeout: 10000 });
+    await t.expect(browserPage.jsonKeyValue.textContent).eql(jsonObjectValue, 'The json object value not found');
+
+    // Add key with value on the same level
+    await browserPage.addJsonKeyOnTheSameLevel('"key1"', '"value1"');
+    // Check the added key contains json object with added key
+    await t.expect(browserPage.addJsonObjectButton.exists).ok('The add Json object button not found', { timeout: 10000 });
+    await t.expect(browserPage.jsonKeyValue.textContent).eql('{name:"xyz"key1:"value1"}', 'The json object value not found');
+    // Add key with value inside the json
+    await browserPage.addJsonKeyOnTheSameLevel('"key2"', '{}');
+    await browserPage.addJsonKeyInsideStructure('"key2222"', '12345');
+    // Check the added key contains json object with added key
+    await t.click(browserPage.expandJsonObject);
+    await t.expect(browserPage.jsonKeyValue.textContent).eql('{name:"xyz"key1:"value1"key2:{key2222:12345}}', 'The json object value not found');
+});

--- a/tests/e2e/tests/smoke/browser/list-key.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/list-key.e2e.ts
@@ -1,66 +1,58 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const element = '1111listElement11111';
 const element2 = '2222listElement22222';
 const element3 = '33333listElement33333';
 
 fixture `List Key verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add element to List', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addListKey(keyName, keyTTL);
-        //Add element to the List key
-        await browserPage.addElementToList(element);
-        //Check the added element
-        await t.expect(browserPage.listElementsList.withExactText(element).exists).ok('The existence of the list element', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can select remove List element position: from tail', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addListKey(keyName, keyTTL);
-        //Add few elements to the List key
-        await browserPage.addElementToList(element);
-        await browserPage.addElementToList(element2);
-        await browserPage.addElementToList(element3);
-        //Remove element from the key
-        await browserPage.removeListElementFromTail('1');
-        //Check the notification message
-        const notification = await browserPage.getMessageText();
-        await t.expect(notification).contains('Elements have been removed', 'The notification');
-        //Check the removed element is not in the list
-        await t.expect(browserPage.listElementsList.withExactText(element3).exists).notOk('The removing of the list element', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can select remove List element position: from head', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addListKey(keyName, keyTTL, element);
-        //Add few elements to the List key
-        await browserPage.addElementToList(element2);
-        await browserPage.addElementToList(element3);
-        //Remove element from the key
-        await browserPage.removeListElementFromHead('1');
-        //Check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Elements have been removed', 'The notification');
-        //Check the removed element is not in the list
-        await t.expect(browserPage.listElementsList.withExactText(element).exists).notOk('The removing of the list element', { timeout: 10000 });
-    });
+test('Verify that user can select remove List element position: from tail', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addListKey(keyName, keyTTL);
+    // Add few elements to the List key
+    await browserPage.addElementToList(element);
+    // Verify that user can add element to List
+    await t.expect(browserPage.listElementsList.withExactText(element).exists).ok('The list element not added', { timeout: 10000 });
+
+    await browserPage.addElementToList(element2);
+    await browserPage.addElementToList(element3);
+    // Remove element from the key
+    await browserPage.removeListElementFromTail('1');
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Elements have been removed', 'The notification not found');
+    // Check the removed element is not in the list
+    await t.expect(browserPage.listElementsList.withExactText(element3).exists).notOk('The list element not removed', { timeout: 10000 });
+});
+test('Verify that user can select remove List element position: from head', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addListKey(keyName, keyTTL, element);
+    // Add few elements to the List key
+    await browserPage.addElementToList(element2);
+    await browserPage.addElementToList(element3);
+    // Remove element from the key
+    await browserPage.removeListElementFromHead('1');
+    // Check the notification message
+    const notofication = await browserPage.getMessageText();
+    await t.expect(notofication).contains('Elements have been removed', 'The notification not found');
+    // Check the removed element is not in the list
+    await t.expect(browserPage.listElementsList.withExactText(element).exists).notOk('The list element not removed', { timeout: 10000 });
+});

--- a/tests/e2e/tests/smoke/browser/list-of-keys-verifications.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/list-of-keys-verifications.e2e.ts
@@ -2,116 +2,90 @@ import { rte } from '../../../helpers/constants';
 import { deleteDatabase, acceptTermsAddDatabaseOrConnectToRedisStack } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 let keyNames: string[] = [];
+const keyTTL = '2147476121';
 
 fixture `List of keys verifications`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
-        for(const name of keyNames) {
-            await browserPage.deleteKeyByName(name);
-        }
-        await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-    ('Verify that user can see List of Keys in DB', async t => {
-        keyNames = [
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`
-        ];
-        await browserPage.addStringKey(keyNames[0]);
-        await browserPage.addHashKey(keyNames[1]);
-        await browserPage.addListKey(keyNames[2]);
-        await browserPage.addStringKey(keyNames[3]);
-        await t.click(browserPage.refreshKeysButton);
-        await t.expect(browserPage.keyNameInTheList.exists).ok('The list of keys is displayed');
     });
 test
-    .meta({ rte: rte.standalone })
-    .after(async () => {
-        //Clear and delete database
+    .after(async() => {
+        // Clear and delete database
         for(const name of keyNames) {
             await browserPage.deleteKeyByName(name);
         }
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-    ('Verify that user can scroll List of Keys in DB', async t => {
+    })('Verify that user can scroll List of Keys in DB', async t => {
         keyNames = [
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`,
-            `key-${chance.word({ length: 10 })}`
+            `key-${common.generateWord(10)}`,
+            `key-${common.generateWord(10)}`,
+            `key-${common.generateWord(10)}`,
+            `key-${common.generateWord(10)}`
         ];
+
         await browserPage.addStringKey(keyNames[0]);
         await browserPage.addHashKey(keyNames[1]);
         await browserPage.addListKey(keyNames[2]);
         await browserPage.addStringKey(keyNames[3]);
         await t.click(browserPage.refreshKeysButton);
-        //Scroll to the key element
+        // Verify that user can see List of Keys in DB
+        await t.expect(browserPage.keyNameInTheList.exists).ok('The list of keys is not displayed');
+
+        // Scroll to the key element
         await t.hover(browserPage.keyNameInTheList);
-        await t.expect(browserPage.keyNameInTheList.exists).ok;
+        await t.expect(browserPage.keyNameInTheList.exists).ok('The list of keys is not displayed');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can refresh Keys', async t => {
-        keyName = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-        const newKeyName = 'KeyNameAfterEdit!testKey';
+test('Verify that user can refresh Keys', async t => {
+    keyName = common.generateWord(10);
+    const newKeyName = 'KeyNameAfterEdit!testKey';
 
-        //add hash key
-        await browserPage.addHashKey(keyName, keyTTL);
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        await t.click(browserPage.closeKeyButton);
-        //search for the added   key
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).eql(true, 'The key is in the list');
-        //edit the key name in details
-        await t.click(browserPage.keyNameInTheList);
-        await browserPage.editKeyName(newKeyName);
-        //refresh Keys
-        await t.click(browserPage.refreshKeysButton);
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsNotDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsNotDisplayedInTheList).eql(false, 'The key is not in the list');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can open key details', async t => {
-        keyName = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-        const keyValue = 'StringValue!';
+    // Add hash key
+    await browserPage.addHashKey(keyName, keyTTL);
+    const notofication = await browserPage.getMessageText();
+    await t.expect(notofication).contains('Key has been added', 'The notification is not displayed');
+    await t.click(browserPage.closeKeyButton);
+    // Search for the added key
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).eql(true, 'The key is not in the list');
+    // Edit the key name in details
+    await t.click(browserPage.keyNameInTheList);
+    await browserPage.editKeyName(newKeyName);
+    // Refresh Keys
+    await t.click(browserPage.refreshKeysButton);
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsNotDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsNotDisplayedInTheList).eql(false, 'The key is still in the list');
+});
+test('Verify that user can open key details', async t => {
+    keyName = common.generateWord(10);
+    const keyValue = 'StringValue!';
 
-        //add String key
-        await browserPage.addStringKey(keyName, keyTTL, keyValue);
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Key has been added', 'The notification');
-        await t.click(browserPage.closeKeyButton);
-        //search for the added key
-        await browserPage.searchByKeyName(keyName);
-        const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is in the list');
-        //open the key details
-        await t.click(browserPage.keyNameInTheList);
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key details is opened');
-    });
+    // Add String key
+    await browserPage.addStringKey(keyName, keyTTL, keyValue);
+    const notofication = await browserPage.getMessageText();
+    await t.expect(notofication).contains('Key has been added', 'The notification is not displayed');
+    await t.click(browserPage.closeKeyButton);
+    // Search for the added key
+    await browserPage.searchByKeyName(keyName);
+    const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
+    await t.expect(isKeyIsDisplayedInTheList).ok('The key is not in the list');
+    // Open the key details
+    await t.click(browserPage.keyNameInTheList);
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    await t.expect(keyNameFromDetails).contains(keyName, 'The Key details is not opened');
+});

--- a/tests/e2e/tests/smoke/browser/set-key.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/set-key.e2e.ts
@@ -1,4 +1,3 @@
-import { Chance } from 'chance';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import {
@@ -6,44 +5,38 @@ import {
     ossStandaloneConfig
 } from '../../../helpers/conf';
 import { rte } from '../../../helpers/constants';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyMember = '1111setMember11111';
 
 fixture `Set Key fields verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add member to Set', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addSetKey(keyName, keyTTL);
-        //Add member to the Set key
-        await browserPage.addMemberToSet(keyMember);
-        //Check the added member
-        await t.expect(browserPage.setMembersList.withExactText(keyMember).exists).ok('The existence of the set member', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can remove member from Set', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addSetKey(keyName, keyTTL);
-        //Add member to the Set key
-        await browserPage.addMemberToSet(keyMember);
-        //Remove member from the key
-        await t.click(browserPage.removeSetMemberButton);
-        await t.click(browserPage.confirmRemoveSetMemberButton);
-        //Check the notification message
-        const notification = await browserPage.getMessageText();
-        await t.expect(notification).contains('Member has been removed', 'The notification');
-    });
+test('Verify that user can remove member from Set', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addSetKey(keyName, keyTTL);
+    // Add member to the Set key
+    await browserPage.addMemberToSet(keyMember);
+    // Verify that user can add member to Set
+    await t.expect(browserPage.setMembersList.withExactText(keyMember).exists).ok('The set member not found', { timeout: 10000 });
+
+    // Remove member from the key
+    await t.click(browserPage.removeSetMemberButton);
+    await t.click(browserPage.confirmRemoveSetMemberButton);
+    // Check the notification message
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Member has been removed', 'The notification not found');
+});

--- a/tests/e2e/tests/smoke/browser/set-ttl-for-key.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/set-ttl-for-key.e2e.ts
@@ -2,43 +2,42 @@ import { rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
-import { Chance } from 'chance';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `Set TTL for Key`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Clear and delete database
+    .afterEach(async() => {
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can specify TTL for Key', async t => {
-        keyName = chance.word({ length: 10 });
-        const ttlValue = '2147476121';
-        //Create new key without TTL
-        await browserPage.addStringKey(keyName);
-        //Open Key details
-        await browserPage.openKeyDetails(keyName);
-        //Click on TTL button to edit TTL
-        await t.click(browserPage.editKeyTTLButton);
-        //Set TTL value
-        await t.typeText(browserPage.editKeyTTLInput, ttlValue);
-        //Save the TTL value
-        await t.click(browserPage.saveTTLValue);
-        //Refresh the page in several seconds
-        await t.wait(3000);
-        await t.click(browserPage.refreshKeyButton);
-        //Verify that TTL was updated
-        const newTtlValue = await browserPage.ttlText.innerText;
-        await t.expect(Number(ttlValue)).gt(Number(newTtlValue), 'ttlValue is greater than newTTLValue');
-    });
+test('Verify that user can specify TTL for Key', async t => {
+    keyName = common.generateWord(10);
+    const ttlValue = '2147476121';
+
+    // Create new key without TTL
+    await browserPage.addStringKey(keyName);
+    // Open Key details
+    await browserPage.openKeyDetails(keyName);
+    // Click on TTL button to edit TTL
+    await t.click(browserPage.editKeyTTLButton);
+    // Set TTL value
+    await t.typeText(browserPage.editKeyTTLInput, ttlValue);
+    // Save the TTL value
+    await t.click(browserPage.saveTTLValue);
+    // Refresh the page in several seconds
+    await t.wait(3000);
+    await t.click(browserPage.refreshKeyButton);
+    // Verify that TTL was updated
+    const newTtlValue = await browserPage.ttlText.innerText;
+    await t.expect(Number(ttlValue)).gt(Number(newTtlValue), 'ttlValue is not greater than newTTLValue');
+});

--- a/tests/e2e/tests/smoke/browser/verify-key-details.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/verify-key-details.e2e.ts
@@ -1,129 +1,117 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const expectedTTL = /214747612*/;
 
 fixture `Key details verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see Hash Key details', async t => {
-        keyName = chance.word({ length: 10 });
-
-        await browserPage.addHashKey(keyName, keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
-
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('Hash', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('Hash', 'The Key Badge');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see List Key details', async t => {
-        keyName = chance.word({ length: 10 });
+test('Verify that user can see Hash Key details', async t => {
+    keyName = common.generateWord(10);
 
-        await browserPage.addListKey(keyName, keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+    await browserPage.addHashKey(keyName, keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
 
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('List', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('List', 'The Key Badge');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see Set Key details', async t => {
-        keyName = chance.word({ length: 10 });
+    await t.expect(keyNameFromDetails).contains(keyName, 'The Hash Key Name is incorrect');
+    await t.expect(keyDetails).contains('Hash', 'The Hash Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The Hash TTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The Hash Key TTL is incorrect');
+    await t.expect(keyBadge).contains('Hash', 'The Hash Key Badge is incorrect');
+});
+test('Verify that user can see List Key details', async t => {
+    keyName = common.generateWord(10);
 
-        await browserPage.addSetKey(keyName, keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+    await browserPage.addListKey(keyName, keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
 
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('Set', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('Set', 'The Key Badge');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see String Key details', async t => {
-        keyName = chance.word({ length: 10 });
-        const value = 'keyValue12334353434;'
+    await t.expect(keyNameFromDetails).contains(keyName, 'The List Key Name is incorrect');
+    await t.expect(keyDetails).contains('List', 'The List Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The List TTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The List Key TTL is incorrect');
+    await t.expect(keyBadge).contains('List', 'The List Key Badge is incorrect');
+});
+test('Verify that user can see Set Key details', async t => {
+    keyName = common.generateWord(10);
 
-        await browserPage.addStringKey(keyName, value, keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+    await browserPage.addSetKey(keyName, keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
 
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('String', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('String', 'The Key Badge');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see ZSet Key details', async t => {
-        keyName = chance.word({ length: 10 });
+    await t.expect(keyNameFromDetails).contains(keyName, 'The Set Key Name is incorrect');
+    await t.expect(keyDetails).contains('Set', 'The Set Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The Set TTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The Set Key TTL is incorrect');
+    await t.expect(keyBadge).contains('Set', 'The Set Key Badge is incorrect');
+});
+test('Verify that user can see String Key details', async t => {
+    keyName = common.generateWord(10);
+    const value = 'keyValue12334353434;';
 
-        await browserPage.addZSetKey(keyName, '1', keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+    await browserPage.addStringKey(keyName, value, keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
 
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('Sorted Set', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('Sorted Set', 'The Key Badge');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see JSON Key details', async t => {
-        keyName = chance.word({ length: 10 });
+    await t.expect(keyNameFromDetails).contains(keyName, 'The String Key Name is incorrect');
+    await t.expect(keyDetails).contains('String', 'The String Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The StringTTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The String Key TTL is incorrect');
+    await t.expect(keyBadge).contains('String', 'The String Key Badge is incorrect');
+});
+test('Verify that user can see ZSet Key details', async t => {
+    keyName = common.generateWord(10);
 
-        const jsonValue = '{"employee":{ "name":"John", "age":30, "city":"New York" }}';
+    await browserPage.addZSetKey(keyName, '1', keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
 
-        await browserPage.addJsonKey(keyName, jsonValue, keyTTL);
-        const keyDetails = await browserPage.keyDetailsHeader.textContent;
-        const keyBadge = await browserPage.keyDetailsBadge.textContent;
-        const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
-        const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+    await t.expect(keyNameFromDetails).contains(keyName, 'The ZSet Key Name is incorrect');
+    await t.expect(keyDetails).contains('Sorted Set', 'The ZSet Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The ZSet TTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The ZSet Key TTL is incorrect');
+    await t.expect(keyBadge).contains('Sorted Set', 'The ZSet Key Badge is incorrect');
+});
+test('Verify that user can see JSON Key details', async t => {
+    keyName = common.generateWord(10);
 
-        await t.expect(keyNameFromDetails).contains(keyName, 'The Key Name');
-        await t.expect(keyDetails).contains('JSON', 'The Key Type');
-        await t.expect(keyDetails).contains('TTL', 'The TTL');
-        await t.expect(keyTTLValue).match(expectedTTL, 'The Key TTL');
-        await t.expect(keyBadge).contains('JSON', 'The Key Badge');
-    });
+    const jsonValue = '{"employee":{ "name":"John", "age":30, "city":"New York" }}';
+
+    await browserPage.addJsonKey(keyName, jsonValue, keyTTL);
+    const keyDetails = await browserPage.keyDetailsHeader.textContent;
+    const keyBadge = await browserPage.keyDetailsBadge.textContent;
+    const keyNameFromDetails = await browserPage.keyNameFormDetails.textContent;
+    const keyTTLValue = await browserPage.keyDetailsTTL.textContent;
+
+    await t.expect(keyNameFromDetails).contains(keyName, 'The JSON Key Name is incorrect');
+    await t.expect(keyDetails).contains('JSON', 'The JSON Key Type is incorrect');
+    await t.expect(keyDetails).contains('TTL', 'The JSON TTL is incorrect');
+    await t.expect(keyTTLValue).match(expectedTTL, 'The JSON Key TTL is incorrect');
+    await t.expect(keyBadge).contains('JSON', 'The JSON Key Badge is incorrect');
+});

--- a/tests/e2e/tests/smoke/browser/verify-keys-refresh.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/verify-keys-refresh.e2e.ts
@@ -1,45 +1,44 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
-let newKeyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
+let newKeyName = common.generateWord(10);
 
 fixture `Keys refresh functionality`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(newKeyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can refresh Keys', async t => {
-        keyName = chance.word({ length: 10 });
-        const keyTTL = '2147476121';
-        newKeyName = chance.word({ length: 10 });
+test('Verify that user can refresh Keys', async t => {
+    keyName = common.generateWord(10);
+    const keyTTL = '2147476121';
+    newKeyName = common.generateWord(10);
 
-        //add hash key
-        await browserPage.addHashKey(keyName, keyTTL);
-        const notification = await browserPage.getMessageText();
-        await t.expect(notification).contains('Key has been added', 'The notification');
-        await t.click(browserPage.closeKeyButton);
-        //search for the added key
-        await browserPage.searchByKeyName(keyName);
-        await t.expect(browserPage.keyNameInTheList.withExactText(keyName).exists).ok('The key is in the list', { timeout: 10000 });
-        //edit the key name
-        await t.click(browserPage.keyNameInTheList);
-        await browserPage.editKeyName(newKeyName);
-        //refresh Keys and check
-        await t.click(browserPage.refreshKeysButton);
-        await browserPage.searchByKeyName(keyName);
-        await t.expect(browserPage.keyNameInTheList.withExactText(keyName).exists).notOk('The key is not in the list', { timeout: 10000 });
-    });
+    // Add hash key
+    await browserPage.addHashKey(keyName, keyTTL);
+    const notification = await browserPage.getMessageText();
+    await t.expect(notification).contains('Key has been added', 'The notification not found');
+    await t.click(browserPage.closeKeyButton);
+    // Search for the added key
+    await browserPage.searchByKeyName(keyName);
+    await t.expect(browserPage.keyNameInTheList.withExactText(keyName).exists).ok('The key is not displayed in the list', { timeout: 10000 });
+    // Edit the key name
+    await t.click(browserPage.keyNameInTheList);
+    await browserPage.editKeyName(newKeyName);
+    // Refresh Keys and check
+    await t.click(browserPage.refreshKeysButton);
+    await browserPage.searchByKeyName(keyName);
+    await t.expect(browserPage.keyNameInTheList.withExactText(keyName).exists).notOk('The key is still in the list', { timeout: 10000 });
+});

--- a/tests/e2e/tests/smoke/browser/zset-key.e2e.ts
+++ b/tests/e2e/tests/smoke/browser/zset-key.e2e.ts
@@ -1,48 +1,41 @@
-import { Chance } from 'chance';
 import { rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { BrowserPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const browserPage = new BrowserPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 const keyTTL = '2147476121';
 const keyMember = '1111ZsetMember11111';
 const score = '0';
 
 fixture `ZSet Key fields verification`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Clear and delete database
+        // Clear and delete database
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
-test
-    .meta({ rte: rte.standalone })('Verify that user can add members to Zset', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addZSetKey(keyName, '5', keyTTL);
-        //Add member to the ZSet key
-        await browserPage.addMemberToZSet(keyMember, score);
-        //Check the added member
-        await t.expect(browserPage.zsetMembersList.withExactText(keyMember).exists).ok('The existence of the Zset member', { timeout: 10000 });
-        await t.expect(browserPage.zsetScoresList.withExactText(score).exists).ok('The existence of the Zset score', { timeout: 10000 });
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can remove member from ZSet', async t => {
-        keyName = chance.word({ length: 10 });
-        await browserPage.addZSetKey(keyName, '6', keyTTL);
-        //Add member to the ZSet key
-        await browserPage.addMemberToZSet(keyMember, score);
-        //Remove member from the key
-        await t.click(browserPage.removeZserMemberButton);
-        await t.click(browserPage.confirmRemovZSetMemberButton);
-        //Check the notification message
-        const notofication = await browserPage.getMessageText();
-        await t.expect(notofication).contains('Member has been removed', 'The notification');
-    });
+test('Verify that user can remove member from ZSet', async t => {
+    keyName = common.generateWord(10);
+    await browserPage.addZSetKey(keyName, '6', keyTTL);
+    // Add member to the ZSet key
+    await browserPage.addMemberToZSet(keyMember, score);
+    // Verify that user can add members to Zset
+    await t.expect(browserPage.zsetMembersList.withExactText(keyMember).exists).ok('The Zset member not found', { timeout: 10000 });
+    await t.expect(browserPage.zsetScoresList.withExactText(score).exists).ok('The Zset score not found', { timeout: 10000 });
+
+    // Remove member from the key
+    await t.click(browserPage.removeZserMemberButton);
+    await t.click(browserPage.confirmRemovZSetMemberButton);
+    // Check the notification message
+    const notofication = await browserPage.getMessageText();
+    await t.expect(notofication).contains('Member has been removed', 'The notification not found');
+});

--- a/tests/e2e/tests/smoke/cli/cli-command-helper.e2e.ts
+++ b/tests/e2e/tests/smoke/cli/cli-command-helper.e2e.ts
@@ -9,97 +9,87 @@ const COMMAND_APPEND = 'APPEND';
 const COMMAND_GROUP_SET = 'Set';
 
 fixture `CLI Command helper`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can close Command helper', async t => {
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Close Command helper
-        await t.click(cliPage.closeCommandHelperButton);
-        //Verify that the Command helper is closed
-        await t.expect(cliPage.cliHelperText.visible).eql(false, 'Command helper');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can search per command in Command Helper and see relevant results', async t => {
-        const commandForSearch = 'ADD';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Search per command
-        await t.typeText(cliPage.cliHelperSearch, commandForSearch);
-        //Verify results in the output
-        const count = await cliPage.cliHelperOutputTitles.count;
-        for(let i = 0; i < count; i++){
-            await t.expect(await cliPage.cliHelperOutputTitles.textContent).contains(commandForSearch, 'Results in the output contains searched value');
-        }
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can select one of the commands from the list of commands described in the Groups table', async t => {
-        const commandForCheck = 'SADD';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from list
-        await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(commandForCheck));
-        //Verify results
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('SADD key member [member ...]', 'Selected command information');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can click on any of searched commands in Command Helper and see details of the command', async t => {
-        const commandForSearch = 'Ap';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from list of searched commands
-        await t.typeText(cliPage.cliHelperSearch, commandForSearch);
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(COMMAND_APPEND));
-        //Verify details of the command
-        await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('APPEND key value', 'Command name and syntax');
-        await t.expect(cliPage.cliHelperTitle.innerText).contains('STRING', 'Command Group badge');
-        await t.expect(cliPage.cliHelperSummary.innerText).contains('Append a value to a key Read more', 'Command summary');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that when user enters command, he can see Command Name, Complexity, Arguments, Summary, Group, Read more', async t => {
-        const commandForSearch = 'pop';
-        const commandForCheck = 'LPOP';
-        //Open Command Helper
-        await t.click(cliPage.expandCommandHelperButton);
-        //Select one command from list of searched commands
-        await t.typeText(cliPage.cliHelperSearch, commandForSearch);
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(commandForCheck));
-        //Verify details of the command
-        await t.expect(cliPage.cliHelperTitleArgs.innerText).eql('LPOP key [count]', 'Command Name');
-        await t.expect(cliPage.cliHelperComplexity.innerText).eql('Complexity:\nO(N) where N is the number of elements returned', 'Complexity');
-        await t.expect(cliPage.cliHelperArguments.innerText).eql('Arguments:\nRequired\nkey\nOptional\n[count]', 'Arguments');
-        await t.expect(cliPage.cliHelperSummary.innerText).contains('Remove and get the first elements in a list', 'Command Summary');
-        await t.expect(cliPage.cliHelperTitle.innerText).contains('LIST', 'Command Group');
-        await t.expect(cliPage.readMoreButton.exists).ok('Read more button');
-    });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can see that command is autocompleted in CLI with required arguments', async t => {
-        const command = 'HDEL';
-        //Open CLI and Helper
-        await t.click(cliPage.cliExpandButton);
-        await t.click(cliPage.expandCommandHelperButton);
-        //Search for the command and remember arguments
-        await t.typeText(cliPage.cliHelperSearch, command);
-        await t.click(cliPage.cliHelperOutputTitles.withExactText(command));
-        const commandArgsFromCliHelper = await cliPage.cliHelperTitleArgs.innerText;
-        //Enter the command in CLI
-        await t.typeText(cliPage.cliCommandInput, command);
-        //Verify autocompleted arguments
-        const commandAutocomplete = await cliPage.cliCommandAutocomplete.innerText;
-        await t.expect(commandArgsFromCliHelper).contains(commandAutocomplete, 'Command autocomplete arguments');
-    });
+test('Verify that user can search per command in Command Helper and see relevant results', async t => {
+    const commandForSearch = 'ADD';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Search per command
+    await t.typeText(cliPage.cliHelperSearch, commandForSearch);
+    // Verify results in the output
+    const count = await cliPage.cliHelperOutputTitles.count;
+    for(let i = 0; i < count; i++){
+        await t.expect(await cliPage.cliHelperOutputTitles.textContent).contains(commandForSearch, 'Results in the output not contains searched value');
+    }
+
+    // Close Command helper
+    await t.click(cliPage.closeCommandHelperButton);
+    // Verify that user can close Command helper
+    await t.expect(cliPage.cliHelperText.visible).eql(false, 'Command helper');
+});
+test('Verify that user can select one of the commands from the list of commands described in the Groups table', async t => {
+    const commandForCheck = 'SADD';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Select one command from list
+    await cliPage.selectFilterGroupType(COMMAND_GROUP_SET);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(commandForCheck));
+    // Verify results
+    await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('SADD key member [member ...]', 'Selected command information not correct');
+});
+test('Verify that user can click on any of searched commands in Command Helper and see details of the command', async t => {
+    const commandForSearch = 'Ap';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Select one command from list of searched commands
+    await t.typeText(cliPage.cliHelperSearch, commandForSearch);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(COMMAND_APPEND));
+    // Verify details of the command
+    await t.expect(cliPage.cliHelperTitleArgs.textContent).eql('APPEND key value', 'Command name and syntax not correct');
+    await t.expect(cliPage.cliHelperTitle.innerText).contains('STRING', 'Command Group badge not correct');
+    await t.expect(cliPage.cliHelperSummary.innerText).contains('Append a value to a key Read more', 'Command summary not correct');
+});
+test('Verify that when user enters command, he can see Command Name, Complexity, Arguments, Summary, Group, Read more', async t => {
+    const commandForSearch = 'pop';
+    const commandForCheck = 'LPOP';
+
+    // Open Command Helper
+    await t.click(cliPage.expandCommandHelperButton);
+    // Select one command from list of searched commands
+    await t.typeText(cliPage.cliHelperSearch, commandForSearch);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(commandForCheck));
+    // Verify details of the command
+    await t.expect(cliPage.cliHelperTitleArgs.innerText).eql('LPOP key [count]', 'Command Name not correct');
+    await t.expect(cliPage.cliHelperComplexity.innerText).eql('Complexity:\nO(N) where N is the number of elements returned', 'Complexity not correct');
+    await t.expect(cliPage.cliHelperArguments.innerText).eql('Arguments:\nRequired\nkey\nOptional\n[count]', 'Arguments not correct');
+    await t.expect(cliPage.cliHelperSummary.innerText).contains('Remove and get the first elements in a list', 'Command Summary not correct');
+    await t.expect(cliPage.cliHelperTitle.innerText).contains('LIST', 'Command Group not correct');
+    await t.expect(cliPage.readMoreButton.exists).ok('Read more button not displayed');
+});
+test('Verify that user can see that command is autocompleted in CLI with required arguments', async t => {
+    const command = 'HDEL';
+
+    // Open CLI and Helper
+    await t.click(cliPage.cliExpandButton);
+    await t.click(cliPage.expandCommandHelperButton);
+    // Search for the command and remember arguments
+    await t.typeText(cliPage.cliHelperSearch, command);
+    await t.click(cliPage.cliHelperOutputTitles.withExactText(command));
+    const commandArgsFromCliHelper = await cliPage.cliHelperTitleArgs.innerText;
+    // Enter the command in CLI
+    await t.typeText(cliPage.cliCommandInput, command);
+    // Verify autocompleted arguments
+    const commandAutocomplete = await cliPage.cliCommandAutocomplete.innerText;
+    await t.expect(commandArgsFromCliHelper).contains(commandAutocomplete, 'Command autocomplete arguments not correct');
+});

--- a/tests/e2e/tests/smoke/cli/cli.e2e.ts
+++ b/tests/e2e/tests/smoke/cli/cli.e2e.ts
@@ -1,95 +1,85 @@
-import { Chance } from 'chance';
 import { env, rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { MyRedisDatabasePage, BrowserPage, CliPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneConfig } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const browserPage = new BrowserPage();
 const cliPage = new CliPage();
-const chance = new Chance();
+const common = new Common();
 
-let keyName = chance.word({ length: 10 });
+let keyName = common.generateWord(10);
 
 fixture `CLI`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
     })
     .afterEach(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     });
 test
-    .meta({ rte: rte.standalone })
     .after(async() => {
         await browserPage.deleteKeyByName(keyName);
         await deleteDatabase(ossStandaloneConfig.databaseName);
     })('Verify that user can add data via CLI', async t => {
-        keyName = chance.word({ length: 10 });
-        //Open CLI
+        keyName = common.generateWord(10);
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Add key from CLI
+        // Verify that user can expand CLI
+        await t.expect(cliPage.cliArea.exists).ok('CLI area is not displayed');
+        await t.expect(cliPage.cliCommandInput.exists).ok('CLI input is not displayed');
+
+        // Add key from CLI
         await t.typeText(cliPage.cliCommandInput, `SADD ${keyName} "chinese" "japanese" "german"`);
         await t.pressKey('enter');
-        //Check that the key is added
+        // Check that the key is added
         await browserPage.searchByKeyName(keyName);
         const isKeyIsDisplayedInTheList = await browserPage.isKeyIsDisplayedInTheList(keyName);
-        await t.expect(isKeyIsDisplayedInTheList).ok('The key is added');
+        await t.expect(isKeyIsDisplayedInTheList).ok('The key is not added');
     });
+test('Verify that user can use blocking command', async t => {
+    // Open CLI
+    await t.click(cliPage.cliExpandButton);
+    // Check that CLI is opened
+    await t.expect(cliPage.cliArea.visible).ok('CLI area is not displayed');
+    // Type blocking command
+    await t.typeText(cliPage.cliCommandInput, 'blpop newKey 10000');
+    await t.pressKey('enter');
+    // Verify that user input is blocked
+    await t.expect(cliPage.cliCommandInput.exists).notOk('Cli input is still shown');
+
+    // Collaple CLI
+    await t.click(cliPage.cliCollapseButton);
+    // Verify that user can collapse CLI
+    await t.expect(cliPage.cliArea.visible).notOk('CLI area should still displayed');
+});
 test
-    .meta({ rte: rte.standalone })('Verify that user can expand CLI', async t => {
-        //Open CLI
+    .meta({ env: env.web })('Verify that user can use unblocking command', async t => {
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Check that CLI is opened
-        await t.expect(cliPage.cliArea.exists).ok('CLI area is displayed');
-        await t.expect(cliPage.cliCommandInput.exists).ok('CLI input is displayed');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can collapse CLI', async t => {
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Check that CLI is opened
-        await t.expect(cliPage.cliArea.visible).ok('CLI area is displayed');
-        //Collaple CLI
-        await t.click(cliPage.cliCollapseButton);
-        //Check that CLI is closed
-        await t.expect(cliPage.cliArea.visible).notOk('CLI area should not be displayed');
-    });
-test
-    .meta({ rte: rte.standalone })('Verify that user can use blocking command', async t => {
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Type blocking command
-        await t.typeText(cliPage.cliCommandInput, 'blpop newKey 10000');
-        await t.pressKey('enter');
-        //Verify that user input is blocked
-        await t.expect(cliPage.cliCommandInput.exists).notOk('Cli input is not shown');
-    });
-test
-    .meta({ env: env.web, rte: rte.standalone })('Verify that user can use unblocking command', async t => {
-        //Open CLI
-        await t.click(cliPage.cliExpandButton);
-        //Get clientId
+        // Get clientId
         await t.typeText(cliPage.cliCommandInput, 'client id');
         await t.pressKey('enter');
         const clientId = (await cliPage.cliOutputResponseSuccess.textContent).replace(/^\D+/g, '');
-        //Type blocking command
+        // Type blocking command
         await t.typeText(cliPage.cliCommandInput, 'blpop newKey 10000');
         await t.pressKey('enter');
-        //Verify that user input is blocked
-        await t.expect(cliPage.cliCommandInput.exists).notOk('Cli input is not shown');
-        //Create new window to unblock the client
+        // Verify that user input is blocked
+        await t.expect(cliPage.cliCommandInput.exists).notOk('Cli input is still shown');
+        // Create new window to unblock the client
         await t
             .openWindow(commonUrl)
             .maximizeWindow();
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        //Open CLI
+        // Open CLI
         await t.click(cliPage.cliExpandButton);
-        //Unblock client
+        // Unblock client
         await t.typeText(cliPage.cliCommandInput, `client unblock ${clientId}`);
         await t.pressKey('enter');
         await t.closeWindow();
-        await t.expect(cliPage.cliCommandInput.exists).ok('Cli input is shown, the client was unblocked', { timeout: 10000 });
+        await t.expect(cliPage.cliCommandInput.exists).ok('Cli input is not shown, the client still blocked', { timeout: 10000 });
     });

--- a/tests/e2e/tests/smoke/database/add-db-from-welcome-page.e2e.ts
+++ b/tests/e2e/tests/smoke/database/add-db-from-welcome-page.e2e.ts
@@ -16,7 +16,7 @@ const homebrewPage = 'https://developer.redis.com/create/homebrew/?utm_source=re
 const promoPage = 'https://redis.com/try-free/?utm_source=redis&utm_medium=app&utm_campaign=redisinsight_offer_jan';
 
 fixture `Add database from welcome page`
-    .meta({ type: 'smoke' })
+    .meta({ type: 'smoke', rte: rte.standalone })
     .page(commonUrl)
     .beforeEach(async() => {
         await acceptLicenseTerms();
@@ -26,17 +26,16 @@ fixture `Add database from welcome page`
     });
 test
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-    .meta({ rte: rte.standalone })('Verify that user can add first DB from Welcome page', async t => {
-        await t.expect(addRedisDatabasePage.welcomePageTitle.exists).ok('The welcome page title');
-        //Add database from Welcome page
+    })('Verify that user can add first DB from Welcome page', async t => {
+        await t.expect(addRedisDatabasePage.welcomePageTitle.exists).ok('The welcome page title not displayed');
+        // Add database from Welcome page
         await addNewStandaloneDatabase(ossStandaloneConfig);
-        await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).exists).ok('The database adding', { timeout: 10000 });
+        await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).exists).ok('The database not added', { timeout: 10000 });
     });
 test
-    .meta({  env: env.web, rte: rte.standalone })('Verify that all the links are valid from Welcome page', async t => {
+    .meta({ env: env.web })('Verify that all the links are valid from Welcome page', async t => {
         // Verify build from source link
         await t.click(addRedisDatabasePage.buildFromSource);
         await t.expect(getPageUrl()).eql(sourcePage, 'Build from source link is not valid');

--- a/tests/e2e/tests/smoke/database/add-sentinel-db.e2e.ts
+++ b/tests/e2e/tests/smoke/database/add-sentinel-db.e2e.ts
@@ -1,5 +1,4 @@
-import { acceptLicenseTerms } from '../../../helpers/database';
-import { discoverSentinelDatabase } from '../../../helpers/database';
+import { acceptLicenseTerms, discoverSentinelDatabase } from '../../../helpers/database';
 import { commonUrl, ossSentinelConfig } from '../../../helpers/conf';
 import { env, rte } from '../../../helpers/constants';
 import { MyRedisDatabasePage } from '../../../pageObjects';
@@ -9,17 +8,16 @@ const myRedisDatabasePage = new MyRedisDatabasePage();
 fixture `Add DBs from Sentinel`
     .page(commonUrl)
     .meta({ type: 'smoke'})
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
     })
-    .afterEach(async t => {
+    .afterEach(async() => {
         //Delete database
         await myRedisDatabasePage.deleteDatabaseByName('primary-group-1');
         await myRedisDatabasePage.deleteDatabaseByName('primary-group-2');
-    })
+    });
 test
-    .meta({ env: env.web, rte: rte.standalone })
-    ('Verify that user can add Sentinel DB', async t => {
+    .meta({ env: env.web, rte: rte.standalone })('Verify that user can add Sentinel DB', async t => {
         await discoverSentinelDatabase(ossSentinelConfig);
-        await t.expect(myRedisDatabasePage.hostPort.textContent).eql(`${ossSentinelConfig.sentinelHost}:${ossSentinelConfig.sentinelPort}`, 'The sentinel database is in the list');
+        await t.expect(myRedisDatabasePage.hostPort.textContent).eql(`${ossSentinelConfig.sentinelHost}:${ossSentinelConfig.sentinelPort}`, 'The sentinel database is not in the list');
     });

--- a/tests/e2e/tests/smoke/database/add-standalone-db.e2e.ts
+++ b/tests/e2e/tests/smoke/database/add-standalone-db.e2e.ts
@@ -1,5 +1,4 @@
-import { addNewStandaloneDatabase, addNewREClusterDatabase, addNewRECloudDatabase, addOSSClusterDatabase } from '../../../helpers/database';
-import { acceptLicenseTerms, deleteDatabase } from '../../../helpers/database';
+import { addNewStandaloneDatabase, addNewREClusterDatabase, addNewRECloudDatabase, addOSSClusterDatabase, acceptLicenseTerms, deleteDatabase } from '../../../helpers/database';
 import {
     commonUrl,
     ossStandaloneConfig,
@@ -11,37 +10,33 @@ import { env, rte } from '../../../helpers/constants';
 fixture `Add database`
     .meta({ type: 'smoke' })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
-    })
+    });
 test
     .meta({ rte: rte.standalone })
-    .after(async () => {
+    .after(async() => {
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-    ('Verify that user can add Standalone Database', async() => {
+    })('Verify that user can add Standalone Database', async() => {
         await addNewStandaloneDatabase(ossStandaloneConfig);
     });
 test
     .meta({ rte: rte.reCluster })
-    .after(async () => {
+    .after(async() => {
         await deleteDatabase(redisEnterpriseClusterConfig.databaseName);
-    })
-    ('Verify that user can add database from RE Cluster via auto-discover flow', async() => {
+    })('Verify that user can add database from RE Cluster via auto-discover flow', async() => {
         await addNewREClusterDatabase(redisEnterpriseClusterConfig);
     });
 test
     .meta({ env: env.web, rte: rte.ossCluster})
-    .after(async () => {
+    .after(async() => {
         await deleteDatabase(ossClusterConfig.ossClusterDatabaseName);
-    })
-    ('Verify that user can add OSS Cluster DB', async() => {
+    })('Verify that user can add OSS Cluster DB', async() => {
         await addOSSClusterDatabase(ossClusterConfig);
     });
 //skiped until the RE Cloud connection is implemented
 test.skip
-    .meta({ rte: rte.reCloud })
-    ('Verify that user can add database from RE Cloud via auto-discover flow', async() => {
+    .meta({ rte: rte.reCloud })('Verify that user can add database from RE Cloud via auto-discover flow', async() => {
         //TODO: add api keys from env
         await addNewRECloudDatabase('', '');
     });

--- a/tests/e2e/tests/smoke/database/connecting-to-the-db.e2e.ts
+++ b/tests/e2e/tests/smoke/database/connecting-to-the-db.e2e.ts
@@ -1,12 +1,11 @@
 import { ClientFunction } from 'testcafe';
-import { acceptLicenseTerms, deleteDatabase } from '../../../helpers/database';
+import { acceptLicenseTerms, deleteDatabase, discoverSentinelDatabase, addOSSClusterDatabase } from '../../../helpers/database';
 import { MyRedisDatabasePage } from '../../../pageObjects';
 import {
     commonUrl,
     ossClusterConfig,
     ossSentinelConfig
 } from '../../../helpers/conf';
-import { discoverSentinelDatabase, addOSSClusterDatabase } from '../../../helpers/database';
 import { env, rte } from '../../../helpers/constants';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
@@ -16,42 +15,40 @@ const getPageUrl = ClientFunction(() => window.location.href);
 fixture `Connecting to the databases verifications`
     .meta({ type: 'smoke' })
     .page(commonUrl)
-    .beforeEach(async () => {
+    .beforeEach(async() => {
         await acceptLicenseTerms();
-    })
+    });
 test
     .meta({ env: env.web, rte: rte.sentinel })
-    .after(async () => {
-        //Delete database
+    .after(async() => {
+        // Delete database
         await myRedisDatabasePage.deleteDatabaseByName('primary-group-1');
         await myRedisDatabasePage.deleteDatabaseByName('primary-group-2');
-    })
-    ('Verify that user can connect to Sentinel DB', async t => {
-        //Add OSS Sentinel DB
+    })('Verify that user can connect to Sentinel DB', async t => {
+        // Add OSS Sentinel DB
         await discoverSentinelDatabase(ossSentinelConfig);
-        //Get groups & their count
+        // Get groups & their count
         const sentinelGroups = myRedisDatabasePage.dbNameList;
         const sentinelGroupsCount = await sentinelGroups.count;
-        //Verify all groups for connection
+        // Verify all groups for connection
         for (let i = 0; i < sentinelGroupsCount; i++) {
             const groupSelector = sentinelGroups.nth(i);
-            //Connect to DB
+            // Connect to DB
             await myRedisDatabasePage.clickOnDBByName(await groupSelector.textContent);
-            //Check that browser page was opened
-            await t.expect(getPageUrl()).contains('browser');
-            //Go to databases list
+            // Check that browser page was opened
+            await t.expect(getPageUrl()).contains('browser', 'Browser page not opened');
+            // Go to databases list
             await t.click(myRedisDatabasePage.myRedisDBButton);
         }
     });
 test
     .meta({ env: env.web, rte: rte.ossCluster })
-    .after(async () => {
+    .after(async() => {
         await deleteDatabase(ossClusterConfig.ossClusterDatabaseName);
-    })
-    ('Verify that user can connect to OSS Cluster DB', async t => {
-        //Add OSS Cluster DB
+    })('Verify that user can connect to OSS Cluster DB', async t => {
+        // Add OSS Cluster DB
         await addOSSClusterDatabase(ossClusterConfig);
         await myRedisDatabasePage.clickOnDBByName(ossClusterConfig.ossClusterDatabaseName);
-        //Check that browser page was opened
-        await t.expect(getPageUrl()).contains('browser');
+        // Check that browser page was opened
+        await t.expect(getPageUrl()).contains('browser', 'Browser page not opened');
     });

--- a/tests/e2e/tests/smoke/database/delete-the-db.e2e.ts
+++ b/tests/e2e/tests/smoke/database/delete-the-db.e2e.ts
@@ -15,5 +15,5 @@ test
     .meta({ rte: rte.standalone })('Verify that user can delete databases', async t => {
         await addNewStandaloneDatabase(ossStandaloneConfig);
         await myRedisDatabasePage.deleteDatabaseByName(ossStandaloneConfig.databaseName);
-        await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).exists).notOk('The database deletion', { timeout: 10000 });
+        await t.expect(myRedisDatabasePage.dbNameList.withExactText(ossStandaloneConfig.databaseName).exists).notOk('The database not deleted', { timeout: 10000 });
     });

--- a/tests/e2e/tests/smoke/database/edit-db.e2e.ts
+++ b/tests/e2e/tests/smoke/database/edit-db.e2e.ts
@@ -18,35 +18,35 @@ fixture `Edit Databases`
     .beforeEach(async() => {
         await acceptLicenseTerms();
     });
-//Returns the URL of the current web page
+// Returns the URL of the current web page
 const getPageUrl = ClientFunction(() => window.location.href);
 test
     .meta({ rte: rte.reCluster })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(redisEnterpriseClusterConfig.databaseName);
     })('Verify that user can connect to the RE cluster database', async t => {
         await addNewREClusterDatabase(redisEnterpriseClusterConfig);
         await myRedisDatabasePage.clickOnDBByName(redisEnterpriseClusterConfig.databaseName);
-        await t.expect(getPageUrl()).contains('browser', 'The edit view is opened');
+        await t.expect(getPageUrl()).contains('browser', 'The edit view is not opened');
     });
 test
     .meta({ rte: rte.standalone })
     .after(async() => {
-        //Delete database
+        // Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
     })('Verify that user open edit view of database', async t => {
         await userAgreementPage.acceptLicenseTerms();
-        await t.expect(addRedisDatabasePage.addDatabaseButton.exists).ok('The add redis database view', { timeout: 10000 });
+        await t.expect(addRedisDatabasePage.addDatabaseButton.exists).ok('The add redis database view not found', { timeout: 10000 });
         await addNewStandaloneDatabase(ossStandaloneConfig);
         await myRedisDatabasePage.clickOnDBByName(ossStandaloneConfig.databaseName);
-        await t.expect(getPageUrl()).contains('browser');
+        await t.expect(getPageUrl()).contains('browser', 'Browser page not opened');
     });
-//skiped until the RE Cloud connection is implemented
+// skiped until the RE Cloud connection is implemented
 test.skip
     .meta({ rte: rte.reCloud })('Verify that user can connect to the RE Cloud database', async t => {
-    //TODO: add api keys from env
+    // TODO: add api keys from env
         const databaseName = await addNewRECloudDatabase('', '');
         await myRedisDatabasePage.clickOnDBByName(databaseName);
-        await t.expect(getPageUrl()).contains('browser', 'The edit view is opened');
+        await t.expect(getPageUrl()).contains('browser', 'The edit view is not opened');
     });

--- a/tests/e2e/tests/smoke/workbench/json-workbench.e2e.ts
+++ b/tests/e2e/tests/smoke/workbench/json-workbench.e2e.ts
@@ -1,46 +1,47 @@
-import { Chance } from 'chance';
 import { env, rte } from '../../../helpers/constants';
 import { acceptTermsAddDatabaseOrConnectToRedisStack, deleteDatabase } from '../../../helpers/database';
 import { MyRedisDatabasePage, WorkbenchPage } from '../../../pageObjects';
 import { commonUrl, ossStandaloneRedisearch } from '../../../helpers/conf';
+import { Common } from '../../../helpers/common';
 
 const myRedisDatabasePage = new MyRedisDatabasePage();
 const workbenchPage = new WorkbenchPage();
-const chance = new Chance();
+const common = new Common();
 
-let indexName = chance.word({ length: 10 });
+let indexName = common.generateWord(10);
 
 fixture `JSON verifications at Workbench`
     .meta({type: 'smoke'})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneRedisearch, ossStandaloneRedisearch.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
     .afterEach(async t => {
-        //Clear and delete database
+        // Clear and delete database
         await t.switchToMainWindow();
         await workbenchPage.sendCommandInWorkbench(`FT.DROPINDEX ${indexName} DD`);
         await deleteDatabase(ossStandaloneRedisearch.databaseName);
     });
 test
     .meta({ env: env.desktop, rte: rte.standalone })('Verify that user can execute redisearch command for JSON data type in Workbench', async t => {
-        indexName = chance.word({ length: 10 });
+        indexName = common.generateWord(10);
         const commandsForSend = [
             `FT.CREATE ${indexName} ON JSON SCHEMA $.title AS title TEXT`,
-            `JSON.SET myDoc $ '{"title": "foo", "content": "bar"}'`
+            'JSON.SET myDoc $ \'{"title": "foo", "content": "bar"}\''
         ];
         const searchCommand = `FT.SEARCH ${indexName} "@title:foo"`;
-        //Send commands for add JSON document and create index
+
+        // Send commands for add JSON document and create index
         await workbenchPage.sendCommandInWorkbench(commandsForSend.join('\n'));
-        //Verify that the commandsForSend are executed
+        // Verify that the commandsForSend are executed
         for(const command of commandsForSend) {
-            await t.expect((await workbenchPage.getCardContainerByCommand(command)).textContent).contains('OK', `The ${command} command is executed`);
+            await t.expect((await workbenchPage.getCardContainerByCommand(command)).textContent).contains('OK', `The ${command} command is not executed`);
         }
-        //Send search command to find JSON document
+        // Send search command to find JSON document
         await workbenchPage.sendCommandInWorkbench(searchCommand);
-        //Verify that the search command is executed
+        // Verify that the search command is executed
         await t.switchToIframe(workbenchPage.iframe);
-        await t.expect(workbenchPage.queryColumns.nth(1).textContent).contains('{\\"title\\":\\"foo\\",\\"content\\":\\"bar\\"}', `The ${searchCommand} command is executed`);
+        await t.expect(workbenchPage.queryColumns.nth(1).textContent).contains('{\\"title\\":\\"foo\\",\\"content\\":\\"bar\\"}', `The ${searchCommand} command is not executed`);
     });

--- a/tests/e2e/tests/smoke/workbench/scripting-area.e2e.ts
+++ b/tests/e2e/tests/smoke/workbench/scripting-area.e2e.ts
@@ -15,64 +15,60 @@ const workbenchPage = new WorkbenchPage();
 const common = new Common();
 
 fixture `Scripting area at Workbench`
-    .meta({type: 'smoke'})
+    .meta({type: 'smoke', rte: rte.standalone})
     .page(commonUrl)
     .beforeEach(async t => {
         await acceptTermsAddDatabaseOrConnectToRedisStack(ossStandaloneConfig, ossStandaloneConfig.databaseName);
-        //Go to Workbench page
+        // Go to Workbench page
         await t.click(myRedisDatabasePage.workbenchButton);
     })
-    .afterEach(async () => {
-        //Delete database
+    .afterEach(async() => {
+        // Delete database
         await deleteDatabase(ossStandaloneConfig.databaseName);
-    })
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can comment out any characters in scripting area and all these characters in this raw number are not send in the request', async t => {
-        const command1 = 'info';
-        const command2 = 'command';
-        const commandForSend = [
-            '// some comment before command',
-            '\n',
-            command1,
-            '\n',
-            '// some comment between commands with slashes // ** //',
-            '\n',
-            `${command2} // comment in the row with command`,
-            '\n',
-            '// some comment after command'
-        ];
-        //Send command
-        await workbenchPage.sendCommandInWorkbench(commandForSend.join(''));
-        // Check that 2 results are shown
-        await t.expect(workbenchPage.queryCardContainer.count).eql(2);
-        // Check that we have results with sent commands
-        const sentCommandText1 = await workbenchPage.queryCardCommand.withExactText(command1);
-        await t.expect(sentCommandText1.exists).ok('Result of sent command exists');
-        const sentCommandText2 = await workbenchPage.queryCardCommand.withExactText(command2);
-        await t.expect(sentCommandText2.exists).ok('Result of sent command exists');
     });
-test
-    .meta({ rte: rte.standalone })
-    ('Verify that user can run multiple commands in one query in Workbench', async t => {
-        const commandForSend1 = 'info';
-        const commandForSend2 = 'FT._LIST';
-        const multipleCommands = [
-            'info',
-            'command',
-            'FT.SEARCH idx *'
-        ];
-        //Send commands
-        await workbenchPage.sendCommandInWorkbench(commandForSend1);
-        await workbenchPage.sendCommandInWorkbench(commandForSend2);
-        //Check that all the previous run commands are saved and displayed
-        await common.reloadPage();
-        await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend1).exists).ok('The previous run commands are saved');
-        await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend2).exists).ok('The previous run commands are saved');
-        //Send multiple commands in one query
-        await workbenchPage.sendCommandInWorkbench(multipleCommands.join('\n'), 0.75);
-        //Check that the results for all commands are displayed
-        for(const command of multipleCommands) {
-            await t.expect(workbenchPage.queryCardCommand.withExactText(command).exists).ok(`The command ${command} from multiple query is displayed`);
-        }
-    });
+test('Verify that user can comment out any characters in scripting area and all these characters in this raw number are not send in the request', async t => {
+    const command1 = 'info';
+    const command2 = 'command';
+    const commandForSend = [
+        '// some comment before command',
+        '\n',
+        command1,
+        '\n',
+        '// some comment between commands with slashes // ** //',
+        '\n',
+        `${command2} // comment in the row with command`,
+        '\n',
+        '// some comment after command'
+    ];
+        // Send command
+    await workbenchPage.sendCommandInWorkbench(commandForSend.join(''));
+    // Check that 2 results are shown
+    await t.expect(workbenchPage.queryCardContainer.count).eql(2);
+    // Check that we have results with sent commands
+    const sentCommandText1 = await workbenchPage.queryCardCommand.withExactText(command1);
+    await t.expect(sentCommandText1.exists).ok('Result of sent command not exists');
+    const sentCommandText2 = await workbenchPage.queryCardCommand.withExactText(command2);
+    await t.expect(sentCommandText2.exists).ok('Result of sent command not exists');
+});
+test('Verify that user can run multiple commands in one query in Workbench', async t => {
+    const commandForSend1 = 'info';
+    const commandForSend2 = 'FT._LIST';
+    const multipleCommands = [
+        'info',
+        'command',
+        'FT.SEARCH idx *'
+    ];
+        // Send commands
+    await workbenchPage.sendCommandInWorkbench(commandForSend1);
+    await workbenchPage.sendCommandInWorkbench(commandForSend2);
+    // Check that all the previous run commands are saved and displayed
+    await common.reloadPage();
+    await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend1).exists).ok('The previous run commands are not saved');
+    await t.expect(workbenchPage.queryCardCommand.withExactText(commandForSend2).exists).ok('The previous run commands are not saved');
+    // Send multiple commands in one query
+    await workbenchPage.sendCommandInWorkbench(multipleCommands.join('\n'), 0.75);
+    // Check that the results for all commands are displayed
+    for(const command of multipleCommands) {
+        await t.expect(workbenchPage.queryCardCommand.withExactText(command).exists).ok(`The command ${command} from multiple query is not displayed`);
+    }
+});


### PR DESCRIPTION
Refactoring of e2e smoke tests from https://redislabs.atlassian.net/browse/RI-3530
Fixed:
1) Many small tests are merged to save test execution time
2) Comments are reduced to one formatting
3) chance.word() replaced by common.generateWord()
4) Error messages of expects are fixed (previously most of them were incorrect)
5) "rte: rte.standalone" moved from tests meta to fixture meta
6) Different updates for some tests