### PR TITLE
RI-6953: Send telemetry events for ReJSON used editor

### DIFF
--- a/redisinsight/ui/src/slices/browser/rejson.ts
+++ b/redisinsight/ui/src/slices/browser/rejson.ts
@@ -19,7 +19,6 @@ import {
 } from 'uiSrc/utils'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { parseJsonData } from 'uiSrc/pages/browser/modules/key-details/components/rejson-details/utils'
-
 import {
   GetRejsonRlResponseDto,
   RemoveRejsonRlResponse,
@@ -216,6 +215,7 @@ export function setReJSONDataAction(
 
     try {
       const state = stateInit()
+
       const { status } = await apiService.patch<GetRejsonRlResponseDto>(
         getUrl(
           state.connections.instances.connectedInstance?.id,
@@ -233,12 +233,12 @@ export function setReJSONDataAction(
           sendEventTelemetry({
             event: getBasedOnViewTypeEvent(
               state.browser.keys?.viewType,
-              TelemetryEvent[
-                `BROWSER_JSON_PROPERTY_${isEditMode ? 'EDITED' : 'ADDED'}`
-              ],
-              TelemetryEvent[
-                `TREE_VIEW_JSON_PROPERTY_${isEditMode ? 'EDITED' : 'ADDED'}`
-              ],
+              isEditMode
+                ? TelemetryEvent.BROWSER_JSON_PROPERTY_EDITED
+                : TelemetryEvent.BROWSER_JSON_PROPERTY_ADDED,
+              isEditMode
+                ? TelemetryEvent.TREE_VIEW_JSON_PROPERTY_EDITED
+                : TelemetryEvent.TREE_VIEW_JSON_PROPERTY_ADDED,
             ),
             eventData: {
               databaseId: state.connections.instances?.connectedInstance?.id,

--- a/redisinsight/ui/src/slices/browser/rejson.ts
+++ b/redisinsight/ui/src/slices/browser/rejson.ts
@@ -37,7 +37,7 @@ import {
 import { AppDispatch, RootState } from '../store'
 
 export const JSON_LENGTH_TO_FORCE_RETRIEVE = 200
-const TELEMETRY_KEY_LEVEL_WHOLE_KEY = 'entireKey'
+const TELEMETRY_KEY_LEVEL_ENTIRE_KEY = 'entireKey'
 
 export const initialState: InitialStateRejson = {
   loading: false,
@@ -234,7 +234,7 @@ export function setReJSONDataAction(
           const { editorType } = state.browser.rejson
           const keyLevel =
             editorType === EditorType.Text
-              ? TELEMETRY_KEY_LEVEL_WHOLE_KEY
+              ? TELEMETRY_KEY_LEVEL_ENTIRE_KEY
               : getJsonPathLevel(path)
           sendEventTelemetry({
             event: getBasedOnViewTypeEvent(

--- a/redisinsight/ui/src/slices/browser/rejson.ts
+++ b/redisinsight/ui/src/slices/browser/rejson.ts
@@ -37,6 +37,7 @@ import {
 import { AppDispatch, RootState } from '../store'
 
 export const JSON_LENGTH_TO_FORCE_RETRIEVE = 200
+const TELEMETRY_KEY_LEVEL_WHOLE_KEY = 'entireKey'
 
 export const initialState: InitialStateRejson = {
   loading: false,
@@ -230,6 +231,11 @@ export function setReJSONDataAction(
 
       if (isStatusSuccessful(status)) {
         try {
+          const { editorType } = state.browser.rejson
+          const keyLevel =
+            editorType === EditorType.Text
+              ? TELEMETRY_KEY_LEVEL_WHOLE_KEY
+              : getJsonPathLevel(path)
           sendEventTelemetry({
             event: getBasedOnViewTypeEvent(
               state.browser.keys?.viewType,
@@ -242,7 +248,7 @@ export function setReJSONDataAction(
             ),
             eventData: {
               databaseId: state.connections.instances?.connectedInstance?.id,
-              keyLevel: getJsonPathLevel(path),
+              keyLevel,
             },
           })
         } catch (error) {

--- a/redisinsight/ui/src/slices/tests/browser/rejson.setJsonDataAction.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/rejson.setJsonDataAction.spec.ts
@@ -1,0 +1,73 @@
+import thunk from 'redux-thunk'
+import configureStore from 'redux-mock-store'
+
+const mockStore = configureStore([thunk])
+
+describe('setReJSONDataAction', () => {
+  let store: any
+  let sendEventTelemetryMock: jest.Mock
+  let setReJSONDataAction: any
+  let apiService: any
+
+  beforeEach(async () => {
+    jest.resetModules()
+
+    sendEventTelemetryMock = jest.fn()
+
+    jest.doMock('uiSrc/telemetry', () => {
+      const actual = jest.requireActual('uiSrc/telemetry')
+      return {
+        ...actual,
+        sendEventTelemetry: sendEventTelemetryMock,
+        getBasedOnViewTypeEvent: jest.fn(() => 'mocked_event'),
+        getJsonPathLevel: jest.fn(() => 42),
+      }
+    })
+
+    jest.doMock('uiSrc/slices/browser/keys', () => {
+      const actual = jest.requireActual('uiSrc/slices/browser/keys')
+      return {
+        ...actual,
+        refreshKeyInfoAction: () => ({ type: 'DUMMY_REFRESH' }),
+      }
+    })
+
+    const rejson = await import('uiSrc/slices/browser/rejson')
+    setReJSONDataAction = rejson.setReJSONDataAction
+    apiService = (await import('uiSrc/services')).apiService
+
+    store = mockStore({
+      browser: {
+        rejson: { editorType: 'Default' },
+        keys: { viewType: 'Browser' },
+      },
+      app: {
+        info: { encoding: 'utf8' },
+      },
+      connections: {
+        instances: {
+          connectedInstance: {
+            id: 'instance-id',
+          },
+        },
+      },
+    })
+
+    apiService.patch = jest.fn().mockResolvedValue({ status: 200 })
+    apiService.post = jest.fn().mockResolvedValue({ status: 200, data: {} })
+
+    jest.clearAllMocks()
+  })
+
+  it('should call sendEventTelemetry with correct args', async () => {
+    await store.dispatch(setReJSONDataAction('key', '$', '{}', true, 100))
+
+    expect(sendEventTelemetryMock).toHaveBeenCalledWith({
+      event: 'mocked_event',
+      eventData: {
+        databaseId: 'instance-id',
+        keyLevel: 42,
+      },
+    })
+  })
+})

--- a/redisinsight/ui/src/telemetry/telemetryUtils.ts
+++ b/redisinsight/ui/src/telemetry/telemetryUtils.ts
@@ -4,7 +4,6 @@
  */
 import isGlob from 'is-glob'
 import { cloneDeep, get } from 'lodash'
-import jsonpath from 'jsonpath'
 import { Maybe, isRedisearchAvailable } from 'uiSrc/utils'
 import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
 import { KeyViewType } from 'uiSrc/slices/interfaces/keys'
@@ -135,18 +134,17 @@ const getBasedOnViewTypeEvent = (
   }
 }
 
-const getJsonPathLevel = (path: string): string => {
+const getJsonPathLevel = (path: string): number => {
   try {
-    if (path === '$') {
-      return 'root'
-    }
-    const levelsLength = jsonpath.parse(
-      `$${path.startsWith('$') ? '.' : '..'}${path}`,
-    ).length
+    if (!path || path === '$') return 0
 
-    return levelsLength === 2 ? 'root' : `${levelsLength - 2}`
+    const stripped = path.startsWith('$.') ? path.slice(2) : path.slice(1)
+
+    const parts = stripped.split(/[.[\]]/).filter(Boolean)
+
+    return parts.length
   } catch (e) {
-    return 'root'
+    return 0
   }
 }
 


### PR DESCRIPTION
`rejson` slice is hard to test due to its architecture. As a temporary solution, I added a new test suite, where modules can be dynamically reloaded in order to use the `jest` mocks.  Ideally, the business logic from this slice should be extracted and properly tested.

Apart from the event properties, this CL fixes a bug with reporting the JSON path level of nesting.