### PR TITLE
RI-6661 apply "count" arg before applying DEFAULT_COUNT value for threshold

### DIFF
--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -524,7 +524,7 @@ export function fetchPatternKeysAction(
       sourceKeysFetch = CancelToken.source()
 
       const state = stateInit()
-      const scanThreshold = state.user.settings.config?.scanThreshold || SCAN_COUNT_DEFAULT
+      const scanThreshold = state.user.settings.config?.scanThreshold || count || SCAN_COUNT_DEFAULT
       const { search: match, filter: type } = state.browser.keys
       const { encoding } = state.app.info
 


### PR DESCRIPTION
This is not even the fix but some kind of workaround to reduce % of affected users.

@KIvanow we need to investigate deeper and fix more general problem when `state.user.settings.config?.scanThreshold` might be `undefined` after page refresh when fetching keys. I assume this might affect core logic and produce more regression. Hope current approach enough for now