### PR TITLE
support hyphens in node names

### DIFF
--- a/redisinsight/api/src/modules/browser/utils/clusterCursor.spec.ts
+++ b/redisinsight/api/src/modules/browser/utils/clusterCursor.spec.ts
@@ -15,6 +15,7 @@ const isClusterCursorValidTests = [
   },
   { input: '172.17.0.1:7001@-1', expected: true },
   { input: 'domain.com:7001@-1', expected: true },
+  { input: 'domain-with-hyphens.com:7001@-1', expected: true },
   { input: '172.17.0.1:7001@1228822', expected: true },
   { input: '172.17.0.1:7001@', expected: false },
   { input: '172.17.0.1:7001@text', expected: false },

--- a/redisinsight/api/src/modules/browser/utils/clusterCursor.ts
+++ b/redisinsight/api/src/modules/browser/utils/clusterCursor.ts
@@ -4,7 +4,7 @@ import { IGetNodeKeysResult } from 'src/modules/browser/services/keys-business/s
 const NODES_SEPARATOR = '||';
 const CURSOR_SEPARATOR = '@';
 // Correct format 172.17.0.1:7001@-1||172.17.0.1:7002@33
-const CLUSTER_CURSOR_REGEX = /^(([a-z0-9.])+:[0-9]+(@-?\d+)(?:\|{2}(?!$)|$))+$/;
+const CLUSTER_CURSOR_REGEX = /^(([a-z0-9.-])+:[0-9]+(@-?\d+)(?:\|{2}(?!$)|$))+$/;
 
 export const isClusterCursorValid = (cursor) => CLUSTER_CURSOR_REGEX.test(cursor);
 


### PR DESCRIPTION
This PR resolves issue described in Issue-2865 by allowing node names to contain hyphens

https://github.com/RedisInsight/RedisInsight/issues/2865
