### PR TITLE
CR-132: web socket connection

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -18,7 +18,6 @@ const defaultsDir = process.env.RI_DEFAULTS_DIR
     : join(__dirname, '..', 'defaults'));
 
 const proxyPath = trim(process.env.RI_PROXY_PATH, '/');
-const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH, '/api');
 
 const customPluginsUri = posix.join('/', proxyPath, 'plugins');
 const staticUri = posix.join('/', proxyPath, 'static');
@@ -28,7 +27,10 @@ const contentUri = posix.join('/', proxyPath, 'static', 'content');
 const defaultPluginsUri = posix.join('/', proxyPath, 'static', 'plugins');
 const pluginsAssetsUri = posix.join('/', proxyPath, 'static', 'resources', 'plugins');
 
+const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH || '/api', '/');
+
 const socketPath = posix.join('/', 'api', 'socket.io');
+
 // const socketPath = posix.join('/', proxyPath, 'socket.io');
 const dataDir = process.env.RI_BUILD_TYPE === 'ELECTRON' && process['resourcesPath']
   ? join(process['resourcesPath'], 'data')

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -27,9 +27,9 @@ const contentUri = posix.join('/', proxyPath, 'static', 'content');
 const defaultPluginsUri = posix.join('/', proxyPath, 'static', 'plugins');
 const pluginsAssetsUri = posix.join('/', proxyPath, 'static', 'resources', 'plugins');
 
-const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH || '/api', '/');
+const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH || 'api', '/');
 
-const socketPath = posix.join('/', 'api', 'socket.io');
+const socketPath = posix.join('/', socketProxyPath, 'socket.io');
 
 // const socketPath = posix.join('/', proxyPath, 'socket.io');
 const dataDir = process.env.RI_BUILD_TYPE === 'ELECTRON' && process['resourcesPath']

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -31,7 +31,6 @@ const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH || 'api', '/');
 
 const socketPath = posix.join('/', socketProxyPath, 'socket.io');
 
-// const socketPath = posix.join('/', proxyPath, 'socket.io');
 const dataDir = process.env.RI_BUILD_TYPE === 'ELECTRON' && process['resourcesPath']
   ? join(process['resourcesPath'], 'data')
   : join(__dirname, '..', 'data');

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -18,6 +18,7 @@ const defaultsDir = process.env.RI_DEFAULTS_DIR
     : join(__dirname, '..', 'defaults'));
 
 const proxyPath = trim(process.env.RI_PROXY_PATH, '/');
+const socketProxyPath = trim(process.env.RI_SOCKET_PROXY_PATH, '/api');
 
 const customPluginsUri = posix.join('/', proxyPath, 'plugins');
 const staticUri = posix.join('/', proxyPath, 'static');
@@ -27,7 +28,7 @@ const contentUri = posix.join('/', proxyPath, 'static', 'content');
 const defaultPluginsUri = posix.join('/', proxyPath, 'static', 'plugins');
 const pluginsAssetsUri = posix.join('/', proxyPath, 'static', 'resources', 'plugins');
 
-const socketPath = posix.join('/', proxyPath, 'socket.io');
+const socketPath = posix.join('/', socketProxyPath, 'socket.io');
 const dataDir = process.env.RI_BUILD_TYPE === 'ELECTRON' && process['resourcesPath']
   ? join(process['resourcesPath'], 'data')
   : join(__dirname, '..', 'data');

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -28,7 +28,8 @@ const contentUri = posix.join('/', proxyPath, 'static', 'content');
 const defaultPluginsUri = posix.join('/', proxyPath, 'static', 'plugins');
 const pluginsAssetsUri = posix.join('/', proxyPath, 'static', 'resources', 'plugins');
 
-const socketPath = posix.join('/', socketProxyPath, 'socket.io');
+const socketPath = posix.join('/', 'api', 'socket.io');
+// const socketPath = posix.join('/', proxyPath, 'socket.io');
 const dataDir = process.env.RI_BUILD_TYPE === 'ELECTRON' && process['resourcesPath']
   ? join(process['resourcesPath'], 'data')
   : join(__dirname, '..', 'data');

--- a/redisinsight/ui/src/App.tsx
+++ b/redisinsight/ui/src/App.tsx
@@ -40,7 +40,6 @@ const AppWrapper = ({ children }: { children?: ReactElement[] }) => (
 )
 const App = ({ children }: { children?: ReactElement[] }) => {
   const { loading: serverLoading } = useSelector(appInfoSelector)
-  console.log('Test');
   return (
     <div className="main-container">
       <ThemeComponent />

--- a/redisinsight/ui/src/App.tsx
+++ b/redisinsight/ui/src/App.tsx
@@ -40,6 +40,7 @@ const AppWrapper = ({ children }: { children?: ReactElement[] }) => (
 )
 const App = ({ children }: { children?: ReactElement[] }) => {
   const { loading: serverLoading } = useSelector(appInfoSelector)
+  console.log('Test');
   return (
     <div className="main-container">
       <ThemeComponent />

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -3,35 +3,40 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Socket } from 'socket.io-client'
 
 import {
-  setLoading,
-  setBulkDeleteLoading,
+  bulkActionsDeleteSelector,
   bulkActionsSelector,
   disconnectBulkDeleteAction,
   setBulkActionConnected,
-  setDeleteOverview,
   setBulkActionsInitialState,
-  bulkActionsDeleteSelector,
+  setBulkDeleteLoading,
+  setDeleteOverview,
   setDeleteOverviewStatus,
+  setLoading,
 } from 'uiSrc/slices/browser/bulkActions'
 import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
 import { sessionStorageService } from 'uiSrc/services'
 import { keysSelector } from 'uiSrc/slices/browser/keys'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { isProcessingBulkAction } from 'uiSrc/pages/browser/components/bulk-actions/utils'
-import { BrowserStorageItem, BulkActionsServerEvent, BulkActionsStatus, BulkActionsType, FeatureFlags, SocketEvent, } from 'uiSrc/constants'
+import {
+  BrowserStorageItem,
+  BulkActionsServerEvent,
+  BulkActionsStatus,
+  BulkActionsType,
+  SocketEvent,
+} from 'uiSrc/constants'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
 import { appCsrfSelector } from 'uiSrc/slices/app/csrf'
-import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
-import { wsService } from 'uiSrc/services/wsService'
+import { useIoConnection } from 'uiSrc/services/hooks/useIoConnection'
 
 const BulkActionsConfig = () => {
   const { id: instanceId = '', db } = useSelector(connectedInstanceSelector)
   const { isConnected } = useSelector(bulkActionsSelector)
   const { isActionTriggered: isDeleteTriggered } = useSelector(bulkActionsDeleteSelector)
   const { filter, search } = useSelector(keysSelector)
-  const { [FeatureFlags.envDependent]: envDependent } = useSelector(appFeatureFlagsFeaturesSelector)
   const { token } = useSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
+  const connectIo = useIoConnection(`${getBaseApiUrl()}/bulk-actions`, { token })
 
   const dispatch = useDispatch()
 
@@ -41,19 +46,7 @@ const BulkActionsConfig = () => {
     }
 
     let retryTimer: NodeJS.Timer
-    socketRef.current = wsService(`${getBaseApiUrl()}/bulk-actions`, { token, }, envDependent?.flag)
-    // socketRef.current = io(`${getBaseApiUrl()}/bulk-actions`, {
-    //   path: getProxyPath(),
-    //   forceNew: true,
-    //   query: { instanceId },
-    //   extraHeaders: {
-    //     [CustomHeaders.WindowId]: window.windowId || '',
-    //     ...(token ? { [CustomHeaders.CsrfToken]: token } : {}),
-    //   },
-    //   rejectUnauthorized: false,
-    //   transports: riConfig.api.socketTransports?.split(','),
-    //   withCredentials: riConfig.api.socketCredentials,
-    // })
+    socketRef.current = connectIo()
 
     socketRef.current.on(SocketEvent.Connect, () => {
       clearTimeout(retryTimer)

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -13,7 +13,7 @@ import {
   setDeleteOverviewStatus,
   setLoading,
 } from 'uiSrc/slices/browser/bulkActions'
-import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
+import { getSocketApiUrl, Nullable } from 'uiSrc/utils'
 import { sessionStorageService } from 'uiSrc/services'
 import { keysSelector } from 'uiSrc/slices/browser/keys'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -36,7 +36,7 @@ const BulkActionsConfig = () => {
   const { filter, search } = useSelector(keysSelector)
   const { token } = useSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(`${getBaseApiUrl()}/bulk-actions`, { token })
+  const connectIo = useIoConnection(getSocketApiUrl('bulk-actions'), { token })
 
   const dispatch = useDispatch()
 

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -1,25 +1,22 @@
 import { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { io, Socket } from 'socket.io-client'
+import { Socket } from 'socket.io-client'
 
 import { remove } from 'lodash'
-import { CloudJobEvents, SocketEvent, SocketFeaturesEvent } from 'uiSrc/constants'
+import { CloudJobEvents, FeatureFlags, SocketEvent, SocketFeaturesEvent } from 'uiSrc/constants'
 import { NotificationEvent } from 'uiSrc/constants/notifications'
 import { setNewNotificationAction } from 'uiSrc/slices/app/notifications'
 import { setIsConnected } from 'uiSrc/slices/app/socket-connection'
-import { getBaseApiUrl, Nullable, getProxyPath } from 'uiSrc/utils'
+import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addUnreadRecommendations } from 'uiSrc/slices/recommendations/recommendations'
 import { RecommendationsSocketEvents } from 'uiSrc/constants/recommendations'
-import { getFeatureFlagsSuccess } from 'uiSrc/slices/app/features'
-import { CustomHeaders } from 'uiSrc/constants/api'
+import { appFeatureFlagsFeaturesSelector, getFeatureFlagsSuccess } from 'uiSrc/slices/app/features'
 import { oauthCloudJobSelector, setJob } from 'uiSrc/slices/oauth/cloud'
 import { CloudJobName } from 'uiSrc/electron/constants'
 import { appCsrfSelector } from 'uiSrc/slices/app/csrf'
-import { getConfig } from 'uiSrc/config'
+import { wsService } from 'uiSrc/services/wsService'
 import { CloudJobInfo } from 'apiSrc/modules/cloud/job/models'
-
-const riConfig = getConfig()
 
 const CommonAppSubscription = () => {
   const { id: jobId = '' } = useSelector(oauthCloudJobSelector) ?? {}
@@ -27,6 +24,7 @@ const CommonAppSubscription = () => {
   const { token } = useSelector(appCsrfSelector)
   const [recommendationsSubscriptions, setRecommendationsSubscriptions] = useState<string[]>([])
   const socketRef = useRef<Nullable<Socket>>(null)
+  const { [FeatureFlags.envDependent]: envDependent } = useSelector(appFeatureFlagsFeaturesSelector)
 
   const dispatch = useDispatch()
 
@@ -35,18 +33,11 @@ const CommonAppSubscription = () => {
       return
     }
 
-    socketRef.current = io(`${getBaseApiUrl()}`, {
-      path: getProxyPath(),
+    socketRef.current = wsService(`${getBaseApiUrl()}`, {
       forceNew: false,
+      token,
       reconnection: true,
-      query: token ? { [CustomHeaders.CsrfToken]: token } : {},
-      extraHeaders: {
-        [CustomHeaders.WindowId]: window.windowId || '',
-      },
-      rejectUnauthorized: false,
-      transports: riConfig.api.socketTransports?.split(','),
-      withCredentials: riConfig.api.socketCredentials,
-    })
+    }, envDependent?.flag)
 
     socketRef.current.on(SocketEvent.Connect, () => {
       dispatch(setIsConnected(true))

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -39,9 +39,9 @@ const CommonAppSubscription = () => {
       path: getProxyPath(),
       forceNew: false,
       reconnection: true,
+      query: token ? { [CustomHeaders.CsrfToken]: token } : {},
       extraHeaders: {
         [CustomHeaders.WindowId]: window.windowId || '',
-        ...(token ? { [CustomHeaders.CsrfToken]: token } : {}),
       },
       rejectUnauthorized: false,
       transports: riConfig.api.socketTransports?.split(','),

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -24,7 +24,7 @@ const CommonAppSubscription = () => {
   const { token } = useSelector(appCsrfSelector)
   const [recommendationsSubscriptions, setRecommendationsSubscriptions] = useState<string[]>([])
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(getSocketApiUrl('/pub-sub'), {
+  const connectIo = useIoConnection(getSocketApiUrl(), {
     forceNew: false,
     token,
     reconnection: true })

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -24,7 +24,7 @@ const CommonAppSubscription = () => {
   const { token } = useSelector(appCsrfSelector)
   const [recommendationsSubscriptions, setRecommendationsSubscriptions] = useState<string[]>([])
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(getSocketApiUrl(), {
+  const connectIo = useIoConnection(getSocketApiUrl('/pub-sub'), {
     forceNew: false,
     token,
     reconnection: true })

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -7,7 +7,7 @@ import { CloudJobEvents, SocketEvent, SocketFeaturesEvent } from 'uiSrc/constant
 import { NotificationEvent } from 'uiSrc/constants/notifications'
 import { setNewNotificationAction } from 'uiSrc/slices/app/notifications'
 import { setIsConnected } from 'uiSrc/slices/app/socket-connection'
-import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
+import { getSocketApiUrl, Nullable } from 'uiSrc/utils';
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addUnreadRecommendations } from 'uiSrc/slices/recommendations/recommendations'
 import { RecommendationsSocketEvents } from 'uiSrc/constants/recommendations'
@@ -24,7 +24,7 @@ const CommonAppSubscription = () => {
   const { token } = useSelector(appCsrfSelector)
   const [recommendationsSubscriptions, setRecommendationsSubscriptions] = useState<string[]>([])
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(getBaseApiUrl(), {
+  const connectIo = useIoConnection(getSocketApiUrl(), {
     forceNew: false,
     token,
     reconnection: true }

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -7,7 +7,7 @@ import { CloudJobEvents, SocketEvent, SocketFeaturesEvent } from 'uiSrc/constant
 import { NotificationEvent } from 'uiSrc/constants/notifications'
 import { setNewNotificationAction } from 'uiSrc/slices/app/notifications'
 import { setIsConnected } from 'uiSrc/slices/app/socket-connection'
-import { getSocketApiUrl, Nullable } from 'uiSrc/utils';
+import { getSocketApiUrl, Nullable } from 'uiSrc/utils'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addUnreadRecommendations } from 'uiSrc/slices/recommendations/recommendations'
 import { RecommendationsSocketEvents } from 'uiSrc/constants/recommendations'
@@ -27,8 +27,7 @@ const CommonAppSubscription = () => {
   const connectIo = useIoConnection(getSocketApiUrl(), {
     forceNew: false,
     token,
-    reconnection: true }
-  )
+    reconnection: true })
 
   const dispatch = useDispatch()
 

--- a/redisinsight/ui/src/components/global-subscriptions/GlobalSubscriptions.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/GlobalSubscriptions.tsx
@@ -1,19 +1,11 @@
 import React from 'react'
-import {
-  MonitorConfig,
-  PubSubConfig,
-  BulkActionsConfig,
-  FeatureFlagComponent,
-  OAuthJobs,
-} from 'uiSrc/components'
+import { BulkActionsConfig, FeatureFlagComponent, MonitorConfig, OAuthJobs, PubSubConfig } from 'uiSrc/components'
 import { FeatureFlags } from 'uiSrc/constants'
 import CommonAppSubscription from './CommonAppSubscription'
 
 const GlobalSubscriptions = () => (
   <>
-    <FeatureFlagComponent name={FeatureFlags.envDependent} enabledByDefault>
-      <CommonAppSubscription />
-    </FeatureFlagComponent>
+    <CommonAppSubscription />
     <MonitorConfig />
     <PubSubConfig />
     <FeatureFlagComponent name={FeatureFlags.envDependent}>

--- a/redisinsight/ui/src/components/monitor-config/MonitorConfig.tsx
+++ b/redisinsight/ui/src/components/monitor-config/MonitorConfig.tsx
@@ -17,7 +17,7 @@ import {
   setStartTimestamp,
   stopMonitor,
 } from 'uiSrc/slices/cli/monitor'
-import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
+import { getSocketApiUrl, Nullable } from 'uiSrc/utils';
 import { MonitorErrorMessages, MonitorEvent, SocketErrors, SocketEvent } from 'uiSrc/constants'
 import { IMonitorDataPayload } from 'uiSrc/slices/interfaces'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -36,7 +36,7 @@ const MonitorConfig = ({ retryDelay = 15000 } : IProps) => {
   const { token } = useSelector(appCsrfSelector)
 
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(`${getBaseApiUrl()}/monitor`, { token })
+  const connectIo = useIoConnection(getSocketApiUrl('monitor'), { token })
   const logFileIdRef = useRef<string>()
   const timestampRef = useRef<number>()
   const retryTimerRef = useRef<NodeJS.Timer>()

--- a/redisinsight/ui/src/components/pub-sub-config/PubSubConfig.tsx
+++ b/redisinsight/ui/src/components/pub-sub-config/PubSubConfig.tsx
@@ -15,7 +15,7 @@ import {
   setLoading,
   setPubSubConnected,
 } from 'uiSrc/slices/pubsub/pubsub'
-import { getBaseApiUrl, Nullable } from 'uiSrc/utils'
+import { getSocketApiUrl, Nullable } from 'uiSrc/utils';
 import { appCsrfSelector } from 'uiSrc/slices/app/csrf'
 import { useIoConnection } from 'uiSrc/services/hooks/useIoConnection'
 
@@ -28,7 +28,7 @@ const PubSubConfig = ({ retryDelay = 5000 } : IProps) => {
   const { isSubscribeTriggered, isConnected, subscriptions } = useSelector(pubSubSelector)
   const { token } = useSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
-  const connectIo = useIoConnection(`${getBaseApiUrl()}/pub-sub`, { token })
+  const connectIo = useIoConnection(getSocketApiUrl('pub-sub'), { token })
 
   const dispatch = useDispatch()
 

--- a/redisinsight/ui/src/services/hooks/useIoConnection.ts
+++ b/redisinsight/ui/src/services/hooks/useIoConnection.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux'
+import { useCallback } from 'react'
+import { WsParams, wsService } from 'uiSrc/services/wsService'
+import { FeatureFlags } from 'uiSrc/constants'
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
+
+export const useIoConnection = (url: string, params: WsParams) => {
+  const { [FeatureFlags.envDependent]: envDependent } = useSelector(appFeatureFlagsFeaturesSelector)
+  return useCallback(() => wsService(url, params, envDependent?.flag), [url, params, envDependent])
+}

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -25,14 +25,14 @@ export function wsService(wsUrl: string, {
     queryParams = { ...queryParams, ...query }
   }
   let headers: Record<string, any> = { [CustomHeaders.WindowId]: window.windowId || '' }
-  if (passTokenViaHeaders) {
+  if (!passTokenViaHeaders) {
     headers = { ...headers, [CustomHeaders.CsrfToken]: token || '' }
   }
 
   if (extraHeaders) {
     headers = { ...headers, ...extraHeaders }
   }
-  const transports = ['polling'] // riConfig.api.socketTransports?.split(',')
+  const transports = riConfig.api.socketTransports?.split(',')
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -36,6 +36,7 @@ export function wsService(wsUrl: string, {
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
+    addTrailingSlash: false,
     path: getProxyPath(),
     forceNew,
     reconnection,

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -5,7 +5,7 @@ import { getConfig } from 'uiSrc/config'
 
 const riConfig = getConfig()
 
-type Params = {
+export type WsParams = {
   forceNew?: boolean,
   token?: string,
   reconnection?: boolean
@@ -19,7 +19,7 @@ export function wsService(wsUrl: string, {
   reconnection,
   query,
   extraHeaders
-}: Params, passTokenViaHeaders: boolean = true,) {
+}: WsParams, passTokenViaHeaders: boolean = true,) {
   let queryParams: Record<string, any> = !passTokenViaHeaders ? { [CustomHeaders.CsrfToken]: token } : {}
   if (query) {
     queryParams = { ...queryParams, ...query }
@@ -32,6 +32,9 @@ export function wsService(wsUrl: string, {
   if (extraHeaders) {
     headers = { ...headers, ...extraHeaders }
   }
+  const transports = riConfig.api.socketTransports?.split(',')
+  const withCredentials = riConfig.api.socketCredentials
+
   const ioOptions = {
     path: getProxyPath(),
     forceNew,
@@ -39,10 +42,19 @@ export function wsService(wsUrl: string, {
     query: queryParams,
     extraHeaders: headers,
     rejectUnauthorized: false,
-    transports: riConfig.api.socketTransports?.split(','),
-    withCredentials: riConfig.api.socketCredentials,
+    transports,
+    withCredentials,
     auth: { token }
   }
+  // eslint-disable-next-line no-console
+  console.log({
+    passTokenViaHeaders,
+    token,
+    queryParams,
+    headers,
+    transports,
+    ioOptions
+  })
 
   return io(wsUrl, ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,0 +1,48 @@
+import { io } from 'socket.io-client'
+import { getProxyPath } from 'uiSrc/utils'
+import { CustomHeaders } from 'uiSrc/constants/api'
+import { getConfig } from 'uiSrc/config'
+
+const riConfig = getConfig()
+
+type Params = {
+  forceNew?: boolean,
+  token?: string,
+  reconnection?: boolean
+  query?: Record<string, any>
+  extraHeaders?: Record<string, any>
+}
+
+export function wsService(wsUrl: string, {
+  forceNew = true,
+  token,
+  reconnection,
+  query,
+  extraHeaders
+}: Params, passTokenViaHeaders: boolean = true,) {
+  let queryParams: Record<string, any> = !passTokenViaHeaders ? { [CustomHeaders.CsrfToken]: token } : {}
+  if (query) {
+    queryParams = { ...queryParams, ...query }
+  }
+  let headers: Record<string, any> = { [CustomHeaders.WindowId]: window.windowId || '' }
+  if (passTokenViaHeaders) {
+    headers = { ...headers, [CustomHeaders.CsrfToken]: token || '' }
+  }
+
+  if (extraHeaders) {
+    headers = { ...headers, ...extraHeaders }
+  }
+  const ioOptions = {
+    path: getProxyPath(),
+    forceNew,
+    reconnection,
+    query: queryParams,
+    extraHeaders: headers,
+    rejectUnauthorized: false,
+    transports: riConfig.api.socketTransports?.split(','),
+    withCredentials: riConfig.api.socketCredentials,
+    auth: { token }
+  }
+
+  return io(wsUrl, ioOptions)
+}

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -25,7 +25,7 @@ export function wsService(wsUrl: string, {
     queryParams = { ...queryParams, ...query }
   }
   let headers: Record<string, any> = { [CustomHeaders.WindowId]: window.windowId || '' }
-  if (!passTokenViaHeaders) {
+  if (passTokenViaHeaders) {
     headers = { ...headers, [CustomHeaders.CsrfToken]: token || '' }
   }
 

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -32,11 +32,11 @@ export function wsService(wsUrl: string, {
   if (extraHeaders) {
     headers = { ...headers, ...extraHeaders }
   }
-  const transports = riConfig.api.socketTransports?.split(',')
+  const transports = ['polling'] // riConfig.api.socketTransports?.split(',')
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    addTrailingSlash: false,
+    // addTrailingSlash: false,
     path: getProxyPath(),
     forceNew,
     reconnection,
@@ -45,7 +45,7 @@ export function wsService(wsUrl: string, {
     rejectUnauthorized: false,
     transports,
     withCredentials,
-    auth: { token }
+    // auth: { token }
   }
   // eslint-disable-next-line no-console
   console.log({

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -20,7 +20,7 @@ export function wsService(wsUrl: string, {
   query,
   extraHeaders
 }: WsParams, passTokenViaHeaders: boolean = true,) {
-  let queryParams: Record<string, any> = !passTokenViaHeaders ? { [CustomHeaders.CsrfToken]: token } : {}
+  let queryParams: Record<string, any> = !passTokenViaHeaders ? { [CustomHeaders.CsrfToken.toLowerCase()]: token } : {}
   if (query) {
     queryParams = { ...queryParams, ...query }
   }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,4 +1,5 @@
 import { io } from 'socket.io-client'
+import path from 'path'
 import { getProxyPath } from 'uiSrc/utils'
 import { CustomHeaders } from 'uiSrc/constants/api'
 import { getConfig } from 'uiSrc/config'
@@ -6,25 +7,27 @@ import { getConfig } from 'uiSrc/config'
 const riConfig = getConfig()
 
 export type WsParams = {
-  forceNew?: boolean,
-  token?: string,
-  reconnection?: boolean
-  query?: Record<string, any>
-  extraHeaders?: Record<string, any>
+  forceNew?: boolean;
+  token?: string;
+  reconnection?: boolean;
+  query?: Record<string, any>;
+  extraHeaders?: Record<string, any>;
 }
 
-export function wsService(wsUrl: string, {
-  forceNew = true,
-  token,
-  reconnection,
-  query,
-  extraHeaders
-}: WsParams, passTokenViaHeaders: boolean = true,) {
-  let queryParams: Record<string, any> = !passTokenViaHeaders ? { [CustomHeaders.CsrfToken.toLowerCase()]: token } : {}
+export function wsService(
+  wsUrl: string,
+  { forceNew = true, token, reconnection, query, extraHeaders }: WsParams,
+  passTokenViaHeaders: boolean = true,
+) {
+  let queryParams: Record<string, any> = !passTokenViaHeaders
+    ? { [CustomHeaders.CsrfToken.toLowerCase()]: token }
+    : {}
   if (query) {
     queryParams = { ...queryParams, ...query }
   }
-  let headers: Record<string, any> = { [CustomHeaders.WindowId]: window.windowId || '' }
+  let headers: Record<string, any> = {
+    [CustomHeaders.WindowId]: window.windowId || '',
+  }
   if (passTokenViaHeaders) {
     headers = { ...headers, [CustomHeaders.CsrfToken]: token || '' }
   }
@@ -37,7 +40,7 @@ export function wsService(wsUrl: string, {
 
   const ioOptions = {
     // addTrailingSlash: false,
-    path: getProxyPath(),
+    path: '/redis-insight/api/socket.io',
     forceNew,
     reconnection,
     query: queryParams,
@@ -47,15 +50,18 @@ export function wsService(wsUrl: string, {
     withCredentials,
     // auth: { token }
   }
+  const fullWsUrl = `${wsUrl}/socket.io`
   // eslint-disable-next-line no-console
   console.log({
+    wsUrl,
+    fullWsUrl,
     passTokenViaHeaders,
     token,
     queryParams,
     headers,
     transports,
-    ioOptions
+    ioOptions,
   })
 
-  return io(wsUrl, ioOptions)
+  return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client'
-import { getProxyPath } from 'uiSrc/utils'
+// import { getProxyPath } from 'uiSrc/utils'
 import { CustomHeaders } from 'uiSrc/constants/api'
 import { getConfig } from 'uiSrc/config'
 
@@ -38,7 +38,8 @@ export function wsService(
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    path: getProxyPath(), // '/redis-insight/api/socket.io',
+    // path: getProxyPath(), // '/redis-insight/api/socket.io',
+    path: '/redis-insight/api/socket.io',
     forceNew,
     reconnection,
     query: queryParams,

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,6 +1,5 @@
 import { io } from 'socket.io-client'
-import path from 'path'
-import { getProxyPath } from 'uiSrc/utils'
+// import { getProxyPath } from 'uiSrc/utils'
 import { CustomHeaders } from 'uiSrc/constants/api'
 import { getConfig } from 'uiSrc/config'
 
@@ -39,8 +38,7 @@ export function wsService(
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    // addTrailingSlash: false,
-    path: '/redis-insight/api/socket.io',
+    // path: getProxyPath(), // '/redis-insight/api/socket.io',
     forceNew,
     reconnection,
     query: queryParams,
@@ -48,13 +46,12 @@ export function wsService(
     rejectUnauthorized: false,
     transports,
     withCredentials,
-    // auth: { token }
   }
-  const fullWsUrl = `${wsUrl}/socket.io`
+  // const fullWsUrl = `${wsUrl}/socket.io`
   // eslint-disable-next-line no-console
   console.log({
     wsUrl,
-    fullWsUrl,
+    // fullWsUrl,
     passTokenViaHeaders,
     token,
     queryParams,
@@ -63,5 +60,6 @@ export function wsService(
     ioOptions,
   })
 
-  return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
+  return io(wsUrl, ioOptions)
+  // return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -48,19 +48,6 @@ export function wsService(
     transports,
     withCredentials,
   }
-  // const fullWsUrl = `${wsUrl}/socket.io`
-  // eslint-disable-next-line no-console
-  console.log({
-    wsUrl,
-    // fullWsUrl,
-    passTokenViaHeaders,
-    token,
-    queryParams,
-    headers,
-    transports,
-    ioOptions,
-  })
 
   return io(wsUrl, ioOptions)
-  // return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client'
-// import { getProxyPath } from 'uiSrc/utils'
+import { getProxyPath } from 'uiSrc/utils'
 import { CustomHeaders } from 'uiSrc/constants/api'
 import { getConfig } from 'uiSrc/config'
 
@@ -38,7 +38,7 @@ export function wsService(
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    // path: getProxyPath(), // '/redis-insight/api/socket.io',
+    path: getProxyPath(), // '/redis-insight/api/socket.io',
     forceNew,
     reconnection,
     query: queryParams,

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -39,7 +39,7 @@ export function wsService(
 
   const ioOptions = {
     // path: getProxyPath(), // '/redis-insight/api/socket.io',
-    path: '/redis-insight/socket.io',
+    path: '/redis-insight/api/socket.io',
     forceNew,
     reconnection,
     query: queryParams,

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client'
-// import { getProxyPath } from 'uiSrc/utils'
+import { getProxyPath } from 'uiSrc/utils'
 import { CustomHeaders } from 'uiSrc/constants/api'
 import { getConfig } from 'uiSrc/config'
 
@@ -16,7 +16,7 @@ export type WsParams = {
 
 export function wsService(
   wsUrl: string,
-  { forceNew = true, token, reconnection, query, extraHeaders, path = '/api/socket.io' }: WsParams,
+  { forceNew = true, token, reconnection, query, extraHeaders, path = getProxyPath() }: WsParams,
   passTokenViaHeaders: boolean = true,
 ) {
   let queryParams: Record<string, any> = !passTokenViaHeaders
@@ -39,7 +39,6 @@ export function wsService(
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    // path: getProxyPath(),
     path,
     forceNew,
     reconnection,
@@ -48,7 +47,6 @@ export function wsService(
     rejectUnauthorized: false,
     transports,
     withCredentials,
-    some: "stupid value"
   }
   // const fullWsUrl = `${wsUrl}/socket.io`
   // eslint-disable-next-line no-console

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -19,22 +19,18 @@ export function wsService(
   { forceNew = true, token, reconnection, query, extraHeaders, path = getProxyPath() }: WsParams,
   passTokenViaHeaders: boolean = true,
 ) {
-  let queryParams: Record<string, any> = !passTokenViaHeaders
-    ? { [CustomHeaders.CsrfToken.toLowerCase()]: token }
-    : {}
-  if (query) {
-    queryParams = { ...queryParams, ...query }
-  }
-  let headers: Record<string, any> = {
-    [CustomHeaders.WindowId]: window.windowId || '',
-  }
-  if (passTokenViaHeaders) {
-    headers = { ...headers, [CustomHeaders.CsrfToken]: token || '' }
+  const tokenObj = { [CustomHeaders.CsrfToken.toLowerCase()]: token }
+  const queryParams = {
+    ...(passTokenViaHeaders ? {} : tokenObj),
+    ...(query || {}),
   }
 
-  if (extraHeaders) {
-    headers = { ...headers, ...extraHeaders }
+  const headers = {
+    [CustomHeaders.WindowId]: window.windowId || '',
+    ...(passTokenViaHeaders ? tokenObj : {}),
+    ...(extraHeaders || {}),
   }
+
   const transports = riConfig.api.socketTransports?.split(',')
   const withCredentials = riConfig.api.socketCredentials
 

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -61,6 +61,6 @@ export function wsService(
     ioOptions,
   })
 
-  // return io(wsUrl, ioOptions)
-  return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
+  return io(wsUrl, ioOptions)
+  // return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -61,6 +61,6 @@ export function wsService(
     ioOptions,
   })
 
-  return io(wsUrl, ioOptions)
-  // return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
+  // return io(wsUrl, ioOptions)
+  return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -48,6 +48,7 @@ export function wsService(
     rejectUnauthorized: false,
     transports,
     withCredentials,
+    some: "stupid value"
   }
   // const fullWsUrl = `${wsUrl}/socket.io`
   // eslint-disable-next-line no-console

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -39,7 +39,7 @@ export function wsService(
 
   const ioOptions = {
     // path: getProxyPath(), // '/redis-insight/api/socket.io',
-    path: '/redis-insight/api/socket.io',
+    path: '/redis-insight/socket.io',
     forceNew,
     reconnection,
     query: queryParams,

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -11,11 +11,12 @@ export type WsParams = {
   reconnection?: boolean;
   query?: Record<string, any>;
   extraHeaders?: Record<string, any>;
+  path?: string;
 }
 
 export function wsService(
   wsUrl: string,
-  { forceNew = true, token, reconnection, query, extraHeaders }: WsParams,
+  { forceNew = true, token, reconnection, query, extraHeaders, path = '/redis-insight/api/socket.io' }: WsParams,
   passTokenViaHeaders: boolean = true,
 ) {
   let queryParams: Record<string, any> = !passTokenViaHeaders
@@ -38,8 +39,8 @@ export function wsService(
   const withCredentials = riConfig.api.socketCredentials
 
   const ioOptions = {
-    // path: getProxyPath(), // '/redis-insight/api/socket.io',
-    path: '/redis-insight/api/socket.io',
+    // path: getProxyPath(),
+    path,
     forceNew,
     reconnection,
     query: queryParams,
@@ -61,6 +62,6 @@ export function wsService(
     ioOptions,
   })
 
-  // return io(wsUrl, ioOptions)
-  return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
+  return io(wsUrl, ioOptions)
+  // return io('https://app-sm.k8s-mw.sm-qa.qa.redislabs.com', ioOptions)
 }

--- a/redisinsight/ui/src/services/wsService.ts
+++ b/redisinsight/ui/src/services/wsService.ts
@@ -16,7 +16,7 @@ export type WsParams = {
 
 export function wsService(
   wsUrl: string,
-  { forceNew = true, token, reconnection, query, extraHeaders, path = '/redis-insight/api/socket.io' }: WsParams,
+  { forceNew = true, token, reconnection, query, extraHeaders, path = '/api/socket.io' }: WsParams,
   passTokenViaHeaders: boolean = true,
 ) {
   let queryParams: Record<string, any> = !passTokenViaHeaders

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -8,7 +8,13 @@ const { apiPort } = window.app?.config || { apiPort: riConfig.api.port }
 const hostedApiBaseUrl = riConfig.api.hostedBaseUrl
 
 export const getSocketApiUrl = (path = '') => {
-  const baseUrl = getBaseApiUrl()
+  let baseUrl = getBaseApiUrl()
+  try {
+    const url = new URL(baseUrl)
+    baseUrl = baseUrl.replace(url.pathname, '')
+  } catch (e) {
+    console.error(e)
+  }
   const proxyPath = getProxyPath()
   // eslint-disable-next-line no-console
   console.log({ baseUrl, proxyPath, path })
@@ -16,12 +22,6 @@ export const getSocketApiUrl = (path = '') => {
 }
 
 export const getBaseApiUrl = () => {
-  // eslint-disable-next-line no-console
-  console.log({
-    hostedApiBaseUrl,
-    isWebApp,
-    origin: window.location.origin
-  })
   if (hostedApiBaseUrl) {
     return hostedApiBaseUrl
   }

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -17,7 +17,7 @@ export const getSocketApiUrl = (path = '') => {
   }
   const proxyPath = getProxyPath()
   // eslint-disable-next-line no-console
-  console.log({ baseUrl, proxyPath, path })
+  // console.log({ baseUrl, proxyPath, path })
   return `${baseUrl}${proxyPath}${path}`
 }
 

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -11,7 +11,7 @@ export const getSocketApiUrl = (path = '') => {
   let baseUrl = getBaseApiUrl()
   try {
     const url = new URL(baseUrl)
-    baseUrl = baseUrl.replace(url.pathname, '/api')
+    baseUrl = baseUrl.replace(url.pathname, '/')
   } catch (e) {
     console.error(e)
   }

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -10,7 +10,8 @@ const hostedApiBaseUrl = riConfig.api.hostedBaseUrl
 export const getSocketApiUrl = (path = '') => {
   const baseUrl = getBaseApiUrl()
   const proxyPath = getProxyPath()
-
+  // eslint-disable-next-line no-console
+  console.log({ baseUrl, proxyPath, path })
   return `${baseUrl}${proxyPath}${path}`
 }
 

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -16,6 +16,12 @@ export const getSocketApiUrl = (path = '') => {
 }
 
 export const getBaseApiUrl = () => {
+  // eslint-disable-next-line no-console
+  console.log({
+    hostedApiBaseUrl,
+    isWebApp,
+    origin: window.location.origin
+  })
   if (hostedApiBaseUrl) {
     return hostedApiBaseUrl
   }

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -1,3 +1,4 @@
+import { trim } from 'lodash'
 import { IpcInvokeEvent } from 'uiSrc/electron/constants'
 import { getConfig } from 'uiSrc/config'
 
@@ -15,10 +16,7 @@ export const getSocketApiUrl = (path = '') => {
   } catch (e) {
     console.error(e)
   }
-  const proxyPath = getProxyPath()
-  // eslint-disable-next-line no-console
-  // console.log({ baseUrl, proxyPath, path })
-  return `${baseUrl}${proxyPath}${path}`
+  return `${baseUrl}/${trim(path, '/')}`
 }
 
 export const getBaseApiUrl = () => {

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -11,7 +11,7 @@ export const getSocketApiUrl = (path = '') => {
   let baseUrl = getBaseApiUrl()
   try {
     const url = new URL(baseUrl)
-    baseUrl = baseUrl.replace(url.pathname, '/')
+    baseUrl = baseUrl.replace(url.pathname, '')
   } catch (e) {
     console.error(e)
   }

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -7,6 +7,13 @@ const isWebApp = riConfig.app.type === 'web'
 const { apiPort } = window.app?.config || { apiPort: riConfig.api.port }
 const hostedApiBaseUrl = riConfig.api.hostedBaseUrl
 
+export const getSocketApiUrl = (path = '') => {
+  const baseUrl = getBaseApiUrl()
+  const proxyPath = getProxyPath()
+
+  return `${baseUrl}${proxyPath}${path}`
+}
+
 export const getBaseApiUrl = () => {
   if (hostedApiBaseUrl) {
     return hostedApiBaseUrl

--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -11,7 +11,7 @@ export const getSocketApiUrl = (path = '') => {
   let baseUrl = getBaseApiUrl()
   try {
     const url = new URL(baseUrl)
-    baseUrl = baseUrl.replace(url.pathname, '')
+    baseUrl = baseUrl.replace(url.pathname, '/api')
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
With this PR, the interface of establishing socket connection is being unified in one place, in order to make it much simpler to use.
`getSocketApiUrl` - required because of how routing on cluster works
`useIoConnection` - extract common logic, that would of been needed in every component that establishes io connection
`wsService` - Connection it-self is established in wsService (WebSocket Service), and because there is some condititional logic for where to put CSRF token, it is also being called via custom hook.