### PR TITLE
fix: update Dockerfile yarn installation to fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,15 @@ FROM node:20.14-alpine as build
 RUN apk update && apk add --no-cache --virtual .gyp \
         python3 \
         make \
-        g++
+        g++ \
+        git
 
 # set workdir
 WORKDIR /usr/src/app
 
 # restore node_modules for front-end
 COPY package.json yarn.lock tsconfig.json ./
-RUN SKIP_POSTINSTALL=1 yarn install
+RUN yarn install --ignore-scripts
 
 # prepare backend by copying scripts/configs and installing node modules
 # this is required to build the static assets


### PR DESCRIPTION
I ran into two yarn-related issues when running docker builds.

First build failed with an error related to git:

```
 > [build  5/15] RUN SKIP_POSTINSTALL=1 yarn install:
0.396 yarn install v1.22.22
0.477 [1/4] Resolving packages...
0.497 warning Resolution field "trim@0.0.3" is incompatible with requested version "trim@0.0.1"
0.656 warning Resolution field "@electron/notarize@2.3.2" is incompatible with requested version "@electron/notarize@2.2.1"
0.781 [2/4] Fetching packages...
8.047 error Couldn't find the binary git
```

I resolved this issue by installing `git` before running `yarn install`.

---

After this is resolved, now there's a later failure in `yarn install`:

```
38.69 [4/4] Building fresh packages...
40.02 error /usr/src/app/node_modules/postinstall-postinstall: Command failed.
40.02 Exit code: 1
40.02 Command: node ./run.js
40.02 Arguments:
40.02 Directory: /usr/src/app/node_modules/postinstall-postinstall
40.02 Output:
40.02 ✘ [ERROR] Could not resolve "/usr/src/app/redisinsight/ui/vite.config.mjs"
```

I resolved this issue by using the `yarn install --ignore-scripts` option, which will correctly stop the postinstall scripts from running.

### Test Plan
Locally I ran docker build and confirmed it now works:

```
$ lsb_release -a
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.2 LTS
Release:        24.04
Codename:       noble

$ docker build .
...
 => => writing image sha256:91f310a1dd1781dba565af73f77f78da6b14fd2411e3e56257f68030663111c3                                             0.0s
```

Fixes RedisInsight/RedisInsight#4404