### PR TITLE
Extend slots refresh timeout to 5s 

### DIFF
--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
@@ -82,6 +82,7 @@ export class IoredisRedisConnectionStrategy extends RedisConnectionStrategy {
   ): Promise<ClusterOptions> {
     return {
       clusterRetryStrategy: options.useRetry ? this.retryStrategy.bind(this) : this.dummyFn.bind(this),
+      slotsRefreshTimeout: 5000,
       redisOptions: await this.getRedisOptions(clientMetadata, database, options),
     };
   }


### PR DESCRIPTION
https://github.com/RedisInsight/RedisInsight/issues/3429

The excessively short default slots refresh timeout, connect error occur when responses are delayed. 
Therefore, the timeout has been extended to 5s to ensure that such delays do not result in connection abnormalities.