### PR TITLE
RI-5395 Add Nightly Virustotal Analyze

### DIFF
--- a/.github/workflows/nightly-virustotal-analyze.yml
+++ b/.github/workflows/nightly-virustotal-analyze.yml
@@ -1,0 +1,86 @@
+name: Nightly Virustotal Analyze
+
+on:
+  workflow_dispatch:
+    inputs:
+      file_url:
+        description: Provide a file URL for manual scanning (optional)
+        required: false
+        default: 'https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-arm64.dmg'
+        type: string
+
+env:
+  VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+
+jobs:
+  analyze:
+    name: Analyze file
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Use File URL
+        id: file_url_check
+        run: |
+          echo "Using File URL: ${{ github.event.inputs.file_url }}"
+          echo "FILE_URL=${{ github.event.inputs.file_url }}" >> $GITHUB_ENV
+
+      - name: Send URL to scan
+        run: |
+          url="${{ env.FILE_URL }}"
+          echo "URL to check: $url"
+
+          # Upload the URL to VirusTotal
+          analysedId=$(curl -sq -XPOST https://www.virustotal.com/api/v3/urls \
+            -H "x-apikey: $VIRUSTOTAL_API_KEY" \
+            --form url=${url} | jq -r '.data.id')
+
+          if [ "$analysedId" == "null" ]; then
+            echo 'Status is null, something went wrong';
+            exit 1;
+          fi
+
+          echo "ANALYZED_ID=$analysedId" >> $GITHUB_ENV
+
+      - name: Check analyze status
+        run: |
+          echo "Virustotal Analyzed ID: ${ANALYZED_ID}"
+          retryAttempts="50"
+          intervalTime=30
+
+          until [ "$retryAttempts" == "0" ]; do
+            analyzeStatus=$(curl -sq -XGET https://www.virustotal.com/api/v3/analyses/${ANALYZED_ID} \
+              -H "x-apikey: $VIRUSTOTAL_API_KEY" | jq -r '.data.attributes.status')
+
+            if [ "$analyzeStatus" == "completed" ]; then
+              echo "Current status: ${analyzeStatus}"
+              break
+            else
+              echo "Current status: ${analyzeStatus}, retries left: ${retryAttempts}"
+              sleep $intervalTime
+              retryAttempts=$((retryAttempts - 1))
+            fi
+          done
+
+          if [ "$analyzeStatus" != "completed" ]; then
+            echo 'Analyze is not completed'
+            exit 1
+          fi
+
+      - name: Validate analyze
+        id: validate
+        run: |
+          analyzeStats=$(curl -sq -XGET https://www.virustotal.com/api/v3/analyses/${ANALYZED_ID} \
+            -H "x-apikey: $VIRUSTOTAL_API_KEY" | jq -r '.data.attributes.stats')
+
+          analazedMalicious=$(echo ${analyzeStats} | jq '.malicious')
+          analazedSuspicious=$(echo ${analyzeStats} | jq '.suspicious')
+          analazedHarmless=$(echo ${analyzeStats} | jq '.harmless')
+
+          echo "Results: Malicious: ${analazedMalicious}, Suspicious: ${analazedSuspicious}, Harmless: ${analazedHarmless}"
+
+          if [ "$analazedMalicious" != "0" ] || [ "$analazedSuspicious" != "0" ]; then
+            echo "FAILED=true" >> $GITHUB_ENV
+            echo 'Found dangers'
+          else
+            echo "FAILED=false" >> $GITHUB_ENV
+          fi


### PR DESCRIPTION
⚠️ The nighlty part would come in next PR. A.k.a.

```
on:
  schedule:
    - cron: 0 0 * * * # <---------------------- this
  workflow_dispatch:
    inputs:
     ....
```
this PR is to merge the `.yml` file in order to be able to test it inside GitHub. That's why it has manual trigger via `workflow_dispatch`.

# Description

We want to run nightly checks on our downloadables:
```
https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-x64.dmg
https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-mac-arm64.dmg
https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-win-installer.exe
https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-linux-x86_64.AppImage
https://s3.amazonaws.com/redisinsight.download/public/latest/Redis-Insight-linux-amd64.deb
```

# Why?

When we publish official release we run the checks. However we rely that virustotal.com database of potential issues grows everyday, so what was OK yesterday may not be OK today. And that's why we want to check them on a daily basis.