### PR TITLE
[RI-4194] Profile Plugin - Show profile tab by default

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/package.json
+++ b/redisinsight/ui/src/packages/redisearch/package.json
@@ -37,13 +37,24 @@
       "matchCommands": [
         "FT.INFO",
         "FT.SEARCH",
-        "FT.AGGREGATE",
-        "FT.PROFILE"
+        "FT.AGGREGATE"
       ],
       "iconDark": "./dist/table_view_icon_dark.svg",
       "iconLight": "./dist/table_view_icon_light.svg",
       "description": "RediSearch default plugin",
       "default": true
+    },
+    {
+      "id": "redisearch-profile",
+      "name": "Table",
+      "activationMethod": "renderRediSearch",
+      "matchCommands": [
+        "FT.PROFILE"
+      ],
+      "iconDark": "./dist/table_view_icon_dark.svg",
+      "iconLight": "./dist/table_view_icon_light.svg",
+      "description": "RediSearch default plugin",
+      "default": false
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
This lets Profile Plugin the default view for `FT.PROFILE` since RediSearch Plugin's `FT.PROFILE` is non-default