### PR TITLE
fe/bugfix/rename-advanced-settings-to-list-view

### DIFF
--- a/redisinsight/ui/src/components/settings-item/SettingItem.spec.tsx
+++ b/redisinsight/ui/src/components/settings-item/SettingItem.spec.tsx
@@ -21,7 +21,7 @@ const mockedProps = {
   initValue: '10000',
   onApply: jest.fn(),
   validation: jest.fn((x) => x),
-  title: 'Keys to Scan in Browser',
+  title: 'Keys to Scan in List view',
   summary: 'Sets the amount of keys to scan per one iteration. Filtering by pattern per a large number of keys may decrease performance.',
   testid: 'keys-to-scan',
   placeholder: '10 000',

--- a/redisinsight/ui/src/pages/settings/components/advanced-settings/AdvancedSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/advanced-settings/AdvancedSettings.tsx
@@ -29,7 +29,7 @@ const AdvancedSettings = () => {
         initValue={scanThreshold.toString()}
         onApply={handleApplyKeysToScanChanges}
         validation={validateCountNumber}
-        title="Keys to Scan in Browser"
+        title="Keys to Scan in List view"
         summary="Sets the amount of keys to scan per one iteration. Filtering by pattern per a large number of keys may decrease performance."
         testid="keys-to-scan"
         placeholder="10 000"


### PR DESCRIPTION
https://redislabs.atlassian.net/browse/RI-3865

Ensure that I can see the “Keys to Scan in List view” title instead of the  “Keys to Scan in Browser” in the “Advanced” section on the Settings page.