### PR TITLE
RI-6879: cluster page force standalone

### DIFF
--- a/redisinsight/ui/src/components/analytics-tabs/AnalyticsTabs.tsx
+++ b/redisinsight/ui/src/components/analytics-tabs/AnalyticsTabs.tsx
@@ -6,17 +6,17 @@ import { useParams, useHistory } from 'react-router-dom'
 import { Pages } from 'uiSrc/constants'
 import { AnalyticsViewTab } from 'uiSrc/slices/interfaces/analytics'
 import { analyticsSettingsSelector, setAnalyticsViewTab } from 'uiSrc/slices/analytics/settings'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 
 import { appFeatureOnboardingSelector, setOnboardNextStep } from 'uiSrc/slices/app/features'
 import { renderOnboardingTourWithChild } from 'uiSrc/utils/onboarding'
 import { OnboardingSteps } from 'uiSrc/constants/onboarding'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
 import { analyticsViewTabs } from './constants'
 
 const AnalyticsTabs = () => {
   const { viewTab } = useSelector(analyticsSettingsSelector)
-  const { connectionType } = useSelector(connectedInstanceSelector)
+  const connectionType = useConnectionType()
   const { currentStep } = useSelector(appFeatureOnboardingSelector)
   const history = useHistory()
 

--- a/redisinsight/ui/src/components/hooks/useConnectionType.spec.ts
+++ b/redisinsight/ui/src/components/hooks/useConnectionType.spec.ts
@@ -1,0 +1,87 @@
+import { cloneDeep } from 'lodash'
+import { ConnectionType, Instance } from 'uiSrc/slices/interfaces'
+import { cleanup, mockedStore, renderHook } from 'uiSrc/utils/test-utils'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  connectedInstanceSelector: jest.fn().mockReturnValue({
+    connectedInstance: {},
+  }),
+}))
+
+let store: typeof mockedStore
+type ConnType = 'cluster' | 'standalone' | 'sentinel'
+let instances: Record<ConnType, Instance>
+beforeEach(() => {
+  cleanup()
+  store = cloneDeep(mockedStore)
+  store.clearActions()
+
+  instances = {
+    standalone: {
+      id: 'e37cc441-a4f2-402c-8bdb-fc2413cbbaff',
+      host: 'localhost',
+      port: 6379,
+      name: 'localhost',
+      connectionType: ConnectionType.Standalone,
+      modules: [],
+      version: '6.2.6'
+    },
+    cluster: {
+      id: 'a0db1bc8-a353-4c43-a856-b72f4811d2d4',
+      host: 'localhost',
+      port: 12000,
+      name: 'oea123123',
+      connectionType: ConnectionType.Cluster,
+      modules: [],
+      version: '6.2.6',
+    },
+    sentinel: {
+      id: 'b83a3932-e95f-4f09-9d8a-55079f400186',
+      version: '6.2.6',
+      host: 'localhost',
+      port: 5005,
+      connectionType: ConnectionType.Sentinel,
+      modules: [],
+    },
+  }
+})
+
+describe('useConnectionType', () => {
+  it.each([[ConnectionType.Cluster, 'cluster' as ConnType], [ConnectionType.Standalone, 'standalone' as ConnType], [ConnectionType.Sentinel, 'sentinel' as ConnType]])(
+    'should return %i when forceStandalone is undefined',
+    async (expected, type) => {
+      const instance = { ...instances[type] };
+      (connectedInstanceSelector as jest.Mock).mockReturnValue(instance)
+
+      const { result } = renderHook(useConnectionType)
+      const connectionType = result.current
+      expect(connectionType).toEqual(expected)
+    }
+  )
+
+  it.each([[ConnectionType.Cluster, 'cluster' as ConnType], [ConnectionType.Standalone, 'standalone' as ConnType], [ConnectionType.Sentinel, 'sentinel' as ConnType]])(
+    'should return %i when forceStandalone is false',
+    async (expected, type) => {
+      const instance = { ...instances[type], forceStandalone: false };
+      (connectedInstanceSelector as jest.Mock).mockReturnValue(instance)
+
+      const { result } = renderHook(useConnectionType)
+      const connectionType = result.current
+      expect(connectionType).toEqual(expected)
+    }
+  )
+  it.each([['cluster' as ConnType], ['standalone' as ConnType], ['sentinel' as ConnType]])(
+    'should return STANDALONE ',
+    async (type) => {
+      const instance = { ...instances[type], forceStandalone: true };
+      (connectedInstanceSelector as jest.Mock).mockReturnValue(instance)
+
+      const { result } = renderHook(useConnectionType)
+      const connectionType = result.current
+      expect(connectionType).toEqual(ConnectionType.Standalone)
+    }
+  )
+})

--- a/redisinsight/ui/src/components/hooks/useConnectionType.spec.ts
+++ b/redisinsight/ui/src/components/hooks/useConnectionType.spec.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
       name: 'localhost',
       connectionType: ConnectionType.Standalone,
       modules: [],
-      version: '6.2.6'
+      version: '6.2.6',
     },
     cluster: {
       id: 'a0db1bc8-a353-4c43-a856-b72f4811d2d4',
@@ -59,29 +59,35 @@ describe('useConnectionType', () => {
       const { result } = renderHook(useConnectionType)
       const connectionType = result.current
       expect(connectionType).toEqual(expected)
-    }
+    },
   )
 
   it.each([[ConnectionType.Cluster, 'cluster' as ConnType], [ConnectionType.Standalone, 'standalone' as ConnType], [ConnectionType.Sentinel, 'sentinel' as ConnType]])(
     'should return %i when forceStandalone is false',
     async (expected, type) => {
-      const instance = { ...instances[type], forceStandalone: false };
+      const instance = {
+        ...instances[type],
+        forceStandalone: false,
+      };
       (connectedInstanceSelector as jest.Mock).mockReturnValue(instance)
 
       const { result } = renderHook(useConnectionType)
       const connectionType = result.current
       expect(connectionType).toEqual(expected)
-    }
+    },
   )
-  it.each([['cluster' as ConnType], ['standalone' as ConnType], ['sentinel' as ConnType]])(
+  it.each([[ConnectionType.Standalone, 'cluster' as ConnType], [ConnectionType.Standalone, 'standalone' as ConnType], [ConnectionType.Sentinel, 'sentinel' as ConnType]])(
     'should return STANDALONE ',
-    async (type) => {
-      const instance = { ...instances[type], forceStandalone: true };
+    async (expected, type) => {
+      const instance = {
+        ...instances[type],
+        forceStandalone: true,
+      };
       (connectedInstanceSelector as jest.Mock).mockReturnValue(instance)
 
       const { result } = renderHook(useConnectionType)
       const connectionType = result.current
-      expect(connectionType).toEqual(ConnectionType.Standalone)
-    }
+      expect(connectionType).toEqual(expected)
+    },
   )
 })

--- a/redisinsight/ui/src/components/hooks/useConnectionType.ts
+++ b/redisinsight/ui/src/components/hooks/useConnectionType.ts
@@ -5,5 +5,8 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 export const useConnectionType = () => {
   const { connectionType, forceStandalone } = useSelector(connectedInstanceSelector)
 
-  return forceStandalone ? ConnectionType.Standalone : connectionType
+  if (forceStandalone && connectionType !== ConnectionType.Sentinel) {
+    return ConnectionType.Standalone
+  }
+  return connectionType
 }

--- a/redisinsight/ui/src/components/hooks/useConnectionType.ts
+++ b/redisinsight/ui/src/components/hooks/useConnectionType.ts
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux'
+import { ConnectionType } from 'uiSrc/slices/interfaces'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+
+export const useConnectionType = () => {
+  const { connectionType, forceStandalone } = useSelector(connectedInstanceSelector)
+
+  return forceStandalone ? ConnectionType.Standalone : connectionType
+}

--- a/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
+++ b/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
@@ -3,8 +3,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useParams, useLocation } from 'react-router-dom'
 import { Pages } from 'uiSrc/constants'
 import { appContextAnalytics, setLastAnalyticsPage } from 'uiSrc/slices/app/context'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
 
 import AnalyticsPageRouter from './AnalyticsPageRouter'
 
@@ -18,14 +18,10 @@ const AnalyticsPage = ({ routes = [] }: Props) => {
   const history = useHistory()
   const { instanceId } = useParams<{ instanceId: string }>()
   const { pathname } = useLocation()
-  const instanceDetails = useSelector(connectedInstanceSelector)
-  let { connectionType, forceStandalone } = instanceDetails
+  const connectionType = useConnectionType()
   const { lastViewedPage } = useSelector(appContextAnalytics)
   const pathnameRef = useRef<string>('')
-  if (forceStandalone) {
-    connectionType = ConnectionType.Standalone
-  }
-  // console.log({instanceDetails, connectionType});
+
   const dispatch = useDispatch()
 
   useEffect(() => () => {

--- a/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
+++ b/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
@@ -18,11 +18,14 @@ const AnalyticsPage = ({ routes = [] }: Props) => {
   const history = useHistory()
   const { instanceId } = useParams<{ instanceId: string }>()
   const { pathname } = useLocation()
-  const { connectionType } = useSelector(connectedInstanceSelector)
+  const instanceDetails = useSelector(connectedInstanceSelector)
+  let { connectionType, forceStandalone } = instanceDetails
   const { lastViewedPage } = useSelector(appContextAnalytics)
-
   const pathnameRef = useRef<string>('')
-
+  if (forceStandalone) {
+    connectionType = ConnectionType.Standalone
+  }
+  // console.log({instanceDetails, connectionType});
   const dispatch = useDispatch()
 
   useEffect(() => () => {

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesList/MessagesList.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesList/MessagesList.tsx
@@ -11,8 +11,8 @@ import styles from './styles.module.scss'
 
 export interface Props {
   items: IMessage[]
-  width: number
-  height: number
+  width?: number
+  height?: number
 }
 
 const PROTRUDING_OFFSET = 2

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListWrapper.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
-import { connectedInstanceSelector, connectedInstanceOverviewSelector } from 'uiSrc/slices/instances/instances'
+import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances/instances'
 import { pubSubSelector } from 'uiSrc/slices/pubsub/pubsub'
 import { isVersionHigherOrEquals } from 'uiSrc/utils'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
 import EmptyMessagesList from './EmptyMessagesList'
 import MessagesList from './MessagesList'
 
@@ -13,7 +14,7 @@ import styles from './MessagesList/styles.module.scss'
 
 const MessagesListWrapper = () => {
   const { messages = [], isSubscribed } = useSelector(pubSubSelector)
-  const { connectionType } = useSelector(connectedInstanceSelector)
+  const connectionType = useConnectionType()
   const { version } = useSelector(connectedInstanceOverviewSelector)
 
   const [isSpublishNotSupported, setIsSpublishNotSupported] = useState<boolean>(true)

--- a/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
@@ -6,17 +6,17 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
-  EuiIcon
+  EuiIcon,
 } from '@elastic/eui'
 import cx from 'classnames'
 import React, { ChangeEvent, FormEvent, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { appContextPubSub, setPubSubFieldsContext } from 'uiSrc/slices/app/context'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 import { publishMessageAction } from 'uiSrc/slices/pubsub/pubsub'
 import UserIcon from 'uiSrc/assets/img/icons/user.svg?react'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
 
 import styles from './styles.module.scss'
 
@@ -24,7 +24,7 @@ const HIDE_BADGE_TIMER = 3000
 
 const PublishMessage = () => {
   const { channel: channelContext, message: messageContext } = useSelector(appContextPubSub)
-  const { connectionType } = useSelector(connectedInstanceSelector)
+  const connectionType = useConnectionType()
 
   const [channel, setChannel] = useState<string>(channelContext)
   const [message, setMessage] = useState<string>(messageContext)

--- a/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
@@ -17,16 +17,16 @@ import {
   DEFAULT_SLOWLOG_DURATION_UNIT,
   DEFAULT_SLOWLOG_MAX_LEN,
   DEFAULT_SLOWLOG_SLOWER_THAN,
-  DurationUnits,
   DURATION_UNITS,
+  DurationUnits,
   MINUS_ONE,
 } from 'uiSrc/constants'
 import { appContextDbConfig } from 'uiSrc/slices/app/context'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 import { patchSlowLogConfigAction, slowLogConfigSelector, slowLogSelector } from 'uiSrc/slices/analytics/slowlog'
 import { errorValidateNegativeInteger, validateNumber } from 'uiSrc/utils'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { numberWithSpaces } from 'uiSrc/utils/numbers'
+import { useConnectionType } from 'uiSrc/components/hooks/useConnectionType'
 import { convertNumberByUnits } from '../../utils'
 import styles from './styles.module.scss'
 
@@ -38,7 +38,7 @@ export interface Props {
 const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
   const options = DURATION_UNITS
   const { instanceId } = useParams<{ instanceId: string }>()
-  const { connectionType } = useSelector(connectedInstanceSelector)
+  const connectionType = useConnectionType()
   const { loading } = useSelector(slowLogSelector)
   const { slowLogDurationUnit } = useSelector(appContextDbConfig)
   const {

--- a/redisinsight/ui/src/utils/test-utils.tsx
+++ b/redisinsight/ui/src/utils/test-utils.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
 import { BrowserRouter } from 'react-router-dom'
 import configureMockStore from 'redux-mock-store'
-import { render as rtlRender, waitFor } from '@testing-library/react'
+import { render as rtlRender, renderHook as rtlRenderHook, waitFor } from '@testing-library/react'
 
 import { RootState, store as rootStore } from 'uiSrc/slices/store'
 import { initialState as initialStateInstances } from 'uiSrc/slices/instances/instances'
@@ -167,6 +167,19 @@ const render = (
   const wrapper = !withRouter ? Wrapper : BrowserRouter
 
   return rtlRender(ui, { wrapper, ...renderOptions })
+}
+
+const renderHook = (
+  hook: (initialProps: unknown) => unknown,
+  { initialState, store = mockedStore, withRouter, ...renderOptions }: Options = initialStateDefault
+) => {
+  const Wrapper = ({ children }: { children: JSX.Element }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+
+  const wrapper = !withRouter ? Wrapper : BrowserRouter
+
+  return rtlRenderHook(hook, { wrapper, ...renderOptions })
 }
 
 // for render components WithRouter
@@ -345,6 +358,7 @@ export * from '@testing-library/react'
 export {
   initialStateDefault,
   render,
+  renderHook,
   renderWithRouter,
   clearStoreActions,
   waitForEuiToolTipVisible,


### PR DESCRIPTION
RI-6879

When database connection in RI is marked as `forceStandalone`, it must be treated as standalone connection (unless it is Sentinel connection)

The behavior of some components is related to this information and with this PR, I am providing correct "connectionType" wherever it is used