### PR TITLE
RI-6547 Apply multiline ellipsis to the table tooltip

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -77,6 +77,7 @@ const TableResult = React.memo((props: Props) => {
             <EuiToolTip
               position="bottom"
               title={title}
+              className="text-multiline-ellipsis"
               anchorClassName={cx('tooltip')}
               content={formatLongName(value.toString())}
             >

--- a/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
+++ b/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
@@ -85,6 +85,10 @@ html {
   display: inline-block !important;
 }
 
+.text-multiline-ellipsis>div:last-child{
+  @include eui.multiline-ellipsis($line-count: 7, $line-height: 1.5rem);
+}
+
 .cell {
   position: relative;
 }

--- a/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
+++ b/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
@@ -85,7 +85,9 @@ html {
   display: inline-block !important;
 }
 
-.text-multiline-ellipsis>div:last-child{
+// The style applies to the last div element in the tooltip, 
+// which is the one containing the text
+.euiToolTipPopover.text-multiline-ellipsis > div:last-child {
   @include eui.multiline-ellipsis($line-count: 7, $line-height: 1.5rem);
 }
 

--- a/redisinsight/ui/src/styles/mixins/_eui.scss
+++ b/redisinsight/ui/src/styles/mixins/_eui.scss
@@ -86,3 +86,12 @@ $euiBreakpointKeys: map-keys($euiBreakpoints);
   $alpha: 1 - $factor;
   color: rgba($color, $alpha);
 }
+
+@mixin multiline-ellipsis($line-count, $line-height) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $line-count;
+  line-height: $line-height;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}


### PR DESCRIPTION
RI-6547 Apply multiline ellipsis to the table tooltip text that overflows, instead of the scroll.
The scroll was the auto behavior when the tooltip text was too long and it lead to the tooltip container height to exceed the one on the table result plugin container. So when attempted to scroll and view the whole text, it was impossible because when focus was lost, the tooltip disappears. 

Implemented the multiline ellipsis solution where maximum 7 lines of text are shown in the tooltip and if longer, ends with "...". If the users wants to view the description,  they can copy it using the copy icon or switch to text view.

Before:
![image](https://github.com/user-attachments/assets/624a0135-3f08-4afa-a141-d9b19dcdfc72)

After:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/fbeb5bfc-5ddb-407c-881e-ab0c8ef4d7ea" />


Verified in both browser and desktop. 