### PR TITLE
#RI-5572 - Explore Redis button opens not only Explore tab

### DIFF
--- a/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.spec.tsx
@@ -96,6 +96,7 @@ describe('CapabilityPromotion', () => {
     fireEvent.click(screen.getByTestId('explore-redis-btn'))
 
     const expectedActions = [
+      changeSelectedTab(InsightsPanelTabs.Explore),
       toggleInsightsPanel()
     ]
 

--- a/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.tsx
+++ b/redisinsight/ui/src/pages/home/components/capability-promotion/CapabilityPromotion.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { filter } from 'lodash'
 
-import { insightsPanelSelector, openTutorialByPath, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
+import { changeSelectedTab, insightsPanelSelector, openTutorialByPath, toggleInsightsPanel } from 'uiSrc/slices/panels/insights'
 import { sendEventTelemetry, TELEMETRY_EMPTY_VALUE, TelemetryEvent } from 'uiSrc/telemetry'
 import { guideLinksSelector } from 'uiSrc/slices/content/guide-links'
 import GUIDE_ICONS from 'uiSrc/components/explore-guides/icons'
@@ -53,6 +53,7 @@ const CapabilityPromotion = (props: Props) => {
 
   const onClickExplore = () => {
     sendTelemetry()
+    dispatch(changeSelectedTab(InsightsPanelTabs.Explore))
     dispatch(toggleInsightsPanel())
   }
 


### PR DESCRIPTION
#RI-5572 - Explore Redis button opens not only Explore tab