### PR TITLE
RI-7026: Add JSON key -> Create free db dialog

### DIFF
--- a/redisinsight/ui/src/components/markdown/CloudLink/CloudLink.tsx
+++ b/redisinsight/ui/src/components/markdown/CloudLink/CloudLink.tsx
@@ -6,17 +6,18 @@ import { OAuthSsoHandlerDialog } from 'uiSrc/components'
 export interface Props {
   url: string
   text: string
+  source: OAuthSocialSource
 }
 
 const CloudLink = (props: Props) => {
-  const { url, text } = props
+  const { url, text, source = OAuthSocialSource.Tutorials } = props
   return (
     <OAuthSsoHandlerDialog>
       {(ssoCloudHandlerClick) => (
         <EuiLink
           color="text"
           onClick={(e) => {
-            ssoCloudHandlerClick(e, { source: OAuthSocialSource.Tutorials, action: OAuthSocialAction.Create })
+            ssoCloudHandlerClick(e, { source, action: OAuthSocialAction.Create })
           }}
           external={false}
           target="_blank"

--- a/redisinsight/ui/src/components/oauth/oauth-sso/oauth-create-db/styles.module.scss
+++ b/redisinsight/ui/src/components/oauth/oauth-sso/oauth-create-db/styles.module.scss
@@ -21,6 +21,7 @@
 
     .title {
       font-weight: bold;
+      text-align: center;
     }
   }
 

--- a/redisinsight/ui/src/constants/help-texts.tsx
+++ b/redisinsight/ui/src/constants/help-texts.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { EuiIcon, EuiText } from '@elastic/eui'
 import { FeatureFlagComponent } from 'uiSrc/components'
-import { FeatureFlags } from './featureFlags'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 
 import styles from 'uiSrc/pages/browser/components/popover-delete/styles.module.scss'
+import { CloudLink } from 'uiSrc/components/markdown'
+import { getUtmExternalLink } from 'uiSrc/utils/links'
+import { FeatureFlags } from './featureFlags'
 
 export default {
   REJSON_SHOULD_BE_LOADED: (
@@ -16,8 +18,9 @@ export default {
       <FeatureFlagComponent name={FeatureFlags.cloudAds}>
         <>You can also create a
           {' '}
-          <a href="https://redis.io/try-free/" target="_blank" rel="noreferrer">free trial Redis Cloud database</a>
+          <CloudLink text="free trial Redis Cloud database" url={getUtmExternalLink(EXTERNAL_LINKS.tryFree, { campaign: 'json_module'})} />
           {' '}
+
           with built-in JSON support.
         </>
       </FeatureFlagComponent>

--- a/redisinsight/ui/src/constants/help-texts.tsx
+++ b/redisinsight/ui/src/constants/help-texts.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { EuiIcon, EuiText } from '@elastic/eui'
 import { FeatureFlagComponent } from 'uiSrc/components'
-import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
+import { EXTERNAL_LINKS, UTM_CAMPAINGS, UTM_MEDIUMS } from 'uiSrc/constants/links'
 
 import styles from 'uiSrc/pages/browser/components/popover-delete/styles.module.scss'
 import { CloudLink } from 'uiSrc/components/markdown'
 import { getUtmExternalLink } from 'uiSrc/utils/links'
+import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { FeatureFlags } from './featureFlags'
 
 export default {
@@ -18,7 +19,14 @@ export default {
       <FeatureFlagComponent name={FeatureFlags.cloudAds}>
         <>You can also create a
           {' '}
-          <CloudLink text="free trial Redis Cloud database" url={getUtmExternalLink(EXTERNAL_LINKS.tryFree, { campaign: 'json_module'})} />
+          <CloudLink
+            text="free trial Redis Cloud database"
+            url={getUtmExternalLink(EXTERNAL_LINKS.tryFree, {
+              source: UTM_MEDIUMS.App,
+              campaign: UTM_CAMPAINGS.RedisJson
+            })}
+            source={OAuthSocialSource.BrowserRedisJSON}
+          />
           {' '}
 
           with built-in JSON support.

--- a/redisinsight/ui/src/constants/links.ts
+++ b/redisinsight/ui/src/constants/links.ts
@@ -27,6 +27,7 @@ export const UTM_CAMPAINGS: Record<any, string> = {
   [OAuthSocialSource.AddDbForm]: 'add_db_form',
   PubSub: 'pub_sub',
   Main: 'main',
+  RedisJson: 'redisinsight_redisjson',
 }
 
 export const UTM_MEDIUMS = {

--- a/redisinsight/ui/src/slices/interfaces/cloud.ts
+++ b/redisinsight/ui/src/slices/interfaces/cloud.ts
@@ -78,6 +78,7 @@ export enum OAuthSocialSource {
   BrowserContentMenu = 'browser content menu',
   BrowserFiltering = 'browser filtering',
   BrowserSearch = 'browser search',
+  BrowserRedisJSON = 'browser RedisJSON',
   RediSearch = 'workbench RediSearch',
   RedisJSON = 'workbench RedisJSON',
   RedisTimeSeries = 'workbench RedisTimeSeries',


### PR DESCRIPTION
Changing the action of this button:
<img width="671" alt="Screenshot 2025-04-03 at 9 08 12" src="https://github.com/user-attachments/assets/d46924e7-66b3-40ca-8cad-5e5cd957ef85" />

Currently, it opens a new browser tab - [https://redis.io/try-free/](https://redis.io/try-free/). This will still be the case when cloudSso is false. But when it is true we want the sso dialog to open:
<img width="986" alt="image" src="https://github.com/user-attachments/assets/e069e16f-f448-4d2c-ac42-6a68084d20f3" />

Changes applied:
- Replace the "free trial redis cloud database" JSON link with the CloudLink component which still does what the link did when ssoCloud=false (open a browser tab with /try-free), and opens the SSO dialog when ssoCloud=true.
- Add UTM properties for the link
- Center the "Free trial Cloud database" title

Prerequisites:
- The database does not contain JSON module (ex. not a redis stack db, just simple redis 7 server)
- cloudSso is set to true
- cloudAds is set to true - this is true by default