### PR TITLE
Push to v1 docker repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,6 +1017,13 @@ jobs:
             -r $DOCKER_REPO \
             -v $appVersion
 
+            docker login -u $DOCKER_V1_USER -p $DOCKER_V1_PASS
+
+            ./.circleci/build/release-docker.sh \
+            -d redisinsight \
+            -r $DOCKER_V1_REPO \
+            -v $appVersion
+
   publish-prod-aws:
     executor: linux-executor
     steps:


### PR DESCRIPTION
This changes pushes the image to v1 repo - `redislabs/redisinsight`

- Creds are populated in CircleCI project environment variables.

