### PR TITLE
RI-4852: Do non strict php unserialization

### DIFF
--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -81,7 +81,7 @@ const formattingBuffer = (
     }
     case KeyValueFormat.PHP: {
       try {
-        const decoded = unserialize(Buffer.from(reply.data), { encoding: 'binary' })
+        const decoded = unserialize(Buffer.from(reply.data), {}, { strict: false, encoding: 'binary' })
         const value = JSONBigInt.stringify(decoded)
         return JSONViewer({ value, ...props })
       } catch (e) {
@@ -148,7 +148,7 @@ const bufferToSerializedFormat = (
     }
     case KeyValueFormat.PHP: {
       try {
-        const decoded = unserialize(Buffer.from(value.data), { encoding: 'binary' })
+        const decoded = unserialize(Buffer.from(value.data), {}, { strict: false, encoding: 'binary' })
         const stringified = JSON.stringify(decoded)
         return reSerializeJSON(stringified, space)
       } catch (e) {


### PR DESCRIPTION
Fixes https://github.com/RedisInsight/RedisInsight/issues/1646

Sample data:
```
O:8:"stdClass":3:{s:3:"one";s:1:"1";s:3:"two";s:3:"...";s:5:"three";i:3;} 
```

Before:
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/3823adcd-00c1-4093-bc4d-0464c739e4fe)


After:
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/e0cf97cb-7682-41b3-86a5-b496ae5cc8ca)
