### PR TITLE
RI-6952: Change length label to top-level values for ReJSONs

### DIFF
--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -123,7 +123,8 @@ export interface LengthNamingByType {
 export const LENGTH_NAMING_BY_TYPE: LengthNamingByType = Object.freeze({
   [ModulesKeyTypes.Graph]: 'Nodes',
   [ModulesKeyTypes.TimeSeries]: 'Samples',
-  [KeyTypes.Stream]: 'Entries'
+  [KeyTypes.Stream]: 'Entries',
+  [KeyTypes.ReJSON]: 'Top-level values',
 })
 
 export interface ModulesKeyTypesNames {

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
@@ -4,6 +4,7 @@ import { cloneDeep } from 'lodash'
 import userEvent from '@testing-library/user-event'
 import { cleanup, mockedStore, render, screen } from 'uiSrc/utils/test-utils'
 import * as keysSlice from 'uiSrc/slices/browser/keys'
+import { KeyTypes } from 'uiSrc/constants'
 import { Props, KeyDetailsHeaderSizeLength } from './KeyDetailsHeaderSizeLength'
 
 let store: typeof mockedStore
@@ -12,8 +13,11 @@ const mockedProps = mock<Props>()
 
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
-  selectedKeyDataSelector: jest.fn()
+  selectedKeyDataSelector: jest.fn(),
 }))
+
+const mockSelectedKeyDataSelector =
+  keysSlice.selectedKeyDataSelector as jest.Mock
 
 describe('KeyDetailsHeaderSizeLength', () => {
   beforeEach(() => {
@@ -23,33 +27,55 @@ describe('KeyDetailsHeaderSizeLength', () => {
   })
 
   it('should render normal size correctly', () => {
-    (keysSlice.selectedKeyDataSelector as jest.Mock).mockReturnValueOnce({
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
       type: 'string',
       size: 1024,
-      length: 1
+      length: 1,
     })
 
-    render(<KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />)
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
 
     expect(screen.getByTestId('key-size-text')).toBeInTheDocument()
     expect(screen.queryByTestId('key-size-info-icon')).not.toBeInTheDocument()
   })
 
   it('should render too large size with warning icon and expected tooltip', async () => {
-    (keysSlice.selectedKeyDataSelector as jest.Mock).mockReturnValueOnce({
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
       type: 'string',
       size: -1,
-      length: 1
+      length: 1,
     })
 
-    render(<KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />)
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
 
     expect(screen.getByTestId('key-size-info-icon')).toBeInTheDocument()
 
     const infoIcon = screen.getByTestId('key-size-info-icon')
     userEvent.hover(infoIcon)
 
-    const tooltipText = await screen.findByText('The key size is too large to run the MEMORY USAGE command, as it may lead to performance issues.')
+    const tooltipText = await screen.findByText(
+      'The key size is too large to run the MEMORY USAGE command, as it may lead to performance issues.',
+    )
     expect(tooltipText).toBeInTheDocument()
+  })
+
+  it('should render "Top-level values" label when type is json', () => {
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
+      type: KeyTypes.ReJSON,
+      size: 512,
+      length: 5,
+    })
+
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
+
+    expect(screen.getByTestId('key-length-text')).toHaveTextContent(
+      'Top-level values: 5',
+    )
   })
 })


### PR DESCRIPTION
# Preview

## JSON

<img width="411" alt="Screenshot 2025-04-02 at 14 31 49" src="https://github.com/user-attachments/assets/0f2ef0a1-7c18-49e6-9edc-c07c73faa4cf" />

## Non JSON

<img width="334" alt="Screenshot 2025-04-02 at 14 32 07" src="https://github.com/user-attachments/assets/8fd0b8dd-39ba-4ff3-b123-388c26677ab8" />
