### PR TITLE
#RI-3898 - Do not use JSON.DEBUG MEMORY when it is not allowed

### DIFF
--- a/redisinsight/api/src/modules/browser/services/rejson-rl-business/rejson-rl-business.service.ts
+++ b/redisinsight/api/src/modules/browser/services/rejson-rl-business/rejson-rl-business.service.ts
@@ -61,11 +61,17 @@ export class RejsonRlBusinessService {
     keyName: RedisString,
     path: string,
   ): Promise<number | null> {
-    const size = await this.browserTool.execCommand(
-      clientMetadata,
-      BrowserToolRejsonRlCommands.JsonDebug,
-      ['MEMORY', keyName, path],
-    );
+    let size = 0
+
+    try {
+      size = await this.browserTool.execCommand(
+        clientMetadata,
+        BrowserToolRejsonRlCommands.JsonDebug,
+        ['MEMORY', keyName, path],
+      );
+    } catch (error) {
+      this.logger.error('Failed to estimate size of json.', error);
+    }
 
     if (size === null) {
       throw new BadRequestException(

--- a/redisinsight/api/test/api/rejson-rl/POST-databases-id-rejson_rl-get.test.ts
+++ b/redisinsight/api/test/api/rejson-rl/POST-databases-id-rejson_rl-get.test.ts
@@ -229,17 +229,34 @@ describe('POST /databases/:instanceId/rejson-rl/get', () => {
           before: () => rte.data.setAclUserRules('~* +@all -json.get')
         },
         {
-          name: 'Should throw error if no permissions for "json.debug" command',
+          name: 'Should return regular item if no permissions for "json.debug" command',
           endpoint: () => endpoint(constants.TEST_INSTANCE_ACL_ID),
           data: {
             keyName: constants.TEST_REJSON_KEY_3,
             path: '.',
             forceRetrieve: false,
           },
-          statusCode: 403,
+          responseSchema,
           responseBody: {
-            statusCode: 403,
-            error: 'Forbidden',
+            downloaded: true,
+            path: '.',
+            data: constants.TEST_REJSON_VALUE_3,
+          },
+          before: () => rte.data.setAclUserRules('~* +@all -json.debug')
+        },
+        {
+          name: 'Should get full json if no permissions for "json.debug" command',
+          endpoint: () => endpoint(constants.TEST_INSTANCE_ACL_ID),
+          data: {
+            keyName: constants.TEST_REJSON_KEY_3,
+            path: '.',
+            forceRetrieve: false,
+          },
+          responseSchema,
+          responseBody: {
+            downloaded: true,
+            path: '.',
+            data: constants.TEST_REJSON_VALUE_3,
           },
           before: () => rte.data.setAclUserRules('~* +@all -json.debug')
         },


### PR DESCRIPTION
#RI-3898 - Do not use JSON.DEBUG MEMORY when it is not allowed