### PR TITLE
Bump protobuf version to fix critical alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "word-wrap": "1.2.4",
     "electron-builder/app-builder-lib/@electron/universal/dir-compare/minimatch": "^3.0.5",
     "**/semver": "^7.5.2",
-    "rawproto/protobufjs": "^7.2.4",
+    "rawproto/protobufjs": "^7.2.5",
     "**/follow-redirects": "^1.15.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11633,10 +11633,10 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.2.0.tgz#b74f522c31c097b5149e3c3cb8d7f3defd986a1d"
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
-protobufjs@^6.10.2, protobufjs@^7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
-  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
+protobufjs@^6.10.2, protobufjs@^7.2.5:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.0.tgz#a32ec0422c039798c41a0700306a6e305b9cb32c"
+  integrity sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
Bump protobuf version.

This fixes - https://github.com/RedisInsight/RedisInsight/security/dependabot/377.