### PR TITLE
RI-4852 - Use msgpackr alternative library to encode/decode msgpack contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "34.6.0",
-    "@msgpack/msgpack": "^2.7.2",
     "@reduxjs/toolkit": "^1.6.2",
     "@stablelib/snappy": "^1.0.2",
     "axios": "^0.25.0",
@@ -252,6 +251,7 @@
     "jsonpath": "^1.1.1",
     "lodash": "^4.17.21",
     "lz4js": "^0.2.0",
+    "msgpackr": "^1.9.7",
     "pako": "^2.1.0",
     "php-serialize": "^4.0.2",
     "rawproto": "^0.7.6",

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -180,7 +180,7 @@ const stringToSerializedBufferFormat = (format: KeyValueFormat, value: string): 
     case KeyValueFormat.Msgpack: {
       try {
         const json = JSON.parse(value)
-        const encoded = pack(json)
+        const encoded = Uint8Array.from(pack(json))
         return anyToBuffer(encoded)
       } catch (e) {
         return stringToBuffer(value, format)

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -139,7 +139,7 @@ const bufferToSerializedFormat = (
     case KeyValueFormat.JSON: return reSerializeJSON(bufferToUTF8(value), space)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = decode(value.data)
+        const decoded = unpack(new Uint8Array(value.data)
         const stringified = JSON.stringify(decoded)
         return reSerializeJSON(stringified, space)
       } catch (e) {

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -1,4 +1,4 @@
-import { decode, encode } from '@msgpack/msgpack'
+import { unpack, pack } from 'msgpackr';
 // eslint-disable-next-line import/order
 import { Buffer } from 'buffer'
 import { isUndefined } from 'lodash'
@@ -72,7 +72,7 @@ const formattingBuffer = (
     case KeyValueFormat.JSON: return bufferToJSON(reply, props as FormattingProps)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = decode(reply.data)
+        const decoded = unpack(new Uint8Array(reply.data));
         const value = JSONBigInt.stringify(decoded)
         return JSONViewer({ value, ...props })
       } catch (e) {
@@ -180,7 +180,7 @@ const stringToSerializedBufferFormat = (format: KeyValueFormat, value: string): 
     case KeyValueFormat.Msgpack: {
       try {
         const json = JSON.parse(value)
-        const encoded = encode(json)
+        const encoded = pack(json)
         return anyToBuffer(encoded)
       } catch (e) {
         return stringToBuffer(value, format)

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -1,4 +1,4 @@
-import { unpack, pack } from 'msgpackr';
+import { encode, decode } from 'msgpackr';
 // eslint-disable-next-line import/order
 import { Buffer } from 'buffer'
 import { isUndefined } from 'lodash'
@@ -72,7 +72,7 @@ const formattingBuffer = (
     case KeyValueFormat.JSON: return bufferToJSON(reply, props as FormattingProps)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = unpack(new Uint8Array(reply.data));
+        const decoded = decode(reply.data);
         const value = JSONBigInt.stringify(decoded)
         return JSONViewer({ value, ...props })
       } catch (e) {
@@ -139,7 +139,7 @@ const bufferToSerializedFormat = (
     case KeyValueFormat.JSON: return reSerializeJSON(bufferToUTF8(value), space)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = unpack(new Uint8Array(value.data)
+        const decoded = decode(value.data)
         const stringified = JSON.stringify(decoded)
         return reSerializeJSON(stringified, space)
       } catch (e) {
@@ -180,7 +180,7 @@ const stringToSerializedBufferFormat = (format: KeyValueFormat, value: string): 
     case KeyValueFormat.Msgpack: {
       try {
         const json = JSON.parse(value)
-        const encoded = Uint8Array.from(pack(json))
+        const encoded = encode(json)
         return anyToBuffer(encoded)
       } catch (e) {
         return stringToBuffer(value, format)

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -72,7 +72,7 @@ const formattingBuffer = (
     case KeyValueFormat.JSON: return bufferToJSON(reply, props as FormattingProps)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = decode(reply.data);
+        const decoded = decode(Uint8Array.from(reply.data));
         const value = JSONBigInt.stringify(decoded)
         return JSONViewer({ value, ...props })
       } catch (e) {
@@ -139,7 +139,7 @@ const bufferToSerializedFormat = (
     case KeyValueFormat.JSON: return reSerializeJSON(bufferToUTF8(value), space)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = decode(value.data)
+        const decoded = decode(Uint8Array.from(value.data))
         const stringified = JSON.stringify(decoded)
         return reSerializeJSON(stringified, space)
       } catch (e) {

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -1,4 +1,4 @@
-import { encode, decode } from 'msgpackr';
+import { decode, encode } from 'msgpackr'
 // eslint-disable-next-line import/order
 import { Buffer } from 'buffer'
 import { isUndefined } from 'lodash'
@@ -72,7 +72,7 @@ const formattingBuffer = (
     case KeyValueFormat.JSON: return bufferToJSON(reply, props as FormattingProps)
     case KeyValueFormat.Msgpack: {
       try {
-        const decoded = decode(Uint8Array.from(reply.data));
+        const decoded = decode(Uint8Array.from(reply.data))
         const value = JSONBigInt.stringify(decoded)
         return JSONViewer({ value, ...props })
       } catch (e) {

--- a/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
@@ -25,7 +25,7 @@ describe('bufferToSerializedFormat', () => {
   describe(KeyValueFormat.Msgpack, () => {
     describe('should properly serialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
-        input: anyToBuffer(pack(v)),
+        input: anyToBuffer(Uint8Array.from(pack(v))),
         expected: JSON.stringify(v)
       }))
 
@@ -88,7 +88,7 @@ describe('stringToSerializedBufferFormat', () => {
     describe('should properly unserialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
         input: JSON.stringify(v),
-        expected: anyToBuffer(pack(v))
+        expected: anyToBuffer(Uint8Array.from(pack(v)))
       }))
 
       test.each(testValues)('test %j', ({ input, expected }) => {

--- a/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
@@ -1,4 +1,4 @@
-import { encode } from '@msgpack/msgpack'
+import { pack } from 'msgpackr'
 import { serialize } from 'php-serialize'
 import { KeyValueFormat } from 'uiSrc/constants'
 import { anyToBuffer, bufferToSerializedFormat, stringToBuffer, stringToSerializedBufferFormat } from 'uiSrc/utils'
@@ -25,7 +25,7 @@ describe('bufferToSerializedFormat', () => {
   describe(KeyValueFormat.Msgpack, () => {
     describe('should properly serialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
-        input: anyToBuffer(encode(v)),
+        input: anyToBuffer(pack(v)),
         expected: JSON.stringify(v)
       }))
 
@@ -88,7 +88,7 @@ describe('stringToSerializedBufferFormat', () => {
     describe('should properly unserialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
         input: JSON.stringify(v),
-        expected: anyToBuffer(encode(v))
+        expected: anyToBuffer(pack(v))
       }))
 
       test.each(testValues)('test %j', ({ input, expected }) => {

--- a/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
@@ -1,4 +1,4 @@
-import { pack } from 'msgpackr'
+import { encode } from 'msgpackr'
 import { serialize } from 'php-serialize'
 import { KeyValueFormat } from 'uiSrc/constants'
 import { anyToBuffer, bufferToSerializedFormat, stringToBuffer, stringToSerializedBufferFormat } from 'uiSrc/utils'
@@ -25,7 +25,7 @@ describe('bufferToSerializedFormat', () => {
   describe(KeyValueFormat.Msgpack, () => {
     describe('should properly serialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
-        input: anyToBuffer(Uint8Array.from(pack(v))),
+        input: anyToBuffer(encode(v)),
         expected: JSON.stringify(v)
       }))
 
@@ -88,7 +88,7 @@ describe('stringToSerializedBufferFormat', () => {
     describe('should properly unserialize', () => {
       const testValues = [{}, '""', 6677, true, { a: { b: [1, 2, '3'] } }].map((v) => ({
         input: JSON.stringify(v),
-        expected: anyToBuffer(Uint8Array.from(pack(v)))
+        expected: anyToBuffer(encode(v))
       }))
 
       test.each(testValues)('test %j', ({ input, expected }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,10 +1636,35 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz#b72a37c654e598f9ae6f8335faaee182bebc6b28"
   integrity sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==
 
-"@msgpack/msgpack@^2.7.2":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.8.0.tgz#4210deb771ee3912964f14a15ddfb5ff877e70b9"
-  integrity sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz#44d752c1a2dc113f15f781b7cc4f53a307e3fa38"
+  integrity sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz#f954f34355712212a8e06c465bc06c40852c6bb3"
+  integrity sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz#45c63037f045c2b15c44f80f0393fa24f9655367"
+  integrity sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz#35707efeafe6d22b3f373caf9e8775e8920d1399"
+  integrity sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz#091b1218b66c341f532611477ef89e83f25fae4f"
+  integrity sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
+  integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
 
 "@mswjs/cookies@^0.2.2":
   version "0.2.2"
@@ -10367,6 +10392,27 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msgpackr-extract@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz#e05ec1bb4453ddf020551bcd5daaf0092a2c279d"
+  integrity sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.7"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
+
+msgpackr@^1.9.7:
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.9.7.tgz#8f13c06d7a22946a6d8351804ce39a6a9e74ca83"
+  integrity sha512-baUNaLvKQvVhzfWTNO07njwbZK1Lxjtb0P1JL6/EhXdLTHzR57/mZqqJC39TtQKvOmkJA4pcejS4dbk7BDgLLA==
+  optionalDependencies:
+    msgpackr-extract "^3.0.2"
+
 msw@^0.45.0:
   version "0.45.0"
   resolved "https://registry.yarnpkg.com/msw/-/msw-0.45.0.tgz#7bab4ff0a03875aa17b7fefd5fbeea0b71f95957"
@@ -10480,6 +10526,11 @@ node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-gyp-build-optional-packages@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz#5d2632bbde0ab2f6e22f1bbac2199b07244ae0b3"
+  integrity sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==
 
 node-gyp-build@^4.2.1:
   version "4.6.0"


### PR DESCRIPTION
Fixes https://github.com/RedisInsight/RedisInsight/issues/2391


Test data:
```
echo '98A44E6F6E6581A15499CD07E7CCE9090408CE26DFE89700000081A15499CD07E7CCE9090409CE05B137F3000000B26C73612F7069755F61737369676E5F7266738192AD637573746F6D65725F6E616D65C081AA556E7265736F6C766564A87B2E2F6E616D657D8081A573746570739080' | xxd -r -p | redis-cli -x SET msg-pack-complex-2
```

Before:
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/0472131d-ea74-495d-85fa-4d0edba570bd)


After:
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/cdd22d62-4faf-44cb-82df-f348e4b3be45)
