### PR TITLE
#RI-4960 - ms not changed to msec in No Slow Logs message

### DIFF
--- a/redisinsight/ui/src/pages/slowLog/components/EmptySlowLog/EmptySlowLog.spec.tsx
+++ b/redisinsight/ui/src/pages/slowLog/components/EmptySlowLog/EmptySlowLog.spec.tsx
@@ -10,4 +10,11 @@ describe('EmptySlowLog', () => {
       <EmptySlowLog durationUnit={DurationUnits.milliSeconds} slowlogLogSlowerThan={100} />
     )).toBeTruthy()
   })
+  it('should contain msec instead of ms', () => {
+    const { container } = render(
+      <EmptySlowLog durationUnit={DurationUnits.milliSeconds} slowlogLogSlowerThan={10000000} />
+    )
+
+    expect(container).toHaveTextContent('10 000 msec')
+  })
 })

--- a/redisinsight/ui/src/pages/slowLog/components/EmptySlowLog/EmptySlowLog.tsx
+++ b/redisinsight/ui/src/pages/slowLog/components/EmptySlowLog/EmptySlowLog.tsx
@@ -22,7 +22,9 @@ const EmptySlowLog = (props: Props) => {
         </EuiTitle>
         <EuiText color="subdued">
           Either no commands exceeding&nbsp;
-          {numberWithSpaces(convertNumberByUnits(slowlogLogSlowerThan, durationUnit))} {durationUnit}
+          {numberWithSpaces(convertNumberByUnits(slowlogLogSlowerThan, durationUnit))}
+          &nbsp;
+          {durationUnit === DurationUnits.milliSeconds ? DurationUnits.mSeconds : DurationUnits.microSeconds}
           &nbsp;were found or Slow Log is disabled on the server.
         </EuiText>
       </div>


### PR DESCRIPTION
#RI-4960 - ms not changed to msec in No Slow Logs message