### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 [![Release](https://img.shields.io/github/v/release/RedisInsight/RedisInsight.svg?sort=semver)](https://github.com/RedisInsight/RedisInsight/releases)
 [![CircleCI](https://circleci.com/gh/RedisInsight/RedisInsight/tree/main.svg?style=svg)](https://circleci.com/gh/RedisInsight/RedisInsight/tree/main)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/RedisInsight/RedisInsight.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RedisInsight/RedisInsight/alerts/)
 
-# <img src="https://redis.com/wp-content/uploads/2019/11/ico-redisinsight.svg" alt="logo" width="25"/>  RedisInsight - Developer GUI for Redis, by Redis. 
+# <img src="https://redis.com/wp-content/uploads/2019/11/ico-redisinsight.svg" alt="logo" width="25"/>  RedisInsight - Developer GUI for Redis, by Redis.
 [![Forum](https://img.shields.io/badge/Forum-RedisInsight-red)](https://forum.redis.com/c/redisinsight/65)
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/QUkjSsk)
 
 
-RedisInsight is a visual tool that provides capabilities to design, develop and optimize your Redis application. 
+RedisInsight is a visual tool that provides capabilities to design, develop and optimize your Redis application.
 Query, analyse and interact with your Redis data. [Download it here](https://redis.com/redis-enterprise/redis-insight/#insight-form)!
 
 ![RedisInsight Browser screenshot](/.github/redisinsight_browser.png)
@@ -33,18 +32,18 @@ RedisInsight is an intuitive and efficient GUI for Redis, allowing you to intera
 * Ability to build your own data visualization plugins
 * Built-in click-through guides for Redis capabilities
 * Oficially supported for Redis OSS, [Redis Cloud](https://redis.com/try-free/). Works with Microsoft Azure Cache for Redis (official support upcoming).
-* Available for macOS (including M1), Windows and Linux 
+* Available for macOS (including M1), Windows and Linux
 
-Check out the [release notes](https://docs.redis.com/latest/ri/release-notes/). 
+Check out the [release notes](https://docs.redis.com/latest/ri/release-notes/).
 
 ## Get started with RedisInsight
 
-This repository includes the code for the GA version of RedisInsight 2.0. Check out the [blogpost](https://redis.com/blog/introducing-redisinsight-2/) announcing it. 
+This repository includes the code for the GA version of RedisInsight 2.0. Check out the [blogpost](https://redis.com/blog/introducing-redisinsight-2/) announcing it.
 
-### Installable 
+### Installable
 Available to download for free from [here](https://redis.com/redis-enterprise/redis-insight/#insight-form).
 
-### Build 
+### Build
 Alternatively you can also build from source. See our wiki for instructions.
 
 * [How to build](https://github.com/RedisInsight/RedisInsight/wiki/How-to-build-and-contribute)
@@ -72,7 +71,7 @@ If you would like to contribute to the code base or fix and issue, please consul
 
 RedisInsight includes an opt-in telemetry system, that is leveraged to help improve the developer experience (DX) within the app. We value your privacy, so stay assured, that all the data collected is anonymised.
 
-## License 
+## License
 
 RedisInsight is licensed under [SSPL](/LICENSE) license.
 

--- a/redisinsight/api/src/modules/encryption/strategies/keytar-encryption.strategy.ts
+++ b/redisinsight/api/src/modules/encryption/strategies/keytar-encryption.strategy.ts
@@ -84,7 +84,7 @@ export class KeytarEncryptionStrategy implements IEncryptionStrategy {
       }
 
       this.cipherKey = await createHash('sha256')
-        .update(password, 'utf8') // lgtm[js/insufficient-password-hash]
+        .update(password, 'utf8')
         .digest();
     }
 

--- a/redisinsight/api/src/modules/redis-enterprise/redis-enterprise.service.ts
+++ b/redisinsight/api/src/modules/redis-enterprise/redis-enterprise.service.ts
@@ -41,7 +41,7 @@ export class RedisEnterpriseService {
   // TODO: maybe find a workaround without Disabling certificate validation.
   private api = axios.create({
     httpsAgent: new https.Agent({
-      rejectUnauthorized: false, // lgtm[js/disabling-certificate-validation]
+      rejectUnauthorized: false,
     }),
   });
 

--- a/redisinsight/api/src/utils/hosting-provider-helper.ts
+++ b/redisinsight/api/src/utils/hosting-provider-helper.ts
@@ -12,13 +12,13 @@ export const getHostingProvider = (host: string): HostingProvider => {
   if (IP_ADDRESS_REGEX.test(host) && PRIVATE_IP_ADDRESS_REGEX.test(host)) {
     return HostingProvider.LOCALHOST;
   }
-  if (host.endsWith('rlrcp.com') || host.endsWith('redislabs.com')) { // lgtm[js/incomplete-url-substring-sanitization]
+  if (host.endsWith('rlrcp.com') || host.endsWith('redislabs.com')) {
     return HostingProvider.RE_CLOUD;
   }
-  if (host.endsWith('cache.amazonaws.com')) { // lgtm[js/incomplete-url-substring-sanitization]
+  if (host.endsWith('cache.amazonaws.com')) {
     return HostingProvider.AWS;
   }
-  if (host.endsWith('cache.windows.net')) { // lgtm[js/incomplete-url-substring-sanitization]
+  if (host.endsWith('cache.windows.net')) {
     return HostingProvider.AZURE;
   }
   return HostingProvider.UNKNOWN;

--- a/redisinsight/api/test/helpers/local-db.ts
+++ b/redisinsight/api/test/helpers/local-db.ts
@@ -54,7 +54,7 @@ export const encryptData = (data) => {
 
   if (constants.TEST_ENCRYPTION_STRATEGY === 'KEYTAR') {
     let cipherKey = createHash('sha256')
-      .update(constants.TEST_KEYTAR_PASSWORD, 'utf8') // lgtm[js/insufficient-password-hash]
+      .update(constants.TEST_KEYTAR_PASSWORD, 'utf8')
       .digest();
     const cipher = createCipheriv('aes-256-cbc', cipherKey, Buffer.alloc(16, 0));
     let encrypted = cipher.update(data, 'utf8', 'hex');
@@ -73,7 +73,7 @@ export const decryptData = (data) => {
 
   if (constants.TEST_ENCRYPTION_STRATEGY === 'KEYTAR') {
     let cipherKey = createHash('sha256')
-      .update(constants.TEST_KEYTAR_PASSWORD, 'utf8') // lgtm[js/insufficient-password-hash]
+      .update(constants.TEST_KEYTAR_PASSWORD, 'utf8')
       .digest();
 
     const decipher = createDecipheriv('aes-256-cbc', cipherKey, Buffer.alloc(16, 0));

--- a/redisinsight/api/test/helpers/server.ts
+++ b/redisinsight/api/test/helpers/server.ts
@@ -9,7 +9,7 @@ import { connect, Socket } from "socket.io-client";
  * When not defined We will up and run local server
  */
 export let server = process.env.TEST_BE_SERVER;
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // lgtm[js/disabling-certificate-validation]
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 export let baseUrl = server;
 

--- a/tests/e2e/helpers/common.ts
+++ b/tests/e2e/helpers/common.ts
@@ -4,7 +4,7 @@ import {apiUrl, commonUrl} from './conf';
 
 const settingsApiUrl = `${commonUrl}/api/settings`;
 const chance = new Chance();
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // lgtm[js/disabling-certificate-validation]
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const mockedSettingsResponse = {
     agreements: {


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.