### PR TITLE
#RI-5497 - Insights_panel_opened/closed not sent 

### DIFF
--- a/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.spec.tsx
@@ -100,5 +100,16 @@ describe('CapabilityPromotion', () => {
     ]
 
     expect(store.getActions()).toEqual(expectedActions)
+
+    expect(sendEventTelemetry).toBeCalledWith({
+      event: TelemetryEvent.INSIGHTS_PANEL_OPENED,
+      eventData: {
+        databaseId: TELEMETRY_EMPTY_VALUE,
+        source: 'home page',
+        tab: InsightsPanelTabs.Explore,
+      }
+    });
+
+    (sendEventTelemetry as jest.Mock).mockRestore()
   })
 })

--- a/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.tsx
+++ b/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.tsx
@@ -5,11 +5,12 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { filter } from 'lodash'
 
-import { openTutorialByPath, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
+import { insightsPanelSelector, openTutorialByPath, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
 import { sendEventTelemetry, TELEMETRY_EMPTY_VALUE, TelemetryEvent } from 'uiSrc/telemetry'
 import { guideLinksSelector } from 'uiSrc/slices/content/guide-links'
 import GUIDE_ICONS from 'uiSrc/components/explore-guides/icons'
 import { findTutorialPath } from 'uiSrc/utils'
+import { InsightsPanelTabs } from 'uiSrc/slices/interfaces/insights'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -22,6 +23,7 @@ const displayedCapabilityIds = ['sq-intro', 'ds-json-intro']
 const CapabilityPromotion = (props: Props) => {
   const { mode = 'wide', wrapperClassName } = props
   const { data: dataInit } = useSelector(guideLinksSelector)
+  const { isOpen: isInsightsOpen } = useSelector(insightsPanelSelector)
 
   const dispatch = useDispatch()
   const history = useHistory()
@@ -29,21 +31,27 @@ const CapabilityPromotion = (props: Props) => {
   // display only RediSearch and JSON. In the future will be configured via github
   const data = filter(dataInit, ({ tutorialId }) => displayedCapabilityIds.includes(tutorialId))
 
-  const onClickTutorial = (id: string) => {
-    const tutorialPath = findTutorialPath({ id: id ?? '' })
-    dispatch(openTutorialByPath(tutorialPath ?? '', history))
-
+  const sendTelemetry = (id?: string) => {
     sendEventTelemetry({
-      event: TelemetryEvent.INSIGHTS_PANEL_OPENED,
+      event: isInsightsOpen ? TelemetryEvent.INSIGHTS_PANEL_CLOSED : TelemetryEvent.INSIGHTS_PANEL_OPENED,
       eventData: {
         databaseId: TELEMETRY_EMPTY_VALUE,
         source: 'home page',
-        tutorialId: id
+        tutorialId: id || undefined,
+        tab: id ? undefined : InsightsPanelTabs.Explore,
       },
     })
   }
 
+  const onClickTutorial = (id: string) => {
+    const tutorialPath = findTutorialPath({ id: id ?? '' })
+    dispatch(openTutorialByPath(tutorialPath ?? '', history))
+
+    sendTelemetry(id)
+  }
+
   const onClickExplore = () => {
+    sendTelemetry()
     dispatch(toggleInsightsPanel())
   }
 


### PR DESCRIPTION
#RI-5497 - Insights_panel_opened/closed not sent when clicking on "Explore Redis" button