### PR TITLE
[RI-3726] Profile Plugin - Add support for leftoff RediSearch expressions

### DIFF
--- a/redisinsight/ui/src/components/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -110,6 +110,7 @@ const QueryCardHeader = (props: Props) => {
     setSelectedValue,
     onQueryDelete,
     onQueryReRun,
+    onQueryProfile,
     db,
   } = props
 

--- a/redisinsight/ui/src/packages/ri-explain/package.json
+++ b/redisinsight/ui/src/packages/ri-explain/package.json
@@ -66,6 +66,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redisinsight-plugin-sdk": "^1.1.0",
     "uuid": "^9.0.0"
   }
 }

--- a/redisinsight/ui/src/packages/ri-explain/src/App.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/App.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import Explain from './Explain'
 
-const isDarkTheme = document.body.classList.contains('theme_DARK')
-
 export function App(props: { command?: string, data: any }) {
 
   const ErrorResponse = HandleError(props)

--- a/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react'
 import { Model, Graph } from '@antv/x6'
 import { register} from '@antv/x6-react-shape'
 import Hierarchy from '@antv/hierarchy'
+import { formatRedisReply } from 'redisinsight-plugin-sdk'
 
 import {
   EuiButtonIcon,
@@ -72,6 +73,18 @@ export default function Explain(props: IExplain): JSX.Element {
 
   const module = ModuleType.Search
 
+  const [parsedRedisReply, setParsedRedisReply] = useState('')
+
+  useEffect(() => {
+    if (command == 'ft.profile') {
+      const getParsedResponse = async () => {
+        const formattedResponse = await formatRedisReply(props.data[0].response, props.command)
+        setParsedRedisReply(formattedResponse)
+      }
+      getParsedResponse()
+    }
+  })
+
   if (command == 'ft.profile') {
     const info = props.data[0].response[1]
 
@@ -82,7 +95,12 @@ export default function Explain(props: IExplain): JSX.Element {
       let [cluster, entityInfo] = ParseProfileCluster(info)
       cluster['Coordinator'].forEach((kv: [string, string]) => profilingTime[kv[0]] = kv[1])
       data = entityInfo
-      return <div className="responseFail">Visualization of FT.PROFILE on cluster is not yet supported.</div>
+      return (
+        <>
+          <div className="responseFail">Visualization is not supported for a clustered database.</div>
+          <div className="parsedRedisReply">{parsedRedisReply}</div>
+        </>
+      )
     } else if (typeof info[0] === 'string' && info[0].toLowerCase().startsWith('coordinator')) {
       const resultsProfile = info[2]
       data = ParseProfile(resultsProfile)
@@ -92,7 +110,12 @@ export default function Explain(props: IExplain): JSX.Element {
         'Parsing time': resultsProfile[1][1],
         'Pipeline creation time': resultsProfile[2][1],
       }
-      return <div className="responseFail">Visualization of FT.PROFILE on cluster is not yet supported.</div>
+      return (
+        <>
+          <div className="responseFail">Visualization is not supported for a clustered database.</div>
+          <div className="parsedRedisReply">{parsedRedisReply}</div>
+        </>
+      )
     } else {
       data = ParseProfile(info)
       profilingTime = {

--- a/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
@@ -31,7 +31,7 @@ export function ExplainNode(props: INodeProps) {
           <div className="InfoData">
             <EuiToolTip delay='long' content={infoData}><span>{infoData}</span></EuiToolTip>
           </div>
-          {subType && [EntityType.GEO, EntityType.NUMERIC, EntityType.TEXT, EntityType.TAG, EntityType.FUZZY].includes(subType) && <div className="Type">{subType}</div> }
+          {subType && [EntityType.GEO, EntityType.NUMERIC, EntityType.TEXT, EntityType.TAG, EntityType.FUZZY, EntityType.WILDCARD, EntityType.PREFIX, EntityType.IDS, EntityType.LEXRANGE].includes(subType) && <div className="Type">{subType}</div> }
         </div>
       </div>
       {

--- a/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
@@ -31,7 +31,7 @@ export function ExplainNode(props: INodeProps) {
           <div className="InfoData">
             <EuiToolTip delay='long' content={infoData}><span>{infoData}</span></EuiToolTip>
           </div>
-          {subType && [EntityType.GEO, EntityType.NUMERIC, EntityType.TEXT, EntityType.TAG, EntityType.FUZZY, EntityType.WILDCARD, EntityType.PREFIX, EntityType.IDS, EntityType.LEXRANGE].includes(subType) && <div className="Type">{subType}</div> }
+          {subType && [EntityType.GEO, EntityType.NUMERIC, EntityType.TEXT, EntityType.TAG, EntityType.FUZZY, EntityType.WILDCARD, EntityType.PREFIX, EntityType.IDS, EntityType.LEXRANGE, EntityType.NUMBER].includes(subType) && <div className="Type">{subType}</div> }
         </div>
       </div>
       {

--- a/redisinsight/ui/src/packages/ri-explain/src/styles/styles.less
+++ b/redisinsight/ui/src/packages/ri-explain/src/styles/styles.less
@@ -84,6 +84,14 @@ body {
   font-family: monospace !important;
 }
 
+.parsedRedisReply {
+  white-space: pre-wrap;
+  word-break: break-all;
+  font: normal normal normal 14px/17px Inconsolata !important;
+  padding: 4px 12px !important;
+  color: var(--info-color);
+}
+
 .responseInfo {
   color: var(--info-color);
   padding: 12px !important;

--- a/redisinsight/ui/src/packages/ri-explain/src/styles/styles.less
+++ b/redisinsight/ui/src/packages/ri-explain/src/styles/styles.less
@@ -291,7 +291,7 @@ body {
   padding-bottom: 3px !important;
 
   position: absolute;
-  bottom: 0px;
+  bottom: 12px;
   width: 100%;
 }
 

--- a/redisinsight/ui/src/packages/ri-explain/yarn.lock
+++ b/redisinsight/ui/src/packages/ri-explain/yarn.lock
@@ -2513,6 +2513,11 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+redisinsight-plugin-sdk@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/redisinsight-plugin-sdk/-/redisinsight-plugin-sdk-1.1.0.tgz#5ac39dc5398b1f73f2357e67ce51e1875fbece4f"
+  integrity sha512-TtPYfpxVZlwASkO8WFEB8+l6H9N9SVGwVxU0hRGzkEdXZyeQ+Xm/1WwnkGKMaeJyvfpIGrPWVl+lN4pDQ3iqbA==
+
 redux@^4.0.0, redux@^4.0.4:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"

--- a/scripts/build-statics.sh
+++ b/scripts/build-statics.sh
@@ -35,6 +35,13 @@ yarn --cwd "${REDISTIMESERIES_DIR}" build
 mkdir -p "${PLUGINS_DIR}/redistimeseries-app"
 cp -R "${REDISTIMESERIES_DIR}/dist" "${REDISTIMESERIES_DIR}/package.json" "${PLUGINS_DIR}/redistimeseries-app"
 
+# Build ri-explain plugin
+RI_EXPLIAIN_DIR="./redisinsight/ui/src/packages/ri-explain"
+yarn --cwd "${RI_EXPLIAIN_DIR}"
+yarn --cwd "${RI_EXPLIAIN_DIR}" build
+mkdir -p "${PLUGINS_DIR}/ri-explain"
+cp -R "${RI_EXPLIAIN_DIR}/dist" "${RI_EXPLIAIN_DIR}/package.json" "${PLUGINS_DIR}/ri-explain"
+
 # Build clients-list plugin
 CLIENTS_LIST_DIR="./redisinsight/ui/src/packages/clients-list"
 yarn --cwd "${CLIENTS_LIST_DIR}"


### PR DESCRIPTION
- Remove edge target marker
- Add support for LEXRANGE, IDS, NOT, OPTION, EXACT, FUZZY, WILDCARD, and PREFIX expressions (All of the expressions' parsing is based on RediSearch's latest source code) - https://github.com/RediSearch/RediSearch/blob/master/src/query.c
- Parse Vector Expressions
- Parse tag identifiers with numbers
- Properly skip backslash if exsits (multiple backslash appears)
- Parse identifiers with pipe character
- Make TAG expressions be parsed via expand expression parser since it might contain children
- Remove support for FT.PROFILE on cluster
- Add max-cap zoom