### PR TITLE
CR-129 feature/build statics extract plugins from archive

### DIFF
--- a/scripts/build-statics.sh
+++ b/scripts/build-statics.sh
@@ -47,8 +47,11 @@ function extract_plugins {
   fi
 }
 
+# env variable pluginsBuild=1 will enforce plugins build
+pluginsBuild="${pluginsBuild:-0}"
+
 # if Extract plugins succeeds, we are done
-if extract_plugins; then
+if [ "$pluginsBuild" = 0 ] &&  extract_plugins; then
   echo "Plugins were extracted successfully"
   exit 0
 fi

--- a/scripts/build-statics.sh
+++ b/scripts/build-statics.sh
@@ -47,6 +47,7 @@ function extract_plugins {
   fi
 }
 
+# if Extract plugins succeeds, we are done
 if extract_plugins; then
   echo "Plugins were extracted successfully"
   exit 0

--- a/scripts/build-statics.sh
+++ b/scripts/build-statics.sh
@@ -8,14 +8,49 @@ PLUGINS_DIR="./redisinsight/api/static/plugins"
 PLUGINS_VENDOR_DIR="./redisinsight/api/static/resources/plugins"
 
 # Default plugins assets
-sass "./redisinsight/ui/src/styles/main_plugin.scss" "./vendor/global_styles.css" --style=compressed --no-source-map;
-sass "./redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss" "./vendor/dark_theme.css" --style=compressed --no-source-map;
-sass "./redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss" "./vendor/light_theme.css" --style=compressed --no-source-map;
+sass "./redisinsight/ui/src/styles/main_plugin.scss" "./vendor/global_styles.css" --style=compressed --no-source-map
+sass "./redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss" "./vendor/dark_theme.css" --style=compressed --no-source-map
+sass "./redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss" "./vendor/light_theme.css" --style=compressed --no-source-map
 cp -R "./redisinsight/ui/src/assets/fonts/graphik/" "./vendor/fonts"
 cp -R "./redisinsight/ui/src/assets/fonts/inconsolata/" "./vendor/fonts"
 mkdir -p "${PLUGINS_VENDOR_DIR}"
 cp -R "./vendor/." "${PLUGINS_VENDOR_DIR}"
 
+function extract_plugins {
+  # use RI_BUILD_ARCHIVE_SRC_URL env variable to override default archive url
+  local ARCHIVE_SRC_URL="${RI_BUILD_ARCHIVE_SRC_URL:-"https://output.circle-artifacts.com/output/job/109205c7-1885-4bd8-a914-638bd0c45fb8/artifacts/0/release/web/Redis-Insight-web-linux-musl.x64.tar.gz"}"
+  local ARCHIVE_PLUGINS_DIR="api/dist/static/plugins"
+  if [ "$pluginsOnlyInstall" != 1 ]; then
+    # create temp dir to extract archive
+    local TEMP
+    TEMP="$(mktemp -d)"
+    echo "Creating temp dir: $TEMP"
+    mkdir -p "$TEMP"
+    echo "Download static build from $ARCHIVE_SRC_URL and copy plugins into '$PLUGINS_DIR'"
+    wget -cq "$ARCHIVE_SRC_URL" -O - | tar -C "$TEMP" -xz $ARCHIVE_PLUGINS_DIR
+    local extracted=$?
+    if [ ! $extracted -eq 0 ]; then
+      echo "Failed to download RI build from $ARCHIVE_SRC_URL"
+      return 1
+    fi
+    mkdir -p "${PLUGINS_DIR}"
+    cp -R "${TEMP}/${ARCHIVE_PLUGINS_DIR}" "${PLUGINS_DIR}"
+
+    if [ -d "${TEMP}" ]; then
+      echo "$TEMP Directory exists. Deleting it"
+      rm -rf "${TEMP}"
+      echo "Deleted $TEMP"
+    fi
+    echo "Done"
+  else
+    echo "Skipping plugins extraction"
+  fi
+}
+
+if extract_plugins; then
+  echo "Plugins were extracted successfully"
+  exit 0
+fi
 
 # Build redisearch plugin
 REDISEARCH_DIR="./redisinsight/ui/src/packages/redisearch"
@@ -25,7 +60,6 @@ if [ $pluginsOnlyInstall != 1 ]; then
   mkdir -p "${PLUGINS_DIR}/redisearch"
   cp -R "${REDISEARCH_DIR}/dist" "${REDISEARCH_DIR}/package.json" "${PLUGINS_DIR}/redisearch"
 fi
-
 
 # Build redisgraph plugin
 REDISGRAPH_DIR="./redisinsight/ui/src/packages/redisgraph"


### PR DESCRIPTION
Add ability to re-use prebuilt RI plugins
use `env pluginsBuild=1 yarn build:statics ` to enforce plugins to be built from source
use `env RI_BUILD_ARCHIVE_SRC_URL="example.com" yarn build:statics`  to point to different archive to extract from