### PR TITLE
#RI-4754 - Source parameter “auto-discovery” not added to sso telemetry

### DIFF
--- a/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.spec.tsx
+++ b/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.spec.tsx
@@ -41,7 +41,10 @@ describe('OAuthSignInDialog', () => {
     fireEvent.click(closeEl as HTMLButtonElement)
 
     expect(sendEventTelemetry).toBeCalledWith({
-      event: TelemetryEvent.CLOUD_SIGN_IN_FORM_CLOSED
+      event: TelemetryEvent.CLOUD_SIGN_IN_FORM_CLOSED,
+      eventData: {
+        action: 'create',
+      }
     })
   })
 })

--- a/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.tsx
+++ b/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.tsx
@@ -33,7 +33,7 @@ const OAuthSignInDialog = () => {
       }
     })
     dispatch(setSignInDialogState(null))
-  }, [])
+  }, [isAutodiscoverySSO])
 
   if (!isOpenSignInDialog) return null
 

--- a/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.tsx
+++ b/redisinsight/ui/src/components/oauth-sign-in-dialog/OAuthSignInDialog.tsx
@@ -15,17 +15,22 @@ import { OAuthSocial } from 'uiSrc/components'
 import { setSignInDialogState, oauthCloudSelector } from 'uiSrc/slices/oauth/cloud'
 
 import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
+import { cloudSelector } from 'uiSrc/slices/instances/cloud'
 import { OAuthAdvantages } from './constants'
 import styles from './styles.module.scss'
 
 const OAuthSignInDialog = () => {
   const { isOpenSignInDialog } = useSelector(oauthCloudSelector)
+  const { isAutodiscoverySSO } = useSelector(cloudSelector)
 
   const dispatch = useDispatch()
 
   const handleOnClose = useCallback(() => {
     sendEventTelemetry({
       event: TelemetryEvent.CLOUD_SIGN_IN_FORM_CLOSED,
+      eventData: {
+        action: isAutodiscoverySSO ? 'import' : 'create',
+      }
     })
     dispatch(setSignInDialogState(null))
   }, [])

--- a/redisinsight/ui/src/components/oauth-social/OAuthSocial.spec.tsx
+++ b/redisinsight/ui/src/components/oauth-social/OAuthSocial.spec.tsx
@@ -48,11 +48,12 @@ describe('OAuthSocial', () => {
       event: TelemetryEvent.CLOUD_SIGN_IN_SOCIAL_ACCOUNT_SELECTED,
       eventData: {
         accountOption: 'Google',
+        action: 'create',
       }
     })
 
     expect(invokeMock).toBeCalledTimes(1)
-    expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, CloudAuthSocial.Google)
+    expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, { action: 'create', strategy: CloudAuthSocial.Google })
 
     const expectedActions = [signIn(), setIsAutodiscoverySSO(false)]
     expect(store.getActions()).toEqual(expectedActions)
@@ -73,11 +74,12 @@ describe('OAuthSocial', () => {
       event: TelemetryEvent.CLOUD_SIGN_IN_SOCIAL_ACCOUNT_SELECTED,
       eventData: {
         accountOption: 'GitHub',
+        action: 'create',
       }
     })
 
     expect(invokeMock).toBeCalledTimes(1)
-    expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, CloudAuthSocial.Github)
+    expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, { action: 'create', strategy: CloudAuthSocial.Github })
     invokeMock.mockRestore()
 
     const expectedActions = [signIn(), setIsAutodiscoverySSO(false)]
@@ -100,11 +102,12 @@ describe('OAuthSocial', () => {
         event: TelemetryEvent.CLOUD_SIGN_IN_SOCIAL_ACCOUNT_SELECTED,
         eventData: {
           accountOption: 'Google',
+          action: 'import',
         }
       })
 
       expect(invokeMock).toBeCalledTimes(1)
-      expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, CloudAuthSocial.Google)
+      expect(invokeMock).toBeCalledWith(IpcInvokeEvent.cloudOauth, { action: 'import', strategy: CloudAuthSocial.Google })
 
       const expectedActions = [
         signIn(),

--- a/redisinsight/ui/src/components/oauth-social/OAuthSocial.tsx
+++ b/redisinsight/ui/src/components/oauth-social/OAuthSocial.tsx
@@ -29,10 +29,13 @@ const OAuthSocial = ({ type = OAuthSocialType.Modal }: Props) => {
   const dispatch = useDispatch()
   const isAutodiscovery = type === OAuthSocialType.Autodiscovery
 
+  const getAction = () => (isAutodiscovery ? 'import' : 'create')
+
   const sendTelemetry = (accountOption: string) => sendEventTelemetry({
     event: TelemetryEvent.CLOUD_SIGN_IN_SOCIAL_ACCOUNT_SELECTED,
     eventData: {
       accountOption,
+      action: getAction(),
     }
   })
 
@@ -43,7 +46,7 @@ const OAuthSocial = ({ type = OAuthSocialType.Modal }: Props) => {
       label: 'google-oauth',
       onButtonClick: () => {
         sendTelemetry('Google')
-        ipcAuthGoogle(isAutodiscovery ? 'import' : 'create')
+        ipcAuthGoogle(getAction())
       },
     },
     {
@@ -52,7 +55,7 @@ const OAuthSocial = ({ type = OAuthSocialType.Modal }: Props) => {
       className: styles.githubButton,
       onButtonClick: () => {
         sendTelemetry('GitHub')
-        ipcAuthGithub(isAutodiscovery ? 'import' : 'create')
+        ipcAuthGithub(getAction())
       },
     }
   ]


### PR DESCRIPTION
#RI-4754 - Source parameter “auto-discovery” not added to sso telemetry events