### PR TITLE
RI-6865 copilot multiline input

### DIFF
--- a/redisinsight/api/.eslintrc.js
+++ b/redisinsight/api/.eslintrc.js
@@ -15,6 +15,13 @@ module.exports = {
     'class-methods-use-this': 'off', // should be ignored since NestJS allow inheritance without using "this" inside class methods
     'no-await-in-loop': 'off',
     'import/no-extraneous-dependencies': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
   },
   parserOptions: {
     project: './tsconfig.json',

--- a/redisinsight/api/src/modules/ai/chat/providers/conv-ai.provider.ts
+++ b/redisinsight/api/src/modules/ai/chat/providers/conv-ai.provider.ts
@@ -47,14 +47,19 @@ export class ConvAiProvider {
     }
   }
 
-  async postMessage(sessionMetadata: SessionMetadata, chatId: string, message: string): Promise<Stream> {
+  async postMessage(
+    _sessionMetadata: SessionMetadata,
+    chatId: string,
+    message: string,
+  ): Promise<Stream> {
+    const messageTransformed = message.replace(/(\r\n|\n|\r)/gm, ' ').trim();
     try {
       const { data } = await this.api.post(
         '/chat',
         {},
         {
           params: {
-            q: message,
+            q: messageTransformed,
           },
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',

--- a/redisinsight/api/src/modules/ai/chat/providers/conv-ai.provider.ts
+++ b/redisinsight/api/src/modules/ai/chat/providers/conv-ai.provider.ts
@@ -11,7 +11,7 @@ export class ConvAiProvider {
     baseURL: aiConfig.convAiApiUrl,
   });
 
-  async auth(sessionMetadata: SessionMetadata): Promise<string> {
+  async auth(_sessionMetadata: SessionMetadata): Promise<string> {
     try {
       const { data } = await this.api.post(
         '/auth',
@@ -30,16 +30,16 @@ export class ConvAiProvider {
     }
   }
 
-  async getHistory(sessionMetadata: SessionMetadata, chatId: string): Promise<object[]> {
+  async getHistory(
+    _sessionMetadata: SessionMetadata,
+    chatId: string,
+  ): Promise<object[]> {
     try {
-      const { data } = await this.api.get(
-        '/history',
-        {
-          headers: {
-            'session-id': chatId,
-          },
+      const { data } = await this.api.get('/history', {
+        headers: {
+          'session-id': chatId,
         },
-      );
+      });
 
       return data;
     } catch (e) {
@@ -75,7 +75,10 @@ export class ConvAiProvider {
     }
   }
 
-  async reset(sessionMetadata: SessionMetadata, chatId: string): Promise<void> {
+  async reset(
+    _sessionMetadata: SessionMetadata,
+    chatId: string,
+  ): Promise<void> {
     try {
       await this.api.post(
         '/reset',


### PR DESCRIPTION
Strip any line breaks in content sent to copilot.

not related to the issue, but changed eslint rules not to flag unused variables starting with underscore

In order to test that this is working a production build is required.

The way I did test is with `yarn package:mac:arm` 

If dev build is used, there is no difference with or without new lines, since the issue is with prod copilot API and staging copilot API is just fine with line breaks