### PR TITLE
#RI-4004, #RI-4009, #RI-4010

### DIFF
--- a/redisinsight/ui/src/components/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -168,7 +168,6 @@ const QueryCardHeader = (props: Props) => {
   }
 
   const handleQueryReRun = (event: React.MouseEvent) => {
-    sendEvent(TelemetryEvent.WORKBENCH_COMMAND_RUN_AGAIN, query)
     eventStop(event)
     onQueryReRun()
   }

--- a/redisinsight/ui/src/slices/tests/workbench/wb-results.spec.ts
+++ b/redisinsight/ui/src/slices/tests/workbench/wb-results.spec.ts
@@ -177,7 +177,7 @@ describe('workbench results slice', () => {
       expect(workbenchResultsSelector(rootState)).toEqual(state)
     })
 
-    it('should properly set the state with fetched data and isOpen = false, for request silent mode and 0 errors', () => {
+    it('should properly set the state with fetched data and isOpen = false, for request silent mode', () => {
       // Arrange
 
       const mockedId = '123'

--- a/redisinsight/ui/src/slices/workbench/wb-results.ts
+++ b/redisinsight/ui/src/slices/workbench/wb-results.ts
@@ -10,7 +10,7 @@ import {
   getApiErrorMessage,
   getUrl,
   isGroupResults,
-  isSilentModeWithoutError,
+  isSilentMode,
   isStatusSuccessful,
 } from 'uiSrc/utils'
 import { WORKBENCH_HISTORY_MAX_LENGTH } from 'uiSrc/pages/workbench/constants'
@@ -129,8 +129,12 @@ const workbenchResultsSlice = createSlice({
         data.forEach((command, i) => {
           if (item.id === (commandId + i)) {
             // don't open a card if silent mode and no errors
-            const isOpen = !isSilentModeWithoutError(command.resultsMode, command?.summary?.fail)
-            newItem = { ...command, isOpen, loading: false, error: '' }
+            newItem = {
+              ...command,
+              loading: false,
+              error: '',
+              isOpen: !isSilentMode(command.resultsMode),
+            }
           }
         })
         return newItem


### PR DESCRIPTION
* #RI-4004 - Telemetry WORKBENCH_COMMAND_SUBMITTED event not sent when auto=true
* #RI-4009 - Silent results not collapsed by default when have errors 
* #RI-4010 - WORKBENCH_COMMAND_RUN_AGAIN event should have the same parameters as WORKBENCH_COMMAND_SUBMITTED