### PR TITLE
#RI-5302, #RI-5304, #RI-5306, #RI-5307, #RI-5308

### DIFF
--- a/redisinsight/ui/src/components/database-side-panels/DatabaseSidePanels.test.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/DatabaseSidePanels.test.tsx
@@ -7,10 +7,12 @@ import {
 } from 'uiSrc/slices/recommendations/recommendations'
 import { fireEvent, screen, cleanup, mockedStore, render } from 'uiSrc/utils/test-utils'
 import { MOCK_RECOMMENDATIONS } from 'uiSrc/constants/mocks/mock-recommendations'
-import { insightsPanelSelector } from 'uiSrc/slices/panels/insights'
-
+import { changeSelectedTab, insightsPanelSelector, resetExplorePanelSearch, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { Pages } from 'uiSrc/constants'
+import { connectedInstanceCDSelector } from 'uiSrc/slices/instances/instances'
+import { InsightsPanelTabs } from 'uiSrc/slices/interfaces/insights'
+import { getTutorialCapability } from 'uiSrc/utils'
 import DatabaseSidePanels from './DatabaseSidePanels'
 
 let store: typeof mockedStore
@@ -36,6 +38,16 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
     connectionType: 'CLUSTER',
     provider: 'RE_CLOUD'
   }),
+  connectedInstanceCDSelector: jest.fn().mockReturnValue({
+    free: false,
+  }),
+}))
+
+jest.mock('uiSrc/slices/app/context', () => ({
+  ...jest.requireActual('uiSrc/slices/app/context'),
+  appContextCapability: jest.fn().mockReturnValue({
+    source: 'workbench RediSearch',
+  }),
 }))
 
 jest.mock('uiSrc/slices/recommendations/recommendations', () => ({
@@ -59,6 +71,11 @@ jest.mock('uiSrc/slices/panels/insights', () => ({
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
   sendEventTelemetry: jest.fn(),
+}))
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  getTutorialCapability: jest.fn().mockReturnValue({ tutorialPage: { id: 'id' }, telemetryName: 'searchAndQuery' }),
 }))
 
 /**
@@ -153,9 +170,9 @@ describe('DatabaseSidePanels', () => {
         page: '/triggered-functions/libraries',
         tab: 'recommendations'
       },
-    })
+    });
 
-    sendEventTelemetry.mockRestore()
+    (sendEventTelemetry as jest.Mock).mockRestore()
   })
 
   it('should call proper telemetry events on change tab', () => {
@@ -180,9 +197,9 @@ describe('DatabaseSidePanels', () => {
         prevTab: 'recommendations',
         currentTab: 'explore',
       },
-    })
+    });
 
-    sendEventTelemetry.mockRestore()
+    (sendEventTelemetry as jest.Mock).mockRestore()
   })
 
   it('should call proper telemetry events on fullscreen', () => {
@@ -203,8 +220,40 @@ describe('DatabaseSidePanels', () => {
         databaseId: 'instanceId',
         state: 'open'
       },
-    })
+    });
 
-    sendEventTelemetry.mockRestore()
+    (sendEventTelemetry as jest.Mock).mockRestore()
+  })
+
+  describe('capability', () => {
+    beforeEach(() => {
+      (connectedInstanceCDSelector as jest.Mock).mockReturnValueOnce({ free: true })
+    })
+    it('should call store actions', () => {
+      (getTutorialCapability as jest.Mock).mockImplementation(() => ({
+        tutorialPage: { args: { path: 'path' } }
+      }))
+      render(<DatabaseSidePanels />)
+
+      const expectedActions = [
+        getRecommendations(),
+        changeSelectedTab(InsightsPanelTabs.Explore),
+        toggleInsightsPanel(true),
+      ]
+      expect(store.getActions()).toEqual(expectedActions);
+
+      (getTutorialCapability as jest.Mock).mockRestore()
+    })
+    it('should call resetExplorePanelSearch if capability was not found', () => {
+      render(<DatabaseSidePanels />)
+
+      const expectedActions = [
+        getRecommendations(),
+        resetExplorePanelSearch(),
+        changeSelectedTab(InsightsPanelTabs.Explore),
+        toggleInsightsPanel(true),
+      ]
+      expect(store.getActions()).toEqual(expectedActions)
+    })
   })
 })

--- a/redisinsight/ui/src/components/database-side-panels/DatabaseSidePanels.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/DatabaseSidePanels.tsx
@@ -4,7 +4,7 @@ import { EuiButtonIcon, EuiTab, EuiTabs, keys } from '@elastic/eui'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 
-import { changeSelectedTab, insightsPanelSelector, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
+import { changeSelectedTab, insightsPanelSelector, resetExplorePanelSearch, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
 import { InsightsPanelTabs } from 'uiSrc/slices/interfaces/insights'
 import { recommendationsSelector } from 'uiSrc/slices/recommendations/recommendations'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -12,7 +12,8 @@ import { connectedInstanceCDSelector, connectedInstanceSelector } from 'uiSrc/sl
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 import { FullScreen, OnboardingTour } from 'uiSrc/components'
 import { appContextCapability } from 'uiSrc/slices/app/context'
-import { getTutorialCapability, showCapabilityTutorialPopover } from 'uiSrc/utils'
+import { getTutorialCapability } from 'uiSrc/utils'
+import { isShowCapabilityTutorialPopover } from 'uiSrc/services'
 import LiveTimeRecommendations from './panels/live-time-recommendations'
 import EnablementAreaWrapper from './panels/enablement-area'
 
@@ -58,14 +59,20 @@ const DatabaseSidePanels = (props: Props) => {
   }, [pathname, isFullScreen])
 
   useEffect(() => {
-    if (!capabilitySource || !showCapabilityTutorialPopover()) {
+    if (!capabilitySource || !isShowCapabilityTutorialPopover(free)) {
       return
     }
 
     const search = new URLSearchParams(window.location.search)
+    const tutorialCapabilityPath = getTutorialCapability(capabilitySource)?.tutorialPage?.args?.path || ''
 
     // set 'guidPath' with the path to capability tutorial
-    search.set('guidePath', getTutorialCapability(capabilitySource)?.tutorialPage?.args?.path)
+    if (tutorialCapabilityPath) {
+      search.set('guidePath', tutorialCapabilityPath)
+    } else {
+      // reset explore if tutorial is not found
+      dispatch(resetExplorePanelSearch())
+    }
 
     history.push({ search: search.toString() })
 

--- a/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/EnablementArea.spec.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/EnablementArea.spec.tsx
@@ -7,7 +7,6 @@ import { MOCK_GUIDES_ITEMS, MOCK_TUTORIALS_ITEMS, MOCK_CUSTOM_TUTORIALS_ITEMS } 
 import { EnablementAreaComponent, IEnablementAreaItem } from 'uiSrc/slices/interfaces'
 
 import { deleteWbCustomTutorial, uploadWbCustomTutorial } from 'uiSrc/slices/workbench/wb-custom-tutorials'
-import { showCapabilityTutorialPopover } from 'uiSrc/utils'
 import EnablementArea, { Props } from './EnablementArea'
 
 const mockedProps = mock<Props>()
@@ -29,11 +28,6 @@ jest.mock('uiSrc/slices/workbench/wb-guides', () => {
     }),
   }
 })
-
-jest.mock('uiSrc/utils', () => ({
-  ...jest.requireActual('uiSrc/utils'),
-  showCapabilityTutorialPopover: jest.fn(),
-}))
 
 describe('EnablementArea', () => {
   beforeEach(() => {
@@ -119,15 +113,6 @@ describe('EnablementArea', () => {
     await waitFor(() => {
       expect(pushMock).toBeCalledWith({ search: '?path=quick-guides/0/1' })
     }, { timeout: 1000 })
-  })
-
-  it('should call showCapabilityTutorialPopover', async () => {
-    const showCapabilityTutorialPopoverMock = jest.fn();
-    (showCapabilityTutorialPopover as jest.Mock).mockImplementation(() => showCapabilityTutorialPopoverMock)
-
-    render(<EnablementArea {...instance(mockedProps)} />)
-
-    expect(showCapabilityTutorialPopover).toBeCalled()
   })
 
   describe('Custom Tutorials', () => {

--- a/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/EnablementArea.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/EnablementArea.tsx
@@ -8,7 +8,7 @@ import { EnablementAreaComponent, IEnablementAreaItem } from 'uiSrc/slices/inter
 import { EnablementAreaProvider, IInternalPage } from 'uiSrc/pages/workbench/contexts/enablementAreaContext'
 import { ApiEndpoints, EAItemActions, EAManifestFirstKey, CodeButtonParams } from 'uiSrc/constants'
 import { deleteCustomTutorial, uploadCustomTutorial } from 'uiSrc/slices/workbench/wb-custom-tutorials'
-import { findMarkdownPathByPath, Nullable, showCapabilityTutorialPopover } from 'uiSrc/utils'
+import { findMarkdownPathByPath, Nullable } from 'uiSrc/utils'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {
   explorePanelSelector,
@@ -16,8 +16,6 @@ import {
   setExplorePanelIsPageOpen,
   setExplorePanelManifest,
 } from 'uiSrc/slices/panels/insights'
-import { appContextCapability } from 'uiSrc/slices/app/context'
-import { connectedInstanceCDSelector } from 'uiSrc/slices/instances/instances'
 import {
   FormValues
 } from './components/UploadTutorialForm/UploadTutorialForm'
@@ -67,8 +65,6 @@ const EnablementArea = (props: Props) => {
   const history = useHistory()
   const dispatch = useDispatch()
   const { manifest, search: searchEAContext, isPageOpen: isInternalPageVisible } = useSelector(explorePanelSelector)
-  const { tutorialPopoverShown } = useSelector(appContextCapability)
-  const { free = false } = useSelector(connectedInstanceCDSelector) ?? {}
 
   const contextManifestPath = new URLSearchParams(searchEAContext).get('path')
 
@@ -77,7 +73,6 @@ const EnablementArea = (props: Props) => {
     manifestPath: contextManifestPath
   })
   const [isCreateOpen, setIsCreateOpen] = useState(false)
-  const [showCapabilityPopover, setShowCapabilityPopover] = useState(showCapabilityTutorialPopover())
 
   const searchRef = useRef<string>('')
   const { instanceId = '' } = useParams<{ instanceId: string }>()
@@ -140,10 +135,6 @@ const EnablementArea = (props: Props) => {
 
     dispatch(setExplorePanelIsPageOpen(false))
   }, [search, customTutorials, guides, tutorials])
-
-  useEffect(() => {
-    setShowCapabilityPopover(showCapabilityTutorialPopover())
-  }, [tutorialPopoverShown, free])
 
   const getManifestByPath = (path: Nullable<string> = '') => {
     const manifestPath = path?.replace(/^\//, '') || ''
@@ -355,7 +346,6 @@ const EnablementArea = (props: Props) => {
               manifestPath={internalPage?.manifestPath}
               sourcePath={getWBSourcePath(internalPage?.path)}
               search={searchRef.current}
-              showCapabilityPopover={showCapabilityPopover}
             />
           )}
         </div>

--- a/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/components/InternalPage/InternalPage.spec.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/components/InternalPage/InternalPage.spec.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import { fireEvent, render } from 'uiSrc/utils/test-utils'
 import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
+import { isShowCapabilityTutorialPopover, setCapabilityPopoverShown } from 'uiSrc/services'
+import { connectedInstanceCDSelector } from 'uiSrc/slices/instances/instances'
+import { getTutorialCapability } from 'uiSrc/utils'
+
 import InternalPage, { Props } from './InternalPage'
 
 const mockedProps = mock<Props>()
@@ -15,6 +19,24 @@ jest.mock('uiSrc/slices/app/context', () => ({
   ...jest.requireActual('uiSrc/slices/app/context'),
   appContextCapability: jest.fn().mockReturnValue({
     source: 'workbench RediSearch',
+  }),
+}))
+
+jest.mock('uiSrc/services', () => ({
+  ...jest.requireActual('uiSrc/services'),
+  isShowCapabilityTutorialPopover: jest.fn(),
+  setCapabilityPopoverShown: jest.fn(),
+}))
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  getTutorialCapability: jest.fn().mockReturnValue({ tutorialPage: { id: 'id' }, telemetryName: 'searchAndQuery' }),
+}))
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  connectedInstanceCDSelector: jest.fn().mockReturnValue({
+    free: false,
   }),
 }))
 
@@ -52,18 +74,37 @@ describe('InternalPage', () => {
 
     expect(queryByTestId('header')).toBeInTheDocument()
   })
-  it('should send CAPABILITY_POPOVER_DISPLAYED telemetry event', () => {
-    const sendEventTelemetryMock = jest.fn();
-    (sendEventTelemetry as jest.Mock).mockImplementation(() => sendEventTelemetryMock)
 
-    render(<InternalPage {...instance(mockedProps)} showCapabilityPopover />)
+  describe('capability', () => {
+    beforeEach(() => {
+      (connectedInstanceCDSelector as jest.Mock).mockReturnValueOnce({ free: true })
+    })
+    it('should call isShowCapabilityTutorialPopover, setCapabilityPopoverShown and getTutorialCapability', async () => {
+      const isShowCapabilityTutorialPopoverMock = jest.fn()
+      const setCapabilityPopoverShownMock = jest.fn();
+      (isShowCapabilityTutorialPopover as jest.Mock).mockImplementation(() => isShowCapabilityTutorialPopoverMock);
+      (setCapabilityPopoverShown as jest.Mock).mockImplementation(() => setCapabilityPopoverShownMock)
 
-    expect(sendEventTelemetry).toBeCalledWith({
-      event: TelemetryEvent.CAPABILITY_POPOVER_DISPLAYED,
-      eventData: {
-        databaseId: 'instanceId',
-        capabilityName: 'searchAndQuery',
-      }
+      render(<InternalPage {...instance(mockedProps)} />)
+
+      expect(isShowCapabilityTutorialPopover).toBeCalled()
+      expect(setCapabilityPopoverShown).toBeCalled()
+      expect(getTutorialCapability).toBeCalled()
+    })
+
+    it('should send CAPABILITY_POPOVER_DISPLAYED telemetry event', () => {
+      const sendEventTelemetryMock = jest.fn();
+      (sendEventTelemetry as jest.Mock).mockImplementation(() => sendEventTelemetryMock)
+
+      render(<InternalPage {...instance(mockedProps)} />)
+
+      expect(sendEventTelemetry).toBeCalledWith({
+        event: TelemetryEvent.CAPABILITY_POPOVER_DISPLAYED,
+        eventData: {
+          databaseId: 'instanceId',
+          capabilityName: 'searchAndQuery',
+        }
+      })
     })
   })
 })

--- a/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
+++ b/redisinsight/ui/src/components/database-side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
@@ -46,11 +46,10 @@ export interface Props {
   manifestPath?: Nullable<string>
   sourcePath: string
   search: string
-  showCapabilityPopover: boolean
 }
 
 const LazyInternalPage = ({
-  onClose, title, path, sourcePath, manifest, manifestPath, search, showCapabilityPopover,
+  onClose, title, path, sourcePath, manifest, manifestPath, search,
 }: Props) => {
   const history = useHistory()
   const { itemScrollTop, data: contentContext, url } = useSelector(explorePanelSelector)
@@ -131,7 +130,6 @@ const LazyInternalPage = ({
       onScroll={handlePageScroll}
       scrollTop={itemScrollTop}
       pagination={pageData.relatedPages}
-      showCapabilityPopover={showCapabilityPopover}
     />
   )
 }

--- a/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.spec.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.spec.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, mockedStore, render } from 'uiSrc/utils/test-utils'
 import { TelemetryEvent, getRedisModulesSummary, sendEventTelemetry } from 'uiSrc/telemetry'
 import { freeInstancesSelector, setDefaultInstance } from 'uiSrc/slices/instances/instances'
 import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
+import { setCapability } from 'uiSrc/slices/app/context'
 import OAuthConnectFreeDb from './OAuthConnectFreeDb'
 
 jest.mock('uiSrc/telemetry', () => ({
@@ -56,7 +57,10 @@ describe('OAuthConnectFreeDb', () => {
       }
     })
 
-    const expectedActions = [setDefaultInstance()]
+    const expectedActions = [
+      setCapability({ source: OAuthSocialSource.ListOfDatabases, tutorialPopoverShown: false }),
+      setDefaultInstance(),
+    ]
     expect(store.getActions()).toEqual(expectedActions)
   })
 

--- a/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
@@ -14,6 +14,7 @@ import {
 } from 'uiSrc/slices/instances/instances'
 import { openNewWindowDatabase } from 'uiSrc/utils'
 import { Pages } from 'uiSrc/constants'
+import { setCapability } from 'uiSrc/slices/app/context'
 
 import styles from './styles.module.scss'
 
@@ -65,6 +66,7 @@ const OAuthConnectFreeDb = ({
   const handleCheckConnectToInstance = (
   ) => {
     sendTelemetry()
+    dispatch(setCapability({ source, tutorialPopoverShown: false }))
     dispatch(checkConnectToInstanceAction(
       targetDatabaseId,
       connectToInstanceSuccess,

--- a/redisinsight/ui/src/services/capability.ts
+++ b/redisinsight/ui/src/services/capability.ts
@@ -1,0 +1,13 @@
+import { CapabilityStorageItem } from 'uiSrc/constants/storage'
+import { getCapabilityStorageField, setCapabilityStorageField } from 'uiSrc/services'
+
+const TIME_TO_READ_POPOVER_TEXT = 1_000
+
+export const isShowCapabilityTutorialPopover = (isFree = false) =>
+  !!isFree && !getCapabilityStorageField(CapabilityStorageItem.tutorialPopoverShown)
+
+export const setCapabilityPopoverShown = () => {
+  setTimeout(() => {
+    setCapabilityStorageField(CapabilityStorageItem.tutorialPopoverShown, true)
+  }, TIME_TO_READ_POPOVER_TEXT)
+}

--- a/redisinsight/ui/src/services/index.ts
+++ b/redisinsight/ui/src/services/index.ts
@@ -5,4 +5,5 @@ export * from './routing'
 export * from './theme'
 export * from './storage'
 export * from './hooks'
+export * from './capability'
 export { apiService, resourcesService }

--- a/redisinsight/ui/src/slices/app/context.ts
+++ b/redisinsight/ui/src/slices/app/context.ts
@@ -69,8 +69,7 @@ export const initialState: StateAppContext = {
     lastViewedPage: ''
   },
   capability: {
-    source: '',
-    tutorialPopoverShown: false,
+    source: ''
   }
 }
 
@@ -182,16 +181,11 @@ const appContextSlice = createSlice({
     setLastTriggeredFunctionsPage: (state, { payload }: { payload: string }) => {
       state.triggeredFunctions.lastViewedPage = payload
     },
-    setCapabilityPopoverShown: (state, { payload }: PayloadAction<boolean>) => {
-      state.capability.tutorialPopoverShown = payload
-      setCapabilityStorageField(CapabilityStorageItem.tutorialPopoverShown, payload)
-    },
     setCapability: (state, { payload }: PayloadAction<Maybe<{ source: string, tutorialPopoverShown: boolean }>>) => {
       const source = payload?.source ?? ''
       const tutorialPopoverShown = !!payload?.tutorialPopoverShown
 
       state.capability.source = source
-      state.capability.tutorialPopoverShown = tutorialPopoverShown
 
       setCapabilityStorageField(CapabilityStorageItem.source, source)
       setCapabilityStorageField(CapabilityStorageItem.tutorialPopoverShown, tutorialPopoverShown)
@@ -228,7 +222,6 @@ export const {
   setLastTriggeredFunctionsPage,
   setBrowserTreeSort,
   setCapability,
-  setCapabilityPopoverShown,
 } = appContextSlice.actions
 
 // Selectors

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -102,7 +102,6 @@ export interface StateAppContext {
   }
   capability: {
     source: string
-    tutorialPopoverShown: boolean
   }
 }
 

--- a/redisinsight/ui/src/slices/tests/app/context.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/context.spec.ts
@@ -37,7 +37,6 @@ import reducer, {
   setDbIndexState,
   appContextDbIndex,
   setRecommendationsShowHidden,
-  setCapabilityPopoverShown,
   appContextCapability,
   setCapability,
 } from '../../app/context'
@@ -66,7 +65,7 @@ describe('slices', () => {
     it('should properly set initial state with existing contextId and capability', () => {
       // Arrange
       const contextInstanceId = '12312-3123'
-      const capability = { source: '123123', tutorialPopoverShown: true }
+      const capability = { source: '123123' }
       const prevState = {
         ...initialState,
         contextInstanceId,
@@ -612,34 +611,11 @@ describe('slices', () => {
     })
   })
 
-  describe('setCapabilityPopoverShown', () => {
-    it('should properly set is show hidden tutorial capability popover', () => {
-      // Arrange
-      const value = true
-
-      const state = {
-        ...initialState.capability,
-        tutorialPopoverShown: value
-      }
-
-      // Act
-      const nextState = reducer(initialState, setCapabilityPopoverShown(value))
-
-      // Assert
-      const rootState = Object.assign(initialStateDefault, {
-        app: { context: nextState },
-      })
-
-      expect(appContextCapability(rootState)).toEqual(state)
-    })
-  })
-
   describe('setCapability', () => {
     it('should properly set db config', () => {
       // Arrange
       const data = {
         source: '123123',
-        tutorialPopoverShown: true,
       }
 
       const state = {

--- a/redisinsight/ui/src/utils/capability.ts
+++ b/redisinsight/ui/src/utils/capability.ts
@@ -12,12 +12,6 @@ const getCapability = (
 })
 
 export const getSourceTutorialByCapability = (moduleName = '') => `${moduleName}_tutorial`
-export const showCapabilityTutorialPopover = () => {
-  const state = store.getState()
-
-  return !!state.connections.instances?.connectedInstance?.cloudDetails?.free
-    && !state.app.context.capability?.tutorialPopoverShown
-}
 
 export const getTutorialCapability = (source: any = '') => {
   switch (source) {
@@ -30,7 +24,7 @@ export const getTutorialCapability = (source: any = '') => {
     case getSourceTutorialByCapability(RedisDefaultModules.FTL):
       return getCapability(
         'searchAndQuery',
-        'Search and Query capability',
+        'Search and query capability',
         findMarkdownPathById(store.getState()?.workbench?.tutorials?.items, 'vector_similarity_search')
       )
 
@@ -48,7 +42,7 @@ export const getTutorialCapability = (source: any = '') => {
     case getSourceTutorialByCapability(RedisDefaultModules.TimeSeries):
       return getCapability(
         'timeSeries',
-        'time series data structure',
+        'Time series data structure',
         findMarkdownPathById(store.getState()?.workbench?.tutorials?.items, 'redis_for_time_series')
       )
 
@@ -57,7 +51,7 @@ export const getTutorialCapability = (source: any = '') => {
     case getSourceTutorialByCapability(RedisDefaultModules.Bloom):
       return getCapability(
         'probabilistic',
-        'probabilistic data structures',
+        'Probabilistic data structures',
         findMarkdownPathById(store.getState()?.workbench?.tutorials?.items, 'probabilistic_data_structures')
       )
 

--- a/redisinsight/ui/src/utils/tests/capability.spec.ts
+++ b/redisinsight/ui/src/utils/tests/capability.spec.ts
@@ -16,10 +16,10 @@ describe('getSourceTutorialByCapability', () => {
 })
 
 const emptyCapability = { name: '', telemetryName: '', tutorialPage: null, }
-const searchCapability = { name: 'Search and Query capability', telemetryName: 'searchAndQuery', tutorialPage: null, }
+const searchCapability = { name: 'Search and query capability', telemetryName: 'searchAndQuery', tutorialPage: null, }
 const jsonCapability = { name: 'JSON capability', telemetryName: 'JSON', tutorialPage: null, }
-const tsCapability = { name: 'time series data structure', telemetryName: 'timeSeries', tutorialPage: null, }
-const bloomCapability = { name: 'probabilistic data structures', telemetryName: 'probabilistic', tutorialPage: null, }
+const tsCapability = { name: 'Time series data structure', telemetryName: 'timeSeries', tutorialPage: null, }
+const bloomCapability = { name: 'Probabilistic data structures', telemetryName: 'probabilistic', tutorialPage: null, }
 
 const getTutorialCapabilityTests: any[] = [
   [OAuthSocialSource.RediSearch, searchCapability],


### PR DESCRIPTION
* #RI-5302 - Pop-over is still displayed if user opens cloud db after user has already launched it
* #RI-5304 - The list of tutorial is not displayed if user does not have a relevant tutorial
* #RI-5306 - Telemetry event is duplicated
* #RI-5307 - Telemetry event is sent if db in not free and popover is not displayed
* #RI-5308 - CAPABILITY_POPOVER_DISPLAYED is sent when 'Compatibility are not available' popover appears