### PR TITLE
Feature: added default port

### DIFF
--- a/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/InstanceForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/AddInstanceForm/InstanceForm/InstanceForm.tsx
@@ -703,7 +703,7 @@ const AddStandaloneForm = (props: Props) => {
                 data-testid="port"
                 style={{ width: '100%' }}
                 placeholder="Enter Port"
-                value={formik.values.port ?? ''}
+                value={formik.values.port ? formik.values.port : '6379'}
                 maxLength={6}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
                   formik.setFieldValue(


### PR DESCRIPTION
Added default Redis port to form.

Before:
![obraz](https://user-images.githubusercontent.com/32015883/201468104-52472977-448b-4429-9d11-a8f6abdd6de6.png)

After:
![obraz](https://user-images.githubusercontent.com/32015883/201467813-4cf0c821-aacd-4178-9f3c-14877c8bcc3b.png)

Tests passed.
Pasting full address with custom port still works.
Related with feature request: https://github.com/RedisInsight/RedisInsight/issues/1156