### PR TITLE
RI-6806: Disable refresh when index not selected

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.spec.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.spec.tsx
@@ -248,5 +248,14 @@ describe('AutoRefresh', () => {
       await new Promise((r) => setTimeout(r, 1300))
     })
     expect(onRefresh).toBeCalledTimes(1)
+  });
+
+  it('refresh tooltip text should contain disabled refresh button reason message when button disabled', async () => {
+    const tooltipText = 'some-disabled-message';
+    render(<AutoRefresh {...instance(mockedProps)} disabled={true} disabledRefreshButtonMessage={tooltipText} />);
+
+    fireEvent.mouseOver(screen.getByTestId('refresh-btn'));
+    await screen.findByTestId('refresh-tooltip');
+    expect(screen.getByTestId('refresh-tooltip')).toHaveTextContent(new RegExp(`^${tooltipText}$`));
   })
 })

--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -39,6 +39,7 @@ export interface Props {
   defaultRefreshRate?: string
   iconSize?: EuiButtonIconSizes
   disabled?: boolean
+  disabledMessage: string
   enableAutoRefreshDefault?: boolean
 }
 
@@ -59,6 +60,7 @@ const AutoRefresh = ({
   onChangeAutoRefreshRate,
   iconSize = 'm',
   disabled,
+  disabledMessage,
   minimumRefreshRate,
   defaultRefreshRate,
   enableAutoRefreshDefault = false
@@ -186,10 +188,10 @@ const AutoRefresh = ({
       </EuiTextColor>
 
       <EuiToolTip
-        title="Last Refresh"
+        title={disabled ? "" : "Last Refresh"}
         className={styles.tooltip}
         position="top"
-        content={refreshMessage}
+        content={disabled ? disabledMessage : refreshMessage}
       >
         <EuiButtonIcon
           size={iconSize}

--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -39,7 +39,7 @@ export interface Props {
   defaultRefreshRate?: string
   iconSize?: EuiButtonIconSizes
   disabled?: boolean
-  disabledMessage: string
+  disabledRefreshButtonMessage: string
   enableAutoRefreshDefault?: boolean
 }
 
@@ -60,7 +60,7 @@ const AutoRefresh = ({
   onChangeAutoRefreshRate,
   iconSize = 'm',
   disabled,
-  disabledMessage,
+  disabledRefreshButtonMessage,
   minimumRefreshRate,
   defaultRefreshRate,
   enableAutoRefreshDefault = false
@@ -188,10 +188,10 @@ const AutoRefresh = ({
       </EuiTextColor>
 
       <EuiToolTip
-        title={disabled ? "" : "Last Refresh"}
+        title={!disabled && "Last Refresh"}
         className={styles.tooltip}
         position="top"
-        content={disabled ? disabledMessage : refreshMessage}
+        content={disabled ? disabledRefreshButtonMessage : refreshMessage}
       >
         <EuiButtonIcon
           size={iconSize}

--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -192,6 +192,7 @@ const AutoRefresh = ({
         className={styles.tooltip}
         position="top"
         content={disabled ? disabledRefreshButtonMessage : refreshMessage}
+        data-testid={getDataTestid('refresh-tooltip')}
       >
         <EuiButtonIcon
           size={iconSize}

--- a/redisinsight/ui/src/components/auto-refresh/styles.module.scss
+++ b/redisinsight/ui/src/components/auto-refresh/styles.module.scss
@@ -94,6 +94,11 @@
     width: 10px !important;
     height: 10px !important;
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 
 .switchOption {

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -266,6 +266,8 @@ const KeysHeader = (props: Props) => {
               </div>
               <div className={styles.keysControlsWrapper}>
                 <AutoRefresh
+                  disabled={searchMode === SearchMode.Redisearch && !selectedIndex}
+                  disabledMessage="Select an index to refresh keys."
                   iconSize="xs"
                   postfix="keys"
                   loading={loading}

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -267,7 +267,7 @@ const KeysHeader = (props: Props) => {
               <div className={styles.keysControlsWrapper}>
                 <AutoRefresh
                   disabled={searchMode === SearchMode.Redisearch && !selectedIndex}
-                  disabledMessage="Select an index to refresh keys."
+                  disabledRefreshButtonMessage="Select an index to refresh keys."
                   iconSize="xs"
                   postfix="keys"
                   loading={loading}


### PR DESCRIPTION
When in Redisearch / index search mode and index is not selected, an error is shown to the user which is not a good UX experience. Instead, the following was applied:
* Disabled the refresh button when index is not selected in redisearch mode, which stops the refresh / data init from happening
* Add a tooltip on the disabled refresh button - "Select an index to refresh keys."
* Add some styling to the arrow next to the refresh button so it is clear that is disabled when hovered. 