### PR TITLE
RI-7081: database connection failed is sent multiple times

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -136,7 +136,6 @@ const AutoRefresh = ({
   // refresh interval
   useEffect(() => {
     updateLastRefresh()
-
     if (enableAutoRefresh && !loading && !disabled) {
       intervalRefresh = setInterval(() => {
         if (document.hidden) return

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.spec.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.spec.tsx
@@ -46,37 +46,28 @@ describe('DatabaseOverview', () => {
   })
 
   it('should render with metrics', () => {
-    const { container, queryByRole } = render(<DatabaseOverview />, {
+    const { queryByRole, queryByTestId } = render(<DatabaseOverview />, {
       store: mockedStore,
     })
 
-    expect(
-      container.querySelector('[data-test-subj="overview-cpu"]'),
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector('[data-test-subj="overview-commands-sec"]'),
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector('[data-test-subj="overview-total-memory"]'),
-    ).toHaveTextContent('45 MB')
-    expect(
-      container.querySelector('[data-test-subj="overview-total-keys"]'),
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector('[data-test-subj="overview-connected-clients"]'),
-    ).toBeInTheDocument()
+    expect(queryByTestId('overview-cpu')).toBeInTheDocument()
+    expect(queryByTestId('overview-commands-sec')).toBeInTheDocument()
+    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB')
+    expect(queryByTestId('overview-total-keys')).toBeInTheDocument()
+    expect(queryByTestId('overview-connected-clients')).toBeInTheDocument()
+    expect(queryByTestId('upgrade-ri-db-button')).not.toBeInTheDocument()
     expect(
       queryByRole('button', { name: 'Upgrade plan' }),
     ).not.toBeInTheDocument()
   })
 
   it('should render auto-refresh component', () => {
-    const { container } = render(<DatabaseOverview />, { store: mockedStore })
+    const { queryByTestId } = render(<DatabaseOverview />, {
+      store: mockedStore,
+    })
 
     expect(
-      container.querySelector(
-        '[data-testid="auto-refresh-overview-auto-refresh-container"]',
-      ),
+      queryByTestId('auto-refresh-overview-auto-refresh-container'),
     ).toBeInTheDocument()
   })
 
@@ -97,13 +88,11 @@ describe('DatabaseOverview', () => {
     )
     mockedStore = mockStore(state)
 
-    const { container, queryByRole } = render(<DatabaseOverview />, {
+    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
       store: mockedStore,
     })
 
-    expect(
-      container.querySelector('[data-test-subj="overview-total-memory"]'),
-    ).toHaveTextContent('45 MB / 75 MB (60.3%)')
+    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
     expect(queryByRole('button', { name: 'Upgrade plan' })).toBeInTheDocument()
   })
 
@@ -124,13 +113,11 @@ describe('DatabaseOverview', () => {
     )
     mockedStore = mockStore(state)
 
-    const { container, queryByRole } = render(<DatabaseOverview />, {
+    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
       store: mockedStore,
     })
 
-    expect(
-      container.querySelector('[data-test-subj="overview-total-memory"]'),
-    ).toHaveTextContent('45 MB / 75 MB (60.3%)')
+    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
     expect(
       queryByRole('button', { name: 'Upgrade plan' }),
     ).not.toBeInTheDocument()
@@ -159,13 +146,11 @@ describe('DatabaseOverview', () => {
     )
     mockedStore = mockStore(state)
 
-    const { container, queryByRole } = render(<DatabaseOverview />, {
+    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
       store: mockedStore,
     })
 
-    expect(
-      container.querySelector('[data-test-subj="overview-total-memory"]'),
-    ).toHaveTextContent('45 MB / 75 MB (60.3%)')
+    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
     const upgradeBtn = queryByRole('button', { name: 'Upgrade plan' })
     expect(upgradeBtn).toBeInTheDocument()
 

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.spec.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.spec.tsx
@@ -1,28 +1,23 @@
 import React from 'react'
-import { cloneDeep, set } from 'lodash'
-import { initialStateDefault, mockStore, render } from 'uiSrc/utils/test-utils'
-import { DatabaseConfigInfo } from 'uiSrc/slices/interfaces'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  KeyLightIcon,
+  MeasureLightIcon,
+  MemoryLightIcon,
+  TimeLightIcon,
+  UserLightIcon,
+} from 'uiSrc/components/database-overview/components/icons'
+import { truncateNumberToRange } from 'uiSrc/utils'
 import DatabaseOverview from './DatabaseOverview'
+import { useDatabaseOverview } from './hooks/useDatabaseOverview'
+import { IMetric } from './components/OverviewMetrics'
+import styles from './styles.module.scss'
 
-const overviewData: DatabaseConfigInfo & { usedMemoryPercent: number | null } =
-  {
-    version: '6.0.0',
-    usedMemory: 45.2 * 1024 * 1024, // 45.2 MB
-    usedMemoryPercent: null,
-    totalKeys: 5000,
-    connectedClients: 1,
-    cpuUsagePercentage: 0.23,
-    networkInKbps: 3,
-    networkOutKbps: 5,
-    opsPerSecond: 10,
-    cloudDetails: undefined,
-  }
-const initialState = set(
-  initialStateDefault,
-  'connections.instances.instanceOverview',
-  overviewData,
-)
+// Mock the useDatabaseOverview hook
+jest.mock('./hooks/useDatabaseOverview')
 
+// Mock the config
 jest.mock('uiSrc/config', () => ({
   getConfig: jest.fn(() => {
     const { getConfig: actualGetConfig } = jest.requireActual('uiSrc/config')
@@ -37,89 +32,232 @@ jest.mock('uiSrc/config', () => ({
   }),
 }))
 
-describe('DatabaseOverview', () => {
-  let mockedStore: ReturnType<typeof mockStore>
+// Create mock metrics for testing
+const mockMetrics: IMetric[] = [
+  {
+    id: 'overview-cpu',
+    title: 'CPU',
+    value: 5,
+    loading: 5 === null,
+    unavailableText: 'CPU is not available',
+    icon: TimeLightIcon,
+    className: styles.cpuWrapper,
+    content: '5 %',
+    tooltip: {
+      title: 'CPU',
+      icon: TimeLightIcon,
+      content: (
+        <>
+          <b>5</b>
+          &nbsp;%
+        </>
+      ),
+    },
+  },
+  {
+    id: 'overview-total-memory',
+    value: 13,
+    unavailableText: 'Total Memory is not available',
+    title: 'Total Memory',
+    tooltip: {
+      title: 'Total Memory',
+      icon: MemoryLightIcon,
+      content: '13 / 30 (43%)',
+    },
+    icon: MemoryLightIcon,
+    content: (
+      <span>
+        13 / <strong>30</strong> (43%)
+      </span>
+    ),
+  },
+  {
+    id: 'overview-total-keys',
+    value: 5000,
+    unavailableText: 'Total Keys are not available',
+    title: 'Total Keys',
+    icon: KeyLightIcon,
+    content: truncateNumberToRange(5000),
+    tooltip: {
+      icon: KeyLightIcon,
+      content: <b>5 000</b>,
+      title: 'Total Keys',
+    },
+    children: [
+      {
+        id: 'total-keys-tip',
+        value: 5000,
+        unavailableText: 'Total Keys are not available',
+        title: 'Total Keys',
+        tooltip: {
+          title: 'Total Keys',
+          content: <b>5 000</b>,
+        },
+        content: <b>5 000</b>,
+      },
+      {
+        id: 'overview-db-total-keys',
+        title: 'Keys',
+        value: 3000,
+        content: (
+          <>
+            <span
+              style={{
+                fontWeight: 200,
+                paddingRight: 1,
+              }}
+            >
+              db0:
+            </span>
+            <b>3 000</b>
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    id: 'overview-connected-clients',
+    value: 3,
+    unavailableText: 'Connected Clients are not available',
+    title: 'Connected Clients',
+    tooltip: {
+      title: 'Connected Clients',
+      content: <b>3</b>,
+      icon: UserLightIcon,
+    },
+    icon: UserLightIcon,
+    content: 3,
+  },
+  {
+    id: 'overview-commands-sec',
+    icon: MeasureLightIcon,
+    content: 5,
+    value: 5,
+    unavailableText: 'Commands/s are not available',
+    title: 'Commands/s',
+    tooltip: {
+      icon: MeasureLightIcon,
+      content: 5,
+    },
+    className: styles.opsPerSecItem,
+    children: [
+      {
+        id: 'commands-per-sec-tip',
+        title: 'Commands/s',
+        icon: MeasureLightIcon,
+        value: 5,
+        content: 5,
+        unavailableText: 'Commands/s are not available',
+      },
+    ],
+  },
+]
 
+// Create a default mock implementation for the hook
+const defaultMockHook = {
+  metrics: mockMetrics,
+  connectivityError: null,
+  lastRefreshTime: Date.now(),
+  subscriptionType: undefined,
+  subscriptionId: undefined,
+  isBdbPackages: undefined,
+  usedMemoryPercent: undefined,
+  handleEnableAutoRefresh: jest.fn(),
+  handleRefresh: jest.fn(),
+  handleRefreshClick: jest.fn(),
+}
+
+describe('DatabaseOverview', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedStore = mockStore(initialState)
+    // Set the default mock implementation
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue(defaultMockHook)
   })
 
   it('should render with metrics', () => {
-    const { queryByRole, queryByTestId } = render(<DatabaseOverview />, {
-      store: mockedStore,
-    })
+    render(<DatabaseOverview />)
 
-    expect(queryByTestId('overview-cpu')).toBeInTheDocument()
-    expect(queryByTestId('overview-commands-sec')).toBeInTheDocument()
-    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB')
-    expect(queryByTestId('overview-total-keys')).toBeInTheDocument()
-    expect(queryByTestId('overview-connected-clients')).toBeInTheDocument()
-    expect(queryByTestId('upgrade-ri-db-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('overview-cpu')).toBeInTheDocument()
+    expect(screen.getByTestId('overview-commands-sec')).toBeInTheDocument()
+    expect(screen.getByTestId('overview-total-memory')).toHaveTextContent(
+      '45 MB',
+    )
+    expect(screen.getByTestId('overview-total-keys')).toBeInTheDocument()
+    expect(screen.getByTestId('overview-connected-clients')).toBeInTheDocument()
+    expect(screen.queryByTestId('upgrade-ri-db-button')).not.toBeInTheDocument()
     expect(
-      queryByRole('button', { name: 'Upgrade plan' }),
+      screen.queryByRole('button', { name: 'Upgrade plan' }),
     ).not.toBeInTheDocument()
   })
 
   it('should render auto-refresh component', () => {
-    const { queryByTestId } = render(<DatabaseOverview />, {
-      store: mockedStore,
-    })
+    render(<DatabaseOverview />)
 
     expect(
-      queryByTestId('auto-refresh-overview-auto-refresh-container'),
+      screen.getByTestId('auto-refresh-overview-auto-refresh-container'),
     ).toBeInTheDocument()
   })
 
   it('should show upgrade button and memory usage percentage if cloud plan limit is present', () => {
-    const state = set(
-      cloneDeep(initialState),
-      'connections.instances.instanceOverview',
-      {
-        ...overviewData,
-        cloudDetails: {
-          cloudId: 123,
-          subscriptionId: 123,
-          subscriptionType: 'fixed',
-          planMemoryLimit: 75,
-          memoryLimitMeasurementUnit: 'MB',
-        },
-      },
+    // Mock the hook with subscription data
+    const mockWithSubscription = {
+      ...defaultMockHook,
+      metrics: mockMetrics.map((m) => {
+        if (m.id === 'overview-total-memory') {
+          return {
+            ...m,
+            value: '45 MB / 75 MB (60.3%)',
+            tooltip: {
+              ...m.tooltip,
+              content: '45 MB / 75 MB (60.3%)',
+            },
+          }
+        }
+        return m
+      }),
+      subscriptionType: 'fixed',
+      subscriptionId: 123,
+      usedMemoryPercent: 60.3,
+    }
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue(mockWithSubscription)
+
+    const { getByTestId, getByRole } = render(<DatabaseOverview />)
+
+    expect(getByTestId('overview-total-memory')).toHaveTextContent(
+      '45 MB / 75 MB (60.3%)',
     )
-    mockedStore = mockStore(state)
-
-    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
-      store: mockedStore,
-    })
-
-    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
-    expect(queryByRole('button', { name: 'Upgrade plan' })).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Upgrade plan' })).toBeInTheDocument()
   })
 
-  it('should show not show upgrade button for flexible subscriptions', () => {
-    const state = set(
-      cloneDeep(initialState),
-      'connections.instances.instanceOverview',
-      {
-        ...overviewData,
-        cloudDetails: {
-          cloudId: 123,
-          subscriptionId: 123,
-          subscriptionType: 'flexible',
-          planMemoryLimit: 75,
-          memoryLimitMeasurementUnit: 'MB',
+  it('should not show upgrade button for flexible subscriptions', () => {
+    // Mock the hook with flexible subscription data
+    const mockWithFlexibleSubscription = {
+      ...defaultMockHook,
+      metrics: [
+        ...mockMetrics.slice(0, 1),
+        {
+          id: 'memory',
+          title: 'Memory',
+          value: '45 MB / 75 MB (60.3%)',
+          tooltip: { content: '45 MB / 75 MB (60.3%)', title: 'Used Memory' },
         },
-      },
+        ...mockMetrics.slice(2),
+      ],
+      subscriptionType: 'flexible',
+      subscriptionId: 123,
+      usedMemoryPercent: 60.3,
+    }
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue(
+      mockWithFlexibleSubscription,
     )
-    mockedStore = mockStore(state)
 
-    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
-      store: mockedStore,
-    })
+    render(<DatabaseOverview />)
 
-    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
+    expect(screen.getByTestId('overview-total-memory')).toHaveTextContent(
+      '45 MB / 75 MB (60.3%)',
+    )
     expect(
-      queryByRole('button', { name: 'Upgrade plan' }),
+      screen.queryByRole('button', { name: 'Upgrade plan' }),
     ).not.toBeInTheDocument()
   })
 
@@ -129,33 +267,68 @@ describe('DatabaseOverview', () => {
   ])('should redirect to %s when isBdbPackages = %s', (url, isBdbPackages) => {
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
 
-    const state = set(
-      cloneDeep(initialState),
-      'connections.instances.instanceOverview',
-      {
-        ...overviewData,
-        cloudDetails: {
-          cloudId: 123,
-          subscriptionId: 123,
-          subscriptionType: 'fixed',
-          planMemoryLimit: 75,
-          memoryLimitMeasurementUnit: 'MB',
-          isBdbPackages,
+    // Mock the hook with subscription data and isBdbPackages flag
+    const mockWithBdbPackages = {
+      ...defaultMockHook,
+      metrics: [
+        ...mockMetrics.slice(0, 1),
+        {
+          id: 'memory',
+          title: 'Memory',
+          value: '45 MB / 75 MB (60.3%)',
+          tooltip: { content: '45 MB / 75 MB (60.3%)', title: 'Used Memory' },
         },
-      },
+        ...mockMetrics.slice(2),
+      ],
+      subscriptionType: 'fixed',
+      subscriptionId: 123,
+      isBdbPackages,
+      usedMemoryPercent: 60.3,
+    }
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue(mockWithBdbPackages)
+
+    render(<DatabaseOverview />)
+
+    expect(screen.getByTestId('overview-total-memory')).toHaveTextContent(
+      '45 MB / 75 MB (60.3%)',
     )
-    mockedStore = mockStore(state)
-
-    const { queryByTestId, queryByRole } = render(<DatabaseOverview />, {
-      store: mockedStore,
-    })
-
-    expect(queryByTestId('overview-total-memory')).toHaveTextContent('45 MB / 75 MB (60.3%)')
-    const upgradeBtn = queryByRole('button', { name: 'Upgrade plan' })
+    const upgradeBtn = screen.getByRole('button', { name: 'Upgrade plan' })
     expect(upgradeBtn).toBeInTheDocument()
 
-    upgradeBtn?.click()
+    userEvent.click(upgradeBtn)
     expect(openSpy).toHaveBeenCalledTimes(1)
     expect(openSpy).toHaveBeenCalledWith(url, '_blank')
+  })
+
+  it('should show connectivity error when present', () => {
+    // Mock the hook with connectivity error
+    const mockWithError = {
+      ...defaultMockHook,
+      connectivityError: 'Connection error',
+    }
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue(mockWithError)
+
+    render(<DatabaseOverview />)
+
+    // Check that the warning icon is displayed
+    expect(screen.getByTestId('connectivityError')).toBeInTheDocument()
+  })
+
+  it('should call handleRefresh when auto-refresh is triggered', () => {
+    const mockHandleRefresh = jest.fn()
+    ;(useDatabaseOverview as jest.Mock).mockReturnValue({
+      ...defaultMockHook,
+      handleRefresh: mockHandleRefresh,
+    })
+
+    render(<DatabaseOverview />)
+
+    // Find and click the refresh button
+    const refreshButton = screen.getByTestId(
+      'auto-refresh-overview-refresh-button',
+    )
+    userEvent.click(refreshButton)
+
+    expect(mockHandleRefresh).toHaveBeenCalled()
   })
 })

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -22,11 +22,8 @@ import {
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { toBytes, truncatePercentage } from 'uiSrc/utils'
-import {
-  appConnectivityError,
-  setConnectivityError,
-} from 'uiSrc/slices/app/connectivity'
-import ApiErrors from 'uiSrc/constants/apiErrors'
+import { appConnectivityError } from 'uiSrc/slices/app/connectivity'
+import WarningIcon from 'uiSrc/assets/img/warning.svg?react'
 import { getOverviewMetrics, IMetric } from './components/OverviewMetrics'
 
 import AutoRefresh from '../auto-refresh'
@@ -141,105 +138,135 @@ const DatabaseOverview = () => {
       gutterSize="none"
       responsive={false}
     >
-      {metrics?.length! > 0 && (
-        <EuiFlexItem key="overview">
-          <EuiFlexGroup
-            className={cx('flex-row', styles.itemContainer, styles.overview)}
-            gutterSize="none"
-            responsive={false}
-            alignItems="center"
-          >
-            {subscriptionId && subscriptionType === 'fixed' && (
-              <EuiFlexItem
-                className={cx(styles.overviewItem, styles.upgradeBtnItem)}
-                grow={false}
-                style={{ borderRight: 'none' }}
-              >
-                <EuiButton
-                  color="secondary"
-                  fill={!!usedMemoryPercent && usedMemoryPercent >= 75}
-                  className={cx(styles.upgradeBtn)}
-                  style={{ fontWeight: '400' }}
-                  onClick={() => {
-                    const upgradeUrl = isBdbPackages
-                      ? `${riConfig.app.returnUrlBase}/databases/upgrade/${subscriptionId}`
-                      : `${riConfig.app.returnUrlBase}/subscription/${subscriptionId}/change-plan`
-                    window.open(upgradeUrl, '_blank')
-                  }}
-                  data-testid="upgrade-ri-db-button"
-                >
-                  Upgrade plan
-                </EuiButton>
-              </EuiFlexItem>
-            )}
-            {metrics?.map((overviewItem) => (
-              <EuiFlexItem
-                className={cx(
-                  styles.overviewItem,
-                  overviewItem.className ?? '',
-                )}
-                key={overviewItem.id}
-                data-test-subj={overviewItem.id}
-                grow={false}
-              >
-                <EuiToolTip
-                  position="bottom"
-                  className={styles.tooltip}
-                  content={getTooltipContent(overviewItem)}
-                >
-                  <EuiFlexGroup
-                    gutterSize="none"
-                    responsive={false}
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    {overviewItem.icon && (
-                      <EuiFlexItem grow={false} className={styles.icon}>
-                        <EuiIcon
-                          size="m"
-                          type={overviewItem.icon}
-                          className={styles.icon}
-                        />
-                      </EuiFlexItem>
-                    )}
-                    <EuiFlexItem
-                      grow={false}
-                      className={styles.overviewItemContent}
-                    >
-                      {overviewItem.content}
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiToolTip>
-              </EuiFlexItem>
-            ))}
+      <EuiFlexItem key="overview">
+        <EuiFlexGroup
+          className={cx('flex-row', styles.itemContainer, styles.overview)}
+          gutterSize="none"
+          responsive={false}
+          alignItems="center"
+        >
+          {connectivityError && (
             <EuiFlexItem
-              className={cx(styles.overviewItem, styles.autoRefresh)}
+              key="connectivityError"
+              className={styles.overviewItem}
+              data-test-subj="connectivityError"
               grow={false}
-              data-testid="overview-auto-refresh"
             >
-              <EuiFlexItem grow={false} className={styles.overviewItemContent}>
-                <AutoRefresh
-                  displayText={false}
-                  displayLastRefresh={false}
-                  iconSize="xs"
-                  loading={false}
-                  enableAutoRefreshDefault
-                  lastRefreshTime={lastRefreshTime}
-                  containerClassName=""
-                  postfix="overview"
-                  testid="auto-refresh-overview"
-                  defaultRefreshRate={DATABASE_OVERVIEW_REFRESH_INTERVAL}
-                  minimumRefreshRate={parseInt(
-                    DATABASE_OVERVIEW_MINIMUM_REFRESH_INTERVAL,
-                  )}
-                  onRefresh={loadData}
-                  onEnableAutoRefresh={handleEnableAutoRefresh}
-                />
-              </EuiFlexItem>
+              <EuiToolTip
+                position="bottom"
+                className={styles.tooltip}
+                content={connectivityError}
+              >
+                <EuiFlexGroup
+                  gutterSize="none"
+                  responsive={false}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiIcon size="m" type={WarningIcon} />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiToolTip>
             </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      )}
+          )}
+          {metrics?.length! > 0 && (
+            <>
+              {subscriptionId && subscriptionType === 'fixed' && (
+                <EuiFlexItem
+                  className={cx(styles.overviewItem, styles.upgradeBtnItem)}
+                  grow={false}
+                  style={{ borderRight: 'none' }}
+                >
+                  <EuiButton
+                    color="secondary"
+                    fill={!!usedMemoryPercent && usedMemoryPercent >= 75}
+                    className={cx(styles.upgradeBtn)}
+                    style={{ fontWeight: '400' }}
+                    onClick={() => {
+                      const upgradeUrl = isBdbPackages
+                        ? `${riConfig.app.returnUrlBase}/databases/upgrade/${subscriptionId}`
+                        : `${riConfig.app.returnUrlBase}/subscription/${subscriptionId}/change-plan`
+                      window.open(upgradeUrl, '_blank')
+                    }}
+                    data-testid="upgrade-ri-db-button"
+                  >
+                    Upgrade plan
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
+              {metrics?.map((overviewItem) => (
+                <EuiFlexItem
+                  className={cx(
+                    styles.overviewItem,
+                    overviewItem.className ?? '',
+                  )}
+                  key={overviewItem.id}
+                  data-test-subj={overviewItem.id}
+                  grow={false}
+                >
+                  <EuiToolTip
+                    position="bottom"
+                    className={styles.tooltip}
+                    content={getTooltipContent(overviewItem)}
+                  >
+                    <EuiFlexGroup
+                      gutterSize="none"
+                      responsive={false}
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      {overviewItem.icon && (
+                        <EuiFlexItem grow={false} className={styles.icon}>
+                          <EuiIcon
+                            size="m"
+                            type={overviewItem.icon}
+                            className={styles.icon}
+                          />
+                        </EuiFlexItem>
+                      )}
+                      <EuiFlexItem
+                        grow={false}
+                        className={styles.overviewItemContent}
+                      >
+                        {overviewItem.content}
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiToolTip>
+                </EuiFlexItem>
+              ))}
+              <EuiFlexItem
+                className={cx(styles.overviewItem, styles.autoRefresh)}
+                grow={false}
+                data-testid="overview-auto-refresh"
+              >
+                <EuiFlexItem
+                  grow={false}
+                  className={styles.overviewItemContent}
+                >
+                  <AutoRefresh
+                    displayText={false}
+                    displayLastRefresh={false}
+                    iconSize="xs"
+                    loading={false}
+                    enableAutoRefreshDefault
+                    lastRefreshTime={lastRefreshTime}
+                    containerClassName=""
+                    postfix="overview"
+                    testid="auto-refresh-overview"
+                    defaultRefreshRate={DATABASE_OVERVIEW_REFRESH_INTERVAL}
+                    minimumRefreshRate={parseInt(
+                      DATABASE_OVERVIEW_MINIMUM_REFRESH_INTERVAL,
+                    )}
+                    onRefresh={loadData}
+                    onEnableAutoRefresh={handleEnableAutoRefresh}
+                  />
+                </EuiFlexItem>
+              </EuiFlexItem>
+            </>
+          )}
+        </EuiFlexGroup>
+      </EuiFlexItem>
     </EuiFlexGroup>
   )
 }

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -22,7 +22,10 @@ import {
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { toBytes, truncatePercentage } from 'uiSrc/utils'
-import { appConnectivityError } from 'uiSrc/slices/app/connectivity'
+import {
+  appConnectivityError,
+  setConnectivityError,
+} from 'uiSrc/slices/app/connectivity'
 import WarningIcon from 'uiSrc/assets/img/warning.svg?react'
 import { getOverviewMetrics, IMetric } from './components/OverviewMetrics'
 
@@ -90,7 +93,6 @@ const DatabaseOverview = () => {
       isBdbPackages,
     } = {},
   } = overview
-
   const loadData = () => {
     if (connectedInstanceId && !connectivityError) {
       dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
@@ -259,6 +261,9 @@ const DatabaseOverview = () => {
                       DATABASE_OVERVIEW_MINIMUM_REFRESH_INTERVAL,
                     )}
                     onRefresh={loadData}
+                    onRefreshClicked={() =>
+                      dispatch(setConnectivityError(null))
+                    }
                     onEnableAutoRefresh={handleEnableAutoRefresh}
                   />
                 </EuiFlexItem>

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useMemo } from 'react'
+import React, { useContext, useState, useMemo, useEffect } from 'react'
 import cx from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -22,6 +22,11 @@ import {
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { toBytes, truncatePercentage } from 'uiSrc/utils'
+import {
+  appConnectivityError,
+  setConnectivityError,
+} from 'uiSrc/slices/app/connectivity'
+import ApiErrors from 'uiSrc/constants/apiErrors'
 import { getOverviewMetrics, IMetric } from './components/OverviewMetrics'
 
 import AutoRefresh from '../auto-refresh'
@@ -75,6 +80,7 @@ const DatabaseOverview = () => {
   const { id: connectedInstanceId = '', db } = useSelector(
     connectedInstanceSelector,
   )
+  const connectivityError = useSelector(appConnectivityError)
 
   const overview = useSelector(connectedInstanceOverviewSelector)
   const {
@@ -89,11 +95,16 @@ const DatabaseOverview = () => {
   } = overview
 
   const loadData = () => {
-    if (connectedInstanceId) {
+    if (connectedInstanceId && !connectivityError) {
       dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
       setLastRefreshTime(Date.now())
     }
   }
+  useEffect(() => {
+    if (!connectivityError) {
+      loadData()
+    }
+  }, [connectivityError])
 
   const handleEnableAutoRefresh = (
     enableAutoRefresh: boolean,

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -1,39 +1,23 @@
-import React, { useContext, useState, useMemo, useEffect } from 'react'
+import React from 'react'
 import cx from 'classnames'
-import { useDispatch, useSelector } from 'react-redux'
-import {
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiToolTip,
-} from '@elastic/eui'
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui'
 import { getConfig } from 'uiSrc/config'
 
 import {
-  DATABASE_OVERVIEW_REFRESH_INTERVAL,
   DATABASE_OVERVIEW_MINIMUM_REFRESH_INTERVAL,
+  DATABASE_OVERVIEW_REFRESH_INTERVAL,
 } from 'uiSrc/constants/browser'
-import {
-  connectedInstanceOverviewSelector,
-  connectedInstanceSelector,
-  getDatabaseConfigInfoAction,
-} from 'uiSrc/slices/instances/instances'
-import { ThemeContext } from 'uiSrc/contexts/themeContext'
-import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import { toBytes, truncatePercentage } from 'uiSrc/utils'
-import {
-  appConnectivityError,
-  setConnectivityError,
-} from 'uiSrc/slices/app/connectivity'
 import WarningIcon from 'uiSrc/assets/img/warning.svg?react'
-import { getOverviewMetrics, IMetric } from './components/OverviewMetrics'
+import MetricItem, {
+  OverviewItem,
+} from 'uiSrc/components/database-overview/components/OverviewMetrics/MetricItem'
+import { useDatabaseOverview } from 'uiSrc/components/database-overview/hooks/useDatabaseOverview'
 
+import { IMetric } from 'uiSrc/components/database-overview/components/OverviewMetrics'
 import AutoRefresh from '../auto-refresh'
 import styles from './styles.module.scss'
 
 const riConfig = getConfig()
-
 const getTooltipContent = (metric: IMetric) => {
   if (!metric.children?.length) {
     return (
@@ -74,66 +58,18 @@ const getTooltipContent = (metric: IMetric) => {
 }
 
 const DatabaseOverview = () => {
-  const { theme } = useContext(ThemeContext)
-  const dispatch = useDispatch()
-  const [lastRefreshTime, setLastRefreshTime] = useState<number | null>(null)
-  const { id: connectedInstanceId = '', db } = useSelector(
-    connectedInstanceSelector,
-  )
-  const connectivityError = useSelector(appConnectivityError)
-
-  const overview = useSelector(connectedInstanceOverviewSelector)
   const {
-    usedMemory,
-    cloudDetails: {
-      subscriptionType,
-      subscriptionId,
-      planMemoryLimit,
-      memoryLimitMeasurementUnit,
-      isBdbPackages,
-    } = {},
-  } = overview
-  const loadData = () => {
-    if (connectedInstanceId && !connectivityError) {
-      dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
-      setLastRefreshTime(Date.now())
-    }
-  }
-  useEffect(() => {
-    if (!connectivityError) {
-      loadData()
-    }
-  }, [connectivityError])
-
-  const handleEnableAutoRefresh = (
-    enableAutoRefresh: boolean,
-    refreshRate: string,
-  ) => {
-    sendEventTelemetry({
-      event: enableAutoRefresh
-        ? TelemetryEvent.OVERVIEW_AUTO_REFRESH_ENABLED
-        : TelemetryEvent.OVERVIEW_AUTO_REFRESH_DISABLED,
-      eventData: {
-        databaseId: connectedInstanceId,
-        refreshRate: +refreshRate,
-      },
-    })
-  }
-
-  const usedMemoryPercent = planMemoryLimit
-    ? parseFloat(
-        `${truncatePercentage(((usedMemory || 0) / toBytes(planMemoryLimit, memoryLimitMeasurementUnit || 'MB')) * 100, 1)}`,
-      )
-    : undefined
-
-  const metrics = useMemo(() => {
-    const overviewItems = {
-      ...overview,
-      usedMemoryPercent,
-    }
-    return getOverviewMetrics({ theme, items: overviewItems, db })
-  }, [theme, overview, db, usedMemoryPercent])
-
+    connectivityError,
+    metrics,
+    subscriptionId,
+    subscriptionType,
+    usedMemoryPercent,
+    isBdbPackages,
+    lastRefreshTime,
+    handleEnableAutoRefresh,
+    handleRefreshClick,
+    handleRefresh,
+  } = useDatabaseOverview()
   return (
     <EuiFlexGroup
       className={styles.container}
@@ -148,36 +84,18 @@ const DatabaseOverview = () => {
           alignItems="center"
         >
           {connectivityError && (
-            <EuiFlexItem
-              key="connectivityError"
-              className={styles.overviewItem}
-              data-test-subj="connectivityError"
-              grow={false}
-            >
-              <EuiToolTip
-                position="bottom"
-                className={styles.tooltip}
-                content={connectivityError}
-              >
-                <EuiFlexGroup
-                  gutterSize="none"
-                  responsive={false}
-                  alignItems="center"
-                  justifyContent="center"
-                >
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon size="m" type={WarningIcon} />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiToolTip>
-            </EuiFlexItem>
+            <MetricItem
+              id="connectivityError"
+              tooltipContent={connectivityError}
+              content={<EuiIcon size="m" type={WarningIcon} />}
+            />
           )}
           {metrics?.length! > 0 && (
             <>
               {subscriptionId && subscriptionType === 'fixed' && (
-                <EuiFlexItem
-                  className={cx(styles.overviewItem, styles.upgradeBtnItem)}
-                  grow={false}
+                <OverviewItem
+                  id="upgrade-ri-db-button"
+                  className={styles.upgradeBtnItem}
                   style={{ borderRight: 'none' }}
                 >
                   <EuiButton
@@ -195,52 +113,18 @@ const DatabaseOverview = () => {
                   >
                     Upgrade plan
                   </EuiButton>
-                </EuiFlexItem>
+                </OverviewItem>
               )}
               {metrics?.map((overviewItem) => (
-                <EuiFlexItem
-                  className={cx(
-                    styles.overviewItem,
-                    overviewItem.className ?? '',
-                  )}
-                  key={overviewItem.id}
-                  data-test-subj={overviewItem.id}
-                  grow={false}
-                >
-                  <EuiToolTip
-                    position="bottom"
-                    className={styles.tooltip}
-                    content={getTooltipContent(overviewItem)}
-                  >
-                    <EuiFlexGroup
-                      gutterSize="none"
-                      responsive={false}
-                      alignItems="center"
-                      justifyContent="center"
-                    >
-                      {overviewItem.icon && (
-                        <EuiFlexItem grow={false} className={styles.icon}>
-                          <EuiIcon
-                            size="m"
-                            type={overviewItem.icon}
-                            className={styles.icon}
-                          />
-                        </EuiFlexItem>
-                      )}
-                      <EuiFlexItem
-                        grow={false}
-                        className={styles.overviewItemContent}
-                      >
-                        {overviewItem.content}
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiToolTip>
-                </EuiFlexItem>
+                <MetricItem
+                  {...overviewItem}
+                  tooltipContent={getTooltipContent(overviewItem)}
+                />
               ))}
-              <EuiFlexItem
-                className={cx(styles.overviewItem, styles.autoRefresh)}
-                grow={false}
+              <OverviewItem
+                className={styles.autoRefresh}
                 data-testid="overview-auto-refresh"
+                id="overview-auto-refresh"
               >
                 <EuiFlexItem
                   grow={false}
@@ -260,14 +144,12 @@ const DatabaseOverview = () => {
                     minimumRefreshRate={parseInt(
                       DATABASE_OVERVIEW_MINIMUM_REFRESH_INTERVAL,
                     )}
-                    onRefresh={loadData}
-                    onRefreshClicked={() =>
-                      dispatch(setConnectivityError(null))
-                    }
+                    onRefresh={handleRefresh}
+                    onRefreshClicked={handleRefreshClick}
                     onEnableAutoRefresh={handleEnableAutoRefresh}
                   />
                 </EuiFlexItem>
-              </EuiFlexItem>
+              </OverviewItem>
             </>
           )}
         </EuiFlexGroup>

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -117,6 +117,7 @@ const DatabaseOverview = () => {
               )}
               {metrics?.map((overviewItem) => (
                 <MetricItem
+                  key={overviewItem.id}
                   {...overviewItem}
                   tooltipContent={getTooltipContent(overviewItem)}
                 />

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -18,44 +18,6 @@ import AutoRefresh from '../auto-refresh'
 import styles from './styles.module.scss'
 
 const riConfig = getConfig()
-const getTooltipContent = (metric: IMetric) => {
-  if (!metric.children?.length) {
-    return (
-      <>
-        <span>{metric.tooltip.content}</span>
-        &nbsp;
-        <span>{metric.tooltip.title}</span>
-      </>
-    )
-  }
-  return metric.children
-    .filter((item) => item.value !== undefined)
-    .map((tooltipItem) => (
-      <EuiFlexGroup
-        className={styles.commandsPerSecTip}
-        key={tooltipItem.id}
-        gutterSize="none"
-        responsive={false}
-        alignItems="center"
-      >
-        {tooltipItem.icon && (
-          <EuiFlexItem grow={false}>
-            <EuiIcon
-              className={styles.moreInfoOverviewIcon}
-              size="m"
-              type={tooltipItem.icon}
-            />
-          </EuiFlexItem>
-        )}
-        <EuiFlexItem className={styles.moreInfoOverviewContent} grow={false}>
-          {tooltipItem.content}
-        </EuiFlexItem>
-        <EuiFlexItem className={styles.moreInfoOverviewTitle} grow={false}>
-          {tooltipItem.title}
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    ))
-}
 
 const DatabaseOverview = () => {
   const {
@@ -70,6 +32,7 @@ const DatabaseOverview = () => {
     handleRefreshClick,
     handleRefresh,
   } = useDatabaseOverview()
+
   return (
     <EuiFlexGroup
       className={styles.container}
@@ -157,6 +120,45 @@ const DatabaseOverview = () => {
       </EuiFlexItem>
     </EuiFlexGroup>
   )
+}
+
+const getTooltipContent = (metric: IMetric) => {
+  if (!metric.children?.length) {
+    return (
+      <>
+        <span>{metric.tooltip.content}</span>
+        &nbsp;
+        <span>{metric.tooltip.title}</span>
+      </>
+    )
+  }
+  return metric.children
+    .filter((item) => item.value !== undefined)
+    .map((tooltipItem) => (
+      <EuiFlexGroup
+        className={styles.commandsPerSecTip}
+        key={tooltipItem.id}
+        gutterSize="none"
+        responsive={false}
+        alignItems="center"
+      >
+        {tooltipItem.icon && (
+          <EuiFlexItem grow={false}>
+            <EuiIcon
+              className={styles.moreInfoOverviewIcon}
+              size="m"
+              type={tooltipItem.icon}
+            />
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem className={styles.moreInfoOverviewContent} grow={false}>
+          {tooltipItem.content}
+        </EuiFlexItem>
+        <EuiFlexItem className={styles.moreInfoOverviewTitle} grow={false}>
+          {tooltipItem.title}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ))
 }
 
 export default DatabaseOverview

--- a/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
+++ b/redisinsight/ui/src/components/database-overview/DatabaseOverview.tsx
@@ -126,9 +126,9 @@ const getTooltipContent = (metric: IMetric) => {
   if (!metric.children?.length) {
     return (
       <>
-        <span>{metric.tooltip.content}</span>
+        <span>{metric.tooltip?.content}</span>
         &nbsp;
-        <span>{metric.tooltip.title}</span>
+        <span>{metric.tooltip?.title}</span>
       </>
     )
   }

--- a/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/MetricItem.tsx
+++ b/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/MetricItem.tsx
@@ -1,0 +1,65 @@
+import cx from 'classnames'
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiToolTip } from '@elastic/eui'
+import React, { CSSProperties, ReactNode } from 'react'
+import styles from 'uiSrc/components/database-overview/styles.module.scss'
+import { IMetric } from 'uiSrc/components/database-overview/components/OverviewMetrics/OverviewMetrics'
+
+export interface OverviewItemProps {
+  children: ReactNode
+  className?: string
+  id?: string
+  style?: CSSProperties
+}
+export const OverviewItem = ({
+  children,
+  className,
+  id,
+  style,
+}: OverviewItemProps) => (
+  <EuiFlexItem
+    className={cx(styles.overviewItem, className)}
+    key={id}
+    data-test-subj={id}
+    data-testid={id}
+    grow={false}
+    style={style}
+  >
+    {children}
+  </EuiFlexItem>
+)
+
+const MetricItem = (
+  props: Partial<IMetric> & {
+    tooltipContent?: ReactNode
+    style?: CSSProperties
+  },
+) => {
+  const { className = '', content, icon, id, tooltipContent, style } = props
+  return (
+    <OverviewItem id={id} className={className} style={style}>
+      <EuiToolTip
+        position="bottom"
+        className={styles.tooltip}
+        content={tooltipContent}
+      >
+        <EuiFlexGroup
+          gutterSize="none"
+          responsive={false}
+          alignItems="center"
+          justifyContent="center"
+        >
+          {icon && (
+            <EuiFlexItem grow={false} className={styles.icon}>
+              <EuiIcon size="m" type={icon} className={styles.icon} />
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false} className={styles.overviewItemContent}>
+            {content}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiToolTip>
+    </OverviewItem>
+  )
+}
+
+export default MetricItem

--- a/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/OverviewMetrics.tsx
+++ b/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/OverviewMetrics.tsx
@@ -1,10 +1,5 @@
 import React, { FunctionComponent, ReactNode } from 'react'
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLoadingSpinner,
-} from '@elastic/eui'
+import { EuiLoadingSpinner } from '@elastic/eui'
 import { isArray, isUndefined, toNumber } from 'lodash'
 
 import {
@@ -419,43 +414,4 @@ export const getOverviewMetrics = ({
   }
 
   return availableItems
-}
-
-export const getTooltipContent = (metric: IMetric) => {
-  if (!metric.children?.length) {
-    return (
-      <>
-        <span>{metric.tooltip.content}</span>
-        &nbsp;
-        <span>{metric.tooltip.title}</span>
-      </>
-    )
-  }
-  return metric.children
-    .filter((item) => item.value !== undefined)
-    .map((tooltipItem) => (
-      <EuiFlexGroup
-        className={styles.commandsPerSecTip}
-        key={tooltipItem.id}
-        gutterSize="none"
-        responsive={false}
-        alignItems="center"
-      >
-        {tooltipItem.icon && (
-          <EuiFlexItem grow={false}>
-            <EuiIcon
-              className={styles.moreInfoOverviewIcon}
-              size="m"
-              type={tooltipItem.icon}
-            />
-          </EuiFlexItem>
-        )}
-        <EuiFlexItem className={styles.moreInfoOverviewContent} grow={false}>
-          {tooltipItem.content}
-        </EuiFlexItem>
-        <EuiFlexItem className={styles.moreInfoOverviewTitle} grow={false}>
-          {tooltipItem.title}
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    ))
 }

--- a/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/OverviewMetrics.tsx
+++ b/redisinsight/ui/src/components/database-overview/components/OverviewMetrics/OverviewMetrics.tsx
@@ -58,11 +58,11 @@ export interface IMetric {
   id: string
   content: ReactNode
   value: any
-  unavailableText: string
+  unavailableText?: string
   title: string
-  tooltip: {
+  tooltip?: {
     title?: string
-    icon: Nullable<string> | FunctionComponent
+    icon?: Nullable<string> | FunctionComponent
     content: ReactNode | string
   }
   loading?: boolean

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
@@ -12,11 +12,8 @@ import { useDatabaseOverview } from './useDatabaseOverview'
 
 // Mock the telemetry function
 jest.mock('uiSrc/telemetry', () => ({
+  ...jest.requireActual('uiSrc/telemetry'),
   sendEventTelemetry: jest.fn(),
-  TelemetryEvent: {
-    OVERVIEW_AUTO_REFRESH_ENABLED: 'overview_auto_refresh_enabled',
-    OVERVIEW_AUTO_REFRESH_DISABLED: 'overview_auto_refresh_disabled',
-  },
 }))
 
 // Mock the getOverviewMetrics function

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
@@ -1,0 +1,254 @@
+import { cloneDeep, set } from 'lodash'
+import {
+  act,
+  initialStateDefault,
+  mockStore,
+  renderHook,
+} from 'uiSrc/utils/test-utils'
+import { getDatabaseConfigInfo } from 'uiSrc/slices/instances/instances'
+import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
+import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { useDatabaseOverview } from './useDatabaseOverview'
+
+// Mock the telemetry function
+jest.mock('uiSrc/telemetry', () => ({
+  sendEventTelemetry: jest.fn(),
+  TelemetryEvent: {
+    OVERVIEW_AUTO_REFRESH_ENABLED: 'overview_auto_refresh_enabled',
+    OVERVIEW_AUTO_REFRESH_DISABLED: 'overview_auto_refresh_disabled',
+  },
+}))
+
+// Mock the getOverviewMetrics function
+jest.mock(
+  'uiSrc/components/database-overview/components/OverviewMetrics',
+  () => ({
+    getOverviewMetrics: jest.fn().mockReturnValue([
+      { id: 'cpu', title: 'CPU' },
+      { id: 'memory', title: 'Memory' },
+      { id: 'keys', title: 'Keys' },
+    ]),
+  }),
+)
+
+const mockInstanceId = 'test-instance-id'
+const mockDb = 0
+
+const overviewData = {
+  version: '6.0.0',
+  usedMemory: 45.2 * 1024 * 1024, // 45.2 MB
+  usedMemoryPercent: null,
+  totalKeys: 5000,
+  connectedClients: 1,
+  cpuUsagePercentage: 0.23,
+  networkInKbps: 3,
+  networkOutKbps: 5,
+  opsPerSecond: 10,
+  cloudDetails: undefined,
+}
+
+const initialState = set(
+  cloneDeep(initialStateDefault),
+  'connections.instances.instanceOverview',
+  overviewData,
+)
+
+// Set connected instance
+set(initialState, 'connections.instances.connectedInstance', {
+  id: mockInstanceId,
+  db: mockDb,
+})
+
+let mockedStore: ReturnType<typeof mockStore>
+
+describe('useDatabaseOverview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedStore = mockStore(initialState)
+  })
+
+  it('should return metrics and other data', () => {
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    expect(data.metrics).toEqual([
+      { id: 'cpu', title: 'CPU' },
+      { id: 'memory', title: 'Memory' },
+      { id: 'keys', title: 'Keys' },
+    ])
+    expect(data.connectivityError).toBeUndefined()
+    expect(data.lastRefreshTime).not.toBeUndefined()
+    expect(data.subscriptionType).toBeUndefined()
+    expect(data.subscriptionId).toBeUndefined()
+    expect(data.isBdbPackages).toBeUndefined()
+    expect(data.usedMemoryPercent).toBeUndefined()
+    expect(typeof data.handleRefresh).toBe('function')
+    expect(typeof data.handleRefreshClick).toBe('function')
+    expect(typeof data.handleEnableAutoRefresh).toBe('function')
+  })
+
+  it('should dispatch getDatabaseConfigInfoAction on mount', () => {
+    renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    const actions = mockedStore.getActions()
+    expect(actions).toContainEqual(getDatabaseConfigInfo())
+  })
+
+  it('should not dispatch getDatabaseConfigInfoAction when connectivity error exists', () => {
+    const stateWithError = set(
+      cloneDeep(initialState),
+      'app.connectivity.error',
+      'Network error',
+    )
+    mockedStore = mockStore(stateWithError)
+
+    renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    const actions = mockedStore.getActions()
+    expect(actions).not.toContainEqual(getDatabaseConfigInfo())
+  })
+
+  it('should calculate usedMemoryPercent when cloud plan limit is present', () => {
+    const stateWithCloudDetails = set(
+      cloneDeep(initialState),
+      'connections.instances.instanceOverview.cloudDetails',
+      {
+        cloudId: 123,
+        subscriptionId: 456,
+        subscriptionType: 'fixed',
+        planMemoryLimit: 75,
+        memoryLimitMeasurementUnit: 'MB',
+      },
+    )
+    mockedStore = mockStore(stateWithCloudDetails)
+
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    // 45.2 MB / 75 MB ≈ 60.3%
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    expect(data.usedMemoryPercent).toBeCloseTo(60.3, 1)
+    expect(data.subscriptionType).toBe('fixed')
+    expect(data.subscriptionId).toBe(456)
+  })
+
+  it('should handle refresh correctly', () => {
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    // Clear previous actions
+    mockedStore.clearActions()
+
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    act(() => {
+      data.handleRefresh()
+    })
+
+    const actions = mockedStore.getActions()
+    expect(actions).toContainEqual(getDatabaseConfigInfo())
+  })
+
+  it('should handle refresh click correctly', () => {
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+
+    // Clear previous actions
+    mockedStore.clearActions()
+
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    act(() => {
+      data.handleRefreshClick()
+    })
+
+    const actions = mockedStore.getActions()
+    expect(actions).toContainEqual(setConnectivityError(null))
+  })
+
+  it('should send telemetry event when auto-refresh is enabled', () => {
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    act(() => {
+      data.handleEnableAutoRefresh(true, '30')
+    })
+
+    expect(sendEventTelemetry).toHaveBeenCalledWith({
+      event: TelemetryEvent.OVERVIEW_AUTO_REFRESH_ENABLED,
+      eventData: {
+        databaseId: mockInstanceId,
+        refreshRate: 30,
+      },
+    })
+  })
+
+  it('should send telemetry event when auto-refresh is disabled', () => {
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+    act(() => {
+      data.handleEnableAutoRefresh(false, '30')
+    })
+
+    expect(sendEventTelemetry).toHaveBeenCalledWith({
+      event: TelemetryEvent.OVERVIEW_AUTO_REFRESH_DISABLED,
+      eventData: {
+        databaseId: mockInstanceId,
+        refreshRate: 30,
+      },
+    })
+  })
+
+  it('should handle flexible subscription type correctly', () => {
+    const stateWithFlexibleSubscription = set(
+      cloneDeep(initialState),
+      'connections.instances.instanceOverview.cloudDetails',
+      {
+        cloudId: 123,
+        subscriptionId: 456,
+        subscriptionType: 'flexible',
+        planMemoryLimit: 75,
+        memoryLimitMeasurementUnit: 'MB',
+      },
+    )
+    mockedStore = mockStore(stateWithFlexibleSubscription)
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+
+    expect(data.subscriptionType).toBe('flexible')
+  })
+
+  it('should handle BDB packages flag correctly', () => {
+    const stateWithBdbPackages = set(
+      cloneDeep(initialState),
+      'connections.instances.instanceOverview.cloudDetails',
+      {
+        cloudId: 123,
+        subscriptionId: 456,
+        subscriptionType: 'fixed',
+        planMemoryLimit: 75,
+        memoryLimitMeasurementUnit: 'MB',
+        isBdbPackages: true,
+      },
+    )
+    mockedStore = mockStore(stateWithBdbPackages)
+    const { result } = renderHook(() => useDatabaseOverview(), {
+      store: mockedStore,
+    })
+    const data = result.current as ReturnType<typeof useDatabaseOverview>
+
+    expect(data.isBdbPackages).toBe(true)
+  })
+})

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
@@ -57,8 +57,6 @@ set(initialState, 'connections.instances.connectedInstance', {
 })
 
 let mockedStore: ReturnType<typeof mockStore>
-// Set up fake timers
-jest.useFakeTimers()
 let mockDate: Date
 type HookReturnType = ReturnType<typeof useDatabaseOverview>
 
@@ -75,10 +73,12 @@ describe('useDatabaseOverview', () => {
     jest.clearAllMocks()
     mockedStore = mockStore(initialState)
 
+    // Set up fake timers
+    jest.useFakeTimers()
     mockDate = new Date('2024-11-22T12:00:00Z')
     jest.setSystemTime(mockDate)
   })
-  
+
   afterEach(() => {
     jest.useRealTimers()
   })

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
@@ -81,6 +81,10 @@ describe('useDatabaseOverview', () => {
     mockDate = new Date('2024-11-22T12:00:00Z')
     jest.setSystemTime(mockDate)
   })
+  
+  afterEach(() => {
+    jest.useRealTimers()
+  })
 
   it('should return metrics and other data', () => {
     const data = helper(mockedStore)

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.spec.ts
@@ -60,7 +60,7 @@ let mockedStore: ReturnType<typeof mockStore>
 let mockDate: Date
 type HookReturnType = ReturnType<typeof useDatabaseOverview>
 
-const helper = (store: typeof mockedStore) => {
+const renderHelper = (store: typeof mockedStore) => {
   const { result } = renderHook(() => useDatabaseOverview(), {
     store,
   })
@@ -84,7 +84,7 @@ describe('useDatabaseOverview', () => {
   })
 
   it('should return metrics and other data', () => {
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
     expect(data.metrics).toEqual([
       { id: 'cpu', title: 'CPU' },
       { id: 'memory', title: 'Memory' },
@@ -102,7 +102,7 @@ describe('useDatabaseOverview', () => {
   })
 
   it('should set lastRefreshTime to current timestamp on mount', () => {
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
     expect(data.lastRefreshTime).toBe(mockDate.getTime())
   })
 
@@ -136,7 +136,7 @@ describe('useDatabaseOverview', () => {
     )
     mockedStore = mockStore(stateWithCloudDetails)
 
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
 
     // 45.2 MB / 75 MB ≈ 60.3%
     expect(data.usedMemoryPercent).toBeCloseTo(60.3, 1)
@@ -145,7 +145,7 @@ describe('useDatabaseOverview', () => {
   })
 
   it('should handle refresh correctly', () => {
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
 
     // Clear previous actions
     mockedStore.clearActions()
@@ -162,7 +162,7 @@ describe('useDatabaseOverview', () => {
     // Clear previous actions
     mockedStore.clearActions()
 
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
     act(() => {
       data.handleRefreshClick()
     })
@@ -172,7 +172,7 @@ describe('useDatabaseOverview', () => {
   })
 
   it('should send telemetry event when auto-refresh is enabled', () => {
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
     act(() => {
       data.handleEnableAutoRefresh(true, '30')
     })
@@ -187,7 +187,7 @@ describe('useDatabaseOverview', () => {
   })
 
   it('should send telemetry event when auto-refresh is disabled', () => {
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
     act(() => {
       data.handleEnableAutoRefresh(false, '30')
     })
@@ -214,7 +214,7 @@ describe('useDatabaseOverview', () => {
       },
     )
     mockedStore = mockStore(stateWithFlexibleSubscription)
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
 
     expect(data.subscriptionType).toBe('flexible')
   })
@@ -233,7 +233,7 @@ describe('useDatabaseOverview', () => {
       },
     )
     mockedStore = mockStore(stateWithBdbPackages)
-    const data = helper(mockedStore)
+    const data = renderHelper(mockedStore)
 
     expect(data.isBdbPackages).toBe(true)
   })

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
@@ -1,0 +1,113 @@
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { ThemeContext } from 'uiSrc/contexts/themeContext'
+import {
+  connectedInstanceOverviewSelector,
+  connectedInstanceSelector,
+  getDatabaseConfigInfoAction,
+} from 'uiSrc/slices/instances/instances'
+import {
+  appConnectivityError,
+  setConnectivityError,
+} from 'uiSrc/slices/app/connectivity'
+import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { Nullable, toBytes, truncatePercentage } from 'uiSrc/utils'
+import { getOverviewMetrics } from 'uiSrc/components/database-overview/components/OverviewMetrics'
+
+function getUsedMemoryPercent(
+  planMemoryLimit: number | undefined,
+  usedMemory: Nullable<number> | undefined,
+  memoryLimitMeasurementUnit = 'MB',
+) {
+  if (!planMemoryLimit) {
+    return undefined
+  }
+  return parseFloat(
+    `${truncatePercentage(((usedMemory || 0) / toBytes(planMemoryLimit, memoryLimitMeasurementUnit)) * 100, 1)}`,
+  )
+}
+
+export const useDatabaseOverview = () => {
+  const { theme } = useContext(ThemeContext)
+  const dispatch = useDispatch()
+  const [lastRefreshTime, setLastRefreshTime] = useState<number | null>(null)
+  const { id: connectedInstanceId = '', db } = useSelector(
+    connectedInstanceSelector,
+  )
+  const connectivityError = useSelector(appConnectivityError)
+
+  const overview = useSelector(connectedInstanceOverviewSelector)
+  const {
+    usedMemory,
+    cloudDetails: {
+      subscriptionType,
+      subscriptionId,
+      planMemoryLimit,
+      memoryLimitMeasurementUnit,
+      isBdbPackages,
+    } = {},
+  } = overview
+  const loadData = () => {
+    if (connectedInstanceId && !connectivityError) {
+      dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
+      setLastRefreshTime(Date.now())
+    }
+  }
+  useEffect(() => {
+    if (!connectivityError) {
+      loadData()
+    }
+  }, [connectivityError])
+
+  const handleEnableAutoRefresh = (
+    enableAutoRefresh: boolean,
+    refreshRate: string,
+  ) =>
+    sendEventTelemetry({
+      event: enableAutoRefresh
+        ? TelemetryEvent.OVERVIEW_AUTO_REFRESH_ENABLED
+        : TelemetryEvent.OVERVIEW_AUTO_REFRESH_DISABLED,
+      eventData: {
+        databaseId: connectedInstanceId,
+        refreshRate: +refreshRate,
+      },
+    })
+
+  const usedMemoryPercent = getUsedMemoryPercent(
+    planMemoryLimit,
+    usedMemory,
+    memoryLimitMeasurementUnit,
+  )
+
+  const metrics = useMemo(() => {
+    const overviewItems = {
+      ...overview,
+      usedMemoryPercent,
+    }
+    return getOverviewMetrics({
+      theme,
+      items: overviewItems,
+      db,
+    })
+  }, [theme, overview, db, usedMemoryPercent])
+
+  const handleRefresh = () => {
+    loadData()
+  }
+  const handleRefreshClick = () => {
+    dispatch(setConnectivityError(null))
+  }
+
+  return {
+    metrics,
+    connectivityError,
+    lastRefreshTime,
+    handleEnableAutoRefresh,
+    subscriptionType,
+    subscriptionId,
+    isBdbPackages,
+    usedMemoryPercent,
+    handleRefresh,
+    handleRefreshClick,
+  }
+}

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
@@ -47,15 +47,17 @@ export const useDatabaseOverview = () => {
       isBdbPackages,
     } = {},
   } = overview
+
   const loadData = () => {
     if (connectedInstanceId && !connectivityError) {
       dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
       setLastRefreshTime(Date.now())
     }
   }
+
   useEffect(() => {
     if (!connectivityError) {
-      loadData()
+      setLastRefreshTime(Date.now())
     }
   }, [connectivityError])
 
@@ -73,6 +75,13 @@ export const useDatabaseOverview = () => {
       },
     })
 
+  const handleRefresh = () => {
+    loadData()
+  }
+  const handleRefreshClick = () => {
+    // clear error, if connectivity is broken, the interceptor will set it again
+    dispatch(setConnectivityError(null))
+  }
   const usedMemoryPercent = getUsedMemoryPercent(
     planMemoryLimit,
     usedMemory,
@@ -91,22 +100,15 @@ export const useDatabaseOverview = () => {
     })
   }, [theme, overview, db, usedMemoryPercent])
 
-  const handleRefresh = () => {
-    loadData()
-  }
-  const handleRefreshClick = () => {
-    dispatch(setConnectivityError(null))
-  }
-
   return {
     metrics,
     connectivityError,
     lastRefreshTime,
-    handleEnableAutoRefresh,
     subscriptionType,
     subscriptionId,
     isBdbPackages,
     usedMemoryPercent,
+    handleEnableAutoRefresh,
     handleRefresh,
     handleRefreshClick,
   }

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
@@ -5,12 +5,12 @@ import { instance, mock } from 'ts-mockito'
 import userEvent from '@testing-library/user-event'
 import {
   cleanup,
-  mockedStore,
-  render,
-  screen,
   fireEvent,
   initialStateDefault,
+  mockedStore,
   mockStore,
+  render,
+  screen,
   waitFor,
 } from 'uiSrc/utils/test-utils'
 import {
@@ -18,7 +18,6 @@ import {
   connectedInstanceInfoSelector,
   connectedInstanceSelector,
 } from 'uiSrc/slices/instances/instances'
-import { loadInstances as loadRdiInstances } from 'uiSrc/slices/rdi/instances'
 import { appContextDbIndex } from 'uiSrc/slices/app/context'
 
 import { FeatureFlags } from 'uiSrc/constants'
@@ -108,8 +107,10 @@ describe('InstanceHeader', () => {
     expect(screen.getByTestId('change-index-input')).toHaveValue('3')
     fireEvent.click(screen.getByTestId('apply-btn'))
 
-    const expectedActions = [checkDatabaseIndex()]
-    expect(store.getActions()).toEqual([...expectedActions])
+    // check if store actions contain proper action: {type: "instances/checkDatabaseIndex"}
+    expect(store.getActions()).toContainEqual(
+      expect.objectContaining(checkDatabaseIndex()),
+    )
   })
 
   it('should be disabled db index button with loading state', () => {
@@ -194,7 +195,7 @@ describe('InstanceHeader', () => {
       store: mockStore(initialStoreState),
     })
 
-    userEvent.click(screen.getByTestId('user-profile-btn'))
+    await userEvent.click(screen.getByTestId('user-profile-btn'))
     await waitFor(() => {
       expect(
         screen.queryByTestId('user-profile-popover-content'),
@@ -231,7 +232,7 @@ describe('InstanceHeader', () => {
       store: mockStore(initialStoreState),
     })
 
-    userEvent.click(screen.getByTestId('user-profile-btn'))
+    await userEvent.click(screen.getByTestId('user-profile-btn'))
     await waitFor(() => {
       expect(
         screen.queryByTestId('user-profile-popover-content'),

--- a/redisinsight/ui/src/constants/apiErrors.ts
+++ b/redisinsight/ui/src/constants/apiErrors.ts
@@ -7,6 +7,7 @@ enum ApiErrors {
   KeytarDecryption = 'KeytarDecryptionError',
   ClientNotFound = 'ClientNotFoundError',
   RedisearchIndexNotFound = 'no such index',
+  ConnectionLost = 'The connection to the server has been lost.',
 }
 
 export const ApiEncryptionErrors: string[] = [

--- a/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
+++ b/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
@@ -18,8 +18,8 @@ export const INSTANCES_MOCK: Instance[] = [
     connectionType: ConnectionType.Standalone,
     nameFromProvider: null,
     modules: [],
-    uoeu: 123,
     lastConnection: new Date('2021-04-22T09:03:56.917Z'),
+    version: null,
   },
   {
     id: 'a0db1bc8-a353-4c43-a856-b72f4811d2d4',
@@ -48,6 +48,7 @@ export const INSTANCES_MOCK: Instance[] = [
     nameFromProvider: null,
     lastConnection: new Date('2021-04-22T18:40:44.031Z'),
     modules: [],
+    version: null,
     endpoints: [
       {
         host: 'localhost',
@@ -66,7 +67,7 @@ export const INSTANCES_MOCK: Instance[] = [
 
 export const getDatabasesApiSpy = jest
   .fn()
-  .mockImplementation(async (req, res, ctx) =>
+  .mockImplementation(async (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
   )
 
@@ -78,7 +79,7 @@ const handlers: RestHandler[] = [
   ),
   rest.post<ExportDatabase>(
     getMswURL(ApiEndpoints.DATABASES_EXPORT),
-    async (req, res, ctx) => res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
+    async (_req, res, ctx) => res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
   ),
   rest.get<DatabaseInstanceResponse>(
     getMswURL(getUrl(INSTANCE_ID_MOCK)),

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.spec.tsx
@@ -20,6 +20,7 @@ import {
 } from 'uiSrc/slices/interfaces/keys'
 import { BrowserColumns } from 'uiSrc/constants'
 
+import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import KeysHeader from './KeysHeader'
 
 let store: typeof mockedStore
@@ -191,6 +192,7 @@ describe('KeysHeader', () => {
       keysSlice.resetKeyInfo(),
       setBrowserSelectedKey(null),
       setBrowserPatternKeyListDataLoaded(true),
+      setConnectivityError(null),
     ]
     expect(store.getActions()).toEqual(expectedActions)
   })

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -55,6 +55,7 @@ import { AutoRefresh, OnboardingTour } from 'uiSrc/components'
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 import { BrowserColumns, KeyValueFormat } from 'uiSrc/constants'
 
+import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import styles from './styles.module.scss'
 
 const HIDE_REFRESH_LABEL_WIDTH = 640
@@ -191,6 +192,7 @@ const KeysHeader = (props: Props) => {
           }
 
           dispatch(setBrowserKeyListDataLoaded(searchMode, true))
+          dispatch(setConnectivityError(null))
         },
         () => dispatch(setBrowserKeyListDataLoaded(searchMode, false)),
       ),

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -91,7 +91,7 @@ describe('InstancePage', () => {
     ;(appContextSelector as jest.Mock).mockReturnValue({
       contextRdiInstanceId: '',
     })
-    await act(() => {
+    act(() => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -144,7 +144,7 @@ describe('InstancePage', () => {
       contextRdiInstanceId: 'prevId',
     })
 
-    await act(() => {
+    act(() => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -183,7 +183,7 @@ describe('InstancePage', () => {
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
 
-    await act(() => {
+    act(() => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -191,7 +191,7 @@ describe('InstancePage', () => {
       )
     })
 
-    expect(pushMock).toBeCalledWith(
+    expect(pushMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
   })
@@ -212,7 +212,7 @@ describe('InstancePage', () => {
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
 
-    await act(() => {
+    act(() => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -220,6 +220,8 @@ describe('InstancePage', () => {
       )
     })
 
-    expect(pushMock).toBeCalledWith(Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK))
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    )
   })
 })

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import reactRouterDom, { BrowserRouter } from 'react-router-dom'
 import { instance, mock } from 'ts-mockito'
 
-import { cleanup, mockedStore, render, act } from 'uiSrc/utils/test-utils'
+import { act, cleanup, mockedStore, render } from 'uiSrc/utils/test-utils'
 import { resetKeys, resetPatternKeysData } from 'uiSrc/slices/browser/keys'
 import { setMonitorInitialState } from 'uiSrc/slices/cli/monitor'
 import { setInitialPubSubState } from 'uiSrc/slices/pubsub/pubsub'
@@ -32,8 +32,8 @@ import {
   resetConnectedInstance as resetConnectedDatabaseInstance,
 } from 'uiSrc/slices/instances/instances'
 import {
-  setConnectedInstance,
   loadInstances as loadRdiInstances,
+  setConnectedInstance,
 } from 'uiSrc/slices/rdi/instances'
 import { PageNames, Pages } from 'uiSrc/constants'
 import {
@@ -91,7 +91,7 @@ describe('InstancePage', () => {
     ;(appContextSelector as jest.Mock).mockReturnValue({
       contextRdiInstanceId: '',
     })
-    act(() => {
+    await act(async () => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -144,7 +144,8 @@ describe('InstancePage', () => {
       contextRdiInstanceId: 'prevId',
     })
 
-    act(() => {
+    // this MUST be awaited, in order for all effects to happen and all actions to be dispatched
+    await act(async () => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />

--- a/redisinsight/ui/src/services/apiService.ts
+++ b/redisinsight/ui/src/services/apiService.ts
@@ -11,6 +11,7 @@ import { store } from 'uiSrc/slices/store'
 import { logoutUserAction } from 'uiSrc/slices/oauth/cloud'
 import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import { getConfig } from 'uiSrc/config'
+import ApiErrors from 'uiSrc/constants/apiErrors'
 
 const riConfig = getConfig()
 
@@ -96,9 +97,7 @@ export const connectivityErrorsInterceptor = (error: AxiosError) => {
     (responseData.code === 'serviceUnavailable' ||
       responseData.error === 'Service Unavailable')
   ) {
-    store?.dispatch<any>(
-      setConnectivityError('The connection to the server has been lost.'),
-    )
+    store?.dispatch<any>(setConnectivityError(ApiErrors.ConnectionLost))
   }
 
   return Promise.reject(error)

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -41,11 +41,7 @@ import {
   addMessageNotification,
   removeInfiniteNotification,
 } from '../app/notifications'
-import {
-  Instance,
-  InitialStateInstances,
-  ConnectionType,
-} from '../interfaces'
+import { Instance, InitialStateInstances, ConnectionType } from '../interfaces'
 
 const HIDE_CREATING_DB_DELAY_MS = 500
 

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -79,7 +79,6 @@ import {
   Instance,
 } from '../../interfaces'
 import { loadMastersSentinel } from '../../instances/sentinel'
-import { fetchTags } from 'uiSrc/slices/instances/tags'
 
 jest.mock('uiSrc/services', () => ({
   ...jest.requireActual('uiSrc/services'),

--- a/redisinsight/ui/src/utils/test-utils.tsx
+++ b/redisinsight/ui/src/utils/test-utils.tsx
@@ -242,13 +242,13 @@ const waitForEuiToolTipHidden = async () => {
   })
 }
 
-const waitForEuiPopoverVisible = async () => {
+const waitForEuiPopoverVisible = async (timeout = 500) => {
   await waitFor(
     () => {
       const tooltip = document.querySelector('.euiPopover__panel-isOpen')
       expect(tooltip).toBeInTheDocument()
     },
-    { timeout: 200 }, // Account for long delay on popover
+    { timeout }, // Account for long delay on popover
   )
 }
 


### PR DESCRIPTION
When DB connection is not working, we're sending telemetry messages. Since `/overview` endpoint is called repeatedly every 5 s by default, we're sending a lot of redundand telemetry messages 

With this PR, overview call is made only if there is no connectivity error registered.

Also small connection lost indicator is added.
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/581fb635-e138-44d7-9ade-e3ec2ffd2d70" />
