### PR TITLE
RI-6564: Download bulk delete report

### DIFF
--- a/redisinsight/api/src/__mocks__/bulk-actions.ts
+++ b/redisinsight/api/src/__mocks__/bulk-actions.ts
@@ -23,6 +23,7 @@ export const mockBulkActionOverview = {
     processed: 0,
     succeed: 0,
     errors: [],
+    keys: [],
   },
 };
 

--- a/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
@@ -188,6 +188,7 @@ describe('BulkImportService', () => {
             succeed: 100_000,
             failed: 0,
             errors: [],
+            keys: [],
           },
           duration: expect.anything(),
         });
@@ -207,6 +208,7 @@ describe('BulkImportService', () => {
             succeed: 10_000,
             failed: 0,
             errors: [],
+            keys: [],
           },
           duration: expect.anything(),
         });
@@ -228,6 +230,7 @@ describe('BulkImportService', () => {
           succeed: 0,
           failed: 2,
           errors: [],
+          keys: [],
         },
         duration: expect.anything(),
       });

--- a/redisinsight/api/src/modules/bulk-actions/bulk-import.service.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-import.service.ts
@@ -80,6 +80,7 @@ export class BulkImportService {
         succeed: 0,
         failed: 0,
         errors: [],
+        keys: [],
       },
       progress: null,
       filter: null,

--- a/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-summary-overview.interface.ts
+++ b/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-summary-overview.interface.ts
@@ -3,4 +3,5 @@ export interface IBulkActionSummaryOverview {
   succeed: number,
   failed: number,
   errors: Array<Record<string, string>>
+  keys: Array<any>
 }

--- a/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-summary-overview.interface.ts
+++ b/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-summary-overview.interface.ts
@@ -1,7 +1,9 @@
+import { RedisString } from 'src/common/constants';
+
 export interface IBulkActionSummaryOverview {
-  processed: number,
-  succeed: number,
-  failed: number,
-  errors: Array<Record<string, string>>
-  keys: Array<any>
+  processed: number;
+  succeed: number;
+  failed: number;
+  errors: Array<Record<string, string>>;
+  keys: Array<RedisString>;
 }

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.spec.ts
@@ -100,6 +100,7 @@ describe('BulkActionSummary', () => {
         succeed: 500,
         failed: 1000,
         errors: generateErrors(500),
+        keys: [],
       });
 
       expect(summary['processed']).toEqual(1500);

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.ts
@@ -1,3 +1,4 @@
+import { RedisString } from 'src/common/constants';
 import { IBulkActionSummaryOverview } from 'src/modules/bulk-actions/interfaces/bulk-action-summary-overview.interface';
 
 export class BulkActionSummary {
@@ -9,8 +10,7 @@ export class BulkActionSummary {
 
   private errors: Array<Record<string, string>> = [];
 
-  // TODO: any - probably some buffer/string
-  private keys: Array<any> = [];
+  private keys: Array<RedisString> = [];
 
   addProcessed(count: number) {
     this.processed += count;
@@ -32,7 +32,7 @@ export class BulkActionSummary {
     }
   }
 
-  addKeys(keys: Array<any>) {
+  addKeys(keys: Array<RedisString>) {
     this.keys.push(...keys);
   }
 

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.ts
@@ -9,6 +9,9 @@ export class BulkActionSummary {
 
   private errors: Array<Record<string, string>> = [];
 
+  // TODO: any - probably some buffer/string
+  private keys: Array<any> = [];
+
   addProcessed(count: number) {
     this.processed += count;
   }
@@ -29,12 +32,17 @@ export class BulkActionSummary {
     }
   }
 
+  addKeys(keys: Array<any>) {
+    this.keys.push(...keys);
+  }
+
   getOverview(): IBulkActionSummaryOverview {
     const overview = {
       processed: this.processed,
       succeed: this.succeed,
       failed: this.failed,
       errors: this.errors,
+      keys: this.keys,
     };
 
     this.errors = [];

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action.spec.ts
@@ -236,6 +236,91 @@ describe('AbstractBulkActionSimpleRunner', () => {
     });
   });
 
+  describe('getOverview - keys aggregation', () => {
+    let mockSummary1;
+    let mockSummary2;
+    let mockSummary3;
+    let mockRunner1;
+    let mockRunner2;
+    let mockRunner3;
+    let mockProgress1;
+    let mockProgress2;
+    let mockProgress3;
+
+    beforeEach(() => {
+      mockProgress1 = {
+        getOverview: jest.fn().mockReturnValue({ total: 500, scanned: 400 }),
+      };
+      mockProgress2 = {
+        getOverview: jest.fn().mockReturnValue({ total: 1000, scanned: 800 }),
+      };
+      mockProgress3 = {
+        getOverview: jest.fn().mockReturnValue({ total: 1500, scanned: 1200 }),
+      };
+
+      mockSummary1 = {
+        getOverview: jest.fn().mockReturnValue({
+          processed: 100,
+          succeed: 90,
+          failed: 10,
+          errors: [],
+          keys: ['key1', 'key2'],
+        }),
+      };
+      mockSummary2 = {
+        getOverview: jest.fn().mockReturnValue({
+          processed: 200,
+          succeed: 180,
+          failed: 20,
+          errors: [],
+          keys: ['key3'],
+        }),
+      };
+      mockSummary3 = {
+        getOverview: jest.fn().mockReturnValue({
+          processed: 300,
+          succeed: 270,
+          failed: 30,
+          errors: [],
+          keys: ['key4', 'key5', 'key6'],
+        }),
+      };
+
+      mockRunner1 = {
+        getSummary: jest.fn().mockReturnValue(mockSummary1),
+        getProgress: jest.fn().mockReturnValue(mockProgress1),
+      };
+      mockRunner2 = {
+        getSummary: jest.fn().mockReturnValue(mockSummary2),
+        getProgress: jest.fn().mockReturnValue(mockProgress2),
+      };
+      mockRunner3 = {
+        getSummary: jest.fn().mockReturnValue(mockSummary3),
+        getProgress: jest.fn().mockReturnValue(mockProgress3),
+      };
+
+      bulkAction['runners'] = [mockRunner1, mockRunner2, mockRunner3];
+      bulkAction['status'] = BulkActionStatus.Completed;
+    });
+
+    it('should correctly concatenate keys from all runners', async () => {
+      const overview = bulkAction.getOverview();
+
+      // Convert to a Set to make the test order-independent
+      const expectedKeys = new Set([
+        'key1',
+        'key2',
+        'key3',
+        'key4',
+        'key5',
+        'key6',
+      ]);
+      const actualKey = new Set(overview.summary.keys);
+
+      expect(actualKey).toEqual(expectedKeys);
+    });
+  });
+
   describe('setStatus', () => {
     const testCases = [
       { input: BulkActionStatus.Completed, affect: true },

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action.spec.ts
@@ -114,6 +114,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
         succeed: 0,
         failed: 0,
         errors: [],
+        keys: [],
       });
 
       await new Promise((res) => setTimeout(res, 100));
@@ -141,6 +142,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
         succeed: 0,
         failed: 0,
         errors: [],
+        keys: [],
       });
 
       await new Promise((res) => setTimeout(res, 100));
@@ -168,6 +170,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
         succeed: 0,
         failed: 0,
         errors: [],
+        keys: [],
       });
 
       await new Promise((res) => setTimeout(res, 100));
@@ -207,6 +210,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
         succeed: 900_000,
         failed: 100_000,
         errors: generateMockBulkActionErrors(500, false),
+        keys: [],
       });
     });
     it('should return overview for cluster', async () => {
@@ -227,6 +231,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
         succeed: 2_700_000,
         failed: 300_000,
         errors: generateMockBulkActionErrors(500, false),
+        keys: [],
       });
     });
   });

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action.ts
@@ -102,18 +102,24 @@ export class BulkAction implements IBulkAction {
         scanned: 0,
       });
 
-    const summary = this.runners.map((runner) => runner.getSummary().getOverview())
-      .reduce((cur, prev) => ({
-        processed: prev.processed + cur.processed,
-        succeed: prev.succeed + cur.succeed,
-        failed: prev.failed + cur.failed,
-        errors: prev.errors.concat(cur.errors),
-      }), {
-        processed: 0,
-        succeed: 0,
-        failed: 0,
-        errors: [],
-      });
+    const summary = this.runners
+      .map((runner) => runner.getSummary().getOverview())
+      .reduce(
+        (cur, prev) => ({
+          processed: prev.processed + cur.processed,
+          succeed: prev.succeed + cur.succeed,
+          failed: prev.failed + cur.failed,
+          errors: prev.errors.concat(cur.errors),
+          keys: [...prev.keys, ...cur.keys],
+        }),
+        {
+          processed: 0,
+          succeed: 0,
+          failed: 0,
+          errors: [],
+          keys: [],
+        },
+      );
 
     summary.errors = summary.errors.slice(0, 500).map((error) => ({
       key: error.key.toString(),

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.spec.ts
@@ -226,4 +226,45 @@ describe('AbstractBulkActionSimpleRunner', () => {
       expect(runIterationSpy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('processIterationResults', () => {
+    let addProcessedSpy;
+    let addKeysSpy;
+    let addSuccessSpy;
+    let addErrorsSpy;
+
+    beforeEach(() => {
+      addProcessedSpy = jest.spyOn(deleteRunner['summary'], 'addProcessed');
+      addKeysSpy = jest.spyOn(deleteRunner['summary'], 'addKeys');
+      addSuccessSpy = jest.spyOn(deleteRunner['summary'], 'addSuccess');
+      addErrorsSpy = jest.spyOn(deleteRunner['summary'], 'addErrors');
+    });
+
+    it('should add keys to the summary and correctly process results', () => {
+      const keys = [
+        Buffer.from('key1'),
+        Buffer.from('key2'),
+        Buffer.from('key3'),
+      ];
+      const results: [Error | null, number | null][] = [
+        [null, 1], // Success
+        [mockReplyError, null], // Error
+        [null, 1], // Success
+      ];
+
+      deleteRunner.processIterationResults(keys, results);
+
+      expect(addProcessedSpy).toHaveBeenCalledWith(3);
+      expect(addKeysSpy).toHaveBeenCalledWith(keys);
+
+      expect(addSuccessSpy).toHaveBeenNthCalledWith(1, 1); // first call
+      expect(addSuccessSpy).toHaveBeenNthCalledWith(2, 1); // second call
+      expect(addErrorsSpy).toHaveBeenCalledWith([
+        {
+          key: Buffer.from('key2'),
+          error: mockRESPError,
+        },
+      ]);
+    });
+  });
 });

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.ts
@@ -77,6 +77,7 @@ export abstract class AbstractBulkActionSimpleRunner extends AbstractBulkActionR
    */
   processIterationResults(keys, res: [Error | null, RedisClientCommandReply][]) {
     this.summary.addProcessed(res.length);
+    this.summary.addKeys(keys);
 
     const errors = [];
 

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -132,6 +132,11 @@ const BulkActionsConfig = () => {
     }
 
     socketRef.current?.on(BulkActionsServerEvent.Overview, (payload: any) => {
+      const { keys } = payload.summary
+      const printableKeys = keys.map((item: any) =>
+        Buffer.from(item).toString(),
+      )
+      console.log('printableKeys :>> ', printableKeys)
       dispatch(setBulkDeleteLoading(isProcessingBulkAction(payload.status)))
       dispatch(setDeleteOverview(payload))
 

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -132,11 +132,6 @@ const BulkActionsConfig = () => {
     }
 
     socketRef.current?.on(BulkActionsServerEvent.Overview, (payload: any) => {
-      const { keys } = payload.summary
-      const printableKeys = keys.map((item: any) =>
-        Buffer.from(item).toString(),
-      )
-      console.log('printableKeys :>> ', printableKeys)
       dispatch(setBulkDeleteLoading(isProcessingBulkAction(payload.status)))
       dispatch(setDeleteOverview(payload))
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.tsx
@@ -21,7 +21,7 @@ export interface Props {
     total: Maybe<number>
     scanned: Maybe<number>
   }
-  children?: React.ReactElement
+  children?: React.ReactNode
 }
 
 const BulkActionsInfo = (props: Props) => {

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.spec.tsx
@@ -1,15 +1,49 @@
 import React from 'react'
-import { mock } from 'ts-mockito'
-import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
-
+import { render, screen } from 'uiSrc/utils/test-utils'
 import BulkDelete, { Props } from './BulkDelete'
 
-const mockedProps = {
-  ...mock<Props>(),
+jest.mock('uiSrc/slices/browser/bulkActions', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/bulkActions'),
+  bulkActionsDeleteOverviewSelector: jest.fn().mockReturnValue({
+    status: 'completed',
+    filter: {},
+  }),
+  bulkActionsDeleteSelector: jest.fn().mockReturnValue({
+    loading: false,
+  }),
+  bulkActionsDeleteSummarySelector: jest.fn().mockReturnValue({
+    keys: ['key1', 'key2'],
+  }),
+}))
+
+jest.mock('uiSrc/slices/browser/keys', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/keys'),
+  keysSelector: jest.fn().mockReturnValue({
+    filter: '',
+    search: '',
+    isSearched: false,
+    isFiltered: false,
+  }),
+}))
+
+const mockedProps: Props = {
+  onCancel: jest.fn(),
 }
 
 describe('BulkDelete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should render', () => {
     expect(render(<BulkDelete {...mockedProps} />)).toBeTruthy()
+  })
+
+  it('should display the download button when the bulk delete process is completed', () => {
+    render(<BulkDelete {...mockedProps} />)
+
+    const downloadButton = screen.queryByText('Keys deleted')
+
+    expect(downloadButton).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -9,6 +9,7 @@ import {
   bulkActionsDeleteSummarySelector,
 } from 'uiSrc/slices/browser/bulkActions'
 import { keysSelector } from 'uiSrc/slices/browser/keys'
+import { getGroupTypeDisplay, NO_TYPE_NAME } from 'uiSrc/utils'
 
 import BulkDeleteFooter from './BulkDeleteFooter'
 import BulkDeleteSummary from './BulkDeleteSummary'
@@ -20,6 +21,8 @@ import styles from './styles.module.scss'
 export interface Props {
   onCancel: () => void
 }
+
+const REPORTED_NO_TYPE_NAME = 'Any'
 
 const BulkDelete = (props: Props) => {
   const { onCancel } = props
@@ -55,20 +58,23 @@ const BulkDelete = (props: Props) => {
             status={status}
             progress={progress}
           >
-            <>
-              <BulkDeleteSummary />
+            <BulkDeleteSummary />
 
-              {isCompleted && (
-                <div className={styles.bulkDeleteSummaryButtonWrapper}>
-                  <BulkDeleteSummaryButton
-                    deletedKeys={deletedKeys}
-                    pattern={searchPattern}
-                  >
-                    Keys deleted
-                  </BulkDeleteSummaryButton>
-                </div>
-              )}
-            </>
+            {isCompleted && (
+              <div className={styles.bulkDeleteSummaryButtonWrapper}>
+                <BulkDeleteSummaryButton
+                  deletedKeys={deletedKeys}
+                  pattern={searchPattern}
+                  keysType={
+                    getGroupTypeDisplay(filter) === NO_TYPE_NAME
+                      ? REPORTED_NO_TYPE_NAME
+                      : getGroupTypeDisplay(filter)
+                  }
+                >
+                  Keys deleted
+                </BulkDeleteSummaryButton>
+              </div>
+            )}
           </BulkActionsInfo>
           <BulkDeleteFooter onCancel={onCancel} />
         </>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { EuiFlexItem, EuiText } from '@elastic/eui'
+import { EuiText } from '@elastic/eui'
 import { useSelector } from 'react-redux'
 
 import { isUndefined } from 'lodash'
@@ -59,12 +59,12 @@ const BulkDelete = (props: Props) => {
               <BulkDeleteSummary />
 
               {isCompleted && (
-                <EuiFlexItem grow={false} style={{ marginTop: 16 }}>
+                <div className={styles.bulkDeleteSummaryButtonWrapper}>
                   <BulkDeleteSummaryButton
                     deletedKeys={deletedKeys}
                     pattern={searchPattern}
                   />
-                </EuiFlexItem>
+                </div>
               )}
             </>
           </BulkActionsInfo>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { EuiText } from '@elastic/eui'
+import { EuiFlexItem, EuiText } from '@elastic/eui'
 import { useSelector } from 'react-redux'
 
 import { isUndefined } from 'lodash'
@@ -59,10 +59,12 @@ const BulkDelete = (props: Props) => {
               <BulkDeleteSummary />
 
               {isCompleted && (
-                <BulkDeleteSummaryButton
-                  deletedKeys={deletedKeys}
-                  pattern={searchPattern}
-                />
+                <EuiFlexItem grow={false} style={{ marginTop: 16 }}>
+                  <BulkDeleteSummaryButton
+                    deletedKeys={deletedKeys}
+                    pattern={searchPattern}
+                  />
+                </EuiFlexItem>
               )}
             </>
           </BulkActionsInfo>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -63,7 +63,9 @@ const BulkDelete = (props: Props) => {
                   <BulkDeleteSummaryButton
                     deletedKeys={deletedKeys}
                     pattern={searchPattern}
-                  />
+                  >
+                    Keys deleted
+                  </BulkDeleteSummaryButton>
                 </div>
               )}
             </>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -46,6 +46,7 @@ const BulkDelete = (props: Props) => {
 
   const isCompleted = !isUndefined(status)
   const searchPattern = match || search || '*'
+  const keysType = getGroupTypeDisplay(filter)
 
   return (
     <>
@@ -66,9 +67,7 @@ const BulkDelete = (props: Props) => {
                   deletedKeys={deletedKeys}
                   pattern={searchPattern}
                   keysType={
-                    getGroupTypeDisplay(filter) === NO_TYPE_NAME
-                      ? REPORTED_NO_TYPE_NAME
-                      : getGroupTypeDisplay(filter)
+                    keysType === NO_TYPE_NAME ? REPORTED_NO_TYPE_NAME : keysType
                   }
                 >
                   Keys deleted

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -6,11 +6,13 @@ import { isUndefined } from 'lodash'
 import {
   bulkActionsDeleteOverviewSelector,
   bulkActionsDeleteSelector,
+  bulkActionsDeleteSummarySelector,
 } from 'uiSrc/slices/browser/bulkActions'
 import { keysSelector } from 'uiSrc/slices/browser/keys'
 
 import BulkDeleteFooter from './BulkDeleteFooter'
 import BulkDeleteSummary from './BulkDeleteSummary'
+import BulkDeleteSummaryButton from './BulkDeleteSummaryButton'
 import BulkActionsInfo from '../BulkActionsInfo'
 
 import styles from './styles.module.scss'
@@ -23,36 +25,59 @@ const BulkDelete = (props: Props) => {
   const { onCancel } = props
   const { filter, search, isSearched, isFiltered } = useSelector(keysSelector)
   const { loading } = useSelector(bulkActionsDeleteSelector)
+  const { keys: deletedKeys } =
+    useSelector(bulkActionsDeleteSummarySelector) || {}
   const {
     status,
     filter: { match, type: filterType },
-    progress
+    progress,
   } = useSelector(bulkActionsDeleteOverviewSelector) ?? { filter: {} }
-  const [showPlaceholder, setShowPlaceholder] = useState<boolean>(!isSearched && !isFiltered)
+
+  const [showPlaceholder, setShowPlaceholder] = useState<boolean>(
+    !isSearched && !isFiltered,
+  )
 
   useEffect(() => {
     setShowPlaceholder(!status && !isSearched && !isFiltered)
   }, [status, isSearched, isFiltered])
+
+  const isCompleted = !isUndefined(status)
+  const searchPattern = match || search || '*'
 
   return (
     <>
       {!showPlaceholder && (
         <>
           <BulkActionsInfo
-            search={match || search || '*'}
+            search={searchPattern}
             loading={loading}
             filter={isUndefined(filterType) ? filter : filterType}
             status={status}
             progress={progress}
           >
-            <BulkDeleteSummary />
+            <>
+              <BulkDeleteSummary />
+
+              {isCompleted && (
+                <BulkDeleteSummaryButton
+                  deletedKeys={deletedKeys}
+                  pattern={searchPattern}
+                />
+              )}
+            </>
           </BulkActionsInfo>
           <BulkDeleteFooter onCancel={onCancel} />
         </>
       )}
+
       {showPlaceholder && (
-        <div className={styles.placeholder} data-testid="bulk-actions-placeholder">
-          <EuiText color="subdued" className={styles.placeholderTitle}>No pattern or key type set</EuiText>
+        <div
+          className={styles.placeholder}
+          data-testid="bulk-actions-placeholder"
+        >
+          <EuiText color="subdued" className={styles.placeholderTitle}>
+            No pattern or key type set
+          </EuiText>
           <EuiText color="subdued" className={styles.placeholderSummary}>
             To perform a bulk action, set the pattern or select the key type
           </EuiText>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import BulkDeleteSummaryButton from './BulkDeleteSummaryButton'
+
+const readBlobContent = (blob: Blob) =>
+  new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.readAsText(blob)
+  })
+
+describe('BulkDeleteSummaryButton', () => {
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn(() => 'mockFileUrl')
+    URL.revokeObjectURL = jest.fn()
+  })
+
+  it('should render', () => {
+    expect(
+      render(
+        <BulkDeleteSummaryButton
+          pattern="test-pattern"
+          deletedKeys={['key1', 'key2']}
+        />,
+      ),
+    ).toBeTruthy()
+
+    expect(
+      screen.getByTestId('donwload-bulk-delete-report'),
+    ).toBeInTheDocument()
+  })
+
+  it('should generate correct file content', async () => {
+    render(
+      <BulkDeleteSummaryButton
+        pattern="test-pattern"
+        deletedKeys={['key1', 'key2']}
+      />,
+    )
+
+    const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0]
+    expect(blob).toBeInstanceOf(Blob)
+
+    const textContent = await readBlobContent(blob)
+    expect(textContent).toBe('Pattern: test-pattern\n\nKeys:\n\nkey1\nkey2')
+  })
+
+  it('should handle empty deletedKeys array correctly', async () => {
+    render(<BulkDeleteSummaryButton pattern="test-pattern" deletedKeys={[]} />)
+
+    const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0]
+    expect(blob).toBeInstanceOf(Blob)
+
+    const textContent = await readBlobContent(blob)
+    expect(textContent).toBe('Pattern: test-pattern\n\nKeys:\n\n')
+  })
+
+  it('should clean up the file URL on unmount', () => {
+    const { unmount } = render(
+      <BulkDeleteSummaryButton pattern="test-pattern" deletedKeys={['key1']} />,
+    )
+
+    unmount()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('mockFileUrl')
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
@@ -13,6 +13,7 @@ const defaultRenderProps = {
   pattern: 'test-pattern',
   deletedKeys: ['key1', 'key2'],
   children: 'Download report',
+  keysType: 'Any',
 }
 
 const renderComponent = (props: any = {}) =>
@@ -39,7 +40,16 @@ describe('BulkDeleteSummaryButton', () => {
     expect(blob).toBeInstanceOf(Blob)
 
     const textContent = await readBlobContent(blob)
-    expect(textContent).toBe('Pattern: test-pattern\n\nKeys:\n\nkey1\nkey2')
+
+    // prettier-ignore
+    const expectedContent =
+     'Pattern: test-pattern\n' +
+     'Keys type: Any\n\n' +
+     'Keys:\n\n' +
+     'key1\n' +
+     'key2'
+
+    expect(textContent).toBe(expectedContent)
   })
 
   it('should handle empty deletedKeys array correctly', async () => {
@@ -51,7 +61,14 @@ describe('BulkDeleteSummaryButton', () => {
     expect(blob).toBeInstanceOf(Blob)
 
     const textContent = await readBlobContent(blob)
-    expect(textContent).toBe('Pattern: test-pattern\n\nKeys:\n\n')
+
+    // prettier-ignore
+    const expectedContent =
+      'Pattern: test-pattern\n' +
+      'Keys type: Any\n\n' +
+      'Keys:\n\n'
+
+    expect(textContent).toBe(expectedContent)
   })
 
   it('should clean up the file URL on unmount', () => {

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
@@ -44,7 +44,7 @@ describe('BulkDeleteSummaryButton', () => {
     // prettier-ignore
     const expectedContent =
      'Pattern: test-pattern\n' +
-     'Keys type: Any\n\n' +
+     'Key type: Any\n\n' +
      'Keys:\n\n' +
      'key1\n' +
      'key2'
@@ -65,7 +65,7 @@ describe('BulkDeleteSummaryButton', () => {
     // prettier-ignore
     const expectedContent =
       'Pattern: test-pattern\n' +
-      'Keys type: Any\n\n' +
+      'Key type: Any\n\n' +
       'Keys:\n\n'
 
     expect(textContent).toBe(expectedContent)

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.spec.tsx
@@ -9,6 +9,15 @@ const readBlobContent = (blob: Blob) =>
     reader.readAsText(blob)
   })
 
+const defaultRenderProps = {
+  pattern: 'test-pattern',
+  deletedKeys: ['key1', 'key2'],
+  children: 'Download report',
+}
+
+const renderComponent = (props: any = {}) =>
+  render(<BulkDeleteSummaryButton {...defaultRenderProps} {...props} />)
+
 describe('BulkDeleteSummaryButton', () => {
   beforeEach(() => {
     URL.createObjectURL = jest.fn(() => 'mockFileUrl')
@@ -16,27 +25,15 @@ describe('BulkDeleteSummaryButton', () => {
   })
 
   it('should render', () => {
-    expect(
-      render(
-        <BulkDeleteSummaryButton
-          pattern="test-pattern"
-          deletedKeys={['key1', 'key2']}
-        />,
-      ),
-    ).toBeTruthy()
+    expect(renderComponent()).toBeTruthy()
 
     expect(
-      screen.getByTestId('donwload-bulk-delete-report'),
+      screen.getByTestId('download-bulk-delete-report'),
     ).toBeInTheDocument()
   })
 
   it('should generate correct file content', async () => {
-    render(
-      <BulkDeleteSummaryButton
-        pattern="test-pattern"
-        deletedKeys={['key1', 'key2']}
-      />,
-    )
+    renderComponent()
 
     const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0]
     expect(blob).toBeInstanceOf(Blob)
@@ -46,7 +43,9 @@ describe('BulkDeleteSummaryButton', () => {
   })
 
   it('should handle empty deletedKeys array correctly', async () => {
-    render(<BulkDeleteSummaryButton pattern="test-pattern" deletedKeys={[]} />)
+    renderComponent({
+      deletedKeys: [],
+    })
 
     const blob = (URL.createObjectURL as jest.Mock).mock.calls[0][0]
     expect(blob).toBeInstanceOf(Blob)
@@ -56,9 +55,9 @@ describe('BulkDeleteSummaryButton', () => {
   })
 
   it('should clean up the file URL on unmount', () => {
-    const { unmount } = render(
-      <BulkDeleteSummaryButton pattern="test-pattern" deletedKeys={['key1']} />,
-    )
+    const { unmount } = renderComponent({
+      deletedKeys: ['key1'],
+    })
 
     unmount()
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('mockFileUrl')

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -27,10 +27,11 @@ const BulkDeleteSummaryButton = ({
   )
 
   return (
-    <EuiFlexItem grow={false}>
+    <EuiFlexItem grow={false} style={{ marginTop: 16 }}>
       <EuiButton
         fill
         download={getFileName()}
+        color="secondary"
         href={fileUrl}
         data-testid="donwload-bulk-delete-report"
       >

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -5,6 +5,7 @@ import { Maybe } from 'uiSrc/utils'
 export interface BulkDeleteSummaryButtonProps {
   pattern: string
   deletedKeys: Maybe<any[]>
+  children: React.ReactNode
 }
 
 const getFileName = () => `bulk-delete-report-${Date.now()}.txt`
@@ -12,6 +13,7 @@ const getFileName = () => `bulk-delete-report-${Date.now()}.txt`
 const BulkDeleteSummaryButton = ({
   pattern,
   deletedKeys,
+  ...rest
 }: BulkDeleteSummaryButtonProps) => {
   const fileUrl = useMemo(() => {
     const content = `Pattern: ${pattern}\n\nKeys:\n\n${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
@@ -35,9 +37,8 @@ const BulkDeleteSummaryButton = ({
       iconSide="left"
       href={fileUrl}
       data-testid="donwload-bulk-delete-report"
-    >
-      Keys deleted
-    </EuiButton>
+      {...rest}
+    />
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -20,7 +20,7 @@ const BulkDeleteSummaryButton = ({
     const content = `Pattern: ${pattern}\n\nKeys:\n\n${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
     const blob = new Blob([content], { type: 'text/plain' })
     return URL.createObjectURL(blob)
-  }, [deletedKeys])
+  }, [deletedKeys, pattern])
 
   useEffect(
     () => () => {
@@ -37,7 +37,7 @@ const BulkDeleteSummaryButton = ({
       iconType="download"
       iconSide="left"
       href={fileUrl}
-      data-testid="donwload-bulk-delete-report"
+      data-testid="download-bulk-delete-report"
       {...rest}
     />
   )

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
-import { EuiButton, EuiFlexItem } from '@elastic/eui'
+import { EuiButton } from '@elastic/eui'
 import { Maybe } from 'uiSrc/utils'
 
 export interface BulkDeleteSummaryButtonProps {
@@ -27,17 +27,15 @@ const BulkDeleteSummaryButton = ({
   )
 
   return (
-    <EuiFlexItem grow={false} style={{ marginTop: 16 }}>
-      <EuiButton
-        fill
-        download={getFileName()}
-        color="secondary"
-        href={fileUrl}
-        data-testid="donwload-bulk-delete-report"
-      >
-        Download Bulk Delete Report
-      </EuiButton>
-    </EuiFlexItem>
+    <EuiButton
+      fill
+      download={getFileName()}
+      color="secondary"
+      href={fileUrl}
+      data-testid="donwload-bulk-delete-report"
+    >
+      Download Bulk Delete Report
+    </EuiButton>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo } from 'react'
 import { EuiButton } from '@elastic/eui'
 import { Maybe } from 'uiSrc/utils'
+import { RedisString } from 'apiSrc/common/constants'
 
 export interface BulkDeleteSummaryButtonProps {
   pattern: string
-  deletedKeys: Maybe<any[]>
+  deletedKeys: Maybe<RedisString[]>
   children: React.ReactNode
 }
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -6,6 +6,7 @@ import { RedisString } from 'apiSrc/common/constants'
 export interface BulkDeleteSummaryButtonProps {
   pattern: string
   deletedKeys: Maybe<RedisString[]>
+  keysType: string
   children: React.ReactNode
 }
 
@@ -14,13 +15,19 @@ const getFileName = () => `bulk-delete-report-${Date.now()}.txt`
 const BulkDeleteSummaryButton = ({
   pattern,
   deletedKeys,
+  keysType,
   ...rest
 }: BulkDeleteSummaryButtonProps) => {
   const fileUrl = useMemo(() => {
-    const content = `Pattern: ${pattern}\n\nKeys:\n\n${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
+    const content =
+      `Pattern: ${pattern}\n` +
+      `Keys type: ${keysType}\n\n` +
+      `Keys:\n\n` +
+      `${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
+
     const blob = new Blob([content], { type: 'text/plain' })
     return URL.createObjectURL(blob)
-  }, [deletedKeys, pattern])
+  }, [deletedKeys, pattern, keysType])
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -21,7 +21,7 @@ const BulkDeleteSummaryButton = ({
   const fileUrl = useMemo(() => {
     const content =
       `Pattern: ${pattern}\n` +
-      `Keys type: ${keysType}\n\n` +
+      `Key type: ${keysType}\n\n` +
       `Keys:\n\n` +
       `${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useMemo } from 'react'
+import { EuiButton, EuiFlexItem } from '@elastic/eui'
+import { Maybe } from 'uiSrc/utils'
+
+export interface BulkDeleteSummaryButtonProps {
+  pattern: string
+  deletedKeys: Maybe<any[]>
+}
+
+const getFileName = () => `bulk-delete-report-${Date.now()}.txt`
+
+const BulkDeleteSummaryButton = ({
+  pattern,
+  deletedKeys,
+}: BulkDeleteSummaryButtonProps) => {
+  const fileUrl = useMemo(() => {
+    const content = `Pattern: ${pattern}\n\nKeys:\n\n${deletedKeys?.map((key) => Buffer.from(key).toString()).join('\n')}`
+    const blob = new Blob([content], { type: 'text/plain' })
+    return URL.createObjectURL(blob)
+  }, [deletedKeys])
+
+  useEffect(
+    () => () => {
+      URL.revokeObjectURL(fileUrl)
+    },
+    [fileUrl],
+  )
+
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiButton
+        fill
+        download={getFileName()}
+        href={fileUrl}
+        data-testid="donwload-bulk-delete-report"
+      >
+        Download Bulk Delete Report
+      </EuiButton>
+    </EuiFlexItem>
+  )
+}
+
+export default BulkDeleteSummaryButton

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/BulkDeleteSummaryButton.tsx
@@ -28,13 +28,15 @@ const BulkDeleteSummaryButton = ({
 
   return (
     <EuiButton
-      fill
+      size="s"
       download={getFileName()}
       color="secondary"
+      iconType="download"
+      iconSide="left"
       href={fileUrl}
       data-testid="donwload-bulk-delete-report"
     >
-      Download Bulk Delete Report
+      Keys deleted
     </EuiButton>
   )
 }

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummaryButton/index.ts
@@ -1,0 +1,3 @@
+import BulkDeleteSummaryButton from './BulkDeleteSummaryButton'
+
+export default BulkDeleteSummaryButton

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/styles.module.scss
@@ -60,3 +60,8 @@
   font-weight: 500 !important;
   padding-bottom: 20px;
 }
+
+.bulkDeleteSummaryButtonWrapper {
+  float: right;
+  margin-top: 16px;
+}


### PR DESCRIPTION
Well, people want to see what they deleted. Truncated keys won't be addressed in this PR, so when you test it, make sure you are using plain text keys (no truncating).

# Preview

<img width="939" alt="Screenshot 2025-03-18 at 14 57 46" src="https://github.com/user-attachments/assets/ef6ba2f0-ee2a-4167-b124-c23a3b527c8b" />

# Example content

`bulk-delete-report-1742302606422.txt`
```
Pattern: *
Keys type: List

Keys:

sample_jobQueue:waitingList
```