### PR TITLE
Fix Add Key panel cancel regression

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -88,10 +88,15 @@ const AddKey = (props: Props) => {
   }
 
   const closeAddKeyPanel = (isCancelled?: boolean) => {
-    onAddKeyPanel(false, stringToBuffer(keyName))
+    // meaning that the user closed the "Add Key" panel when clicked on the cancel button
     if (isCancelled) {
+      onAddKeyPanel(false)
       onClosePanel()
       closeKeyTelemetry()
+    } 
+    // meaning that the user closed the "Add Key" panel when added a key
+    else {
+      onAddKeyPanel(false, stringToBuffer(keyName))
     }
   }
 


### PR DESCRIPTION
While fixing another bug in this PR - https://github.com/RedisInsight/RedisInsight/pull/4339, I introduced a regression.
When user has opened the add key form but clicks on the cancel button (right next to the Add button), an toast message appears:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/51a25b15-a251-4a34-b3c8-3b9ae9e0a7d2" />

It attempts to add the empty key object, or even if there is some input for the name to the state, not considering that it may be canceled. 

Applying this changes so  If add key panel is closed by clicking cancel, do not pass the key name to the add key panel handler above, otherwise, include it - as is. 