### PR TITLE
[RI-5545] [RI-5543] Add support for non-native big integers and allow non-native big integers for Vector formatting

### DIFF
--- a/redisinsight/ui/src/components/json-viewer/JSONViewer.tsx
+++ b/redisinsight/ui/src/components/json-viewer/JSONViewer.tsx
@@ -11,10 +11,10 @@ interface Props {
 }
 
 const JSONViewer = (props: Props) => {
-  const { value, expanded = false, space = 2 } = props
+  const { value, expanded = false, space = 2, useNativeBigInt = true } = props
 
   try {
-    const data = JSONBigInt({ useNativeBigInt: true }).parse(value)
+    const data = JSONBigInt({ useNativeBigInt }).parse(value)
 
     return {
       value: (

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -108,7 +108,7 @@ const formattingBuffer = (
       try {
         const vector = Array.from(bufferToFloat32Array(reply.data))
         const value = JSONBigInt.stringify(vector)
-        return JSONViewer({ value, ...props })
+        return JSONViewer({ value, useNativeBigInt: false, ...props })
       } catch (e) {
         return { value: bufferToUTF8(reply), isValid: false }
       }
@@ -117,8 +117,7 @@ const formattingBuffer = (
       try {
         const vector = Array.from(bufferToFloat64Array(reply.data))
         const value = JSONBigInt.stringify(vector)
-
-        return JSONViewer({ value, ...props })
+        return JSONViewer({ value, useNativeBigInt: false, ...props })
       } catch (e) {
         return { value: bufferToUTF8(reply), isValid: false }
       }


### PR DESCRIPTION
Allow non-native big integers in JSONBigInt to convert large decimals. This can be the case for some language models that use large decimals in data. JSONBigInt will fall back to non-native big integers if they can't be packed in the native ones, so we still have support for the old ones. The support is explicitly added to Vector 32-bit and Vector 64-bit data.


When viewing some vector data that uses large numbers, which are often decimals, we try to pack them into javascript's native big int. Javascript's native big int doesn't support Big decimals yet. - https://github.com/sidorares/json-bigint/issues/88


We have two options:
1. Add support for non-native big integers when native big integers are not supported
2. Raise an exception and show the data in UTF8

This PR chooses 1. Please check [ticket comment](https://redislabs.atlassian.net/browse/RI-5545?focusedCommentId=1789830).



## Vector visualization
### Data that can be packed into native big int
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/bd7a6e7d-8c07-4998-9fec-210dd0353522)

### Data that are too large to be packed into native big Int
![image](https://github.com/RedisInsight/RedisInsight/assets/20211167/15659809-0b88-4416-a328-6bc947293fb6)
