### PR TITLE
#RI-4011, #RI-4010, #RI-4013

### DIFF
--- a/redisinsight/ui/src/pages/workbench/WorkbenchPage.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/WorkbenchPage.spec.tsx
@@ -232,11 +232,11 @@ describe('Telemetry', () => {
       event: TelemetryEvent.WORKBENCH_COMMAND_RUN_AGAIN,
       eventData: {
         auto: undefined,
+        pipeline: undefined,
         command: 'INFO;',
         databaseId: INSTANCE_ID_MOCK,
         multiple: 'Single',
         results: 'single',
-        pipeline: true,
         rawMode: true,
       }
     })

--- a/redisinsight/ui/src/utils/monaco/monacoUtils.ts
+++ b/redisinsight/ui/src/utils/monaco/monacoUtils.ts
@@ -25,6 +25,11 @@ const removeCommentsFromLine = (text: string = '', prefix: string = ''): string 
 export const splitMonacoValuePerLines = (command = '') => {
   const linesResult: string[] = []
   const lines = getMonacoLines(command)
+  // remove execute params
+  if (isParamsLine(first(lines))) {
+    lines.splice(0, 1, removeParams(first(lines)))
+  }
+
   lines.forEach((line) => {
     const [commandLine, countRepeat] = getCommandRepeat(line || '')
 
@@ -35,10 +40,6 @@ export const splitMonacoValuePerLines = (command = '') => {
     linesResult.push(...Array(countRepeat).fill(commandLine))
   })
 
-  // remove execute params
-  if (isParamsLine(first(linesResult))) {
-    linesResult.shift()
-  }
   return linesResult
 }
 
@@ -204,6 +205,12 @@ export const createSyntaxWidget = (text: string, shortcutText: string) => {
 export const isParamsLine = (commandInit: string = '') => {
   const command = commandInit.trim()
   return command.startsWith('[') && (command.indexOf(']') !== -1)
+}
+
+const removeParams = (commandInit: string = '') => {
+  const command = commandInit.trim()
+  const paramsLastIndex = command.indexOf(']')
+  return command.substring(paramsLastIndex + 1).trim()
 }
 
 export const getMonacoLines = (command: string = '') =>

--- a/redisinsight/ui/src/utils/tests/monaco/monacoUtils.spec.ts
+++ b/redisinsight/ui/src/utils/tests/monaco/monacoUtils.spec.ts
@@ -100,8 +100,8 @@ describe('splitMonacoValuePerLines', () => {
     ],
     // Multi commands with parameters and repeating syntax error
     [
-      '[results=group;mode=raw]\nget test\n3get test2\nget bar',
-      ['get test', '3get test2', 'get bar']
+      '[results=group;mode=raw]info\nget test\n3get test2\nget bar',
+      ['info', 'get test', '3get test2', 'get bar']
     ],
   ]
   test.each(cases)(

--- a/redisinsight/ui/src/utils/tests/workbench.spec.ts
+++ b/redisinsight/ui/src/utils/tests/workbench.spec.ts
@@ -42,6 +42,7 @@ describe('getParsedParamsInQuery', () => {
     ['get test\n[mode=raw]\nget test2\nget test3', {}],
     ['[mode=raw]\nget test\nget test2\nget test3', { mode: 'raw' }],
     ['[mode=raw;mode=ascii]\nget test\nget test2\nget test3', { mode: 'raw' }],
+    ['[mode=raw;results=ascii]info\nget test\nget test2\nget test3', { mode: 'raw', results: 'ascii' }],
     ['[mode=raw;results=group;pipeline=10]\nget test\nget test2\nget test3', { mode: 'raw', results: 'group', pipeline: '10' }],
   ])('for input: %s (input), should be output: %s',
     (input, expected) => {

--- a/redisinsight/ui/src/utils/workbench.ts
+++ b/redisinsight/ui/src/utils/workbench.ts
@@ -37,9 +37,11 @@ export const getParsedParamsInQuery = (query: string) => {
   const lines = getMonacoLines(query)
 
   if (isParamsLine(first(lines))) {
-    const params = lines.shift()
-      ?.replaceAll?.('\n', '')
+    const paramsLine = lines.shift() || ''
+    const params = paramsLine
+      ?.substring?.(paramsLine.indexOf(']') + 1, 0)
       ?? ''
+
     parsedParams = parseParams(params)
   }
 


### PR DESCRIPTION
* #RI-4011 - WORKBENCH_COMMAND_SUBMITTED event has incorrect "command" parameter value if command contains number of runs
* #RI-4013 - Parameters are not applied if there is any text on the same row
* #RI-4010 - WORKBENCH_COMMAND_RUN_AGAIN event should have the same parameters as WORKBENCH_COMMAND_SUBMITTED