### PR TITLE
RI-6457: Display proper RDI version

### DIFF
--- a/redisinsight/api/src/modules/rdi/rdi.service.spec.ts
+++ b/redisinsight/api/src/modules/rdi/rdi.service.spec.ts
@@ -145,6 +145,13 @@ describe('RdiService', () => {
   });
 
   describe('create', () => {
+    const validGetPipelineStatus = () => Promise.resolve({
+      components: {
+        processor:{
+          version: "test-version"
+        }
+      }});
+
     it('should create an Rdi instance', async () => {
       const dto: CreateRdiDto = {
         name: 'name',
@@ -154,7 +161,9 @@ describe('RdiService', () => {
       };
       const sessionMetadata = { userId: '123', sessionId: '789' };
       repository.create.mockResolvedValue(mockRdi);
-      rdiClientFactory.createClient.mockResolvedValue(undefined);
+      rdiClientFactory.createClient.mockReturnValue({
+        getPipelineStatus: validGetPipelineStatus
+      });
 
       const result = await service.create(sessionMetadata, dto);
 
@@ -176,6 +185,52 @@ describe('RdiService', () => {
       rdiClientFactory.createClient.mockRejectedValue(error);
 
       await expect(service.create(sessionMetadata, dto)).rejects.toThrowError(wrapRdiPipelineError(error));
+    });
+
+    it('should get the RDI version', async () => {
+      const dto: CreateRdiDto = {
+        name: 'name',
+        url: 'http://localhost:4000',
+        password: 'pass',
+        username: 'user',
+      };
+      const sessionMetadata = { userId: '123', sessionId: '789' };
+
+      repository.create.mockResolvedValue(mockRdi);
+      rdiClientFactory.createClient.mockReturnValue({
+        getPipelineStatus: validGetPipelineStatus
+      });
+
+      await service.create(sessionMetadata, dto);
+
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
+        version: 'test-version'
+      }))
+    });
+
+    it('should get the default RDI version when other information is missing', async () => {
+      const dto: CreateRdiDto = {
+        name: 'name',
+        url: 'http://localhost:4000',
+        password: 'pass',
+        username: 'user',
+      };
+      const sessionMetadata = { userId: '123', sessionId: '789' };
+
+      repository.create.mockResolvedValue(mockRdi);
+      rdiClientFactory.createClient.mockResolvedValue({
+        getPipelineStatus: () => Promise.resolve(({
+          components: {
+            // missing processor.version
+          }
+        }))
+      });
+
+      await service.create(sessionMetadata, dto);
+
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
+        version: '-'
+      }))
     });
   });
 

--- a/redisinsight/api/src/modules/rdi/rdi.service.ts
+++ b/redisinsight/api/src/modules/rdi/rdi.service.ts
@@ -18,6 +18,8 @@ import { deepMerge } from 'src/common/utils';
 import { RdiAnalytics } from './rdi.analytics';
 import { RdiClient } from './client/rdi.client';
 
+const DEFAULT_RDI_VERSION = '-';
+
 @Injectable()
 export class RdiService {
   private logger = new Logger('RdiService');
@@ -40,7 +42,7 @@ export class RdiService {
 
   private static async getRdiVersion(client: RdiClient): Promise<string> {
     const pipelineStatus = await client.getPipelineStatus();
-    const version = pipelineStatus.components.processor.version;
+    const version = pipelineStatus?.components?.processor?.version || DEFAULT_RDI_VERSION;
     return version;
   }
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
@@ -118,7 +118,7 @@ const Config = () => {
           />
         </div>
         <EuiText className="rdi__text" color="subdued">
-          {'Configure target instance '}
+          {'Provide '}
           <EuiLink
             external={false}
             data-testid="rdi-pipeline-config-link"
@@ -133,7 +133,7 @@ const Config = () => {
           >
             connection details
           </EuiLink>
-          {' and applier settings.'}
+          {' for source and target databases and other collector configurations, such as tables and columns to track.'}
         </EuiText>
         {pipelineLoading ? (
           <div className={cx('rdi__editorWrapper', 'rdi__loading')} data-testid="rdi-config-loading">

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
@@ -180,7 +180,7 @@ const Job = (props: Props) => {
           </div>
         </div>
         <EuiText className="rdi__text" color="subdued">
-          {'Describe the '}
+          {'Create a job per source table to filter, transform, and '}
           <EuiLink
             external={false}
             data-testid="rdi-pipeline-transformation-link"
@@ -193,9 +193,9 @@ const Job = (props: Props) => {
               }
             )}
           >
-            transformation logic
+            map data
           </EuiLink>
-          {' to perform on data from a single source'}
+          {' to Redis.'}
         </EuiText>
         {loading ? (
           <div className={cx('rdi__editorWrapper', 'rdi__loading')} data-testid="rdi-job-loading">

--- a/redisinsight/ui/src/pages/rdi/statistics/status/Status.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/status/Status.tsx
@@ -25,8 +25,6 @@ interface Props {
 const Status = ({ data }: Props) => (
   <Panel paddingSize="l">
     <EuiFlexGroup>
-      <StatusItem label="RDI Version" value={data.rdiVersion} />
-      <VerticalDivider />
       <StatusItem label="Address" value={data.address} />
       <VerticalDivider />
       <StatusItem label="Run status" value={data.runStatus} />


### PR DESCRIPTION
# Description 

This task has 3 sub-tasks:

- First is to hide the RDI version on the `Status page` as it's incorrect.
- The second one is to display the proper version of RDI on the connections screen.
- And the third to update few texts related to the task.

- [x] Add tests

# Preview

<img width="830" alt="Screenshot 2025-01-06 at 17 00 45" src="https://github.com/user-attachments/assets/7f16f96d-ff09-419d-9298-e6c82003ede1" />


