### PR TITLE
[RI-4101] Profile/Explain Plugin - Add edge split port when multiple targets, add arrow for target ends

### DIFF
--- a/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
@@ -126,7 +126,6 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
 
   const [done, setDone] = useState(false)
   const [collapse, setCollapse] = useState(true)
-  const [infoWidth, setInfoWidth] = useState(document.body.offsetWidth)
   const [isFullScreen, setIsFullScreen] = useState(false)
   const [core, setCore] = useState<Graph>()
 
@@ -152,7 +151,6 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
         core?.resize(width, (b?.height || 585) + 100)
       }
     }
-    setInfoWidth(width)
   }
 
   window.addEventListener('resize', resize)
@@ -187,14 +185,15 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
         document.querySelector(`#node-${p[0]}`)?.setAttribute("style", "outline: 1px solid #85A2FE !important;")
         // Get edge size of parent ancestor to apply the right edge stroke
         const edge = graph.getCellById(`${p[0]}-${p[1]}`)
+        const edgeColor = '#85A2FE'
         edge.setAttrs({
           line: {
-            stroke: '#85A2FE',
+            stroke: edgeColor,
             strokeWidth: (edge.getAttrs() as any)?.line?.strokeWidth,
             targetMarker: {
               name: 'block',
-              stroke: '#85A2FE',
-              fill: '#85A2FE',
+              stroke: edgeColor,
+              fill: edgeColor,
             },
           },
         })
@@ -207,14 +206,15 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
       ancestors.pairs.forEach(p => {
         document.querySelector(`#node-${p[0]}`)?.setAttribute("style", "")
         const edge = graph.getCellById(`${p[0]}-${p[1]}`)
+        const edgeColor = isDarkTheme ? '#6B6B6B' : '#8992B3'
         edge.setAttrs({
           line: {
-            stroke: isDarkTheme ? '#6B6B6B' : '#8992B3',
+            stroke: edgeColor,
             strokeWidth: (edge.getAttrs() as any)?.line?.strokeWidth,
             targetMarker: {
               name: 'block',
-              fill: isDarkTheme ? '#6B6B6B' : '#8992B3',
-              stroke: isDarkTheme ? '#6B6B6B' : '#8992B3',
+              fill: edgeColor,
+              stroke: edgeColor,
             }
           },
         })
@@ -361,7 +361,7 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
       if (data.children) {
         data.children.forEach((item: any) => {
           const itemRecords = parseInt(item.data.counter || 0)
-
+          const edgeColor = isDarkTheme ? '#6B6B6B' : '#8992B3'
           model.edges?.push({
             id: `${data.id}-${item.id}`,
             source: {
@@ -389,12 +389,12 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
             },
             attrs: {
               line: {
-                stroke: isDarkTheme ? '#6B6B6B' : '#8992B3',
+                stroke: edgeColor,
                 strokeWidth: getEdgeSize(itemRecords),
                 targetMarker: {
                   name: 'block',
-                  fill: isDarkTheme ? '#6B6B6B' : '#8992B3',
-                  stroke: isDarkTheme ? '#6B6B6B' : '#8992B3',
+                  fill: edgeColor,
+                  stroke: edgeColor,
                 },
               },
             },

--- a/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
@@ -10,6 +10,13 @@ import {
 } from '@elastic/eui'
 
 import {
+  EDGE_COLOR_BODY_DARK,
+  EDGE_COLOR_BODY_LIGHT,
+  NODE_COLOR_BODY_DARK,
+  NODE_COLOR_BODY_LIGHT,
+} from './constants'
+
+import {
   CoreType,
   ModuleType,
   EntityInfo,
@@ -29,6 +36,14 @@ interface IExplain {
 
 function getEdgeSize(c: number) {
   return Math.floor(Math.log(c || 1) + 1)
+}
+
+function getNodeColor(isDarkTheme: boolean) {
+  return isDarkTheme ? NODE_COLOR_BODY_DARK : NODE_COLOR_BODY_LIGHT
+}
+
+function getEdgeColor(isDarkTheme: boolean) {
+  return isDarkTheme ? EDGE_COLOR_BODY_DARK : EDGE_COLOR_BODY_LIGHT
 }
 
 export default function Explain(props: IExplain): JSX.Element {
@@ -206,7 +221,7 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
       ancestors.pairs.forEach(p => {
         document.querySelector(`#node-${p[0]}`)?.setAttribute("style", "")
         const edge = graph.getCellById(`${p[0]}-${p[1]}`)
-        const edgeColor = isDarkTheme ? '#6B6B6B' : '#8992B3'
+        const edgeColor = getEdgeColor(isDarkTheme)
         edge.setAttrs({
           line: {
             stroke: edgeColor,
@@ -333,7 +348,7 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
           data: info,
           attrs: {
             body: {
-              fill: isDarkTheme ? '#5F95FF' : '#8992B3',
+              fill: getNodeColor(isDarkTheme),
               stroke: 'transparent',
             },
           },
@@ -361,7 +376,7 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
       if (data.children) {
         data.children.forEach((item: any) => {
           const itemRecords = parseInt(item.data.counter || 0)
-          const edgeColor = isDarkTheme ? '#6B6B6B' : '#8992B3'
+          const edgeColor = getEdgeColor(isDarkTheme)
           model.edges?.push({
             id: `${data.id}-${item.id}`,
             source: {
@@ -421,7 +436,14 @@ function ExplainDraw({data, type, module, profilingTime}: {data: any, type: Core
   return (
     <div>
       { collapse && <div style={{ paddingTop: '50px' }}></div> }
-      <div id="container-parent" style={{ height: isFullScreen ? (window.outerHeight - 170) + 'px' : collapse ? '500px' : '585px', width: '100%', overflow: 'auto' }}>
+      <div
+        id="container-parent"
+        style={{
+          height: isFullScreen ? (window.outerHeight - 170) + 'px' : collapse ? '500px' : '585px',
+          width: '100%',
+          overflow: 'auto',
+        }}
+      >
         <div style={{ margin: 0, width: '100vw' }} ref={container} id="container" />
         { !collapse && (
           <div className="ZoomMenu">

--- a/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
@@ -85,9 +85,8 @@ export function ProfileNode(props: INodeProps) {
   }
 
   const infoData = data ? data : type
-
   return (
-    <div className="ProfileContainer" id={`node-${id}`} data-size={counter || size || recordsProduced}>
+    <div className="ProfileContainer" id={`node-${id}`}>
       <div className="Main">
         <div className="InfoData">
           <EuiToolTip delay='long' content={infoData}><span>{infoData}</span></EuiToolTip>

--- a/redisinsight/ui/src/packages/ri-explain/src/constants.ts
+++ b/redisinsight/ui/src/packages/ri-explain/src/constants.ts
@@ -1,0 +1,6 @@
+export const NODE_COLOR_BODY_DARK = '#5F95FF'
+export const NODE_COLOR_BODY_LIGHT = '#8992B3'
+
+export const EDGE_COLOR_BODY_DARK = '#6B6B6B'
+export const EDGE_COLOR_BODY_LIGHT = '#8992B3'
+


### PR DESCRIPTION
- Add port support which distinguishes when the node has multiple outputs.
- Add arrow for targets

![image](https://user-images.githubusercontent.com/20211167/219865771-fa3a651a-8592-4fd1-a0e8-18146745f2be.png)
