### PR TITLE
RI-6605 handle Redis.quit rejection

### DIFF
--- a/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.spec.ts
+++ b/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.spec.ts
@@ -122,6 +122,20 @@ describe('RedisClient', () => {
 
   describe('destroy', () => {
     it('should remove all listeners, disconnect, set client to null and emit end event', async () => {
+      nodeClient.quit = jest.fn().mockResolvedValue(undefined);
+      const removeAllListenersSpy = jest.spyOn(nodeClient, 'removeAllListeners');
+
+      await redisClientSubscriber['connect']();
+      redisClientSubscriber.destroy();
+
+      expect(redisClientSubscriber['client']).toEqual(null);
+      expect(redisClientSubscriber['status']).toEqual(RedisClientSubscriberStatus.End);
+      expect(removeAllListenersSpy).toHaveBeenCalled();
+      expect(nodeClient.quit).toHaveBeenCalled();
+    });
+    it('should not crash if quick promise was rejected', async () => {
+      nodeClient.quit = jest.fn().mockRejectedValueOnce(new Error('Connection is closed'));
+
       const removeAllListenersSpy = jest.spyOn(nodeClient, 'removeAllListeners');
 
       await redisClientSubscriber['connect']();

--- a/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.spec.ts
+++ b/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.spec.ts
@@ -10,7 +10,6 @@ nodeClient.pSubscribe = jest.fn();
 nodeClient.unsubscribe = jest.fn();
 nodeClient.pUnsubscribe = jest.fn();
 nodeClient.disconnect = jest.fn();
-nodeClient.quit = jest.fn();
 
 describe('RedisClient', () => {
   let redisClientSubscriber: RedisClientSubscriber;
@@ -21,6 +20,7 @@ describe('RedisClient', () => {
     getRedisClientFn.mockResolvedValue(nodeClient);
     nodeClient.subscribe.mockResolvedValue('OK');
     nodeClient.pSubscribe.mockResolvedValue('OK');
+    nodeClient.quit = jest.fn().mockResolvedValue(undefined);
   });
 
   describe('getClient', () => {
@@ -122,7 +122,6 @@ describe('RedisClient', () => {
 
   describe('destroy', () => {
     it('should remove all listeners, disconnect, set client to null and emit end event', async () => {
-      nodeClient.quit = jest.fn().mockResolvedValue(undefined);
       const removeAllListenersSpy = jest.spyOn(nodeClient, 'removeAllListeners');
 
       await redisClientSubscriber['connect']();

--- a/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.ts
+++ b/redisinsight/api/src/modules/pub-sub/model/redis-client-subscriber.ts
@@ -95,7 +95,9 @@ export class RedisClientSubscriber extends EventEmitter2 {
    */
   destroy() {
     this.client?.removeAllListeners();
-    this.client?.quit();
+    this.client?.quit().catch((e) => {
+      this.logger.warn('Error when closing Redis client', e);
+    });
     this.client = null;
     this.status = RedisClientSubscriberStatus.End;
   }

--- a/redisinsight/api/src/modules/pub-sub/model/user-session.spec.ts
+++ b/redisinsight/api/src/modules/pub-sub/model/user-session.spec.ts
@@ -49,6 +49,7 @@ describe('UserSession', () => {
     getRedisClientFn.mockResolvedValue(nodeClient);
     nodeClient.subscribe.mockResolvedValue('OK');
     nodeClient.pSubscribe.mockResolvedValue('OK');
+    nodeClient.quit = jest.fn().mockResolvedValue(undefined);
   });
 
   describe('subscribe', () => {


### PR DESCRIPTION
`client.quit` is async function which wasn't handled properly