### PR TITLE
RI-6864: add `reason` to `ANALYTICS_PERMISSION` event.

### DIFF
--- a/redisinsight/api/src/constants/telemetry-events.ts
+++ b/redisinsight/api/src/constants/telemetry-events.ts
@@ -104,13 +104,4 @@ export enum CommandType {
   Module = 'module',
 }
 
-export const ToggleAnalyticsReason = {
-  None: 'none',
-  OauthAgreement: 'oauth-agreement',
-  Google: 'google',
-  GitHub: 'github',
-  SSO: 'sso',
-  User: 'user',
-} as const;
-export type ToggleAnalyticsReasonType = typeof ToggleAnalyticsReason[keyof typeof ToggleAnalyticsReason];
 export const unknownCommand = 'unknown';

--- a/redisinsight/api/src/constants/telemetry-events.ts
+++ b/redisinsight/api/src/constants/telemetry-events.ts
@@ -104,4 +104,13 @@ export enum CommandType {
   Module = 'module',
 }
 
+export const ToggleAnalyticsReason = {
+  None: 'none',
+  OauthAgreement: 'oauth-agreement',
+  Google: 'google',
+  GitHub: 'github',
+  SSO: 'sso',
+  User: 'user',
+} as const;
+export type ToggleAnalyticsReasonType = typeof ToggleAnalyticsReason[keyof typeof ToggleAnalyticsReason];
 export const unknownCommand = 'unknown';

--- a/redisinsight/api/src/modules/settings/constants/settings.ts
+++ b/redisinsight/api/src/modules/settings/constants/settings.ts
@@ -1,0 +1,9 @@
+export const ToggleAnalyticsReason = {
+  None: 'none',
+  OauthAgreement: 'oauth-agreement',
+  Google: 'google',
+  GitHub: 'github',
+  SSO: 'sso',
+  User: 'user',
+} as const;
+export type ToggleAnalyticsReasonType = typeof ToggleAnalyticsReason[keyof typeof ToggleAnalyticsReason];

--- a/redisinsight/api/src/modules/settings/constants/settings.ts
+++ b/redisinsight/api/src/modules/settings/constants/settings.ts
@@ -1,9 +1,10 @@
-export const ToggleAnalyticsReason = {
-  None: 'none',
-  OauthAgreement: 'oauth-agreement',
-  Google: 'google',
-  GitHub: 'github',
-  SSO: 'sso',
-  User: 'user',
-} as const;
-export type ToggleAnalyticsReasonType = typeof ToggleAnalyticsReason[keyof typeof ToggleAnalyticsReason];
+export type ToggleAnalyticsReasonType = 'none' | 'oauth-agreement' | 'google' | 'github' | 'sso' | 'user';
+
+export enum ToggleAnalyticsReason {
+  None = 'none',
+  OAuthAgreement = 'oauth-agreement',
+  Google = 'google',
+  Github = 'github',
+  Sso = 'sso',
+  User = 'user',
+}

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -15,8 +15,9 @@ import { pickDefinedAgreements } from 'src/dto/dto-transformer';
 import { Default } from 'src/common/decorators';
 import config from 'src/utils/config';
 import { IAgreementSpec } from 'src/modules/settings/models/agreements.interface';
-import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'src/constants/telemetry-events';
+import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'src/modules/settings/constants/settings';
 
+export { ToggleAnalyticsReason, ToggleAnalyticsReasonType };
 const REDIS_SCAN_CONFIG = config.get('redis_scan');
 const WORKBENCH_CONFIG = config.get('workbench');
 

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsBoolean, IsEnum,
-  IsIn,
   IsInstance,
   IsInt,
   IsOptional,

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsBoolean,
+  IsIn,
   IsInstance,
   IsInt,
   IsOptional,
@@ -14,6 +15,7 @@ import { pickDefinedAgreements } from 'src/dto/dto-transformer';
 import { Default } from 'src/common/decorators';
 import config from 'src/utils/config';
 import { IAgreementSpec } from 'src/modules/settings/models/agreements.interface';
+import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'src/constants/telemetry-events';
 
 const REDIS_SCAN_CONFIG = config.get('redis_scan');
 const WORKBENCH_CONFIG = config.get('workbench');
@@ -195,5 +197,6 @@ export class UpdateSettingsDto {
   })
   @IsOptional()
   @IsString()
-  analyticsReason?: string;
+  @IsIn(Object.values(ToggleAnalyticsReason))
+  analyticsReason?: ToggleAnalyticsReasonType;
 }

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  IsBoolean,
+  IsBoolean, IsEnum,
   IsIn,
   IsInstance,
   IsInt,
@@ -17,7 +17,6 @@ import config from 'src/utils/config';
 import { IAgreementSpec } from 'src/modules/settings/models/agreements.interface';
 import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'src/modules/settings/constants/settings';
 
-export { ToggleAnalyticsReason, ToggleAnalyticsReasonType };
 const REDIS_SCAN_CONFIG = config.get('redis_scan');
 const WORKBENCH_CONFIG = config.get('workbench');
 
@@ -198,6 +197,6 @@ export class UpdateSettingsDto {
   })
   @IsOptional()
   @IsString()
-  @IsIn(Object.values(ToggleAnalyticsReason))
+  @IsEnum(ToggleAnalyticsReason)
   analyticsReason?: ToggleAnalyticsReasonType;
 }

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -187,4 +187,13 @@ export class UpdateSettingsDto {
   @Transform(pickDefinedAgreements)
   @IsBoolean({ each: true })
   agreements?: Map<string, boolean>;
+
+  @ApiPropertyOptional({
+    description: 'Reason describing why analytics are enabled',
+    type: String,
+    example: 'install',
+  })
+  @IsOptional()
+  @IsString()
+  analyticsReason?: string;
 }

--- a/redisinsight/api/src/modules/settings/models/agreements.interface.ts
+++ b/redisinsight/api/src/modules/settings/models/agreements.interface.ts
@@ -9,6 +9,7 @@ export interface IAgreement {
   title?: string;
   label?: string;
   description?: string;
+  requiredText?: string;
   options?: {
     [key: string]: IAgreement;
   }

--- a/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
@@ -45,6 +45,43 @@ describe('SettingsAnalytics', () => {
         },
       );
     });
+    it('should emit ANALYTICS_PERMISSION with state enabled and reason undefined', async () => {
+      service.sendAnalyticsAgreementChange(
+        mockSessionMetadata,
+        new Map([['analytics', true]]),
+        undefined,
+        undefined,
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        AppAnalyticsEvents.Track,
+        mockSessionMetadata,
+        {
+          event: TelemetryEvents.AnalyticsPermission,
+          eventData: { reason: undefined, state: 'enabled' },
+          nonTracking: true,
+        },
+      );
+    });
+    it('should emit ANALYTICS_PERMISSION with state enabled and reason "test-reason"', async () => {
+      service.sendAnalyticsAgreementChange(
+        mockSessionMetadata,
+        new Map([['analytics', true]]),
+        undefined,
+        'test-reason',
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        AppAnalyticsEvents.Track,
+        mockSessionMetadata,
+        {
+          event: TelemetryEvents.AnalyticsPermission,
+          eventData: { reason: 'test-reason', state: 'enabled' },
+          nonTracking: true,
+
+        },
+      );
+    });
     it('should emit ANALYTICS_PERMISSION with state disabled on first app launch', async () => {
       service.sendAnalyticsAgreementChange(
         mockSessionMetadata,
@@ -67,6 +104,7 @@ describe('SettingsAnalytics', () => {
         mockSessionMetadata,
         new Map([['analytics', false]]),
         new Map([['analytics', false]]),
+        'test-reason',
       );
 
       expect(eventEmitter.emit).not.toHaveBeenCalledWith(
@@ -83,6 +121,7 @@ describe('SettingsAnalytics', () => {
         mockSessionMetadata,
         new Map([['analytics', false]]),
         new Map([['analytics', true]]),
+        'test-reason',
       );
 
       expect(eventEmitter.emit).toHaveBeenCalledWith(
@@ -90,7 +129,7 @@ describe('SettingsAnalytics', () => {
         mockSessionMetadata,
         {
           event: TelemetryEvents.AnalyticsPermission,
-          eventData: { state: 'disabled' },
+          eventData: { state: 'disabled', reason: 'test-reason' },
           nonTracking: true,
         },
       );

--- a/redisinsight/api/src/modules/settings/settings.analytics.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.ts
@@ -1,12 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import {
-  differenceWith,
-  isEqual,
-  has,
-} from 'lodash';
-import { AppAnalyticsEvents, TelemetryEvents } from 'src/constants';
-import { getRangeForNumber, getIsPipelineEnable, SCAN_THRESHOLD_BREAKPOINTS } from 'src/utils';
+import { differenceWith, has, isEqual } from 'lodash';
+import { AppAnalyticsEvents, TelemetryEvents, ToggleAnalyticsReasonType } from 'src/constants';
+import { getIsPipelineEnable, getRangeForNumber, SCAN_THRESHOLD_BREAKPOINTS } from 'src/utils';
 import { TelemetryBaseService } from 'src/modules/analytics/telemetry.base.service';
 import { GetAppSettingsResponse } from 'src/modules/settings/dto/settings.dto';
 import { SessionMetadata } from 'src/common/models';
@@ -42,7 +38,7 @@ export class SettingsAnalytics extends TelemetryBaseService {
     sessionMetadata: SessionMetadata,
     newAgreements: Map<string, boolean>,
     oldAgreements: Map<string, boolean> = new Map(),
-    reason?: string,
+    reason?: ToggleAnalyticsReasonType,
   ) {
     try {
       const newPermission = newAgreements.get('analytics');

--- a/redisinsight/api/src/modules/settings/settings.analytics.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.ts
@@ -42,6 +42,7 @@ export class SettingsAnalytics extends TelemetryBaseService {
     sessionMetadata: SessionMetadata,
     newAgreements: Map<string, boolean>,
     oldAgreements: Map<string, boolean> = new Map(),
+    reason?: string,
   ) {
     try {
       const newPermission = newAgreements.get('analytics');
@@ -54,6 +55,7 @@ export class SettingsAnalytics extends TelemetryBaseService {
             event: TelemetryEvents.AnalyticsPermission,
             eventData: {
               state: newPermission ? 'enabled' : 'disabled',
+              reason,
             },
             nonTracking: true,
           },

--- a/redisinsight/api/src/modules/settings/settings.service.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.spec.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/__mocks__';
 import { UpdateSettingsDto } from 'src/modules/settings/dto/settings.dto';
 import * as AGREEMENTS_SPEC from 'src/constants/agreements-spec.json';
-import { AgreementIsNotDefinedException } from 'src/constants';
+import { AgreementIsNotDefinedException, ToggleAnalyticsReason } from 'src/constants';
 import config from 'src/utils/config';
 import { KeytarEncryptionStrategy } from 'src/modules/encryption/strategies/keytar-encryption.strategy';
 import { SettingsAnalytics } from 'src/modules/settings/settings.analytics';
@@ -157,7 +157,7 @@ describe('SettingsService', () => {
         agreements: new Map(Object.entries({
           analytics: false,
         })),
-        analyticsReason: 'some reason',
+        analyticsReason: ToggleAnalyticsReason.GitHub,
       };
 
       const response = await service.updateAppSettings(mockSessionMetadata, dto);

--- a/redisinsight/api/src/modules/settings/settings.service.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.spec.ts
@@ -157,6 +157,7 @@ describe('SettingsService', () => {
         agreements: new Map(Object.entries({
           analytics: false,
         })),
+        analyticsReason: 'some reason',
       };
 
       const response = await service.updateAppSettings(mockSessionMetadata, dto);
@@ -178,6 +179,7 @@ describe('SettingsService', () => {
         new Map(Object.entries({
           ...mockAgreements.data,
         })),
+        'some reason',
       );
     });
     it('should update agreements and settings', async () => {

--- a/redisinsight/api/src/modules/settings/settings.service.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.ts
@@ -74,7 +74,7 @@ export class SettingsService {
     dto: UpdateSettingsDto,
   ): Promise<GetAppSettingsResponse> {
     this.logger.debug('Updating application settings.', sessionMetadata);
-    const { agreements, ...settings } = dto;
+    const { agreements, analyticsReason, ...settings } = dto;
     try {
       const oldAppSettings = await this.getAppSettings(sessionMetadata);
       if (!isEmpty(settings)) {
@@ -90,7 +90,7 @@ export class SettingsService {
         await this.settingsRepository.update(sessionMetadata, toUpdate);
       }
       if (agreements) {
-        await this.updateAgreements(sessionMetadata, agreements);
+        await this.updateAgreements(sessionMetadata, agreements, analyticsReason);
       }
       this.logger.debug('Succeed to update application settings.', sessionMetadata);
       const results = await this.getAppSettings(sessionMetadata);
@@ -177,6 +177,7 @@ export class SettingsService {
   private async updateAgreements(
     sessionMetadata: SessionMetadata,
     dtoAgreements: Map<string, boolean> = new Map(),
+    analyticsReason?: string,
   ): Promise<void> {
     this.logger.debug('Updating application agreements.', sessionMetadata);
     const oldAgreements = await this.agreementRepository.getOrCreate(sessionMetadata);
@@ -190,7 +191,6 @@ export class SettingsService {
         ...Object.fromEntries(dtoAgreements),
       },
     };
-
     // Detect which agreements should be defined according to the settings specification
     const diff = difference(
       Object.keys(agreementsSpec.agreements),
@@ -210,6 +210,7 @@ export class SettingsService {
         sessionMetadata,
         dtoAgreements,
         new Map(Object.entries(oldAgreements.data || {})),
+        analyticsReason,
       );
     }
   }

--- a/redisinsight/api/src/modules/settings/settings.service.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.ts
@@ -14,7 +14,7 @@ import { readFile } from 'fs-extra';
 import { join } from 'path';
 import * as AGREEMENTS_SPEC from 'src/constants/agreements-spec.json';
 import config, { Config } from 'src/utils/config';
-import { AgreementIsNotDefinedException } from 'src/constants';
+import { AgreementIsNotDefinedException, ToggleAnalyticsReasonType } from 'src/constants';
 import { KeytarEncryptionStrategy } from 'src/modules/encryption/strategies/keytar-encryption.strategy';
 import { KeyEncryptionStrategy } from 'src/modules/encryption/strategies/key-encryption.strategy';
 import { SettingsAnalytics } from 'src/modules/settings/settings.analytics';
@@ -177,7 +177,7 @@ export class SettingsService {
   private async updateAgreements(
     sessionMetadata: SessionMetadata,
     dtoAgreements: Map<string, boolean> = new Map(),
-    analyticsReason?: string,
+    analyticsReason?: ToggleAnalyticsReasonType,
   ): Promise<void> {
     this.logger.debug('Updating application agreements.', sessionMetadata);
     const oldAgreements = await this.agreementRepository.getOrCreate(sessionMetadata);

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -22,6 +22,7 @@ import cx from 'classnames'
 import { compareConsents } from 'uiSrc/utils'
 import { updateUserConfigSettingsAction, userSettingsSelector } from 'uiSrc/slices/user/user-settings'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { ToggleAnalyticsReason } from 'apiSrc/constants/telemetry-events'
 import ConsentOption from './ConsentOption'
 
 import styles from './styles.module.scss'
@@ -189,7 +190,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
     }
     const settings: Record<string, any> = { agreements: values }
     if (values.analytics) {
-      settings.analyticsReason = 'install'
+      settings.analyticsReason = ToggleAnalyticsReason.User
     }
     dispatch(updateUserConfigSettingsAction(settings, onSubmitted))
   }

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -157,6 +157,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
         recommended = false
         return false
       }
+      return true
     })
 
     forEach(notificationConsents, (consent) => {
@@ -164,6 +165,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
         recommended = false
         return false
       }
+      return true
     })
 
     return recommended
@@ -185,7 +187,11 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
           : TelemetryEvent.SETTINGS_NOTIFICATION_MESSAGES_DISABLED,
       })
     }
-    dispatch(updateUserConfigSettingsAction({ agreements: values }, onSubmitted))
+    const settings: Record<string, any> = { agreements: values }
+    if (values.analytics) {
+      settings.analyticsReason = 'install'
+    }
+    dispatch(updateUserConfigSettingsAction(settings, onSubmitted))
   }
 
   return (

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -22,7 +22,6 @@ import cx from 'classnames'
 import { compareConsents } from 'uiSrc/utils'
 import { updateUserConfigSettingsAction, userSettingsSelector } from 'uiSrc/slices/user/user-settings'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import { ToggleAnalyticsReason } from 'apiSrc/constants/telemetry-events'
 import ConsentOption from './ConsentOption'
 
 import styles from './styles.module.scss'
@@ -190,7 +189,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
     }
     const settings: Record<string, any> = { agreements: values }
     if (values.analytics) {
-      settings.analyticsReason = ToggleAnalyticsReason.User
+      settings.analyticsReason = 'user'
     }
     dispatch(updateUserConfigSettingsAction(settings, onSubmitted))
   }

--- a/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
@@ -8,7 +8,6 @@ import { BrowserStorageItem } from 'uiSrc/constants'
 import { setAgreement, oauthCloudPAgreementSelector } from 'uiSrc/slices/oauth/cloud'
 
 import { enableUserAnalyticsAction } from 'uiSrc/slices/user/user-settings'
-import { ToggleAnalyticsReason } from 'apiSrc/constants/telemetry-events'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -23,7 +22,7 @@ const OAuthAgreement = (props: Props) => {
 
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {
-      dispatch(enableUserAnalyticsAction(ToggleAnalyticsReason.OauthAgreement))
+      dispatch(enableUserAnalyticsAction('oauth-agreement'))
     }
     dispatch(setAgreement(e.target.checked))
     localStorageService.set(BrowserStorageItem.OAuthAgreement, e.target.checked)

--- a/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
@@ -8,6 +8,7 @@ import { BrowserStorageItem } from 'uiSrc/constants'
 import { setAgreement, oauthCloudPAgreementSelector } from 'uiSrc/slices/oauth/cloud'
 
 import { enableUserAnalyticsAction } from 'uiSrc/slices/user/user-settings'
+import { ToggleAnalyticsReason } from 'apiSrc/constants/telemetry-events'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -22,7 +23,7 @@ const OAuthAgreement = (props: Props) => {
 
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {
-      dispatch(enableUserAnalyticsAction('oauth-agreement'))
+      dispatch(enableUserAnalyticsAction(ToggleAnalyticsReason.OauthAgreement))
     }
     dispatch(setAgreement(e.target.checked))
     localStorageService.set(BrowserStorageItem.OAuthAgreement, e.target.checked)

--- a/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
@@ -22,7 +22,7 @@ const OAuthAgreement = (props: Props) => {
 
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {
-      dispatch(enableUserAnalyticsAction())
+      dispatch(enableUserAnalyticsAction('oauth-agreement'))
     }
     dispatch(setAgreement(e.target.checked))
     localStorageService.set(BrowserStorageItem.OAuthAgreement, e.target.checked)

--- a/redisinsight/ui/src/components/oauth/shared/oauth-form/OAuthForm.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-form/OAuthForm.tsx
@@ -35,7 +35,7 @@ const OAuthForm = ({
   const onSocialButtonClick = (authStrategy: OAuthStrategy) => {
     setDisabled(true)
     setTimeout(() => { setDisabled(false) }, 1000)
-    dispatch(enableUserAnalyticsAction())
+    dispatch(enableUserAnalyticsAction(authStrategy))
     setAuthStrategy(authStrategy)
     onClick?.(authStrategy)
 

--- a/redisinsight/ui/src/slices/user/user-settings.ts
+++ b/redisinsight/ui/src/slices/user/user-settings.ts
@@ -4,7 +4,6 @@ import { apiService, localStorageService } from 'uiSrc/services'
 import { ApiEndpoints, BrowserStorageItem } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
-import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'apiSrc/constants/telemetry-events'
 import { GetAgreementsSpecResponse, GetAppSettingsResponse, UpdateSettingsDto } from 'apiSrc/modules/settings/dto/settings.dto'
 
 import { AppDispatch, RootState } from '../store'
@@ -185,7 +184,7 @@ export function updateUserConfigSettingsAction(
   }
 }
 
-export function enableUserAnalyticsAction(reason: ToggleAnalyticsReasonType = ToggleAnalyticsReason.None) {
+export function enableUserAnalyticsAction(reason: string = 'none') {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     const state = stateInit()
     const agreements = state?.user?.settings?.config?.agreements

--- a/redisinsight/ui/src/slices/user/user-settings.ts
+++ b/redisinsight/ui/src/slices/user/user-settings.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { apiService, localStorageService } from 'uiSrc/services'
 import { ApiEndpoints, BrowserStorageItem } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
@@ -106,7 +107,7 @@ export function fetchAppInfo(onSuccessAction?: () => void, onFailAction?: () => 
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as unknown as AxiosError)
       dispatch(getUserConfigSettingsFailure(errorMessage))
       onFailAction?.()
     }
@@ -126,7 +127,7 @@ export function fetchUserConfigSettings(onSuccessAction?: () => void, onFailActi
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as unknown as AxiosError)
       dispatch(getUserConfigSettingsFailure(errorMessage))
       onFailAction?.()
     }
@@ -148,7 +149,7 @@ export function fetchUserSettingsSpec(onSuccessAction?: () => void, onFailAction
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as unknown as AxiosError)
       dispatch(getUserSettingsSpecFailure(errorMessage))
       onFailAction?.()
     }
@@ -175,21 +176,24 @@ export function updateUserConfigSettingsAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as unknown as AxiosError)
       dispatch(updateUserConfigSettingsFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as unknown as AxiosError))
       onFailAction?.()
     }
   }
 }
 
-export function enableUserAnalyticsAction() {
+export function enableUserAnalyticsAction(reason = '') {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     const state = stateInit()
     const agreements = state?.user?.settings?.config?.agreements
 
     if (agreements && !agreements.analytics) {
-      dispatch(updateUserConfigSettingsAction({ agreements: { ...agreements, analytics: true } }))
+      dispatch(updateUserConfigSettingsAction({
+        agreements: { ...agreements, analytics: true },
+        analyticsReason: reason
+      }))
     }
   }
 }

--- a/redisinsight/ui/src/slices/user/user-settings.ts
+++ b/redisinsight/ui/src/slices/user/user-settings.ts
@@ -4,7 +4,11 @@ import { apiService, localStorageService } from 'uiSrc/services'
 import { ApiEndpoints, BrowserStorageItem } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
-import { GetAgreementsSpecResponse, GetAppSettingsResponse, UpdateSettingsDto } from 'apiSrc/modules/settings/dto/settings.dto'
+import {
+  GetAgreementsSpecResponse,
+  GetAppSettingsResponse,
+  UpdateSettingsDto
+} from 'apiSrc/modules/settings/dto/settings.dto'
 
 import { AppDispatch, RootState } from '../store'
 import { StateUserSettings } from '../interfaces/user'
@@ -184,7 +188,9 @@ export function updateUserConfigSettingsAction(
   }
 }
 
-export function enableUserAnalyticsAction(reason: string = 'none') {
+type ToggleAnalyticsReasonType = 'none' | 'oauth-agreement' | 'google' | 'github' | 'sso' | 'user'
+
+export function enableUserAnalyticsAction(reason: ToggleAnalyticsReasonType = 'none') {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     const state = stateInit()
     const agreements = state?.user?.settings?.config?.agreements

--- a/redisinsight/ui/src/slices/user/user-settings.ts
+++ b/redisinsight/ui/src/slices/user/user-settings.ts
@@ -4,6 +4,7 @@ import { apiService, localStorageService } from 'uiSrc/services'
 import { ApiEndpoints, BrowserStorageItem } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
+import { ToggleAnalyticsReason, ToggleAnalyticsReasonType } from 'apiSrc/constants/telemetry-events'
 import { GetAgreementsSpecResponse, GetAppSettingsResponse, UpdateSettingsDto } from 'apiSrc/modules/settings/dto/settings.dto'
 
 import { AppDispatch, RootState } from '../store'
@@ -184,7 +185,7 @@ export function updateUserConfigSettingsAction(
   }
 }
 
-export function enableUserAnalyticsAction(reason = '') {
+export function enableUserAnalyticsAction(reason: ToggleAnalyticsReasonType = ToggleAnalyticsReason.None) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     const state = stateInit()
     const agreements = state?.user?.settings?.config?.agreements


### PR DESCRIPTION
If the event is triggered by accepting consents, reason is `install`, if it is because of `sso\social-login\oauth` reasons, appropriate strategy is sent `google | github | sso`. One last place where analytics is being enabled is in OAuthAgreement.tsx, where reason is sent as `oauth-agreement`