### PR TITLE
RI-6614: Rework Consumer Group integration tests

### DIFF
--- a/redisinsight/api/test/api/stream/PATCH-databases-id-streams-consumer_groups.test.ts
+++ b/redisinsight/api/test/api/stream/PATCH-databases-id-streams-consumer_groups.test.ts
@@ -39,46 +39,96 @@ describe('PATCH /databases/:instanceId/streams/consumer-groups', () => {
     requirements('!rte.bigData');
     beforeEach(() => rte.data.generateBinKeys(true));
 
-    [
-      {
-        name: 'Should update consumer group lastDeliveredId from buff',
-        data: {
-          keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
-          name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
-          lastDeliveredId: constants.TEST_STREAM_ID_2,
+    describe('Redis version < 7', () => {
+      requirements('rte.version<7.0');
+      [
+        {
+          name: 'Should update consumer group lastDeliveredId from buff',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
+            name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
+            lastDeliveredId: constants.TEST_STREAM_ID_2,
+          },
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
+              ]
+            ]);
+          },
         },
-        after: async () => {
-          const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
-          expect(groups).to.deep.eq([
-            [
-              Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
-              Buffer.from('consumers'), 0,
-              Buffer.from('pending'), 0,
-              Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
-            ]
-          ]);
+        {
+          name: 'Should update consumer group lastDeliveredId from ascii',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
+            name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
+            lastDeliveredId: constants.TEST_STREAM_ID_2,
+          },
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
+              ]
+            ]);
+          },
         },
-      },
-      {
-        name: 'Should update consumer group lastDeliveredId from ascii',
-        data: {
-          keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
-          name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
-          lastDeliveredId: constants.TEST_STREAM_ID_2,
+      ].forEach(mainCheckFn);
+    });
+    describe('Redis version >= 7', () => {
+      requirements('rte.version>=7.0');
+      [
+        {
+          name: 'Should update consumer group lastDeliveredId from buff',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
+            name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
+            lastDeliveredId: constants.TEST_STREAM_ID_2,
+          },
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
+                Buffer.from('entries-read'), null,
+                Buffer.from('lag'), 1,
+              ]
+            ]);
+          },
         },
-        after: async () => {
-          const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
-          expect(groups).to.deep.eq([
-            [
-              Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
-              Buffer.from('consumers'), 0,
-              Buffer.from('pending'), 0,
-              Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
-            ]
-          ]);
+        {
+          name: 'Should update consumer group lastDeliveredId from ascii',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
+            name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
+            lastDeliveredId: constants.TEST_STREAM_ID_2,
+          },
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_2),
+                Buffer.from('entries-read'), null,
+                Buffer.from('lag'), 1,
+              ]
+            ]);
+          },
         },
-      },
-    ].map(mainCheckFn);
+      ].forEach(mainCheckFn);
+    });
   });
 
   describe('Main', () => {

--- a/redisinsight/api/test/api/stream/POST-databases-id-streams-consumer_groups.test.ts
+++ b/redisinsight/api/test/api/stream/POST-databases-id-streams-consumer_groups.test.ts
@@ -53,56 +53,121 @@ describe('POST /databases/:instanceId/streams/consumer-groups', () => {
       ]);
     });
 
-    [
-      {
-        name: 'Should create consumer group from buff',
-        data: {
-          keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
-          consumerGroups: [
-            {
-              name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
-              lastDeliveredId: constants.TEST_STREAM_ID_1,
-            }
-          ],
+    describe('Redis version < 7', () => {
+      requirements('rte.version<7.0');
+      [
+        {
+          name: 'Should create consumer group from buff',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
+            consumerGroups: [
+              {
+                name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
+                lastDeliveredId: constants.TEST_STREAM_ID_1,
+              }
+            ],
+          },
+          statusCode: 201,
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            const expected = [
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
+              ]
+            ];
+  
+            expect(groups).to.deep.eq(expected);
+          },
         },
-        statusCode: 201,
-        after: async () => {
-          const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
-          expect(groups).to.deep.eq([
-            [
-              Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
-              Buffer.from('consumers'), 0,
-              Buffer.from('pending'), 0,
-              Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
-            ]
-          ]);
+        {
+          name: 'Should create consumer group from ascii',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
+            consumerGroups: [
+              {
+                name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
+                lastDeliveredId: constants.TEST_STREAM_ID_1,
+              }
+            ],
+          },
+          statusCode: 201,
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
+              ]
+            ]);
+          },
         },
-      },
-      {
-        name: 'Should create consumer group from ascii',
-        data: {
-          keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
-          consumerGroups: [
-            {
-              name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
-              lastDeliveredId: constants.TEST_STREAM_ID_1,
-            }
-          ],
+      ].map(mainCheckFn);
+    })
+
+    describe('Redis version >= 7', () => {
+      requirements('rte.version>=7.0');
+      [
+        {
+          name: 'Should create consumer group from buff',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_BUF_OBJ_1,
+            consumerGroups: [
+              {
+                name: constants.TEST_STREAM_GROUP_BIN_BUF_OBJ_1,
+                lastDeliveredId: constants.TEST_STREAM_ID_1,
+              }
+            ],
+          },
+          statusCode: 201,
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            const expected = [
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
+                Buffer.from('entries-read'), null,
+                Buffer.from('lag'), 1,
+              ]
+            ];
+  
+            expect(groups).to.deep.eq(expected);
+          },
         },
-        statusCode: 201,
-        after: async () => {
-          const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
-          expect(groups).to.deep.eq([
-            [
-              Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
-              Buffer.from('consumers'), 0,
-              Buffer.from('pending'), 0,
-              Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
-            ]
-          ]);
+        {
+          name: 'Should create consumer group from ascii',
+          data: {
+            keyName: constants.TEST_STREAM_KEY_BIN_ASCII_1,
+            consumerGroups: [
+              {
+                name: constants.TEST_STREAM_GROUP_BIN_ASCII_1,
+                lastDeliveredId: constants.TEST_STREAM_ID_1,
+              }
+            ],
+          },
+          statusCode: 201,
+          after: async () => {
+            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_BIN_BUFFER_1], null);
+            expect(groups).to.deep.eq([
+              [
+                Buffer.from('name'), constants.TEST_STREAM_GROUP_BIN_BUFFER_1,
+                Buffer.from('consumers'), 0,
+                Buffer.from('pending'), 0,
+                Buffer.from('last-delivered-id'), Buffer.from(constants.TEST_STREAM_ID_1),
+                Buffer.from('entries-read'), null,
+                Buffer.from('lag'), 1,
+              ]
+            ]);
+          },
         },
-      },
-    ].map(mainCheckFn);
+      ].map(mainCheckFn);
+    });
   });
 
   describe('Main', () => {
@@ -120,73 +185,157 @@ describe('POST /databases/:instanceId/streams/consumer-groups', () => {
         await rte.client.xadd(constants.TEST_STREAM_KEY_2, '*', 'f', 'v');
       });
 
-      [
-        {
-          name: 'Should create single consumer group',
-          data: {
-            keyName: constants.TEST_STREAM_KEY_2,
-            consumerGroups: [
-              {
-                name: constants.TEST_STREAM_GROUP_1,
-                lastDeliveredId: constants.TEST_STREAM_ID_1,
-              }
-            ],
-          },
-          before: async () => {
-            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
-            expect(groups.length).to.eq(0);
-          },
-          statusCode: 201,
-          after: async () => {
-            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
-            expect(groups).to.deep.eq([
-              [
-                'name', constants.TEST_STREAM_GROUP_1,
-                'consumers', 0,
-                'pending', 0,
-                'last-delivered-id', constants.TEST_STREAM_ID_1,
-              ]
-            ]);
-          },
-        },
-        {
-          name: 'Should create multiple consumer groups',
-          data: {
-            keyName: constants.TEST_STREAM_KEY_2,
-            consumerGroups: [
-              {
-                name: constants.TEST_STREAM_GROUP_1,
-                lastDeliveredId: constants.TEST_STREAM_ID_1,
-              },
-              {
-                name: constants.TEST_STREAM_GROUP_2,
-                lastDeliveredId: constants.TEST_STREAM_ID_1,
-              }
-            ],
-          },
-          before: async () => {
-            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
-            expect(groups.length).to.eq(0);
-          },
-          statusCode: 201,
-          after: async () => {
-            const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
-            expect(groups).to.deep.eq([
-              [
-                'name', constants.TEST_STREAM_GROUP_1,
-                'consumers', 0,
-                'pending', 0,
-                'last-delivered-id', constants.TEST_STREAM_ID_1,
+      describe('Redis version < 7', () => {
+        requirements('rte.version<7.0');
+        [
+          {
+            name: 'Should create single consumer group',
+            data: {
+              keyName: constants.TEST_STREAM_KEY_2,
+              consumerGroups: [
+                {
+                  name: constants.TEST_STREAM_GROUP_1,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                }
               ],
-              [
-                'name', constants.TEST_STREAM_GROUP_2,
-                'consumers', 0,
-                'pending', 0,
-                'last-delivered-id', constants.TEST_STREAM_ID_1,
-              ]
-            ]);
+            },
+            before: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups.length).to.eq(0);
+            },
+            statusCode: 201,
+            after: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups).to.deep.eq([
+                [
+                  'name', constants.TEST_STREAM_GROUP_1,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                ]
+              ]);
+            },
           },
-        },
+          {
+            name: 'Should create multiple consumer groups',
+            data: {
+              keyName: constants.TEST_STREAM_KEY_2,
+              consumerGroups: [
+                {
+                  name: constants.TEST_STREAM_GROUP_1,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                },
+                {
+                  name: constants.TEST_STREAM_GROUP_2,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                }
+              ],
+            },
+            before: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups.length).to.eq(0);
+            },
+            statusCode: 201,
+            after: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups).to.deep.eq([
+                [
+                  'name', constants.TEST_STREAM_GROUP_1,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                ],
+                [
+                  'name', constants.TEST_STREAM_GROUP_2,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                ]
+              ]);
+            },
+          },
+        ].forEach(mainCheckFn);
+      });
+
+      describe('Redis version >= 7', () => {
+        requirements('rte.version>=7.0');
+        [
+          {
+            name: 'Should create single consumer group',
+            data: {
+              keyName: constants.TEST_STREAM_KEY_2,
+              consumerGroups: [
+                {
+                  name: constants.TEST_STREAM_GROUP_1,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                }
+              ],
+            },
+            before: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups.length).to.eq(0);
+            },
+            statusCode: 201,
+            after: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups).to.deep.eq([
+                [
+                  'name', constants.TEST_STREAM_GROUP_1,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                  'entries-read', null,
+                  'lag', 1,
+                ]
+              ]);
+            },
+          },
+          {
+            name: 'Should create multiple consumer groups',
+            data: {
+              keyName: constants.TEST_STREAM_KEY_2,
+              consumerGroups: [
+                {
+                  name: constants.TEST_STREAM_GROUP_1,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                },
+                {
+                  name: constants.TEST_STREAM_GROUP_2,
+                  lastDeliveredId: constants.TEST_STREAM_ID_1,
+                }
+              ],
+            },
+            before: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups.length).to.eq(0);
+            },
+            statusCode: 201,
+            after: async () => {
+              const groups = await rte.data.sendCommand('xinfo', ['groups', constants.TEST_STREAM_KEY_2]);
+              expect(groups).to.deep.eq([
+                [
+                  'name', constants.TEST_STREAM_GROUP_1,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                  'entries-read', null,
+                  'lag', 1,
+                ],
+                [
+                  'name', constants.TEST_STREAM_GROUP_2,
+                  'consumers', 0,
+                  'pending', 0,
+                  'last-delivered-id', constants.TEST_STREAM_ID_1,
+                  'entries-read', null,
+                  'lag', 1,
+                ]
+              ]);
+            },
+          },
+        ].forEach(mainCheckFn);
+      });
+
+      [
         {
           name: 'Should return 409 Conflict error when group exists',
           data: {


### PR DESCRIPTION
Given the upcoming release for Redis 8, we want to make sure that all Redis Insight features work fine.
However, consumer group tests need reworking due to some changes in their contracts which occurred in Redis 7, more precisely two new properties were added to the post and patch consumer group responses:
- entries_read
- lag

Changes applied:
- Separate the same tests to run when Redis < 7 and Redis >=7 with the appropriate response body expectations

Same was done for the redisearch tests -> https://github.com/RedisInsight/RedisInsight/pull/4314 

Verified on: redis:8.0-M02-alpine, redis:7.2.4 , redis: 6.2.17