### PR TITLE
RI-6797: Prevent editing of Hex and Binary values

### DIFF
--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -51,6 +51,8 @@ const isFormatEditable = (format: KeyValueFormat) => ![
   KeyValueFormat.Pickle,
   KeyValueFormat.Vector32Bit,
   KeyValueFormat.Vector64Bit,
+  KeyValueFormat.HEX,
+  KeyValueFormat.Binary,
 ].includes(format)
 
 const isFullStringLoaded = (currentLength: Maybe<number>, fullLength: Maybe<number>) => currentLength === fullLength


### PR DESCRIPTION
Editing values that are  `Hex` or `Binary` encoded has to be re-reworked in order to support the value conversion and validation rules. So for now we turn the editing off.

Here its enabled:

<img width="931" alt="Screenshot 2025-02-24 at 20 33 00" src="https://github.com/user-attachments/assets/2406fa9c-ac20-45e8-9314-0dfa630e1320" />

And here is not:

<img width="933" alt="Screenshot 2025-02-24 at 20 32 53" src="https://github.com/user-attachments/assets/51eb5a8e-9bb4-4f4e-a884-2d361a33e26e" />

<img width="935" alt="Screenshot 2025-02-24 at 20 32 44" src="https://github.com/user-attachments/assets/d14c5527-9e34-4340-9fe2-2dab58a3467b" />
 