### PR TITLE
RI-5883: Keys displayed after cli -> flushdb

### DIFF
--- a/redisinsight/ui/src/pages/browser/BrowserPage.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.spec.tsx
@@ -118,7 +118,7 @@ describe('BrowserPage', () => {
 
     fireEvent.click(screen.getByTestId('handleAddKeyPanel-btn'))
 
-    const expectedActions = [resetKeyInfo(), toggleBrowserFullScreen(false)]
+    const expectedActions = [resetKeyInfo(), toggleBrowserFullScreen(false), setBrowserSelectedKey(null)]
     expect(store.getActions()).toEqual([...afterRenderActions, ...expectedActions])
   })
 

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -182,6 +182,7 @@ const BrowserPage = () => {
   }, [])
 
   const handleRemoveSelectedKey = useCallback(() => {
+    setBrowserSelectedKey(null);
     handlePanel(true)
   }, [])
 

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -172,8 +172,9 @@ const BrowserPage = () => {
   }
 
   const handleAddKeyPanel = useCallback((value: boolean, keyName?: RedisResponseBuffer) => {
-    handlePanel(value, keyName)
-    setIsAddKeyPanelOpen(value)
+    handlePanel(value, keyName);
+    setIsAddKeyPanelOpen(value);
+    dispatch(setBrowserSelectedKey(keyName || null));
   }, [])
 
   const handleBulkActionsPanel = useCallback((value: boolean) => {

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -224,6 +224,7 @@ const BrowserPage = () => {
 
       dispatch(setInitialStateByType(prevSelectedType.current))
       setSelectedKey(rowData.name)
+      dispatch(setBrowserSelectedKey(rowData.name));
       closeRightPanels()
       prevSelectedType.current = rowData.type
     }

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
-import { cleanup, mockedStore, render, screen } from 'uiSrc/utils/test-utils'
-import { KeysStoreData, KeyViewType, SearchMode } from 'uiSrc/slices/interfaces/keys'
+import { cleanup, fireEvent, mockedStore, render, screen } from 'uiSrc/utils/test-utils'
+import { setBrowserPatternKeyListDataLoaded, setBrowserSelectedKey } from 'uiSrc/slices/app/context'
 import * as keysSlice from 'uiSrc/slices/browser/keys'
+import { KeysStoreData, KeyViewType, SearchMode } from 'uiSrc/slices/interfaces/keys'
 import { BrowserColumns } from 'uiSrc/constants'
 import KeysHeader from './KeysHeader'
 
@@ -19,8 +20,9 @@ beforeEach(() => {
 
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
-  keysSelector: jest.fn().mockReturnValue(mockSelectorData)
-}))
+  keysSelector: jest.fn().mockReturnValue(mockSelectorData),
+  fetchKeys: jest.fn(),
+}));
 
 const propsMock = {
   keysState: {
@@ -123,4 +125,19 @@ describe('KeysHeader', () => {
 
     expect(queryByTestId('scan-more')).not.toBeInTheDocument()
   })
+
+  it('should reset selected key data when no keys data is returned', async () => {
+    (keysSlice.fetchKeys as jest.Mock).mockImplementation((_options: any, onSuccess: (data: any) => void, __onFailed: () => void) => {
+      return () => {
+        onSuccess({ keys: [] }); // Simulate empty data response
+      };
+    });
+
+    render(<KeysHeader {...propsMock} />)
+
+    fireEvent.click(screen.getByTestId("keys-refresh-btn"));
+
+    const expectedActions = [keysSlice.resetKeyInfo(), setBrowserSelectedKey(null), setBrowserPatternKeyListDataLoaded(true)]
+    expect(store.getActions()).toEqual(expectedActions)
+   });
 })

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
@@ -139,5 +139,5 @@ describe('KeysHeader', () => {
 
     const expectedActions = [keysSlice.resetKeyInfo(), setBrowserSelectedKey(null), setBrowserPatternKeyListDataLoaded(true)]
     expect(store.getActions()).toEqual(expectedActions)
-   });
+  });
 })

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -130,7 +130,7 @@ const KeysHeader = (props: Props) => {
       (data) => {
         const keys = Array.isArray(data) ? data[0].keys : data.keys;
 
-        if (!keys?.length) {
+        if (!keys.length) {
           dispatch(resetKeyInfo());
           dispatch(setBrowserSelectedKey(null));
         }

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -9,9 +9,9 @@ import ColumnsIcon from 'uiSrc/assets/img/icons/columns.svg?react'
 import TreeViewIcon from 'uiSrc/assets/img/icons/treeview.svg?react'
 import KeysSummary from 'uiSrc/components/keys-summary'
 import { SCAN_COUNT_DEFAULT, SCAN_TREE_COUNT_DEFAULT } from 'uiSrc/constants/api'
-import { appContextDbConfig, resetBrowserTree, setBrowserKeyListDataLoaded, setBrowserShownColumns, } from 'uiSrc/slices/app/context'
+import { appContextDbConfig, resetBrowserTree, setBrowserKeyListDataLoaded, setBrowserSelectedKey, setBrowserShownColumns, } from 'uiSrc/slices/app/context'
 
-import { changeKeyViewType, fetchKeys, keysSelector, resetKeysData } from 'uiSrc/slices/browser/keys'
+import { changeKeyViewType, fetchKeys, keysSelector, resetKeyInfo, resetKeysData } from 'uiSrc/slices/browser/keys'
 import { redisearchSelector } from 'uiSrc/slices/browser/redisearch'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { KeysStoreData, KeyViewType, SearchMode } from 'uiSrc/slices/interfaces/keys'
@@ -127,7 +127,21 @@ const KeysHeader = (props: Props) => {
         cursor: '0',
         count: viewType === KeyViewType.Browser ? SCAN_COUNT_DEFAULT : SCAN_TREE_COUNT_DEFAULT,
       },
-      () => dispatch(setBrowserKeyListDataLoaded(searchMode, true)),
+      (data) => {
+        if (Array.isArray(data)) {
+          if (data[0].keys.length === 0) {
+            dispatch(resetKeyInfo());
+            dispatch(setBrowserSelectedKey(null));
+          }
+        } else {
+          if (data.keys.length === 0) {
+            dispatch(resetKeyInfo());
+            dispatch(setBrowserSelectedKey(null));
+          }
+        }
+
+        dispatch(setBrowserKeyListDataLoaded(searchMode, true));
+      },
       () => dispatch(setBrowserKeyListDataLoaded(searchMode, false)),
     ))
   }

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -129,15 +129,14 @@ const KeysHeader = (props: Props) => {
       },
       (data) => {
         const keys = Array.isArray(data) ? data[0].keys : data.keys;
-      
+
         if (!keys?.length) {
           dispatch(resetKeyInfo());
           dispatch(setBrowserSelectedKey(null));
         }
-      
-        dispatch(setBrowserKeyListDataLoaded(searchMode, true));
-      }
 
+        dispatch(setBrowserKeyListDataLoaded(searchMode, true));
+      },
       () => dispatch(setBrowserKeyListDataLoaded(searchMode, false)),
     ))
   }

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -128,20 +128,16 @@ const KeysHeader = (props: Props) => {
         count: viewType === KeyViewType.Browser ? SCAN_COUNT_DEFAULT : SCAN_TREE_COUNT_DEFAULT,
       },
       (data) => {
-        if (Array.isArray(data)) {
-          if (data[0].keys.length === 0) {
-            dispatch(resetKeyInfo());
-            dispatch(setBrowserSelectedKey(null));
-          }
-        } else {
-          if (data.keys.length === 0) {
-            dispatch(resetKeyInfo());
-            dispatch(setBrowserSelectedKey(null));
-          }
+        const keys = Array.isArray(data) ? data[0].keys : data.keys;
+      
+        if (!keys?.length) {
+          dispatch(resetKeyInfo());
+          dispatch(setBrowserSelectedKey(null));
         }
-
+      
         dispatch(setBrowserKeyListDataLoaded(searchMode, true));
-      },
+      }
+
       () => dispatch(setBrowserKeyListDataLoaded(searchMode, false)),
     ))
   }

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { cloneDeep, remove, get, isUndefined } from 'lodash'
 import axios, { AxiosError, CancelTokenSource } from 'axios'
-import { useSelector } from 'react-redux'
 import { apiService, localStorageService } from 'uiSrc/services'
 import {
   ApiEndpoints,
@@ -32,7 +31,7 @@ import { DEFAULT_SEARCH_MATCH, SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import { getBasedOnViewTypeEvent, sendEventTelemetry, TelemetryEvent, getAdditionalAddedEventData, getMatchType } from 'uiSrc/telemetry'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { IFetchKeyArgs, IKeyPropTypes } from 'uiSrc/constants/prop-types/keys'
-import { appContextDbConfig, resetBrowserTree, setBrowserSelectedKey } from 'uiSrc/slices/app/context'
+import { resetBrowserTree, setBrowserSelectedKey } from 'uiSrc/slices/app/context'
 
 import { CreateListWithExpireDto, } from 'apiSrc/modules/browser/list/dto'
 import { SetStringWithExpireDto } from 'apiSrc/modules/browser/string/dto'

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -727,7 +727,6 @@ export function fetchKeyInfo(
       const status = get(error, ['response', 'status'])
       if (status && isStatusNotFoundError(status)) {
         dispatch(resetKeyInfo())
-        dispatch(deleteKeyFromList(key))
         dispatch(setBrowserSelectedKey(null));
       }
     }

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -32,7 +32,7 @@ import { DEFAULT_SEARCH_MATCH, SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import { getBasedOnViewTypeEvent, sendEventTelemetry, TelemetryEvent, getAdditionalAddedEventData, getMatchType } from 'uiSrc/telemetry'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { IFetchKeyArgs, IKeyPropTypes } from 'uiSrc/constants/prop-types/keys'
-import { appContextDbConfig, resetBrowserTree } from 'uiSrc/slices/app/context'
+import { appContextDbConfig, resetBrowserTree, setBrowserSelectedKey } from 'uiSrc/slices/app/context'
 
 import { CreateListWithExpireDto, } from 'apiSrc/modules/browser/list/dto'
 import { SetStringWithExpireDto } from 'apiSrc/modules/browser/string/dto'
@@ -728,6 +728,7 @@ export function fetchKeyInfo(
       if (status && isStatusNotFoundError(status)) {
         dispatch(resetKeyInfo())
         dispatch(deleteKeyFromList(key))
+        dispatch(setBrowserSelectedKey(null));
       }
     }
   }
@@ -1065,10 +1066,8 @@ export function fetchKeysMetadata(
         { params: { encoding: state.app.info.encoding }, signal }
       )
 
-      console.log(`here are we:`)
       onSuccessAction?.(data)
     } catch (_err) {
-      console.log(`here's the error:`+_err)
       if (!axios.isCancel(_err)) {
         const error = _err as AxiosError
         onFailAction?.()

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -724,6 +724,11 @@ export function fetchKeyInfo(
       const errorMessage = getApiErrorMessage(error)
       dispatch(addErrorNotification(error))
       dispatch(defaultSelectedKeyActionFailure(errorMessage))
+      const status = get(error, ['response', 'status'])
+      if (status && isStatusNotFoundError(status)) {
+        dispatch(resetKeyInfo())
+        dispatch(deleteKeyFromList(key))
+      }
     }
   }
 }
@@ -1060,8 +1065,10 @@ export function fetchKeysMetadata(
         { params: { encoding: state.app.info.encoding }, signal }
       )
 
+      console.log(`here are we:`)
       onSuccessAction?.(data)
     } catch (_err) {
+      console.log(`here's the error:`+_err)
       if (!axios.isCancel(_err)) {
         const error = _err as AxiosError
         onFailAction?.()

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -8,7 +8,7 @@ import { cleanup, clearStoreActions, initialStateDefault, mockedStore, mockStore
 import { addErrorNotification, addMessageNotification } from 'uiSrc/slices/app/notifications'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { SearchHistoryItem, SearchMode } from 'uiSrc/slices/interfaces/keys'
-import { resetBrowserTree } from 'uiSrc/slices/app/context'
+import { resetBrowserTree, setBrowserSelectedKey } from 'uiSrc/slices/app/context'
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 import { rootReducer } from 'uiSrc/slices/store'
 import { CreateHashWithExpireDto } from 'apiSrc/modules/browser/hash/dto'
@@ -1285,6 +1285,32 @@ describe('keys slice', () => {
           defaultSelectedKeyAction(),
           addErrorNotification(responsePayload as AxiosError),
           defaultSelectedKeyActionFailure(errorMessage),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+
+      it('key info is reset when key not found', async () => {
+        // Arrange
+        const errorMessage = 'resource not found error'
+        const responsePayload = {
+          response: {
+            status: 404,
+            data: { message: errorMessage },
+          },
+        }
+
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+
+        // Act
+        await store.dispatch<any>(fetchKeyInfo("keyName"))
+
+        // Assert
+        const expectedActions = [
+          defaultSelectedKeyAction(),
+          addErrorNotification(responsePayload as AxiosError),
+          defaultSelectedKeyActionFailure(errorMessage),
+          resetKeyInfo(),
+          setBrowserSelectedKey(null),
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })


### PR DESCRIPTION
Problem:
- Redis instance is created and keys are added to it.  One key is selected and displayed in the right panel. 
- When cli command `flushdb` is ran, it deletes all the keys.
- The opened key in the right panel does not disappear when keys are refreshed (left panel) or when navigated away from the db instance and navigating back to it. Error message is displayed "key does not exist".

Solution:
- Right panel state is cleared when refreshing the keys in the left panel and is still clear when navigating back to the db instance.

Dev testing: 
- Fixed and enhanced existing unit tests for the BrowserPage, keys.ts and create new test for KeysHeader component. 

Manual testing: browser and desktop, when having one and two DB instances. 
**See the use cases in the video provided in the ticket.** 