### PR TITLE
RI-5362 Fix nightly tests running

### DIFF
--- a/.circleci/build/build.Dockerfile
+++ b/.circleci/build/build.Dockerfile
@@ -28,8 +28,8 @@ RUN mkdir -p /data && chmod -R 777 /data
 COPY ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
-# since RI is hard-code to port 5000, expose it from the container
-EXPOSE 5000
+# since RI is hard-code to port 5540, expose it from the container
+EXPOSE 5540
 
 # serve the application 🚀
 ENTRYPOINT ["./docker-entry.sh", "node", "redisinsight/api/dist/src/main"]

--- a/.circleci/build/build.Dockerfile
+++ b/.circleci/build/build.Dockerfile
@@ -22,14 +22,17 @@ ADD $DIST /usr/src/app/redisinsight
 RUN ls -la /usr/src/app/redisinsight
 
 # folder to store local database, plugins, logs and all other files
-RUN mkdir -p /data && chmod -R 777 /data
+RUN mkdir -p /data && chown -R node:node /data
 
 # copy the docker entry point script and make it executable
-COPY ./docker-entry.sh ./
+COPY --chown=node:node ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
 # since RI is hard-code to port 5540, expose it from the container
 EXPOSE 5540
+
+# don't run the node process as root
+USER node
 
 # serve the application 🚀
 ENTRYPOINT ["./docker-entry.sh", "node", "redisinsight/api/dist/src/main"]

--- a/.circleci/build/build.Dockerfile
+++ b/.circleci/build/build.Dockerfile
@@ -22,17 +22,14 @@ ADD $DIST /usr/src/app/redisinsight
 RUN ls -la /usr/src/app/redisinsight
 
 # folder to store local database, plugins, logs and all other files
-RUN mkdir -p /data && chown -R node:node /data
+RUN mkdir -p /data && chmod -R 777 /data
 
 # copy the docker entry point script and make it executable
-COPY --chown=node:node ./docker-entry.sh ./
+COPY ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
 # since RI is hard-code to port 5000, expose it from the container
 EXPOSE 5000
-
-# don't run the node process as root
-USER node
 
 # serve the application 🚀
 ENTRYPOINT ["./docker-entry.sh", "node", "redisinsight/api/dist/src/main"]

--- a/.github/build/build.Dockerfile
+++ b/.github/build/build.Dockerfile
@@ -28,8 +28,8 @@ RUN mkdir -p /data && chown -R node:node /data
 COPY --chown=node:node ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
-# since RI is hard-code to port 5000, expose it from the container
-EXPOSE 5000
+# since RI is hard-code to port 5540, expose it from the container
+EXPOSE 5540
 
 # don't run the node process as root
 USER node

--- a/.github/build/build.Dockerfile
+++ b/.github/build/build.Dockerfile
@@ -22,17 +22,14 @@ ADD $DIST /usr/src/app/redisinsight
 RUN ls -la /usr/src/app/redisinsight
 
 # folder to store local database, plugins, logs and all other files
-RUN mkdir -p /data && chown -R node:node /data
+RUN mkdir -p /data && chmod -R 777 /data
 
 # copy the docker entry point script and make it executable
-COPY --chown=node:node ./docker-entry.sh ./
+COPY ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
 # since RI is hard-code to port 5000, expose it from the container
 EXPOSE 5000
-
-# don't run the node process as root
-USER node
 
 # serve the application 🚀
 ENTRYPOINT ["./docker-entry.sh", "node", "redisinsight/api/dist/src/main"]

--- a/.github/build/build.Dockerfile
+++ b/.github/build/build.Dockerfile
@@ -22,14 +22,17 @@ ADD $DIST /usr/src/app/redisinsight
 RUN ls -la /usr/src/app/redisinsight
 
 # folder to store local database, plugins, logs and all other files
-RUN mkdir -p /data && chmod -R 777 /data
+RUN mkdir -p /data && chown -R node:node /data
 
 # copy the docker entry point script and make it executable
-COPY ./docker-entry.sh ./
+COPY --chown=node:node ./docker-entry.sh ./
 RUN chmod +x docker-entry.sh
 
 # since RI is hard-code to port 5000, expose it from the container
 EXPOSE 5000
+
+# don't run the node process as root
+USER node
 
 # serve the application 🚀
 ENTRYPOINT ["./docker-entry.sh", "node", "redisinsight/api/dist/src/main"]

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -126,7 +126,7 @@ jobs:
         fi
 
         ./redisinsight/api/test/test-runs/start-test-run.sh -r ${{ matrix.rte }} -t ${{ inputs.build }}
-        mkdir -p mkdir itest/coverages && mkdir -p itest/results
+        mkdir -p itest/coverages && mkdir -p itest/results
 
         cp ./redisinsight/api/test/test-runs/coverage/test-run-result.json ./itest/results/${{ matrix.rte }}.result.json
         cp ./redisinsight/api/test/test-runs/coverage/test-run-result.xml ./itest/results/${{ matrix.rte }}.result.xml

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -114,6 +114,10 @@ jobs:
       run: |
         docker image load -i ./release/docker/docker-linux-alpine.amd64.tar
 
+    - name: Make sure coverage dir exists
+      # Important: this directory is mounted on both the `app` and `test` Docker containers.
+      run: mkdir -p ./redisinsight/api/test/test-runs/coverage
+
     - name: Run tests
       timeout-minutes: 20
       run: |

--- a/redisinsight/api/test/test-runs/docker.build.env
+++ b/redisinsight/api/test/test-runs/docker.build.env
@@ -2,6 +2,6 @@ COV_FOLDER=./coverage
 ID=defaultid
 RTE=defaultrte
 APP_IMAGE=redisinsight:amd64
-TEST_BE_SERVER=https://app:5000/api
+TEST_BE_SERVER=http://app:5540/api
 RI_NOTIFICATION_UPDATE_URL=https://s3.amazonaws.com/redisinsight.test/public/tests/notifications.json
 CERTS_FOLDER=/root/.redisinsight-v2.0

--- a/redisinsight/api/test/test-runs/docker.build.env
+++ b/redisinsight/api/test/test-runs/docker.build.env
@@ -1,7 +1,7 @@
 COV_FOLDER=./coverage
 ID=defaultid
 RTE=defaultrte
-APP_IMAGE=riv2:latest
+APP_IMAGE=redisinsight:amd64
 TEST_BE_SERVER=https://app:5000/api
 RI_NOTIFICATION_UPDATE_URL=https://s3.amazonaws.com/redisinsight.test/public/tests/notifications.json
 CERTS_FOLDER=/root/.redisinsight-v2.0

--- a/redisinsight/api/test/test-runs/docker.build.yml
+++ b/redisinsight/api/test/test-runs/docker.build.yml
@@ -14,9 +14,9 @@ services:
       dockerfile: ./test/test-runs/test.Dockerfile
     tty: true
     volumes:
-      - ${COV_FOLDER}:/usr/src/app/coverage
-      - ${COV_FOLDER}:/root/.redisinsight-v2.0
-      - ${COV_FOLDER}:/data
+      - shared-data:/usr/src/app/coverage
+      - shared-data:/root/.redisinsight-v2.0
+      - shared-data:/data
     depends_on:
       - redis
       - app
@@ -35,8 +35,8 @@ services:
     depends_on:
       - redis
     volumes:
-      - ${COV_FOLDER}:/root/.redisinsight-v2.0
-      - ${COV_FOLDER}:/data
+      - shared-data:/root/.redisinsight-v2.0
+      - shared-data:/data
     environment:
       RI_REDIS_CLIENTS_FORCE_STRATEGY: ${RI_REDIS_CLIENTS_FORCE_STRATEGY}
       CERTS_FOLDER: "/root/.redisinsight-v2.0"
@@ -51,3 +51,10 @@ networks:
   default:
     name: ${ID}
 
+volumes:
+  shared-data:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${COV_FOLDER}
+      o: bind

--- a/redisinsight/api/test/test-runs/docker.build.yml
+++ b/redisinsight/api/test/test-runs/docker.build.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${COV_FOLDER}:/usr/src/app/coverage
       - ${COV_FOLDER}:/root/.redisinsight-v2.0
+      - ${COV_FOLDER}:/data
     depends_on:
       - redis
       - app
@@ -35,6 +36,7 @@ services:
       - redis
     volumes:
       - ${COV_FOLDER}:/root/.redisinsight-v2.0
+      - ${COV_FOLDER}:/data
     environment:
       RI_REDIS_CLIENTS_FORCE_STRATEGY: ${RI_REDIS_CLIENTS_FORCE_STRATEGY}
       CERTS_FOLDER: "/root/.redisinsight-v2.0"


### PR DESCRIPTION
# TL;DR

- Switch to the `redisinsight` image instead of `riv2`, as this is the one built in the [pipeline-build-docker.yml](https://github.com/RedisInsight/RedisInsight/blob/main/.github/workflows/pipeline-build-docker.yml#L82).  
- Mount the `/data` directory to containers since it’s where `redisinsight` stores all the required files.  
- Update the backend URL to disable SSL support: Again, the goal is to get everything running first, and then address this.  

# Few notes

- Tests are currently failing because they need updates. For example, in [this run](https://github.com/RedisInsight/RedisInsight/actions/runs/12551271839), the test suite with passing tests generates all required files, which is why it succeeds. The failing tests don’t produce a `test-run-coverage.json` file, leading to their failure. Latest run here: https://github.com/RedisInsight/RedisInsight/actions/runs/12653756107. Again - due to test not passing, the `test-run-coverage` file can not be generated, hence flow is failing.
- This PR focuses solely on resolving issues that prevent the tests from running properly. Updates to the test scenarios themselves will be addressed in subsequent PRs.
- There are two definitions for the RedisInsight container—one in `.circleci` and one in `.github`. Do we need the one in `.circleci`? Do we need the entire `.circleci` directory?

-----

- [ ] TODO: Add some high level documentation
- [ ] TODO: Add some debug suggestions for the future

-----


# Nah... I want to read novels  

This setup requires three components: the RedisInsight application, a Redis instance, and the test runner. Here's the breakdown:  

1. **RedisInsight Application**  
   The `redisinsight` Docker image bundles the RedisInsight application. To enable other containers to access necessary files, we mount a shared directory (`/data`). This directory stores the local database file `redisinsight.db`. The image definition file is located at `RedisInsight/.github/build/build.Dockerfile`.  

2. **Redis Instance**  
   We use containers to test against different Redis distributions and configurations, such as `oss-st-6` and `oss-st-6-tls`. The definition files for these configurations can be found in `RedisInsight/redisinsight/api/test/test-runs`.  

3. **Test Runner**  
   The test runner is a separate Docker image defined by `RedisInsight/redisinsight/api/test/test-runs/test.Dockerfile`. This image orchestrates the tests and ensures they run against the configured Redis instances and the application.  

The issues described above are currently preventing the tests from running successfully. Resolving these will allow us to proceed with further updates to the test scenarios.  
 