### PR TITLE
fix for Verify that user can see the information message that the Red…

### DIFF
--- a/tests/e2e/tests/critical-path/workbench/redisearch-module-not-available.e2e.ts
+++ b/tests/e2e/tests/critical-path/workbench/redisearch-module-not-available.e2e.ts
@@ -25,5 +25,5 @@ test('Verify that user can see the information message that the RediSearch modul
     // Send command with 'FT.'
     await workbenchPage.sendCommandInWorkbench(commandForSend);
     // Verify the information message
-    await t.expect(await workbenchPage.commandExecutionResult.textContent).eql('Looks like RediSearch is not available', 'The information message');
+    await t.expect(await workbenchPage.commandExecutionResult.textContent).contains('Looks like RediSearch is not available', 'The information message');
 });


### PR DESCRIPTION
…iSearch module is not available when he runs any input with "FT." prefix in Workbench