### PR TITLE
[RedisGraph] Convert id to string before rendering node label

### DIFF
--- a/redisinsight/ui/src/packages/redisgraph/src/Graph.tsx
+++ b/redisinsight/ui/src/packages/redisgraph/src/Graph.tsx
@@ -239,7 +239,7 @@ export default function Graph(props: { graphKey: string, data: any[] }) {
       graphData: graphData,
       infoPanel: true,
       // nodeRadius: 25,
-      onLabelNode: (node) => node.properties?.name || node.properties?.title || node.id || (node.labels ? node.labels[0] : ''),
+      onLabelNode: (node) => node.properties?.name || node.properties?.title || node.id.toString() || (node.labels ? node.labels[0] : ''),
       onNodeClick: (nodeSvg, node, event) => {
         if (d3.select(nodeSvg).attr('class').indexOf('selected') > 0) {
           d3.select(nodeSvg)


### PR DESCRIPTION
A tiny regression occured due to this: https://github.com/RedisInsight/RedisInsight/pull/1444


Now that we consider graph Ids as integer as received by redisgraph, when rendering label on a node, convert the id from integer to string if id is chosen as label.