### PR TITLE
#RI-4754, #RI-4748, #RI-4751, #RI-4753

### DIFF
--- a/redisinsight/ui/src/components/oauth-select-account-dialog/OAuthSelectAccountDialog.spec.tsx
+++ b/redisinsight/ui/src/components/oauth-select-account-dialog/OAuthSelectAccountDialog.spec.tsx
@@ -4,10 +4,13 @@ import { act, cleanup, fireEvent, mockedStore, render } from 'uiSrc/utils/test-u
 import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
 import {
   getUserInfo,
+  getUserInfoSuccess,
   oauthCloudSelector,
   oauthCloudUserDataSelector,
+  setSelectAccountDialogState,
 } from 'uiSrc/slices/oauth/cloud'
 import { apiService } from 'uiSrc/services'
+import { loadSubscriptionsRedisCloud } from 'uiSrc/slices/instances/cloud'
 import OAuthSelectAccountDialog from './OAuthSelectAccountDialog'
 
 jest.mock('uiSrc/telemetry', () => ({
@@ -92,7 +95,12 @@ describe('OAuthSelectAccountDialog', () => {
       fireEvent.click(submitEl as HTMLButtonElement)
     })
 
-    const expectedActions = [getUserInfo()]
+    const expectedActions = [
+      getUserInfo(),
+      getUserInfoSuccess(),
+      loadSubscriptionsRedisCloud(),
+      setSelectAccountDialogState(false),
+    ]
     expect(store.getActions().slice(0, expectedActions.length)).toEqual(expectedActions)
 
     expect(sendEventTelemetry).toBeCalledWith({

--- a/redisinsight/ui/src/components/oauth-select-account-dialog/OAuthSelectAccountDialog.tsx
+++ b/redisinsight/ui/src/components/oauth-select-account-dialog/OAuthSelectAccountDialog.tsx
@@ -36,7 +36,7 @@ interface FormValues {
 
 const OAuthSelectAccountDialog = () => {
   const { isAutodiscoverySSO } = useSelector(cloudSelector)
-  const { accounts = [], id } = useSelector(oauthCloudUserDataSelector) ?? {}
+  const { accounts = [], currentAccountId } = useSelector(oauthCloudUserDataSelector) ?? {}
   const { isOpenSelectAccountDialog } = useSelector(oauthCloudSelector)
   const { loading } = useSelector(oauthCloudUserSelector)
 
@@ -44,7 +44,7 @@ const OAuthSelectAccountDialog = () => {
   const dispatch = useDispatch()
 
   const initialValues = {
-    accountId: `${id}`,
+    accountId: `${currentAccountId}`,
   }
 
   const formik = useFormik({
@@ -62,7 +62,6 @@ const OAuthSelectAccountDialog = () => {
 
   const onActivateAccountSuccess = useCallback(() => {
     if (isAutodiscoverySSO) {
-      dispatch(addInfiniteNotification(INFINITE_MESSAGES.PENDING_CREATE_DB))
       dispatch(fetchSubscriptionsRedisCloud(
         null,
         () => {
@@ -71,6 +70,7 @@ const OAuthSelectAccountDialog = () => {
         },
       ))
     } else {
+      dispatch(addInfiniteNotification(INFINITE_MESSAGES.PENDING_CREATE_DB))
       dispatch(createFreeDbJob())
     }
     dispatch(setSelectAccountDialogState(false))

--- a/redisinsight/ui/src/components/oauth-social/OAuthSocial.tsx
+++ b/redisinsight/ui/src/components/oauth-social/OAuthSocial.tsx
@@ -43,7 +43,7 @@ const OAuthSocial = ({ type = OAuthSocialType.Modal }: Props) => {
       label: 'google-oauth',
       onButtonClick: () => {
         sendTelemetry('Google')
-        ipcAuthGoogle()
+        ipcAuthGoogle(isAutodiscovery ? 'import' : 'create')
       },
     },
     {
@@ -52,7 +52,7 @@ const OAuthSocial = ({ type = OAuthSocialType.Modal }: Props) => {
       className: styles.githubButton,
       onButtonClick: () => {
         sendTelemetry('GitHub')
-        ipcAuthGithub()
+        ipcAuthGithub(isAutodiscovery ? 'import' : 'create')
       },
     }
   ]

--- a/redisinsight/ui/src/electron/utils/ipcAuth.ts
+++ b/redisinsight/ui/src/electron/utils/ipcAuth.ts
@@ -1,8 +1,14 @@
 import { CloudAuthSocial, IpcInvokeEvent } from '../constants'
 
-export const ipcAuthGoogle = async () => {
-  await window.app?.ipc?.invoke(IpcInvokeEvent.cloudOauth, CloudAuthSocial.Google)
+export const ipcAuthGoogle = async (action: string) => {
+  await window.app?.ipc?.invoke(
+    IpcInvokeEvent.cloudOauth,
+    { strategy: CloudAuthSocial.Google, action }
+  )
 }
-export const ipcAuthGithub = async () => {
-  await window.app?.ipc?.invoke(IpcInvokeEvent.cloudOauth, CloudAuthSocial.Github)
+export const ipcAuthGithub = async (action: string) => {
+  await window.app?.ipc?.invoke(
+    IpcInvokeEvent.cloudOauth,
+    { strategy: CloudAuthSocial.Github, action }
+  )
 }


### PR DESCRIPTION
* #RI-4754 - Source parameter “auto-discovery” not added to sso telemetry events
* #RI-4754 - [FE] Active account is not preselected by default
* #RI-4748 - [FE] Waiting message displayed endlessly with error when connecting to account with no write access
* #RI-4751 - [FE] Waiting message not displayed after selecting account