### PR TITLE
RI-6775: Change key not found error message on delete

### DIFF
--- a/redisinsight/api/src/modules/browser/keys/keys.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/keys/keys.service.spec.ts
@@ -314,7 +314,7 @@ describe('KeysService', () => {
 
       await expect(
         service.deleteKeys(mockBrowserClientMetadata, keyNames),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(new NotFoundException(ERROR_MESSAGES.KEY_NOT_EXIST));
     });
     it("user don't have required permissions for deleteKeys", async () => {
       const replyError: ReplyError = {

--- a/redisinsight/api/src/modules/browser/keys/keys.service.ts
+++ b/redisinsight/api/src/modules/browser/keys/keys.service.ts
@@ -182,7 +182,7 @@ export class KeysService {
 
       if (!result) {
         this.logger.error('Failed to delete keys. Not Found keys', clientMetadata);
-        return Promise.reject(new NotFoundException());
+        return Promise.reject(new NotFoundException(ERROR_MESSAGES.KEY_NOT_EXIST));
       }
 
       this.logger.debug('Succeed to delete keys', clientMetadata);

--- a/redisinsight/api/test/api/keys/DELETE-databases-id-keys.test.ts
+++ b/redisinsight/api/test/api/keys/DELETE-databases-id-keys.test.ts
@@ -189,7 +189,8 @@ describe('DELETE /databases/:instanceId/keys', () => {
           // todo: investigate error payload. Seems that missed fields and wrong message
           responseBody: {
             statusCode: 404,
-            message: 'Not Found',
+            error: 'Not Found',
+            message: 'Key with this name does not exist.'
           },
         },
       ].map(deleteCheckFn);


### PR DESCRIPTION
When delete is called on a key that has already been deleted, the error message should be "Key with that name does not exist".

e.g. key had expired after its details have been shown, and user can still click on the delete button. 