### PR TITLE
RI-5337 bad display of long keys

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -257,7 +257,7 @@ const StreamDataViewWrapper = (props: Props) => {
               </div>
             </EuiText>
           )}
-          <EuiText size="s" style={{ maxWidth: '100%' }} className="truncateText">
+          <EuiText size="s" style={{ maxWidth: '100%', height: '38px' }} className="truncateText">
             <div className="streamItemId truncateText" data-testid={`stream-entry-${id}`} title={idStr}>
               {id}
             </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -258,8 +258,8 @@ const StreamDataViewWrapper = (props: Props) => {
               </div>
             </EuiText>
           )}
-          <EuiText size="s" style={{ maxWidth: '100%' }}>
-            <div className="streamItemId" data-testid={`stream-entry-${id}`}>
+          <EuiText size="s" style={{ maxWidth: '100%' }} className="truncateText">
+            <div className="streamItemId truncateText" data-testid={`stream-entry-${id}`} title={idStr}>
               {id}
             </div>
           </EuiText>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -207,7 +207,6 @@ const StreamDataViewWrapper = (props: Props) => {
     render: function Id({ id, fields }: StreamEntryDto, expanded: boolean) {
       const index = toNumber(last(label.split('-')))
       const values = fields.filter(({ name: fieldName }) => bufferToString(fieldName, viewFormat) === name)
-      const value = values[index] ? bufferToString(values[index]?.value) : ''
 
       const { value: decompressedBufferValue } = decompressingBuffer(values[index]?.value || stringToBuffer(''), compressor)
       // const bufferValue = values[index]?.value || stringToBuffer('')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -247,7 +247,7 @@ const StreamDataViewWrapper = (props: Props) => {
       const timestamp = idStr.split('-')?.[0]
 
       return (
-        <div>
+        <div style={{ minHeight: '38px' }}>
           {id.length < MAX_VISIBLE_LENGTH_STREAM_TIMESTAMP && (
             <EuiText color="subdued" size="s" style={{ maxWidth: '100%' }}>
               <div className="streamItem truncateText" style={{ display: 'flex' }} data-testid={`stream-entry-${id}-date`}>
@@ -257,7 +257,7 @@ const StreamDataViewWrapper = (props: Props) => {
               </div>
             </EuiText>
           )}
-          <EuiText size="s" style={{ maxWidth: '100%', height: '38px' }} className="truncateText">
+          <EuiText size="s" style={{ maxWidth: '100%' }} className="truncateText">
             <div className="streamItemId truncateText" data-testid={`stream-entry-${id}`} title={idStr}>
               {id}
             </div>


### PR DESCRIPTION
When stream entry's key is not valid timestamp and exceeds certain length (25 chars), it is not being displayed as date string and only as id string. If that key is long - 30+ characters, it does not look good

![image](https://github.com/user-attachments/assets/37f31097-39fe-4b61-b17d-67d3c16a3236)

So with this PR, the key is truncated to one line and minimum cell height is applied, because otherwise it ruins the layout of the trash button at the end of the grid

<img width="355" alt="image" src="https://github.com/user-attachments/assets/1598bd62-d5b9-4a9d-9849-17a49c1949e6" />
