### PR TITLE
fix: ensure BigInt values show correctly in JSON view

### DIFF
--- a/redisinsight/api/src/app.module.ts
+++ b/redisinsight/api/src/app.module.ts
@@ -26,17 +26,19 @@ import { CloudModule } from 'src/modules/cloud/cloud.module';
 import { RdiModule } from 'src/modules/rdi/rdi.module';
 import { AiChatModule } from 'src/modules/ai/chat/ai-chat.module';
 import { AiQueryModule } from 'src/modules/ai/query/ai-query.module';
-import { BrowserModule } from './modules/browser/browser.module';
-import { RedisEnterpriseModule } from './modules/redis-enterprise/redis-enterprise.module';
-import { RedisSentinelModule } from './modules/redis-sentinel/redis-sentinel.module';
-import { ProfilerModule } from './modules/profiler/profiler.module';
-import { CliModule } from './modules/cli/cli.module';
-import { StaticsManagementModule } from './modules/statics-management/statics-management.module';
-import { ExcludeRouteMiddleware } from './middleware/exclude-route.middleware';
-import SubpathProxyMiddleware from './middleware/subpath-proxy.middleware';
-import XFrameOptionsMiddleware from './middleware/x-frame-options.middleware';
-import { routes } from './app.routes';
-import { RedisConnectionMiddleware, redisConnectionControllers } from './middleware/redis-connection';
+import { BrowserModule } from 'src/modules/browser/browser.module';
+import { RedisEnterpriseModule } from 'src/modules/redis-enterprise/redis-enterprise.module';
+import { RedisSentinelModule } from 'src/modules/redis-sentinel/redis-sentinel.module';
+import { ProfilerModule } from 'src/modules/profiler/profiler.module';
+import { CliModule } from 'src/modules/cli/cli.module';
+import { StaticsManagementModule } from 'src/modules/statics-management/statics-management.module';
+import { ExcludeRouteMiddleware } from 'src/middleware/exclude-route.middleware';
+import SubpathProxyMiddleware from 'src/middleware/subpath-proxy.middleware';
+import XFrameOptionsMiddleware from 'src/middleware/x-frame-options.middleware';
+import { routes } from 'src/app.routes';
+import { RedisConnectionMiddleware, redisConnectionControllers } from 'src/middleware/redis-connection';
+import { JSONBigIntSerializationMiddleware } from 'src/middleware/json-bigint-serialization.middleware';
+import { RejsonRlController } from 'src/modules/browser/rejson-rl/rejson-rl.controller';
 
 const SERVER_CONFIG = config.get('server') as Config['server'];
 const PATH_CONFIG = config.get('dir_path') as Config['dir_path'];
@@ -142,5 +144,9 @@ export class AppModule implements OnModuleInit, NestModule {
     consumer
       .apply(RedisConnectionMiddleware)
       .forRoutes(...redisConnectionControllers);
+
+    consumer
+      .apply(JSONBigIntSerializationMiddleware)
+      .forRoutes(RejsonRlController)
   }
 }

--- a/redisinsight/api/src/middleware/json-bigint-serialization.middleware.ts
+++ b/redisinsight/api/src/middleware/json-bigint-serialization.middleware.ts
@@ -1,0 +1,19 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import * as JSONBigInt from 'json-bigint';
+
+@Injectable()
+export class JSONBigIntSerializationMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    res.json = (body: any) => {
+      try {
+        const jsonString = JSONBigInt.stringify(body);
+        return res.send(jsonString);
+      } catch (e) {
+        const jsonString = JSON.stringify(body);
+        return res.send(jsonString);
+      }
+    };
+
+    next();
+  }
+}

--- a/redisinsight/api/src/modules/browser/rejson-rl/dto/safe.rejson-rl-data.dto.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/dto/safe.rejson-rl-data.dto.ts
@@ -40,5 +40,5 @@ export class SafeRejsonRlDataDto {
     type: String,
     description: 'Any value',
   })
-  value?: string | number | boolean | null;
+  value?: string | number | boolean | bigint | null;
 }

--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
@@ -5,6 +5,8 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import * as JSONBigInt from 'json-bigint';
+
 import { RedisErrorCodes } from 'src/constants';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { catchAclError } from 'src/utils';
@@ -51,7 +53,11 @@ export class RejsonRlService {
       );
     }
 
-    return JSON.parse(data);
+    try {
+      return JSONBigInt({ useNativeBigInt: true }).parse(data);
+    }catch (e) {
+      return JSON.parse(data);
+    }
   }
 
   private async estimateSize(

--- a/redisinsight/ui/src/services/apiService.ts
+++ b/redisinsight/ui/src/services/apiService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { isNumber } from 'lodash'
+import JSONBigInt from 'json-bigint'
 import { sessionStorageService } from 'uiSrc/services'
 import { BrowserStorageItem } from 'uiSrc/constants'
 import { CLOUD_AUTH_API_ENDPOINTS, CustomHeaders } from 'uiSrc/constants/api'
@@ -25,6 +26,15 @@ export const getBaseUrl = () => (!isDevelopment && isWebApp
 const mutableAxiosInstance: AxiosInstance = axios.create({
   baseURL: hostedApiBaseUrl || getBaseUrl(),
   withCredentials: !!hostedApiBaseUrl,
+  transformResponse: [
+    (data) => {
+      try {
+        return JSONBigInt({ useNativeBigInt: true }).parse(data)
+      } catch (e) {
+        return JSON.parse(data)
+      }
+    },
+  ],
 })
 
 export const setApiCsrfHeader = (token: string) => {


### PR DESCRIPTION
As you know, Node.js doesn't support scalar over 2^53 defaultly but support in Redis. So when receive scalar over 2^53 then loses precision in JSON.

"MailId" is Bigint but BigInt loses precision in JSON view like follow as.  

![Group 41](https://github.com/user-attachments/assets/406463ac-8197-422f-9567-480344616349)


So I added handler about BigInt. BigInt(MailId) doesn't lose precision follow as.  

![Group 40](https://github.com/user-attachments/assets/6c24a201-9bc8-46db-8cb0-e26618bf40fb)
