### PR TITLE
RI-6591: disable primary group name field

### DIFF
--- a/redisinsight/ui/src/pages/home/components/form/sentinel/PrimaryGroupSentinel.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/sentinel/PrimaryGroupSentinel.tsx
@@ -42,6 +42,7 @@ const PrimaryGroupSentinel = (props: Props) => {
               value={formik.values.sentinelMasterName ?? ''}
               maxLength={500}
               onChange={formik.handleChange}
+              disabled
             />
           </EuiFormRow>
         </EuiFlexItem>


### PR DESCRIPTION
Since it seems that changing primary group name during cloning is breaking the app, I have decided to disable the field until better solution is found