### PR TITLE
bugfix web sockets

### DIFF
--- a/redisinsight/ui/src/utils/common.ts
+++ b/redisinsight/ui/src/utils/common.ts
@@ -12,7 +12,7 @@ export const getSocketApiUrl = (path = '') => {
   let baseUrl = getBaseApiUrl()
   try {
     const url = new URL(baseUrl)
-    baseUrl = baseUrl.replace(url.pathname, '')
+    baseUrl = url.origin
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
fix: get base url from api url origin instead of replacing path.
Whenever there is no path - `http://localhost` - then path becomes `/` and is being replaced in http:// part and breaks the url like `http:/localhost`