### PR TITLE
RI-6950: Fetch whole json when Monaco editor is selected

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
@@ -1,14 +1,89 @@
 import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { instance, mock } from 'ts-mockito'
 import { render } from 'uiSrc/utils/test-utils'
+import { fetchReJSON } from 'uiSrc/slices/browser/rejson'
+import { EditorType } from 'uiSrc/slices/interfaces'
+import { stringToBuffer } from 'uiSrc/utils'
+
 import { RejsonDetailsWrapper, Props } from './RejsonDetailsWrapper'
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}))
+
+jest.mock('uiSrc/slices/browser/rejson', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/rejson'),
+  fetchReJSON: jest.fn((key) => ({ type: 'FETCH_REJSON', payload: key })),
+}))
 
 const mockedProps = mock<Props>()
 
+const mockUseSelector = useSelector as jest.Mock
+const mockUseDispatch = useDispatch as jest.Mock
+
+type Selector = {
+  name: string
+}
+
+const commonSelectorsMock = (selector: Selector) => {
+  if (selector.name === 'rejsonSelector') {
+    return { loading: false, editorType: EditorType.Default }
+  }
+  if (selector.name === 'rejsonDataSelector') {
+    return { data: '{}', downloaded: true, type: 'string', path: '' }
+  }
+  if (selector.name === 'selectedKeyDataSelector') {
+    return {
+      name: stringToBuffer('test-key'),
+      nameString: 'test-key',
+      length: 1,
+    }
+  }
+  if (selector.name === 'keysSelector') {
+    return { viewType: 'Browser' }
+  }
+  if (selector.name === 'connectedInstanceSelector') {
+    return { id: 'instanceId' }
+  }
+  return {}
+}
+
 describe('RejsonDetailsWrapper', () => {
+  const mockDispatch = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseDispatch.mockReturnValue(mockDispatch)
+  })
+
   it('should render', () => {
+    mockUseSelector.mockImplementation(commonSelectorsMock)
+
     expect(
       render(<RejsonDetailsWrapper {...instance(mockedProps)} />),
     ).toBeTruthy()
+  })
+
+  it('should dispatch fetchReJSON when editorType changes', () => {
+    let editorType = EditorType.Default
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector.name === 'rejsonSelector') {
+        return { loading: false, editorType }
+      }
+      return commonSelectorsMock(selector)
+    })
+
+    const { rerender } = render(
+      <RejsonDetailsWrapper {...instance(mockedProps)} />,
+    )
+
+    editorType = EditorType.Text
+    rerender(<RejsonDetailsWrapper {...instance(mockedProps)} />)
+
+    const expectedKey = stringToBuffer('test-key')
+    expect(mockDispatch).toHaveBeenCalledWith(fetchReJSON(expectedKey))
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -1,9 +1,13 @@
-import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import React, { useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { EuiProgress } from '@elastic/eui'
 import { isUndefined } from 'lodash'
 
-import { rejsonDataSelector, rejsonSelector } from 'uiSrc/slices/browser/rejson'
+import {
+  fetchReJSON,
+  rejsonDataSelector,
+  rejsonSelector,
+} from 'uiSrc/slices/browser/rejson'
 import {
   selectedKeyDataSelector,
   keysSelector,
@@ -32,6 +36,8 @@ export interface Props extends KeyDetailsHeaderProps {}
 const RejsonDetailsWrapper = (props: Props) => {
   const { loading, editorType } = useSelector(rejsonSelector)
   const { data, downloaded, type, path } = useSelector(rejsonDataSelector)
+  const dispatch = useDispatch()
+
   const {
     name: selectedKey,
     nameString,
@@ -43,10 +49,22 @@ const RejsonDetailsWrapper = (props: Props) => {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
 
   const updatedData = parseJsonData(data)
+  const prevEditorTypeRef = useRef(editorType)
 
   useEffect(() => {
     setExpandedRows(new Set())
   }, [nameString])
+
+  // TODO: the whole workflow should be refactored
+  useEffect(() => {
+    if (!selectedKey) return
+
+    if (prevEditorTypeRef.current !== editorType) {
+      prevEditorTypeRef.current = editorType
+
+      dispatch(fetchReJSON(selectedKey))
+    }
+  }, [editorType, selectedKey, dispatch])
 
   const reportJSONKeyCollapsed = (level: number) => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { EuiProgress } from '@elastic/eui'
 import { isUndefined } from 'lodash'
@@ -49,7 +49,6 @@ const RejsonDetailsWrapper = (props: Props) => {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
 
   const updatedData = parseJsonData(data)
-  const prevEditorTypeRef = useRef(editorType)
 
   useEffect(() => {
     setExpandedRows(new Set())
@@ -61,11 +60,7 @@ const RejsonDetailsWrapper = (props: Props) => {
   useEffect(() => {
     if (!selectedKey) return
 
-    if (prevEditorTypeRef.current !== editorType) {
-      prevEditorTypeRef.current = editorType
-
-      dispatch(fetchReJSON(selectedKey))
-    }
+    dispatch(fetchReJSON(selectedKey))
   }, [editorType, selectedKey, dispatch])
 
   const reportJSONKeyCollapsed = (level: number) => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -60,6 +60,11 @@ const RejsonDetailsWrapper = (props: Props) => {
   useEffect(() => {
     if (!selectedKey) return
 
+    // Not including `loading` in deps is intentional
+    // This check avoids double fetching of data
+    // which happens when new key is selected for example.
+    if (loading) return
+
     dispatch(fetchReJSON(selectedKey))
   }, [editorType, selectedKey, dispatch])
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -56,6 +56,8 @@ const RejsonDetailsWrapper = (props: Props) => {
   }, [nameString])
 
   // TODO: the whole workflow should be refactored
+  // in a way that this component will not be responsible for fetching data
+  // based on the editor type
   useEffect(() => {
     if (!selectedKey) return
 

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -62,7 +62,7 @@ import {
   refreshZsetMembersAction,
 } from './zset'
 import { fetchSetMembers, refreshSetMembersAction } from './set'
-import { fetchReJSON } from './rejson'
+import { fetchReJSON, setEditorType } from './rejson'
 import {
   setHashInitialState,
   fetchHashFields,
@@ -102,7 +102,7 @@ import {
 } from '../interfaces/keys'
 import { AppDispatch, RootState } from '../store'
 import { StreamViewType } from '../interfaces/stream'
-import { RedisResponseBuffer, RedisString } from '../interfaces'
+import { EditorType, RedisResponseBuffer, RedisString } from '../interfaces'
 
 const defaultViewFormat = KeyValueFormat.Unicode
 
@@ -807,6 +807,7 @@ export function fetchKeyInfo(
       }
       if (data.type === KeyTypes.ReJSON) {
         dispatch<any>(fetchReJSON(key, '$', data.length, resetData))
+        dispatch<any>(setEditorType(EditorType.Default))
       }
       if (data.type === KeyTypes.Stream) {
         const { viewType } = state.browser.stream

--- a/redisinsight/ui/src/slices/browser/rejson.ts
+++ b/redisinsight/ui/src/slices/browser/rejson.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import axios, { AxiosError, CancelTokenSource } from 'axios'
 
-import { isNumber } from 'lodash'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
 import {
@@ -36,8 +35,6 @@ import {
   addMessageNotification,
 } from '../app/notifications'
 import { AppDispatch, RootState } from '../store'
-
-const JSON_LENGTH_TO_FORCE_RETRIEVE = 200
 
 export const initialState: InitialStateRejson = {
   loading: false,
@@ -149,7 +146,7 @@ export let sourceRejson: Nullable<CancelTokenSource> = null
 export function fetchReJSON(
   key: RedisResponseBuffer,
   path = '$',
-  length?: number,
+  _length?: number,
   resetData?: boolean,
 ) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
@@ -162,6 +159,7 @@ export function fetchReJSON(
       sourceRejson = CancelToken.source()
 
       const state = stateInit()
+      const { editorType } = state.browser.rejson
       const { encoding } = state.app.info
       const { data, status } = await apiService.post<GetRejsonRlResponseDto>(
         getUrl(
@@ -171,8 +169,7 @@ export function fetchReJSON(
         {
           keyName: key,
           path,
-          forceRetrieve:
-            isNumber(length) && length > JSON_LENGTH_TO_FORCE_RETRIEVE,
+          forceRetrieve: editorType === EditorType.Text,
           encoding,
         },
         { cancelToken: sourceRejson.token },
@@ -189,7 +186,6 @@ export function fetchReJSON(
         dispatch(addErrorNotification(error))
       }
     }
-    dispatch(setEditorType(EditorType.Default))
   }
 }
 

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -33,6 +33,8 @@ import {
 } from 'uiSrc/slices/app/context'
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 import { rootReducer } from 'uiSrc/slices/store'
+import { setEditorType } from 'uiSrc/slices/browser/rejson'
+import { EditorType } from 'uiSrc/slices/interfaces'
 import { CreateHashWithExpireDto } from 'apiSrc/modules/browser/hash/dto'
 import {
   CreateListWithExpireDto,
@@ -1374,6 +1376,29 @@ describe('keys slice', () => {
           setBrowserSelectedKey(null),
         ]
         expect(store.getActions()).toEqual(expectedActions)
+      })
+
+      it('should set default JSON editor', async () => {
+        // Arrange
+        const data = {
+          name: stringToBuffer('rejson'),
+          type: KeyTypes.ReJSON,
+          ttl: -1,
+          size: 10,
+        }
+        const responsePayload = { data, status: 200 }
+
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        // Act
+        await store.dispatch<any>(fetchKeyInfo(data.name))
+
+        // Assert
+        expect(store.getActions()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining(setEditorType(EditorType.Default)),
+          ]),
+        )
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
@@ -7,7 +7,6 @@ import {
   mockedStore,
   mockStore,
 } from 'uiSrc/utils/test-utils'
-import { EditorType } from 'uiSrc/slices/interfaces'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { GetRejsonRlResponseDto } from 'apiSrc/modules/browser/rejson-rl/dto'
 import reducer, {
@@ -30,7 +29,6 @@ import reducer, {
   setReJSONDataAction,
   appendReJSONArrayItemAction,
   removeReJSONKeyAction,
-  setEditorType,
 } from '../../browser/rejson'
 import {
   addErrorNotification,
@@ -407,7 +405,6 @@ describe('rejson slice', () => {
         const expectedActions = [
           loadRejsonBranch(),
           loadRejsonBranchSuccess(responsePayload.data),
-          setEditorType(EditorType.Default), // and always set editor type to default
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })
@@ -435,7 +432,6 @@ describe('rejson slice', () => {
           loadRejsonBranch(),
           loadRejsonBranchFailure(responsePayload.response.data.message),
           addErrorNotification(responsePayload as AxiosError),
-          setEditorType(EditorType.Default), // and always set editor type to default
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })


### PR DESCRIPTION
3 major things are happening in this PR.

1. `forceRetrieve` flag used for the `ApiEndpoints.REJSON_GET` call is `true` when the selected editor is Monaco.
2. When the selected editor changes, the `ApiEndpoints.REJSON_GET` gets called (because, based on the editor, the result is going to be different).
3. When the selected Redis key is changed, the selected editor resets to the default value.

With these constraints, the logic inside `RejsonDetailsWrapper` gets a bit complicated, so we should rework the data flow to make the component dummy. 