### PR TITLE
RI-6700: disable auto updates for enterprise builds

### DIFF
--- a/.github/workflows/pipeline-build-docker.yml
+++ b/.github/workflows/pipeline-build-docker.yml
@@ -135,5 +135,6 @@ jobs:
       RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
       RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK }}
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == 'false' }}
+      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise == 'true' }}
 
 

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -120,3 +120,4 @@ jobs:
       RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
       RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK }}
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == 'false' }}
+      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise == 'true' }}

--- a/.github/workflows/pipeline-build-macos.yml
+++ b/.github/workflows/pipeline-build-macos.yml
@@ -144,3 +144,4 @@ jobs:
       RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
       RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK }}
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == 'false' }}
+      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise == 'true' }}

--- a/.github/workflows/pipeline-build-windows.yml
+++ b/.github/workflows/pipeline-build-windows.yml
@@ -89,3 +89,4 @@ jobs:
       RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
       RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK }}
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == 'false' }}
+      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise == 'true' }}

--- a/configs/webpack.config.main.prod.ts
+++ b/configs/webpack.config.main.prod.ts
@@ -62,6 +62,7 @@ export default merge(baseConfig, {
       RI_SERVE_STATICS: false,
       RI_APP_FOLDER_NAME: process.env.RI_APP_FOLDER_NAME || '',
       RI_UPGRADES_LINK: process.env.RI_UPGRADES_LINK || '',
+      RI_DISABLE_AUTO_UPGRADE: process.env.RI_DISABLE_AUTO_UPGRADE || 'false',
       RI_ANALYTICS_START_EVENTS: 'true',
       RI_APP_HOST: '127.0.0.1',
       RI_BUILD_TYPE: 'ELECTRON',

--- a/redisinsight/desktop/app.ts
+++ b/redisinsight/desktop/app.ts
@@ -71,10 +71,12 @@ const init = async () => {
 
     await windowFactory(WindowType.Main, splashWindow, { parsedDeepLink })
 
-    initAutoUpdateChecks(
-      process.env.RI_MANUAL_UPGRADES_LINK || process.env.RI_UPGRADES_LINK,
-      parseInt(process.env.RI_AUTO_UPDATE_INTERVAL, 10) || 84 * 3600 * 1000,
-    )
+    if (process.env.RI_DISABLE_AUTO_UPGRADE !== 'true') {
+      initAutoUpdateChecks(
+        process.env.RI_MANUAL_UPGRADES_LINK || process.env.RI_UPGRADES_LINK,
+        parseInt(process.env.RI_AUTO_UPDATE_INTERVAL ?? '', 10) || 84 * 3600 * 1000,
+      )
+    }
   } catch (err) {
     log.error(wrapErrorMessageSensitiveData(err as Error))
   }


### PR DESCRIPTION
### Description:

Disable automated updates for Enterprise Electron builds (windows/mac/docker/linux)