### PR TITLE
RI-6382: Test multiple source connections

### DIFF
--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.spec.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.spec.ts
@@ -1,0 +1,47 @@
+import { Expose, Type, plainToClass } from 'class-transformer';
+import { TransformToMap } from './transform-to-map.decorator';
+
+class DummyClass {
+  @Expose()
+  value: string;
+}
+
+class TestDto {
+  @TransformToMap(DummyClass)
+  @Expose()
+  @Type(() => DummyClass)
+  data: Record<string, DummyClass>;
+}
+
+describe('TransformToMap decorator', () => {
+  it('should transform each map value into an instance of DummyClass', () => {
+    const input = {
+      data: {
+        key1: { value: 'test1' },
+        key2: { value: 'test2' },
+      },
+    };
+
+    const instance = plainToClass(TestDto, input);
+
+    expect(instance.data).toBeDefined();
+    expect(instance.data.key1).toBeInstanceOf(DummyClass);
+    expect(instance.data.key2).toBeInstanceOf(DummyClass);
+    expect(instance.data.key1.value).toEqual('test1');
+    expect(instance.data.key2.value).toEqual('test2');
+  });
+
+  it('should handle empty objects gracefully', () => {
+    const input = { data: {} };
+    const instance = plainToClass(TestDto, input);
+
+    expect(instance.data).toEqual({});
+  });
+
+  it('should handle undefined values gracefully', () => {
+    const input = { data: undefined };
+    const instance = plainToClass(TestDto, input);
+
+    expect(instance.data).toEqual(undefined);
+  });
+});

--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.spec.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.spec.ts
@@ -1,4 +1,4 @@
-import { Expose, Type, plainToClass } from 'class-transformer';
+import { Expose, classToPlain, plainToClass } from 'class-transformer';
 import { TransformToMap } from './transform-to-map.decorator';
 
 class DummyClass {
@@ -9,7 +9,6 @@ class DummyClass {
 class TestDto {
   @TransformToMap(DummyClass)
   @Expose()
-  @Type(() => DummyClass)
   data: Record<string, DummyClass>;
 }
 
@@ -43,5 +42,46 @@ describe('TransformToMap decorator', () => {
     const instance = plainToClass(TestDto, input);
 
     expect(instance.data).toEqual(undefined);
+  });
+
+  it('should convert a class instance to a plain object', () => {
+    const dummy1 = new DummyClass();
+    dummy1.value = 'test1';
+    const dummy2 = new DummyClass();
+    dummy2.value = 'test2';
+
+    const dataMap = {
+      key1: { value: 'test1' },
+      key2: { value: 'test2' },
+    };
+
+    const instance = new TestDto();
+    instance.data = dataMap;
+
+    const plain = classToPlain(instance);
+
+    expect(plain).toHaveProperty('data');
+    expect(plain.data).toEqual({
+      key1: { value: 'test1' },
+      key2: { value: 'test2' },
+    });
+  });
+
+  it('should handle an empty Map gracefully on reverse conversion', () => {
+    const instance = new TestDto();
+    instance.data = {};
+
+    const plain = classToPlain(instance);
+
+    expect(plain.data).toEqual({});
+  });
+
+  it('should handle undefined values gracefully on reverse conversion', () => {
+    const instance = new TestDto();
+    instance.data = undefined;
+
+    const plain = classToPlain(instance);
+
+    expect(plain.data).toEqual(undefined);
   });
 });

--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
@@ -1,0 +1,10 @@
+import { Transform, plainToClass } from 'class-transformer';
+
+export function TransformToMap<T>(cls: new (...args: any[]) => T) {
+  return Transform(({ value }) => Object.fromEntries(
+    Object.entries(value || {}).map(([key, val]) => [
+      key,
+      plainToClass(cls, val),
+    ]),
+  ));
+}

--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
@@ -4,30 +4,36 @@ import { ClassType } from 'class-transformer/ClassTransformer';
 
 export function TransformToMap<T>(targetClass: ClassType<T>) {
   return applyDecorators(
-    Transform((value) => {
-      if (!value) {
-        return value;
-      }
+    Transform(
+      (value) => {
+        if (!value) {
+          return value;
+        }
 
-      return Object.fromEntries(
-        Object.entries(value).map(([key, val]) => [
-          key,
-          plainToClass(targetClass, val),
-        ]),
-      );
-    }),
+        return Object.fromEntries(
+          Object.entries(value).map(([key, val]) => [
+            key,
+            plainToClass(targetClass, val),
+          ]),
+        );
+      },
+      { toClassOnly: true },
+    ),
 
-    Transform((value) => {
-      if (!value) {
-        return value;
-      }
+    Transform(
+      (value) => {
+        if (!value) {
+          return value;
+        }
 
-      return Object.fromEntries(
-        Object.entries(value).map(([key, instance]) => [
-          key,
-          classToPlain(instance),
-        ]),
-      );
-    }),
+        return Object.fromEntries(
+          Object.entries(value).map(([key, instance]) => [
+            key,
+            classToPlain(instance),
+          ]),
+        );
+      },
+      { toPlainOnly: true },
+    ),
   );
 }

--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
@@ -1,10 +1,15 @@
 import { Transform, plainToClass } from 'class-transformer';
 
 export function TransformToMap<T>(cls: new (...args: any[]) => T) {
-  return Transform(({ value }) => Object.fromEntries(
-    Object.entries(value || {}).map(([key, val]) => [
-      key,
-      plainToClass(cls, val),
-    ]),
-  ));
+  return Transform(({ value }) => {
+    if (value === undefined || value === null) {
+      return value;
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) => [
+        key,
+        plainToClass(cls, val),
+      ]),
+    );
+  });
 }

--- a/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
+++ b/redisinsight/api/src/common/decorators/transform-to-map.decorator.ts
@@ -1,15 +1,33 @@
-import { Transform, plainToClass } from 'class-transformer';
+import { applyDecorators } from '@nestjs/common';
+import { Transform, classToPlain, plainToClass } from 'class-transformer';
+import { ClassType } from 'class-transformer/ClassTransformer';
 
-export function TransformToMap<T>(cls: new (...args: any[]) => T) {
-  return Transform(({ value }) => {
-    if (value === undefined || value === null) {
-      return value;
-    }
-    return Object.fromEntries(
-      Object.entries(value).map(([key, val]) => [
-        key,
-        plainToClass(cls, val),
-      ]),
-    );
-  });
+export function TransformToMap<T>(targetClass: ClassType<T>) {
+  return applyDecorators(
+    Transform((value) => {
+      if (!value) {
+        return value;
+      }
+
+      return Object.fromEntries(
+        Object.entries(value).map(([key, val]) => [
+          key,
+          plainToClass(targetClass, val),
+        ]),
+      );
+    }),
+
+    Transform((value) => {
+      if (!value) {
+        return value;
+      }
+
+      return Object.fromEntries(
+        Object.entries(value).map(([key, instance]) => [
+          key,
+          classToPlain(instance),
+        ]),
+      );
+    }),
+  );
 }

--- a/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
+++ b/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
@@ -184,7 +184,7 @@ export class ApiRdiClient extends RdiClient {
     config: ConnectionsConfig,
   ): Promise<RdiTestConnectionsResponseDto> {
     let targets: Record<string, RdiTestConnectionResult> = {};
-    let sources: Record<string, RdiSourcesConnectionResult> = {};
+    const sources: Record<string, RdiSourcesConnectionResult> = {};
 
     try {
       const targetsResponse = await this.client.post(

--- a/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
+++ b/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
@@ -15,9 +15,9 @@ import {
 import {
   RdiDryRunJobDto,
   RdiDryRunJobResponseDto,
-  RdiSourcesConnectionResult,
+  RdiTestSourceConnectionResult,
   RdiTemplateResponseDto,
-  RdiTestConnectionResult,
+  RdiTestTargetConnectionResult,
   RdiTestConnectionsResponseDto,
 } from 'src/modules/rdi/dto';
 import {
@@ -183,8 +183,8 @@ export class ApiRdiClient extends RdiClient {
   async testConnections(
     config: ConnectionsConfig,
   ): Promise<RdiTestConnectionsResponseDto> {
-    let targets: Record<string, RdiTestConnectionResult> = {};
-    const sources: Record<string, RdiSourcesConnectionResult> = {};
+    let targets: Record<string, RdiTestTargetConnectionResult> = {};
+    const sources: Record<string, RdiTestSourceConnectionResult> = {};
 
     try {
       const targetsResponse = await this.client.post(

--- a/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
+++ b/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
@@ -56,8 +56,9 @@ export class RdiTestConnectionsResponseDto {
     description: 'Sources connection results',
   })
   @Expose()
-  @Type(() => RdiSourcesConnectionResult)
-  sources: RdiSourcesConnectionResult;
+  // TODO: fix this
+  // @Type(() => RdiSourcesConnectionResult)
+  sources: Record<string, RdiSourcesConnectionResult>
 
   @ApiProperty({
     description: 'Targets connection results',

--- a/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
+++ b/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
@@ -23,7 +23,7 @@ class ErrorDetails {
   message: string;
 }
 
-export class RdiTestConnectionResult {
+export class RdiTestTargetConnectionResult {
   @ApiProperty({
     description: 'Connection status',
     enum: RdiTestConnectionStatus,
@@ -40,7 +40,7 @@ export class RdiTestConnectionResult {
   error?: ErrorDetails;
 }
 
-export class RdiSourcesConnectionResult {
+export class RdiTestSourceConnectionResult {
   @ApiProperty({ description: 'Indicates if the source is connected' })
   @Expose()
   connected: boolean;
@@ -58,13 +58,13 @@ export class RdiTestConnectionsResponseDto {
     description: 'Sources connection results',
   })
   @Expose()
-  @TransformToMap(RdiSourcesConnectionResult)
-  sources: Record<string, RdiSourcesConnectionResult>;
+  @TransformToMap(RdiTestSourceConnectionResult)
+  sources: Record<string, RdiTestSourceConnectionResult>;
 
   @ApiProperty({
     description: 'Targets connection results',
   })
   @Expose()
-  @TransformToMap(RdiTestConnectionResult)
-  targets: Record<string, RdiTestConnectionResult>;
+  @TransformToMap(RdiTestTargetConnectionResult)
+  targets: Record<string, RdiTestTargetConnectionResult>;
 }

--- a/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
+++ b/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  Expose, Transform, Type, plainToClass,
-} from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
+import { TransformToMap } from 'src/common/decorators/transform-to-map.decorator';
 
 export enum RdiTestConnectionStatus {
   Success = 'success',
@@ -46,7 +45,10 @@ export class RdiSourcesConnectionResult {
   @Expose()
   connected: boolean;
 
-  @ApiProperty({ description: 'Error message if connection fails', required: false })
+  @ApiProperty({
+    description: 'Error message if connection fails',
+    required: false,
+  })
   @Expose()
   error?: string;
 }
@@ -56,16 +58,13 @@ export class RdiTestConnectionsResponseDto {
     description: 'Sources connection results',
   })
   @Expose()
-  // TODO: fix this
-  // @Type(() => RdiSourcesConnectionResult)
-  sources: Record<string, RdiSourcesConnectionResult>
+  @TransformToMap(RdiSourcesConnectionResult)
+  sources: Record<string, RdiSourcesConnectionResult>;
 
   @ApiProperty({
     description: 'Targets connection results',
   })
   @Expose()
-  @Transform(({ value }) => Object.fromEntries(
-    Object.entries(value || {}).map(([key, val]) => [key, plainToClass(RdiTestConnectionResult, val)]),
-  ))
+  @TransformToMap(RdiTestConnectionResult)
   targets: Record<string, RdiTestConnectionResult>;
 }

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/TestConnectionsLog.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/TestConnectionsLog.spec.tsx
@@ -1,30 +1,43 @@
 import React from 'react'
 import { render, screen, fireEvent, within } from 'uiSrc/utils/test-utils'
-import { ITestConnection, TestConnectionStatus } from 'uiSrc/slices/interfaces'
+import { TransformGroupResult } from 'uiSrc/slices/interfaces'
 
 import TestConnectionsLog from './TestConnectionsLog'
 
 describe('TestConnectionsLog', () => {
   it('should render', () => {
-    const mockedData = { fail: [], success: [] }
+    const mockedData: TransformGroupResult = { fail: [], success: [] }
     render(<TestConnectionsLog data={mockedData} />)
   })
 
-  it('should be a collapsed nav group', () => {
-    const mockedData: ITestConnection = {
-      fail: [{ index: 0, status: TestConnectionStatus.Fail, endpoint: 'localhost:1233', error: 'some error' }],
+  it('should render the correct status when only failed connections exist', () => {
+    const mockedData: TransformGroupResult = {
+      fail: [{ target: 'localhost:1233', error: 'some error' }],
       success: []
     }
     render(<TestConnectionsLog data={mockedData} />)
 
-    expect(screen.queryByTestId('success-connections-closed')).not.toBeInTheDocument()
     expect(screen.getByTestId('failed-connections-closed')).toBeInTheDocument()
+    expect(screen.queryByTestId('success-connections-closed')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mixed-connections-closed')).not.toBeInTheDocument()
   })
 
-  it('should open and collapse other groups', () => {
-    const mockedData: ITestConnection = {
+  it('should render the correct status when only successful connections exist', () => {
+    const mockedData: TransformGroupResult = {
       fail: [],
-      success: [{ index: 1, status: TestConnectionStatus.Success, endpoint: 'localhost:1233' }]
+      success: [{ target: 'localhost:1233' }]
+    }
+    render(<TestConnectionsLog data={mockedData} />)
+
+    expect(screen.getByTestId('success-connections-closed')).toBeInTheDocument()
+    expect(screen.queryByTestId('failed-connections-closed')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mixed-connections-closed')).not.toBeInTheDocument()
+  })
+
+  it('should expand and collapse successful connections', () => {
+    const mockedData: TransformGroupResult = {
+      fail: [],
+      success: [{ target: 'localhost:1233' }]
     }
     render(<TestConnectionsLog data={mockedData} />)
 
@@ -34,12 +47,12 @@ describe('TestConnectionsLog', () => {
     expect(screen.getByTestId('success-connections-open')).toBeInTheDocument()
   })
 
-  it('should show proper items length', () => {
-    const mockedData: ITestConnection = {
+  it('should display the correct number of successful connections', () => {
+    const mockedData: TransformGroupResult = {
       fail: [],
       success: [
-        { index: 1, status: TestConnectionStatus.Success, endpoint: 'localhost:1233' },
-        { index: 2, status: TestConnectionStatus.Success, endpoint: 'localhost:1233' }
+        { target: 'localhost:1233' },
+        { target: 'localhost:1234' }
       ]
     }
     render(<TestConnectionsLog data={mockedData} />)
@@ -47,5 +60,41 @@ describe('TestConnectionsLog', () => {
     expect(
       within(screen.getByTestId('success-connections-closed')).getByTestId('number-of-connections')
     ).toHaveTextContent('2')
+  })
+
+  it('should display "Partially connected" when there are both successful and failed connections', () => {
+    const mockedData: TransformGroupResult = {
+      fail: [{ target: 'localhost:1233', error: 'some error' }],
+      success: [{ target: 'localhost:1234' }]
+    }
+    render(<TestConnectionsLog data={mockedData} />)
+
+    expect(screen.getByText('Partially connected:')).toBeInTheDocument()
+  })
+
+  it('should expand and collapse the "Mixed" state correctly', () => {
+    const mockedData: TransformGroupResult = {
+      fail: [{ target: 'localhost:1233', error: 'some error' }],
+      success: [{ target: 'localhost:1234' }]
+    }
+    render(<TestConnectionsLog data={mockedData} />)
+
+    fireEvent.click(within(screen.getByTestId('mixed-connections-closed')).getByRole('button'))
+    expect(screen.getByTestId('mixed-connections-open')).toBeInTheDocument()
+  })
+
+  it('should display the correct number of connections for the "Mixed" state', () => {
+    const mockedData: TransformGroupResult = {
+      fail: [
+        { target: 'localhost:1233', error: 'some error' },
+        { target: 'localhost:1234', error: 'timeout' }
+      ],
+      success: [{ target: 'localhost:1235' }]
+    }
+    render(<TestConnectionsLog data={mockedData} />)
+
+    expect(
+      within(screen.getByTestId('mixed-connections-closed')).getByTestId('number-of-connections')
+    ).toHaveTextContent('3') // 2 failed + 1 success
   })
 })

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/TestConnectionsLog.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/TestConnectionsLog.tsx
@@ -9,17 +9,36 @@ import styles from './styles.module.scss'
 
 enum ResultsStatus {
   Success = 'success',
-  Failed = 'failed'
+  Failed = 'failed',
+  Mixed = 'mixed'
 }
 
 export interface Props {
   data: TransformGroupResult
 }
 
+const getStatus = (data: TransformGroupResult) => {
+  if (data.fail.length && data.success.length) {
+    return ResultsStatus.Mixed
+  }
+
+  if (data.fail.length) {
+    return ResultsStatus.Failed
+  }
+
+  return ResultsStatus.Success
+}
+
+const statusToLabel = {
+  [ResultsStatus.Success]: 'Connected successfully',
+  [ResultsStatus.Failed]: 'Failed to connect',
+  [ResultsStatus.Mixed]: 'Partially connected',
+}
+
 const TestConnectionsLog = (props: Props) => {
   const { data } = props
   const statusData = [...data.success, ...data.fail]
-  const status = data?.fail?.length ? ResultsStatus.Failed : ResultsStatus.Success
+  const status = getStatus(data)
   const [openedNav, setOpenedNav] = useState<string>('')
 
   const onToggle = (length: number = 0, isOpen: boolean, name: string) => {
@@ -40,7 +59,7 @@ const TestConnectionsLog = (props: Props) => {
     </div>
   )
 
-  const navTitle = status === ResultsStatus.Success ? 'Connected successfully' : 'Failed to connect'
+  const navTitle = statusToLabel[status]
 
   const getNavGroupState = (name: ResultsStatus) => (openedNav === name ? 'open' : 'closed')
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/styles.module.scss
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-log/styles.module.scss
@@ -30,6 +30,12 @@
     }
   }
 
+  &:global(.mixed) {
+    &:before {
+      background-color: var(--warningBorderColor);
+    }
+  }
+
   &:global(.failed) {
     &:before {
       background-color: var(--errorBorderColor);

--- a/redisinsight/ui/src/slices/tests/rdi/testConnections.spec.ts
+++ b/redisinsight/ui/src/slices/tests/rdi/testConnections.spec.ts
@@ -104,8 +104,10 @@ describe('rdi test connections slice', () => {
           },
 
           sources: {
-            connected: true,
-            error: '',
+            source: {
+              connected: true,
+              error: '',
+            }
           },
         }
 

--- a/redisinsight/ui/src/utils/tests/transformers/transformRdiPipeline.spec.ts
+++ b/redisinsight/ui/src/utils/tests/transformers/transformRdiPipeline.spec.ts
@@ -245,8 +245,10 @@ const transformConnectionResultsTests: any[] = [
         target1: { status: 'success' },
       },
       sources: {
-        connected: true,
-        error: 'Success',
+        source1: {
+          connected: true,
+          error: 'Success',
+        }
       },
     },
     {
@@ -255,7 +257,7 @@ const transformConnectionResultsTests: any[] = [
         fail: [],
       },
       source: {
-        success: [{ target: 'source' }],
+        success: [{ target: 'source1' }],
         fail: [],
       },
     },
@@ -266,8 +268,10 @@ const transformConnectionResultsTests: any[] = [
         target1: { status: 'success' },
       },
       sources: {
-        connected: false,
-        error: 'Database unreachable',
+        source1: {
+          connected: false,
+          error: 'Database unreachable',
+        }
       },
     },
     {
@@ -277,7 +281,34 @@ const transformConnectionResultsTests: any[] = [
       },
       source: {
         success: [],
-        fail: [{ target: 'source', error: 'Database unreachable' }],
+        fail: [{ target: 'source1', error: 'Database unreachable' }],
+      },
+    },
+  ],
+  [
+    {
+      targets: {
+        target1: { status: 'success' },
+      },
+      sources: {
+        source1: {
+          connected: false,
+          error: 'Database unreachable',
+        },
+        source2: {
+          connected: true,
+          error: '',
+        }
+      },
+    },
+    {
+      target: {
+        success: [{ target: 'target1' }],
+        fail: [],
+      },
+      source: {
+        success: [{ target: 'source2' }],
+        fail: [{ target: 'source1', error: 'Database unreachable' }],
       },
     },
   ],

--- a/redisinsight/ui/src/utils/transformers/transformRdiPipeline.ts
+++ b/redisinsight/ui/src/utils/transformers/transformRdiPipeline.ts
@@ -81,11 +81,14 @@ export const transformConnectionResults = (
     return result
   }
 
-  if (results.sources.connected) {
-    result.source.success.push({ target: 'source' })
-  } else {
-    result.source.fail.push({ target: 'source', error: results.sources.error })
-  }
+  Object.entries(results.sources).forEach(([source, details]) => {
+    if (details.connected) {
+      result.source.success.push({ target: source })
+    } else {
+      const errorMessage = details.error || 'Error'
+      result.source.fail.push({ target: source, error: errorMessage })
+    }
+  })
 
   return result
 }


### PR DESCRIPTION
As additional work to #4368, here you can test multiple sources.

Maybe going commit by commit would be easier to review.

# Preview

<img width="452" alt="Screenshot 2025-02-21 at 15 23 40" src="https://github.com/user-attachments/assets/d9f78b50-4fba-49ad-94b4-a71c8253f179" />
<img width="451" alt="Screenshot 2025-02-21 at 15 23 25" src="https://github.com/user-attachments/assets/72e7cd44-8b77-4e28-b06a-00cbd25996bd" />
<img width="447" alt="Screenshot 2025-02-21 at 15 23 14" src="https://github.com/user-attachments/assets/6045fb47-95e1-485d-8b2d-5ab694af7295" />
