### PR TITLE
RI-6964: Add link to Redis Insight desktop

### DIFF
--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -8,7 +8,7 @@ import {
 } from 'uiSrc/slices/oauth/cloud'
 import CloudIcon from 'uiSrc/assets/img/oauth/cloud.svg?react'
 
-import { getUtmExternalLink } from 'uiSrc/utils/links'
+import { buildRedisInsightUrl, BuildRedisInsightUrlParams, getUtmExternalLink } from 'uiSrc/utils/links'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -15,7 +15,7 @@ import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { getTruncatedName, Nullable } from 'uiSrc/utils'
 import { fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
-import { connectedInstanceOverviewSelector, connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { FeatureFlags, Pages } from 'uiSrc/constants'
 import { FeatureFlagComponent } from 'uiSrc/components'
 import { getConfig } from 'uiSrc/config'
@@ -43,8 +43,9 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
     'data-testid': dataTestId,
   } = props
 
-  const overview = useSelector(connectedInstanceOverviewSelector)
   const connectedInstance = useSelector(connectedInstanceSelector)
+
+  const riDesktopLink = buildRedisInsightUrl(connectedInstance)
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const [isImportLoading, setIsImportLoading] = useState(false)
@@ -97,19 +98,6 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
       })
     }
     setIsProfileOpen((v) => !v)
-  }
-
-  const handleOpenRiDesktop = () => {
-    console.log('cloudData', overview.cloudDetails)
-    console.log('connectedInstance', connectedInstance)
-
-    const url = buildRedisInsightUrl(
-      `${connectedInstance.host}:${connectedInstance.port}`,
-      overview.cloudDetails,
-      connectedInstance
-    )
-    
-    window.open(url)
   }
 
   const { accounts, currentAccountId, name } = data
@@ -173,7 +161,7 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
               <>
                 <EuiLink
                   className={cx(styles.option, styles.clickableOption)}
-                  onClick={handleOpenRiDesktop}
+                  href={riDesktopLink}
                   data-testid="open-ri-desktop-link"
                 >
                   <EuiText>Open in Redis Insight Desktop version</EuiText>

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { EuiIcon, EuiLink, EuiLoadingSpinner, EuiPopover, EuiText } from '@elastic/eui'
 import cx from 'classnames'
 import { useHistory } from 'react-router-dom'
@@ -14,7 +14,7 @@ import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { getTruncatedName, Nullable } from 'uiSrc/utils'
-import { fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
+import { cloudSelector, fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { FeatureFlags, Pages } from 'uiSrc/constants'
 import { FeatureFlagComponent } from 'uiSrc/components'
 import { getConfig } from 'uiSrc/config'
@@ -41,6 +41,8 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
     selectingAccountId,
     'data-testid': dataTestId,
   } = props
+
+  const { subscriptions, credentials, data: cloudData } = useSelector(cloudSelector)
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const [isImportLoading, setIsImportLoading] = useState(false)
@@ -93,6 +95,23 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
       })
     }
     setIsProfileOpen((v) => !v)
+  }
+
+  const handleOpenRiDesktop = () => {
+    console.log('subscriptions', subscriptions)
+    console.log('credentials', credentials)
+    console.log('data', cloudData)
+
+    // TODO [DA]: Pass the right params
+    // const urlRequestParams: BuildRedisInsightUrlParams = {
+    //   endpoint: '',
+    //   plan: {},
+    //   subscription: {},
+    //   bdb: {},
+    // }
+    // const url = buildRedisInsightUrl(urlRequestParams)
+    
+    // window.open(url)
   }
 
   const { accounts, currentAccountId, name } = data
@@ -156,7 +175,7 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
               <>
                 <EuiLink
                   className={cx(styles.option, styles.clickableOption)}
-                  href="redisinsight://databases/connect"
+                  onClick={handleOpenRiDesktop}
                   data-testid="open-ri-desktop-link"
                 >
                   <EuiText>Open in Redis Insight Desktop version</EuiText>

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -14,7 +14,8 @@ import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { getTruncatedName, Nullable } from 'uiSrc/utils'
-import { cloudSelector, fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
+import { fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
+import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances/instances'
 import { FeatureFlags, Pages } from 'uiSrc/constants'
 import { FeatureFlagComponent } from 'uiSrc/components'
 import { getConfig } from 'uiSrc/config'
@@ -42,7 +43,17 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
     'data-testid': dataTestId,
   } = props
 
-  const { subscriptions, credentials, data: cloudData } = useSelector(cloudSelector)
+  const overview = useSelector(connectedInstanceOverviewSelector)
+  const {
+    usedMemory,
+    cloudDetails: {
+      subscriptionType,
+      subscriptionId,
+      planMemoryLimit,
+      memoryLimitMeasurementUnit,
+      isBdbPackages,
+    } = {},
+  } = overview
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const [isImportLoading, setIsImportLoading] = useState(false)
@@ -98,9 +109,7 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
   }
 
   const handleOpenRiDesktop = () => {
-    console.log('subscriptions', subscriptions)
-    console.log('credentials', credentials)
-    console.log('data', cloudData)
+    console.log('overview', overview)
 
     // TODO [DA]: Pass the right params
     // const urlRequestParams: BuildRedisInsightUrlParams = {

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -152,18 +152,32 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
           </div>
           <FeatureFlagComponent
             name={FeatureFlags.envDependent}
-            otherwise={(
-              <EuiLink
-                external={false}
-                target="_blank"
-                className={cx(styles.option, styles.clickableOption)}
-                href={riConfig.app.smConsoleRedirect}
-                data-testid="cloud-admin-console-link"
-              >
-                <EuiText>Back to Redis Cloud Admin console</EuiText>
-                <EuiIcon type={CloudIcon} style={{ fill: 'none' }} viewBox="-1 0 30 20" strokeWidth={1.8} />
-              </EuiLink>
-            )}
+            otherwise={
+              <>
+                <EuiLink
+                  className={cx(styles.option, styles.clickableOption)}
+                  href="redisinsight://databases/connect"
+                  data-testid="open-ri-desktop-link"
+                >
+                  <EuiText>Open in Redis Insight Desktop version</EuiText>
+                </EuiLink>
+                <EuiLink
+                  external={false}
+                  target="_blank"
+                  className={cx(styles.option, styles.clickableOption)}
+                  href={riConfig.app.smConsoleRedirect}
+                  data-testid="cloud-admin-console-link"
+                >
+                  <EuiText>Back to Redis Cloud Admin console</EuiText>
+                  <EuiIcon
+                    type={CloudIcon}
+                    style={{ fill: 'none' }}
+                    viewBox="-1 0 30 20"
+                    strokeWidth={1.8}
+                  />
+                </EuiLink>
+              </>
+            }
           >
             <div
               role="presentation"

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -8,14 +8,14 @@ import {
 } from 'uiSrc/slices/oauth/cloud'
 import CloudIcon from 'uiSrc/assets/img/oauth/cloud.svg?react'
 
-import { buildRedisInsightUrl, BuildRedisInsightUrlParams, getUtmExternalLink } from 'uiSrc/utils/links'
+import { buildRedisInsightUrl, getUtmExternalLink } from 'uiSrc/utils/links'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { getTruncatedName, Nullable } from 'uiSrc/utils'
 import { fetchSubscriptionsRedisCloud, setSSOFlow } from 'uiSrc/slices/instances/cloud'
-import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances/instances'
+import { connectedInstanceOverviewSelector, connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { FeatureFlags, Pages } from 'uiSrc/constants'
 import { FeatureFlagComponent } from 'uiSrc/components'
 import { getConfig } from 'uiSrc/config'
@@ -44,16 +44,7 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
   } = props
 
   const overview = useSelector(connectedInstanceOverviewSelector)
-  const {
-    usedMemory,
-    cloudDetails: {
-      subscriptionType,
-      subscriptionId,
-      planMemoryLimit,
-      memoryLimitMeasurementUnit,
-      isBdbPackages,
-    } = {},
-  } = overview
+  const connectedInstance = useSelector(connectedInstanceSelector)
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const [isImportLoading, setIsImportLoading] = useState(false)
@@ -109,18 +100,16 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
   }
 
   const handleOpenRiDesktop = () => {
-    console.log('overview', overview)
+    console.log('cloudData', overview.cloudDetails)
+    console.log('connectedInstance', connectedInstance)
 
-    // TODO [DA]: Pass the right params
-    // const urlRequestParams: BuildRedisInsightUrlParams = {
-    //   endpoint: '',
-    //   plan: {},
-    //   subscription: {},
-    //   bdb: {},
-    // }
-    // const url = buildRedisInsightUrl(urlRequestParams)
+    const url = buildRedisInsightUrl(
+      `${connectedInstance.host}:${connectedInstance.port}`,
+      overview.cloudDetails,
+      connectedInstance
+    )
     
-    // window.open(url)
+    window.open(url)
   }
 
   const { accounts, currentAccountId, name } = data

--- a/redisinsight/ui/src/utils/links.ts
+++ b/redisinsight/ui/src/utils/links.ts
@@ -60,6 +60,6 @@ export const buildRedisInsightUrl = (instanceData: Instance) => {
 }
 
 const appendParams = (params: Record<string, string>) => {
-  const searchParams = new URLSearchParams(params);
-  return `?${searchParams.toString()}`;
+  const searchParams = new URLSearchParams(params)
+  return `?${searchParams.toString()}`
 }

--- a/redisinsight/ui/src/utils/links.ts
+++ b/redisinsight/ui/src/utils/links.ts
@@ -59,11 +59,7 @@ export const buildRedisInsightUrl = (instanceData: Instance) => {
   return `${RI_PROTOCOL_SCHEMA}databases/connect${appendParams(params)}`
 }
 
-const appendParams = (params: Record<string, string>) =>
-  Object.entries(params).reduce(
-    (acc, [key, value], index) =>
-      acc.concat(
-        `${index === 0 ? '?' : '&'}${key}=${encodeURIComponent(value)}`,
-      ),
-    '',
-  )
+const appendParams = (params: Record<string, string>) => {
+  const searchParams = new URLSearchParams(params);
+  return `?${searchParams.toString()}`;
+}

--- a/redisinsight/ui/src/utils/links.ts
+++ b/redisinsight/ui/src/utils/links.ts
@@ -1,4 +1,6 @@
 import { UTM_MEDIUMS } from 'uiSrc/constants/links'
+import { Instance, RedisCloudSubscription } from 'uiSrc/slices/interfaces'
+import { Nullable } from '.'
 
 export interface UTMParams {
   source?: string
@@ -18,3 +20,74 @@ export const getUtmExternalLink = (baseUrl: string, params: UTMParams) => {
     return baseUrl
   }
 }
+
+export interface Bdb {
+  id: number
+  name: string
+  access_control?: {
+    redis_password?: string
+    has_ssl_auth?: boolean
+    enforce_client_authentication?: boolean
+  }
+}
+export interface Plan {
+  plan_type: string
+  size: number
+}
+export interface BuildRedisInsightUrlParams {
+  endpoint: string
+  bdb: Instance
+  plan: CloudSubscriptionPlan
+  subscription: Nullable<RedisCloudSubscription>
+}
+const RI_PROTOCOL_SCHEMA = 'redisinsight://'
+export const buildRedisInsightUrl = ({
+  endpoint,
+  bdb,
+  subscription,
+  plan,
+}: BuildRedisInsightUrlParams) => {
+  if (!bdb) {
+    return ''
+  }
+  const defaultPassword = bdb.password
+
+  const dbUrl = defaultPassword
+    ? `redis://default:${defaultPassword}@${endpoint}`
+    : `redis://@${endpoint}`
+
+  const params: Record<string, string> = {
+    redisUrl: dbUrl,
+    cloudBdbId: bdb.id.toString(),
+    databaseAlias: bdb.nameFromProvider || '',
+  }
+
+  if (bdb.tls) {
+    // requiredTls is for backwards compatibility, in the future we may remove it
+    params.requiredTls = 'true'
+    params.requiredCaCert = 'true'
+  }
+
+  if (bdb.tlsClientAuthRequired) {
+    params.requiredClientCert = 'true'
+  }
+
+  if (plan) {
+    if (subscription.type === 'fixed') {
+      params.planMemoryLimit = planMemoryLimit;
+      params.memoryLimitMeasurementUnit = memoryLimitMeasurementUnit
+      if (subscription.free === true) {
+        params.free = 'true'
+      }
+    }
+  }
+
+  return `${RI_PROTOCOL_SCHEMA}databases/connect${appendParams(params)}`
+}
+
+const appendParams = (params: Record<string, string>) =>
+  Object.entries(params).reduce(
+    (acc, [key, value], index) =>
+      acc.concat(`${index === 0 ? '?' : '&'}${key}=${encodeURIComponent(value)}`),
+    ''
+  )

--- a/redisinsight/ui/src/utils/links.ts
+++ b/redisinsight/ui/src/utils/links.ts
@@ -30,10 +30,7 @@ export const buildRedisInsightUrl = (
   }
 
   const endpoint = `${instanceData.host}:${instanceData.port}`
-  const defaultPassword = instanceData.password
-  const dbUrl = defaultPassword
-    ? `redis://default:${defaultPassword}@${endpoint}`
-    : `redis://@${endpoint}`
+  const dbUrl = `redis://@${endpoint}`
 
   const params: Record<string, string> = {
     redisUrl: dbUrl,

--- a/redisinsight/ui/src/utils/links.ts
+++ b/redisinsight/ui/src/utils/links.ts
@@ -22,9 +22,7 @@ export const getUtmExternalLink = (baseUrl: string, params: UTMParams) => {
 
 const RI_PROTOCOL_SCHEMA = 'redisinsight://'
 
-export const buildRedisInsightUrl = (
-  instanceData: Instance,
-) => {
+export const buildRedisInsightUrl = (instanceData: Instance) => {
   if (!instanceData) {
     return ''
   }
@@ -34,12 +32,11 @@ export const buildRedisInsightUrl = (
 
   const params: Record<string, string> = {
     redisUrl: dbUrl,
-    cloudBdbId: instanceData.cloudDetails?.cloudId.toString() || '',
+    cloudBdbId: instanceData.cloudDetails?.cloudId?.toString() || '',
     databaseAlias: instanceData.name || '',
   }
 
   if (instanceData.tls) {
-    // requiredTls is for backwards compatibility, in the future we may remove it
     params.requiredTls = 'true'
     params.requiredCaCert = 'true'
   }
@@ -48,11 +45,13 @@ export const buildRedisInsightUrl = (
     params.requiredClientCert = 'true'
   }
 
-  params.subscriptionType = instanceData.cloudDetails?.subscriptionType || ''
-  if (instanceData.cloudDetails?.subscriptionType === 'fixed') {
-    params.planMemoryLimit = instanceData.cloudDetails?.planMemoryLimit?.toString() || ''
-    params.memoryLimitMeasurementUnit = instanceData.cloudDetails?.memoryLimitMeasurementUnit || ''
-    if (instanceData.cloudDetails?.free) {
+  if (instanceData.cloudDetails) {
+    params.subscriptionType = instanceData.cloudDetails.subscriptionType || ''
+    params.planMemoryLimit =
+      instanceData.cloudDetails?.planMemoryLimit?.toString() || ''
+    params.memoryLimitMeasurementUnit =
+      instanceData.cloudDetails?.memoryLimitMeasurementUnit || ''
+    if (instanceData.cloudDetails.free) {
       params.free = 'true'
     }
   }

--- a/redisinsight/ui/src/utils/tests/links.spec.ts
+++ b/redisinsight/ui/src/utils/tests/links.spec.ts
@@ -1,4 +1,9 @@
-import { getUtmExternalLink, UTMParams } from 'uiSrc/utils/links'
+import {
+  getUtmExternalLink,
+  buildRedisInsightUrl,
+  UTMParams,
+} from 'uiSrc/utils/links'
+import { Instance } from 'uiSrc/slices/interfaces'
 
 const addUtmToLinkTests: Array<{
   input: [string, UTMParams]
@@ -6,24 +11,90 @@ const addUtmToLinkTests: Array<{
 }> = [
   {
     input: ['http://www.google.com', { campaign: 'name' }],
-    expected: 'http://www.google.com/?utm_source=redisinsight&utm_medium=app&utm_campaign=name'
+    expected:
+      'http://www.google.com/?utm_source=redisinsight&utm_medium=app&utm_campaign=name',
   },
   {
     input: ['http://www.google.com', { campaign: 'name', medium: 'main' }],
-    expected: 'http://www.google.com/?utm_source=redisinsight&utm_medium=main&utm_campaign=name'
+    expected:
+      'http://www.google.com/?utm_source=redisinsight&utm_medium=main&utm_campaign=name',
   },
   {
-    input: ['http://www.google.com', { campaign: 'name', medium: 'main', source: 'source' }],
-    expected: 'http://www.google.com/?utm_source=source&utm_medium=main&utm_campaign=name'
+    input: [
+      'http://www.google.com',
+      { campaign: 'name', medium: 'main', source: 'source' },
+    ],
+    expected:
+      'http://www.google.com/?utm_source=source&utm_medium=main&utm_campaign=name',
   },
 ]
 
 describe('getUtmExternalLink', () => {
-  test.each(addUtmToLinkTests)(
-    '%j',
-    ({ input, expected }) => {
-      const result = getUtmExternalLink(...input)
-      expect(result).toEqual(expected)
-    }
-  )
+  test.each(addUtmToLinkTests)('%j', ({ input, expected }) => {
+    const result = getUtmExternalLink(...input)
+    expect(result).toEqual(expected)
+  })
+})
+
+const buildRedisInsightUrlTests: Array<{
+  input: Instance
+  expected: string
+}> = [
+  {
+    input: {
+      id: '0',
+      host: 'localhost',
+      port: 6379,
+      name: 'TestInstance',
+      tls: false,
+      tlsClientAuthRequired: false,
+      cloudDetails: {
+        subscriptionId: 0,
+        cloudId: 123,
+        subscriptionType: 'fixed',
+        planMemoryLimit: 1024,
+        memoryLimitMeasurementUnit: 'MB',
+        free: true,
+      },
+      modules: [],
+      version: '1.0.0',
+    },
+    expected:
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40localhost%3A6379&cloudBdbId=123&databaseAlias=TestInstance&subscriptionType=fixed&planMemoryLimit=1024&memoryLimitMeasurementUnit=MB&free=true',
+  },
+  {
+    input: {
+      id: '1',
+      host: '127.0.0.1',
+      port: 6380,
+      name: '',
+      tls: true,
+      tlsClientAuthRequired: true,
+      modules: [],
+      version: '1.0.0',
+    },
+    expected:
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40127.0.0.1%3A6380&cloudBdbId=&databaseAlias=&requiredTls=true&requiredCaCert=true&requiredClientCert=true',
+  },
+  {
+    input: {
+      id: '2',
+      host: 'example.com',
+      port: 6379,
+      name: 'ExampleInstance',
+      tls: true,
+      tlsClientAuthRequired: false,
+      modules: [],
+      version: '1.0.0',
+    },
+    expected:
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40example.com%3A6379&cloudBdbId=&databaseAlias=ExampleInstance&requiredTls=true&requiredCaCert=true',
+  },
+]
+
+describe('buildRedisInsightUrl', () => {
+  test.each(buildRedisInsightUrlTests)('%j', ({ input, expected }) => {
+    const result = buildRedisInsightUrl(input)
+    expect(result).toEqual(expected)
+  })
 })

--- a/redisinsight/ui/src/utils/tests/links.spec.ts
+++ b/redisinsight/ui/src/utils/tests/links.spec.ts
@@ -43,52 +43,59 @@ const buildRedisInsightUrlTests: Array<{
   {
     input: {
       id: '0',
-      host: 'localhost',
+      host: 'aws-instance.amazonaws.com',
       port: 6379,
-      name: 'TestInstance',
+      name: 'free aws instance',
       tls: false,
       tlsClientAuthRequired: false,
+      modules: [],
+      version: '1.0.0',
       cloudDetails: {
-        subscriptionId: 0,
-        cloudId: 123,
+        subscriptionId: 1,
+        cloudId: 1,
         subscriptionType: 'fixed',
         planMemoryLimit: 1024,
         memoryLimitMeasurementUnit: 'MB',
         free: true,
       },
-      modules: [],
-      version: '1.0.0',
     },
     expected:
-      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40localhost%3A6379&cloudBdbId=123&databaseAlias=TestInstance&subscriptionType=fixed&planMemoryLimit=1024&memoryLimitMeasurementUnit=MB&free=true',
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40aws-instance.amazonaws.com%3A6379&cloudBdbId=1&databaseAlias=free+aws+instance&subscriptionType=fixed&planMemoryLimit=1024&memoryLimitMeasurementUnit=MB&free=true',
   },
   {
     input: {
       id: '1',
       host: '127.0.0.1',
       port: 6380,
-      name: '',
+      name: 'cert localhost instance',
       tls: true,
       tlsClientAuthRequired: true,
       modules: [],
       version: '1.0.0',
     },
     expected:
-      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40127.0.0.1%3A6380&cloudBdbId=&databaseAlias=&requiredTls=true&requiredCaCert=true&requiredClientCert=true',
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40127.0.0.1%3A6380&cloudBdbId=&databaseAlias=cert+localhost+instance&requiredTls=true&requiredCaCert=true&requiredClientCert=true',
   },
   {
     input: {
       id: '2',
-      host: 'example.com',
+      host: 'gcp-instance.example.com',
       port: 6379,
-      name: 'ExampleInstance',
+      name: 'mixed cert gcp instance',
       tls: true,
       tlsClientAuthRequired: false,
       modules: [],
       version: '1.0.0',
+      cloudDetails: {
+        subscriptionId: 2,
+        cloudId: 2,
+        subscriptionType: 'fixed',
+        planMemoryLimit: 2048,
+        memoryLimitMeasurementUnit: 'MB',
+      },
     },
     expected:
-      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40example.com%3A6379&cloudBdbId=&databaseAlias=ExampleInstance&requiredTls=true&requiredCaCert=true',
+      'redisinsight://databases/connect?redisUrl=redis%3A%2F%2F%40gcp-instance.example.com%3A6379&cloudBdbId=2&databaseAlias=mixed+cert+gcp+instance&requiredTls=true&requiredCaCert=true&subscriptionType=fixed&planMemoryLimit=2048&memoryLimitMeasurementUnit=MB',
   },
 ]
 


### PR DESCRIPTION
When opening an instance in RI cloud, we want to be able to open it in RI desktop as well, by clicking the user icon and 'Open in Redis Insight Desktop version' button:
<img width="578" alt="ri desktop button" src="https://github.com/user-attachments/assets/eccd526f-757e-403d-a79d-9c562f5f0846" />

after that, user gets prompted to click 'Open RedisInsight.app':
<img width="609" alt="ri desktop button action" src="https://github.com/user-attachments/assets/d85c9996-9abc-4680-8e2b-b4c469bfc31e" />

Attaching all kinds of query params as well to the RI desktop link.

Note: password is not available in the state so it has been decided not to set it in the URL. When opening in the desktop app, user will be prompt to input it manually. 