### PR TITLE
RI-7076: Use legacy ReJSON path

### DIFF
--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
@@ -842,6 +842,70 @@ describe('JsonService', () => {
         });
       });
     });
+
+    describe('prepareJsonPath', () => {
+      it('should convert "$" to "." for RedisJSON v1 (legacy)', async () => {
+        const database = {
+          ...mockDatabaseWithModules,
+          modules: [{ name: 'ReJSON', semanticVersion: ['1', '0', '0'] }],
+        };
+        databaseService.get.mockResolvedValue(database);
+
+        const result = await service['prepareJsonPath'](
+          mockBrowserClientMetadata,
+          '$',
+        );
+
+        expect(result).toBe('.');
+      });
+
+      it('should strip "$" from path for RedisJSON v1', async () => {
+        const database = {
+          ...mockDatabaseWithModules,
+          modules: [{ name: 'ReJSON', semanticVersion: ['1', '4', '2'] }],
+        };
+        databaseService.get.mockResolvedValue(database);
+
+        const result = await service['prepareJsonPath'](
+          mockBrowserClientMetadata,
+          '$.user.name',
+        );
+
+        expect(result).toBe('.user.name');
+      });
+
+      it('should fallback to dot path when semanticVersion is missing', async () => {
+        const database = {
+          ...mockDatabaseWithModules,
+          modules: [
+            { name: 'ReJSON' }, // no semanticVersion field
+          ],
+        };
+        databaseService.get.mockResolvedValue(database);
+
+        const result = await service['prepareJsonPath'](
+          mockBrowserClientMetadata,
+          '$',
+        );
+
+        expect(result).toBe('.');
+      });
+
+      it('should return original path for RedisJSON v2', async () => {
+        const database = {
+          ...mockDatabaseWithModules,
+          modules: [{ name: 'ReJSON', semanticVersion: ['2', '0', '0'] }],
+        };
+        databaseService.get.mockResolvedValue(database);
+
+        const result = await service['prepareJsonPath'](
+          mockBrowserClientMetadata,
+          '$.user.name',
+        );
+
+        expect(result).toBe('$.user.name');
+      });
+    });
   });
   describe('create', () => {
     beforeEach(() => {

--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
@@ -1158,6 +1158,11 @@ describe('JsonService', () => {
       // JSON.ARRAPEND returns an array of integer replies for each path, the array's new size,
       // or nil, if the matching JSON value is not an array
       client.sendCommand.mockReturnValueOnce([10]);
+      const database = {
+        ...mockDatabaseWithModules,
+        modules: [{ name: 'ReJSON', semanticVersion: ['2', '0', '0'] }],
+      };
+      databaseService.get.mockResolvedValue(database);
       await service.arrAppend(mockBrowserClientMetadata, {
         keyName: testKey,
         path: testPath,

--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
@@ -58,8 +58,10 @@ export class RejsonRlService {
       (module) => module.name === AdditionalRedisModuleName.RedisJSON,
     );
 
-    // first version needs to have different path
-    if (jsonModule && jsonModule.semanticVersion[0] === '1') {
+    // RedisJSON v1 (legacy) uses a different path format.
+    // If the module version isn't reported, assume legacy format just to be safe.
+    // Ref: https://redis.io/docs/latest/develop/data-types/json/path/#legacy-path-syntax
+    if (!jsonModule?.semanticVersion || jsonModule.semanticVersion[0] === '1') {
       if (path.length === 1) {
         return '.';
       }


### PR DESCRIPTION
You can get more context on ReJSON path from the [official documentation.](https://redis.io/docs/latest/develop/data-types/json/path/#legacy-path-syntax).

But if you want just the TL;DR:

- ReJSON v2 uses `$.this.syntax`
- ReJSON v1 uses `.this.syntax` and this one is also supported in ReJSON v2, but it's considered legacy.

So with this PR:
- if ReJSON version is not reported - we fallback to legacy path option (a.k.a. `.`)
- if ReJSON version is 1 - again, the `.` path
- if ReJSON version is 2 - `$`