### PR TITLE
RI-5336: Fix profiler timestamp if its invalid

### DIFF
--- a/redisinsight/api/src/modules/profiler/models/profiler.client.ts
+++ b/redisinsight/api/src/modules/profiler/models/profiler.client.ts
@@ -43,8 +43,14 @@ export class ProfilerClient {
       time, args, source, database,
     } = payload;
 
+    // If there's [ in the time, strip it out.
+    //
+    // There is a case of a timestamp coming with '[' on Alibaba
+    // Redis's monitor.
+    const newTime = time.split('[')[0];
+
     this.items.push({
-      time, args, source, database,
+      time: newTime, args, source, database,
     });
 
     this.debounce();


### PR DESCRIPTION
Strip of '[' and the trailing data if there's any in the MONITOR timestamp.

A timestamp is coming with '[' on Alibaba Redis's monitor - #2915.