### PR TITLE
Use proxy path prefix for theme to make it work for multiple subpath instances

### DIFF
--- a/redisinsight/ui/src/services/theme.ts
+++ b/redisinsight/ui/src/services/theme.ts
@@ -7,7 +7,7 @@ interface Themes {
 
 class ThemeService {
   readonly themes: Themes = {}
-
+  readonly keyName = window.__RI_PROXY_PATH__ ? (window.__RI_PROXY_PATH__ + '_' +  BrowserStorageItem.theme) : BrowserStorageItem.theme
   registerTheme(theme: Theme, cssFiles: any) {
     this.themes[theme] = cssFiles
   }
@@ -26,13 +26,12 @@ class ThemeService {
     sheet?.replaceSync(this.themes[newTheme])
 
     document.adoptedStyleSheets = [sheet]
-
-    localStorageService.set(BrowserStorageItem.theme, actualTheme)
+    localStorageService.set(this.keyName, actualTheme)
     document.body.classList.value = `theme_${newTheme}`
   }
 
   static getTheme() {
-    return localStorageService.get(BrowserStorageItem.theme)
+    return localStorageService.get(this.keyName)
   }
 }
 export const themeService = new ThemeService()


### PR DESCRIPTION
Fix: https://github.com/RedisInsight/RedisInsight/issues/3282

Use proxy path prefix in the theme keyname to respect multiple subpath instances running simultaneously.


