### PR TITLE
RI-7106: additiona data in config databases open database

### DIFF
--- a/redisinsight/api/src/modules/database/dto/redis-info.dto.ts
+++ b/redisinsight/api/src/modules/database/dto/redis-info.dto.ts
@@ -1,5 +1,39 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+class RedisDatabaseStatsDto {
+  @ApiProperty({
+    type: String,
+  })
+  instantaneous_input_kbps: string | undefined;
+
+  @ApiProperty({
+    type: String,
+  })
+  instantaneous_ops_per_sec: string | undefined;
+
+  @ApiProperty({
+    type: String,
+  })
+  instantaneous_output_kbps: string | undefined;
+
+  @ApiProperty({
+    type: Number,
+  })
+  maxmemory_policy: string | undefined;
+
+  @ApiProperty({
+    description: 'Redis database mode',
+    type: String,
+  })
+  numberOfKeysRange: string | undefined;
+
+  @ApiProperty({
+    description: 'Redis database role',
+    type: String,
+  })
+  uptime_in_days: string | undefined;
+}
+
 export class RedisNodeInfoResponse {
   @ApiProperty({
     description: 'Redis database version',
@@ -24,9 +58,9 @@ export class RedisNodeInfoResponse {
 
   @ApiPropertyOptional({
     description: 'Various Redis stats',
-    type: Object,
+    type: RedisDatabaseStatsDto,
   })
-  stats?: any;
+  stats?: RedisDatabaseStatsDto;
 
   @ApiPropertyOptional({
     description: 'The number of Redis databases',

--- a/redisinsight/api/src/modules/database/dto/redis-info.dto.ts
+++ b/redisinsight/api/src/modules/database/dto/redis-info.dto.ts
@@ -23,6 +23,12 @@ export class RedisNodeInfoResponse {
   server?: any;
 
   @ApiPropertyOptional({
+    description: 'Various Redis stats',
+    type: Object,
+  })
+  stats?: any;
+
+  @ApiPropertyOptional({
     description: 'The number of Redis databases',
     type: Number,
     default: 16,

--- a/redisinsight/api/src/modules/database/providers/database-info.provider.spec.ts
+++ b/redisinsight/api/src/modules/database/providers/database-info.provider.spec.ts
@@ -32,12 +32,21 @@ const mockRedisServerInfoDto = {
   tcp_port: '11113',
   uptime_in_seconds: '1000',
 };
+const mockRedisStatsDto = {
+  instantaneous_input_kbps: undefined,
+  instantaneous_ops_per_sec: undefined,
+  instantaneous_output_kbps: undefined,
+  maxmemory_policy: undefined,
+  numberOfKeysRange: '0 - 500 000',
+  uptime_in_days: undefined,
+};
 
 const mockRedisGeneralInfo: RedisDatabaseInfoResponse = {
   version: mockRedisServerInfoDto.redis_version,
   databases: 16,
   role: 'master',
   server: mockRedisServerInfoDto,
+  stats: mockRedisStatsDto,
   usedMemory: 1000000,
   totalKeys: 1,
   connectedClients: 1,
@@ -441,6 +450,10 @@ describe('DatabaseInfoProvider', () => {
 
       expect(result).toEqual({
         ...mockRedisGeneralInfo,
+        stats: {
+          ...mockRedisStatsDto,
+          numberOfKeysRange: undefined,
+        },
         totalKeys: undefined,
         usedMemory: undefined,
         hitRatio: undefined,
@@ -481,6 +494,10 @@ describe('DatabaseInfoProvider', () => {
 
       expect(result).toEqual({
         ...mockRedisGeneralInfo,
+        stats: {
+          ...mockRedisStatsDto,
+          numberOfKeysRange: undefined,
+        },
         server: {
           redis_mode: mockRedisServerInfoDto.redis_mode,
           redis_version: mockRedisGeneralInfo.version,

--- a/redisinsight/api/src/modules/database/providers/database-info.provider.ts
+++ b/redisinsight/api/src/modules/database/providers/database-info.provider.ts
@@ -164,17 +164,6 @@ export class DatabaseInfoProvider {
       const statsInfo = info['stats'];
       const replicationInfo = info['replication'];
       const databases = await this.getDatabasesCount(client, keyspaceInfo);
-      /*
-redis_version
-uptime_in_days
-used_memory
-connected_clients
-maxmemory_policy
-instantaneous_ops_per_sec
-instantaneous_input_kbps:
-instantaneous_output_kbps
-Number of keys (grouped and actual value) - the same as for CONFIG_DATABASES_DATABASE_ADDED
-       */
       const totalKeys = this.getRedisNodeTotalKeysCount(keyspaceInfo);
       return {
         version: serverInfo?.redis_version,
@@ -199,8 +188,7 @@ Number of keys (grouped and actual value) - the same as for CONFIG_DATABASES_DAT
           instantaneous_output_kbps:
             get(statsInfo, 'instantaneous_output_kbps') || undefined,
           uptime_in_days: get(serverInfo, 'uptime_in_days') || undefined,
-          maxmemory_policy:
-            parseInt(get(memoryInfo, 'maxmemory_policy'), 10) || undefined,
+          maxmemory_policy: get(memoryInfo, 'maxmemory_policy') || undefined,
           numberOfKeysRange: getRangeForNumber(
             totalKeys,
             TOTAL_KEYS_BREAKPOINTS,

--- a/redisinsight/api/src/modules/database/providers/database-info.provider.ts
+++ b/redisinsight/api/src/modules/database/providers/database-info.provider.ts
@@ -168,7 +168,7 @@ export class DatabaseInfoProvider {
       return {
         version: serverInfo?.redis_version,
         databases,
-        role: get(replicationInfo, 'role') || undefined,
+        role: get(replicationInfo, 'role'),
         totalKeys,
         usedMemory: parseInt(get(memoryInfo, 'used_memory'), 10) || undefined,
         connectedClients:
@@ -181,14 +181,17 @@ export class DatabaseInfoProvider {
           undefined,
         server: serverInfo,
         stats: {
-          instantaneous_ops_per_sec:
-            get(statsInfo, 'instantaneous_ops_per_sec') || undefined,
-          instantaneous_input_kbps:
-            get(statsInfo, 'instantaneous_input_kbps') || undefined,
-          instantaneous_output_kbps:
-            get(statsInfo, 'instantaneous_output_kbps') || undefined,
-          uptime_in_days: get(serverInfo, 'uptime_in_days') || undefined,
-          maxmemory_policy: get(memoryInfo, 'maxmemory_policy') || undefined,
+          instantaneous_ops_per_sec: get(
+            statsInfo,
+            'instantaneous_ops_per_sec',
+          ),
+          instantaneous_input_kbps: get(statsInfo, 'instantaneous_input_kbps'),
+          instantaneous_output_kbps: get(
+            statsInfo,
+            'instantaneous_output_kbps',
+          ),
+          uptime_in_days: get(serverInfo, 'uptime_in_days', undefined),
+          maxmemory_policy: get(memoryInfo, 'maxmemory_policy', undefined),
           numberOfKeysRange: getRangeForNumber(
             totalKeys,
             TOTAL_KEYS_BREAKPOINTS,

--- a/redisinsight/ui/src/components/base/layout/list/Item.tsx
+++ b/redisinsight/ui/src/components/base/layout/list/Item.tsx
@@ -118,7 +118,6 @@ const Item = ({
       $isActive={isActive}
       $isDisabled={isDisabled}
       $color={color}
-      onClick={onClick}
       className={cx(ListClassNames.listItem, className, {
         [ListClassNames.listItemActive]: isActive,
         [ListClassNames.listItemDisabled]: isDisabled,

--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.spec.tsx
@@ -9,8 +9,7 @@ import {
   render,
   screen,
 } from 'uiSrc/utils/test-utils'
-import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
-import { apiService } from 'uiSrc/services'
+import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { Instance, RdiInstance } from 'uiSrc/slices/interfaces'
 import InstancesList, { InstancesListProps } from './InstancesList'
 import { InstancesTabs } from '../../InstancesNavigationPopover'
@@ -120,15 +119,8 @@ describe('InstancesList', () => {
     ;(sendEventTelemetry as jest.Mock).mockImplementation(
       () => sendEventTelemetryMock,
     )
-    jest
-      .spyOn(apiService, 'get')
-      .mockImplementation(
-        jest
-          .fn()
-          .mockResolvedValue({ data: { version: '7.4.0' }, status: 200 }),
-      )
 
-    render(
+    const { getByTestId } = render(
       <InstancesList
         {...instance(mockedProps)}
         selectedTab={InstancesTabs.Databases}
@@ -136,10 +128,8 @@ describe('InstancesList', () => {
       />,
     )
 
-    const listItem = screen.getByTestId(`instance-item-${mockDbs[1].id}`)
-    await act(() => {
-      fireEvent.click(listItem)
-    })
+    const listItem = getByTestId(`instance-item-${mockDbs[1].id}`)
+    await act(() => fireEvent.click(listItem))
 
     expect(sendEventTelemetry).toHaveBeenCalledWith({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,

--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
@@ -13,6 +13,7 @@ import {
   TelemetryEvent,
   getRedisModulesSummary,
   sendEventTelemetry,
+  getRedisInfoSummary,
 } from 'uiSrc/telemetry'
 import { getDbIndex } from 'uiSrc/utils'
 import {
@@ -56,20 +57,22 @@ const InstancesList = ({
     history.push(Pages.browser(id))
   }
 
-  const goToInstance = (instance: Instance) => {
+  const goToInstance = async (instance: Instance) => {
     if (instanceId === instance.id) {
       // already connected so do nothing
       return
     }
     setLoading(true)
     const modulesSummary = getRedisModulesSummary(instance.modules)
-    sendEventTelemetry({
+    const infoData = await getRedisInfoSummary(instance.id)
+    await sendEventTelemetry({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: {
         databaseId: instance.id,
         source: 'navigation_panel',
         provider: instance.provider,
         ...modulesSummary,
+        ...infoData,
       },
     })
     dispatch(

--- a/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.spec.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.spec.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
-import { cleanup, fireEvent, mockedStore, render } from 'uiSrc/utils/test-utils'
 import {
-  TelemetryEvent,
+  act,
+  cleanup,
+  fireEvent,
+  mockedStore,
+  render,
+} from 'uiSrc/utils/test-utils'
+import {
   getRedisModulesSummary,
   sendEventTelemetry,
+  TelemetryEvent,
 } from 'uiSrc/telemetry'
 import {
   freeInstancesSelector,
@@ -12,6 +18,7 @@ import {
 } from 'uiSrc/slices/instances/instances'
 import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { setCapability } from 'uiSrc/slices/app/context'
+import { MOCK_ADDITIONAL_INFO } from 'uiSrc/mocks/data/instances'
 import OAuthConnectFreeDb from './OAuthConnectFreeDb'
 
 jest.mock('uiSrc/telemetry', () => ({
@@ -56,15 +63,20 @@ describe('OAuthConnectFreeDb', () => {
 
     const { queryByTestId } = render(<OAuthConnectFreeDb id="providedId" />)
 
-    fireEvent.click(queryByTestId('connect-free-db-btn') as HTMLButtonElement)
+    await act(() =>
+      fireEvent.click(
+        queryByTestId('connect-free-db-btn') as HTMLButtonElement,
+      ),
+    )
 
-    expect(sendEventTelemetry).toBeCalledWith({
+    expect(sendEventTelemetry).toHaveBeenCalledWith({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: {
         databaseId: 'providedId',
         provider: undefined,
         source: OAuthSocialSource.ListOfDatabases,
         ...getRedisModulesSummary(),
+        ...MOCK_ADDITIONAL_INFO,
       },
     })
 

--- a/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
@@ -8,6 +8,7 @@ import {
   TelemetryEvent,
   getRedisModulesSummary,
   sendEventTelemetry,
+  getRedisInfoSummary,
 } from 'uiSrc/telemetry'
 import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import {
@@ -48,8 +49,9 @@ const OAuthConnectFreeDb = ({
     return null
   }
 
-  const sendTelemetry = () => {
+  const sendTelemetry = async () => {
     const modulesSummary = getRedisModulesSummary(modules)
+    const infoData = await getRedisInfoSummary(targetDatabaseId)
     sendEventTelemetry({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: {
@@ -57,6 +59,7 @@ const OAuthConnectFreeDb = ({
         provider,
         source,
         ...modulesSummary,
+        ...infoData,
       },
     })
   }
@@ -67,8 +70,8 @@ const OAuthConnectFreeDb = ({
     openNewWindowDatabase(Pages.browser(targetDatabaseId) + search)
   }
 
-  const handleCheckConnectToInstance = () => {
-    sendTelemetry()
+  const handleCheckConnectToInstance = async () => {
+    await sendTelemetry()
     dispatch(setCapability({ source, tutorialPopoverShown: false }))
     dispatch(
       checkConnectToInstanceAction(

--- a/redisinsight/ui/src/mocks/data/instances.ts
+++ b/redisinsight/ui/src/mocks/data/instances.ts
@@ -1,0 +1,27 @@
+export const MOCK_INFO_API_RESPONSE = {
+  version: '7.4.0',
+  usedMemory: 1234,
+  connectedClients: 2,
+  totalKeys: 123,
+  stats: {
+    uptime_in_days: '2',
+    maxmemory_policy: 'allkeys-lru',
+    instantaneous_ops_per_sec: 123,
+    instantaneous_input_kbps: 123,
+    instantaneous_output_kbps: 123,
+    numberOfKeysRange: '0-123',
+  },
+}
+
+export const MOCK_ADDITIONAL_INFO = {
+  connected_clients: 2,
+  instantaneous_input_kbps: 123,
+  instantaneous_ops_per_sec: 123,
+  instantaneous_output_kbps: 123,
+  maxmemory_policy: 'allkeys-lru',
+  numberOfKeysRange: '0-123',
+  redis_version: '7.4.0',
+  totalKeys: 123,
+  uptime_in_days: '2',
+  used_memory: 1234,
+}

--- a/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
+++ b/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
@@ -1,8 +1,10 @@
 import { rest, RestHandler } from 'msw'
+import { RedisNodeInfoResponse } from 'src/modules/database/dto/redis-info.dto'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { ConnectionType, Instance } from 'uiSrc/slices/interfaces'
 import { getMswURL } from 'uiSrc/utils/test-utils'
 import { getUrl } from 'uiSrc/utils'
+import { MOCK_INFO_API_RESPONSE } from 'uiSrc/mocks/data/instances'
 import { Database as DatabaseInstanceResponse } from 'apiSrc/modules/database/models/database'
 import { ExportDatabase } from 'apiSrc/modules/database/models/export-database'
 
@@ -10,6 +12,7 @@ export const INSTANCE_ID_MOCK = 'instanceId'
 export const INSTANCES_MOCK: Instance[] = [
   {
     id: INSTANCE_ID_MOCK,
+    version: '6.2.6',
     host: 'localhost',
     port: 6379,
     name: 'localhost',
@@ -18,7 +21,7 @@ export const INSTANCES_MOCK: Instance[] = [
     connectionType: ConnectionType.Standalone,
     nameFromProvider: null,
     modules: [],
-    uoeu: 123,
+    db: 123,
     lastConnection: new Date('2021-04-22T09:03:56.917Z'),
   },
   {
@@ -39,6 +42,7 @@ export const INSTANCES_MOCK: Instance[] = [
   },
   {
     id: 'b83a3932-e95f-4f09-9d8a-55079f400186',
+    version: '6.2.6',
     host: 'localhost',
     port: 5005,
     name: 'sentinel',
@@ -66,7 +70,7 @@ export const INSTANCES_MOCK: Instance[] = [
 
 export const getDatabasesApiSpy = jest
   .fn()
-  .mockImplementation(async (req, res, ctx) =>
+  .mockImplementation(async (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
   )
 
@@ -78,11 +82,17 @@ const handlers: RestHandler[] = [
   ),
   rest.post<ExportDatabase>(
     getMswURL(ApiEndpoints.DATABASES_EXPORT),
-    async (req, res, ctx) => res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
+    async (_req, res, ctx) => res(ctx.status(200), ctx.json(INSTANCES_MOCK)),
   ),
   rest.get<DatabaseInstanceResponse>(
     getMswURL(getUrl(INSTANCE_ID_MOCK)),
     async (_req, res, ctx) => res(ctx.status(200), ctx.json(INSTANCES_MOCK[0])),
+  ),
+  rest.get<RedisNodeInfoResponse>(
+    getMswURL(`/${ApiEndpoints.DATABASES}/:id/info`),
+    // getMswURL(getUrl(INSTANCE_ID_MOCK, 'info')),
+    async (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json(MOCK_INFO_API_RESPONSE)),
   ),
 ]
 

--- a/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.test.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.test.tsx
@@ -23,6 +23,7 @@ import { CREATE_CLOUD_DB_ID } from 'uiSrc/pages/home/constants'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { setSocialDialogState } from 'uiSrc/slices/oauth/cloud'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
+import { MOCK_ADDITIONAL_INFO } from 'uiSrc/mocks/data/instances'
 import DatabasesListWrapper, { Props } from './DatabasesListWrapper'
 
 const mockedProps = mock<Props>()
@@ -208,26 +209,22 @@ describe('DatabasesListWrapper', () => {
 
   it('should call proper telemetry on open database', async () => {
     const sendEventTelemetryMock = jest.fn()
-
     ;(sendEventTelemetry as jest.Mock).mockImplementation(
       () => sendEventTelemetryMock,
     )
-    render(
+    const { getByTestId } = render(
       <DatabasesListWrapper
         {...instance(mockedProps)}
         instances={mockInstances}
       />,
     )
 
-    await act(() => {
+    await act(() =>
       fireEvent.click(
-        screen.getByTestId(
-          'instance-name-e37cc441-a4f2-402c-8bdb-fc2413cbbaff',
-        ),
-      )
-    })
-
-    expect(sendEventTelemetry).toBeCalledWith({
+        getByTestId('instance-name-e37cc441-a4f2-402c-8bdb-fc2413cbbaff'),
+      ),
+    )
+    expect(sendEventTelemetry).toHaveBeenCalledWith({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: {
         databaseId: 'e37cc441-a4f2-402c-8bdb-fc2413cbbaff',
@@ -255,6 +252,7 @@ describe('DatabasesListWrapper', () => {
           loaded: false,
         },
         customModules: [],
+        ...MOCK_ADDITIONAL_INFO,
       },
     })
     ;(sendEventTelemetry as jest.Mock).mockRestore()

--- a/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
@@ -65,6 +65,7 @@ import {
   OAuthSocialSource,
 } from 'uiSrc/slices/interfaces'
 import {
+  getRedisInfoSummary,
   getRedisModulesSummary,
   sendEventTelemetry,
   TelemetryEvent,
@@ -184,12 +185,13 @@ const DatabasesListWrapper = (props: Props) => {
 
     history.push(Pages.browser(id))
   }
-  const handleCheckConnectToInstance = (
+  const handleCheckConnectToInstance = async (
     event: React.MouseEvent | React.KeyboardEvent,
     { id, provider, modules }: Instance,
   ) => {
     event.preventDefault()
     const modulesSummary = getRedisModulesSummary(modules)
+    const infoData = await getRedisInfoSummary(id)
     sendEventTelemetry({
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: {
@@ -197,6 +199,7 @@ const DatabasesListWrapper = (props: Props) => {
         provider,
         source: 'db_list',
         ...modulesSummary,
+        ...infoData,
       },
     })
     dispatch(

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -92,7 +92,7 @@ describe('InstancePage', () => {
       contextRdiInstanceId: '',
     })
 
-    await act(async () => {
+    await act(async () =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
@@ -151,7 +151,7 @@ describe('InstancePage', () => {
     })
 
     // this MUST be awaited, in order for all effects to happen and all actions to be dispatched
-    await act(async () => {
+    await act(async () =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -91,13 +91,13 @@ describe('InstancePage', () => {
     ;(appContextSelector as jest.Mock).mockReturnValue({
       contextRdiInstanceId: '',
     })
-    await act(() => {
+    await act(() =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
         </BrowserRouter>,
-      )
-    })
+      ),
+    )
 
     const resetContextActions = [
       resetKeys(),
@@ -144,13 +144,13 @@ describe('InstancePage', () => {
       contextRdiInstanceId: 'prevId',
     })
 
-    await act(() => {
+    await act(() =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
         </BrowserRouter>,
-      )
-    })
+      ),
+    )
 
     const expectedActions = [
       setConfigValidationErrors(['Error: unknown error']),
@@ -183,15 +183,15 @@ describe('InstancePage', () => {
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
 
-    await act(() => {
+    await act(() =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
         </BrowserRouter>,
-      )
-    })
+      ),
+    )
 
-    expect(pushMock).toBeCalledWith(
+    expect(pushMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
   })
@@ -212,14 +212,16 @@ describe('InstancePage', () => {
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
 
-    await act(() => {
+    await act(() =>
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
         </BrowserRouter>,
-      )
-    })
+      ),
+    )
 
-    expect(pushMock).toBeCalledWith(Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK))
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    )
   })
 })

--- a/redisinsight/ui/src/services/database/instancesService.ts
+++ b/redisinsight/ui/src/services/database/instancesService.ts
@@ -14,7 +14,6 @@ export async function getInstanceInfo(id: string) {
   const { data, status } = await apiService.get<RedisNodeInfoResponse>(
     `${endpoint}/${id}/info`,
   )
-
   return isStatusSuccessful(status) ? data : null
 }
 export async function getInstanceOverview(id: string) {

--- a/redisinsight/ui/src/services/database/instancesService.ts
+++ b/redisinsight/ui/src/services/database/instancesService.ts
@@ -1,0 +1,142 @@
+import { RedisNodeInfoResponse } from 'src/modules/database/dto/redis-info.dto'
+import { Database as DatabaseInstanceResponse } from 'src/modules/database/models/database'
+import { ExportDatabase } from 'src/modules/database/models/export-database'
+import axios, { CancelTokenSource } from 'axios'
+import { ApiEndpoints } from 'uiSrc/constants'
+import { apiService } from 'uiSrc/services'
+import { isStatusSuccessful, Nullable } from 'uiSrc/utils'
+import { Instance } from 'uiSrc/slices/interfaces'
+import { PartialInstance } from 'uiSrc/slices/instances/instances'
+
+const endpoint = ApiEndpoints.DATABASES
+
+export async function getInstanceInfo(id: string) {
+  const { data, status } = await apiService.get<RedisNodeInfoResponse>(
+    `${endpoint}/${id}/info`,
+  )
+
+  return isStatusSuccessful(status) ? data : null
+}
+export async function getInstanceOverview(id: string) {
+  const { data, status } = await apiService.get<RedisNodeInfoResponse>(
+    `${endpoint}/${id}/overview`,
+  )
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export const sourceInstance: {
+  source: Nullable<CancelTokenSource>
+} = {
+  source: null,
+}
+
+export async function updateInstanceAlias(id: string, name: string) {
+  sourceInstance.source?.cancel?.()
+  const { CancelToken } = axios
+  sourceInstance.source = CancelToken.source()
+
+  const { status } = await apiService.patch(
+    `${endpoint}/${id}`,
+    { name },
+    { cancelToken: sourceInstance.source.token },
+  )
+
+  sourceInstance.source = null
+
+  return isStatusSuccessful(status)
+}
+
+export async function checkInstanceDbIndex(id: string, index: number) {
+  const { status } = await apiService.get(`${endpoint}/${id}/db/${index}`)
+
+  return isStatusSuccessful(status)
+}
+
+export async function importInstances(importData: FormData) {
+  const { status, data } = await apiService.post(
+    ApiEndpoints.DATABASES_IMPORT,
+    importData,
+    {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  )
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export async function testInstanceConnection(
+  id?: string,
+  payload?: PartialInstance,
+) {
+  const url = id
+    ? `${ApiEndpoints.DATABASES_TEST_CONNECTION}/${id}`
+    : `${ApiEndpoints.DATABASES_TEST_CONNECTION}`
+  const { status } = await apiService.post(url, payload)
+
+  return isStatusSuccessful(status)
+}
+
+export async function getInstance(id: string) {
+  const { data, status } = await apiService.get<Instance>(`${endpoint}/${id}`)
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export async function connectInstance(id: string) {
+  const { status } = await apiService.get(`${endpoint}/${id}/connect`)
+
+  return isStatusSuccessful(status)
+}
+
+export async function listDatabases() {
+  const { data, status } =
+    await apiService.get<DatabaseInstanceResponse[]>(endpoint)
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export async function createInstance(instance: Instance) {
+  const { data, status } = await apiService.post(endpoint, instance)
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export async function updateInstance(
+  id: string,
+  instance: Partial<Instance> | PartialInstance,
+) {
+  const { status } = await apiService.patch(`${endpoint}/${id}`, instance)
+
+  return isStatusSuccessful(status)
+}
+
+export async function cloneInstance(id: string, instance: Partial<Instance>) {
+  const { status, data } = await apiService.post(
+    `${endpoint}/clone/${id}`,
+    instance,
+  )
+
+  return isStatusSuccessful(status) ? data : null
+}
+
+export async function deleteInstances(databasesIds: string[]) {
+  const { status } = await apiService.delete(endpoint, {
+    data: { ids: databasesIds },
+  })
+  return isStatusSuccessful(status)
+}
+
+export async function exportInstances(ids: string[], withSecrets: boolean) {
+  const { data, status } = await apiService.post<ExportDatabase>(
+    ApiEndpoints.DATABASES_EXPORT,
+    {
+      ids,
+      withSecrets,
+    },
+  )
+  return isStatusSuccessful(status) ? data : null
+}

--- a/redisinsight/ui/src/services/index.ts
+++ b/redisinsight/ui/src/services/index.ts
@@ -12,3 +12,4 @@ export * from './hooks'
 export * from './capability'
 export { apiService, resourcesService }
 export { WorkbenchStorage } from 'uiSrc/services/workbenchStorage'
+export * as instancesService from 'uiSrc/services/database/instancesService'

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -1,15 +1,14 @@
-import { first, isNull, map, filter, orderBy, get } from 'lodash'
+import { filter, first, get, isNull, map, orderBy } from 'lodash'
 import { createSlice } from '@reduxjs/toolkit'
-import axios, { AxiosError, CancelTokenSource } from 'axios'
+import axios, { AxiosError } from 'axios'
 
 import ApiErrors from 'uiSrc/constants/apiErrors'
 import {
-  apiService,
+  instancesService,
   localStorageService,
   sessionStorageService,
 } from 'uiSrc/services'
 import {
-  ApiEndpoints,
   BrowserStorageItem,
   COLUMN_FIELD_NAME_MAP,
   CustomErrorCodes,
@@ -18,12 +17,7 @@ import {
 import { setAppContextInitialState } from 'uiSrc/slices/app/context'
 import { resetKeys } from 'uiSrc/slices/browser/keys'
 import successMessages from 'uiSrc/components/notifications/success-messages'
-import {
-  checkRediStack,
-  getApiErrorMessage,
-  isStatusSuccessful,
-  Nullable,
-} from 'uiSrc/utils'
+import { checkRediStack, getApiErrorMessage, Nullable } from 'uiSrc/utils'
 import {
   INFINITE_MESSAGES,
   InfiniteMessagesIds,
@@ -41,11 +35,7 @@ import {
   addMessageNotification,
   removeInfiniteNotification,
 } from '../app/notifications'
-import {
-  Instance,
-  InitialStateInstances,
-  ConnectionType,
-} from '../interfaces'
+import { ConnectionType, InitialStateInstances, Instance } from '../interfaces'
 
 const HIDE_CREATING_DB_DELAY_MS = 500
 
@@ -378,9 +368,6 @@ export const importInstancesSelector = (state: RootState) =>
 // The reducer
 export default instancesSlice.reducer
 
-// eslint-disable-next-line import/no-mutable-exports
-export let sourceInstance: Nullable<CancelTokenSource> = null
-
 // Asynchronous thunk action
 export function fetchInstancesAction(onSuccess?: (data: Instance[]) => void) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
@@ -399,11 +386,9 @@ export function fetchInstancesAction(onSuccess?: (data: Instance[]) => void) {
     dispatch(loadInstances())
 
     try {
-      const { data, status } = await apiService.get<DatabaseInstanceResponse[]>(
-        `${ApiEndpoints.DATABASES}`,
-      )
+      const data = await instancesService.listDatabases()
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         localStorageService.set(BrowserStorageItem.instancesCount, data?.length)
         onSuccess?.(data as Instance[])
         dispatch(loadInstancesSuccess(data))
@@ -429,12 +414,9 @@ export function createInstanceStandaloneAction(
     dispatch(defaultInstanceChanging())
 
     try {
-      const { data, status } = await apiService.post(
-        `${ApiEndpoints.DATABASES}`,
-        payload,
-      )
+      const data = await instancesService.createInstance(payload)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(defaultInstanceChangingSuccess())
         dispatch<any>(fetchInstancesAction())
 
@@ -500,13 +482,10 @@ export function autoCreateAndConnectToInstanceAction(
     )
 
     try {
-      const { status, data } = await apiService.post(
-        `${ApiEndpoints.DATABASES}`,
-        payload,
-      )
+      const data = await instancesService.createInstance(payload)
 
-      if (isStatusSuccessful(status)) {
-        dispatch(
+      if (data !== null) {
+        await dispatch(
           autoCreateAndConnectToInstanceActionSuccess(
             data?.id,
             successMessages.ADDED_NEW_INSTANCE(data?.name),
@@ -581,7 +560,7 @@ function autoCreateAndConnectToInstanceActionSuccess(
   }
 }
 
-type PartialInstance = Partial<Omit<Instance, 'tags'>> & {
+export type PartialInstance = Partial<Omit<Instance, 'tags'>> & {
   tags?: {
     key: string
     value: string
@@ -597,12 +576,9 @@ export function updateInstanceAction(
     dispatch(defaultInstanceChanging())
 
     try {
-      const { status } = await apiService.patch(
-        `${ApiEndpoints.DATABASES}/${id}`,
-        payload,
-      )
+      const result = await instancesService.updateInstance(id!, payload)
 
-      if (isStatusSuccessful(status)) {
+      if (result) {
         dispatch(defaultInstanceChangingSuccess())
         dispatch<any>(fetchInstancesAction())
         if (payload.tags) {
@@ -628,12 +604,9 @@ export function cloneInstanceAction(
     dispatch(defaultInstanceChanging())
 
     try {
-      const { status, data } = await apiService.post(
-        `${ApiEndpoints.DATABASES}/clone/${id}`,
-        payload,
-      )
+      const data = await instancesService.cloneInstance(id!, payload)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(defaultInstanceChangingSuccess())
         dispatch<any>(fetchInstancesAction())
 
@@ -664,11 +637,9 @@ export function deleteInstancesAction(
     try {
       const state = stateInit()
       const databasesIds = map(instances, 'id')
-      const { status } = await apiService.delete(ApiEndpoints.DATABASES, {
-        data: { ids: databasesIds },
-      })
+      const result = await instancesService.deleteInstances(databasesIds)
 
-      if (isStatusSuccessful(status)) {
+      if (result) {
         dispatch(setDefaultInstanceSuccess())
         dispatch<any>(fetchInstancesAction())
         dispatch(fetchTags())
@@ -714,15 +685,9 @@ export function exportInstancesAction(
     dispatch(setDefaultInstance())
 
     try {
-      const { data, status } = await apiService.post<ExportDatabase>(
-        ApiEndpoints.DATABASES_EXPORT,
-        {
-          ids,
-          withSecrets,
-        },
-      )
+      const data = await instancesService.exportInstances(ids, withSecrets)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(setDefaultInstanceSuccess())
 
         onSuccess?.(data)
@@ -748,11 +713,9 @@ export function fetchConnectedInstanceAction(
     dispatch(setConnectedInstance())
 
     try {
-      const { data, status } = await apiService.get<Instance>(
-        `${ApiEndpoints.DATABASES}/${id}`,
-      )
+      const data = await instancesService.getInstance(id)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(setConnectedInstanceSuccess(data))
         dispatch(setDefaultInstanceSuccess())
       }
@@ -777,13 +740,13 @@ export function fetchConnectedInstanceInfoAction(
     dispatch(setConnectedInfoInstance())
 
     try {
-      const { data, status } = await apiService.get<RedisNodeInfoResponse>(
-        `${ApiEndpoints.DATABASES}/${id}/info`,
-      )
+      const data = await instancesService.getInstanceInfo(id)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(setConnectedInfoInstanceSuccess(data))
         onSuccess?.()
+      } else {
+        onFail?.()
       }
     } catch (error) {
       onFail?.()
@@ -801,11 +764,9 @@ export function fetchEditedInstanceAction(
     dispatch(setEditedInstance(instance))
 
     try {
-      const { data, status } = await apiService.get<Instance>(
-        `${ApiEndpoints.DATABASES}/${instance.id}`,
-      )
+      const data = await instancesService.getInstance(instance.id)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(updateEditedInstance(data))
         dispatch(setDefaultInstanceSuccess())
       }
@@ -832,11 +793,9 @@ export function checkConnectToInstanceAction(
     dispatch(setDefaultInstance())
     resetInstance && dispatch(resetConnectedInstance())
     try {
-      const { status } = await apiService.get(
-        `${ApiEndpoints.DATABASES}/${id}/connect`,
-      )
+      const result = await instancesService.connectInstance(id)
 
-      if (isStatusSuccessful(status)) {
+      if (result) {
         dispatch(setDefaultInstanceSuccess())
         onSuccessAction?.(id)
       }
@@ -873,11 +832,9 @@ export function getDatabaseConfigInfoAction(
   return async (dispatch: AppDispatch) => {
     dispatch(getDatabaseConfigInfo())
     try {
-      const { status, data } = await apiService.get(
-        `${ApiEndpoints.DATABASES}/${id}/overview`,
-      )
+      const data = await instancesService.getInstanceOverview(id)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(getDatabaseConfigInfoSuccess(data))
         onSuccessAction?.(id)
       }
@@ -901,18 +858,8 @@ export function changeInstanceAliasAction(
     dispatch(changeInstanceAlias())
 
     try {
-      sourceInstance?.cancel?.()
-      const { CancelToken } = axios
-      sourceInstance = CancelToken.source()
-
-      const { status } = await apiService.patch(
-        `${ApiEndpoints.DATABASES}/${id}`,
-        { name },
-        { cancelToken: sourceInstance.token },
-      )
-
-      sourceInstance = null
-      if (isStatusSuccessful(status)) {
+      const result = await instancesService.updateInstanceAlias(id, name)
+      if (result) {
         dispatch(changeInstanceAliasSuccess({ id, name }))
         onSuccessAction?.()
       }
@@ -938,11 +885,9 @@ export function checkDatabaseIndexAction(
     dispatch(checkDatabaseIndex())
 
     try {
-      const { status } = await apiService.get(
-        `${ApiEndpoints.DATABASES}/${id}/db/${index}`,
-      )
+      const result = await instancesService.checkInstanceDbIndex(id, index)
 
-      if (isStatusSuccessful(status)) {
+      if (result) {
         dispatch(checkDatabaseIndexSuccess(index))
         onSuccessAction?.()
       }
@@ -958,7 +903,7 @@ export function checkDatabaseIndexAction(
 export function resetInstanceUpdateAction() {
   return async (dispatch: AppDispatch) => {
     dispatch(resetInstanceUpdate())
-    sourceInstance?.cancel?.()
+    instancesService.sourceInstance?.source?.cancel?.()
   }
 }
 
@@ -972,18 +917,9 @@ export function uploadInstancesFile(
     dispatch(importInstancesFromFile())
 
     try {
-      const { status, data } = await apiService.post(
-        ApiEndpoints.DATABASES_IMPORT,
-        file,
-        {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'multipart/form-data',
-          },
-        },
-      )
+      const data = await instancesService.importInstances(file)
 
-      if (isStatusSuccessful(status)) {
+      if (data !== null) {
         dispatch(fetchTags())
         dispatch(importInstancesFromFileSuccess(data))
         onSuccessAction?.(data)
@@ -1004,14 +940,9 @@ export function testInstanceStandaloneAction(
 ) {
   return async (dispatch: AppDispatch) => {
     dispatch(testConnection())
-    const url = id
-      ? `${ApiEndpoints.DATABASES_TEST_CONNECTION}/${id}`
-      : `${ApiEndpoints.DATABASES_TEST_CONNECTION}`
-
     try {
-      const { status } = await apiService.post(url, payload)
-
-      if (isStatusSuccessful(status)) {
+      const result = await instancesService.testInstanceConnection(id, payload)
+      if (result) {
         dispatch(testConnectionSuccess())
 
         dispatch(addMessageNotification(successMessages.TEST_CONNECTION()))

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -79,7 +79,6 @@ import {
   Instance,
 } from '../../interfaces'
 import { loadMastersSentinel } from '../../instances/sentinel'
-import { fetchTags } from 'uiSrc/slices/instances/tags'
 
 jest.mock('uiSrc/services', () => ({
   ...jest.requireActual('uiSrc/services'),
@@ -96,6 +95,7 @@ beforeEach(() => {
   instances = [
     {
       id: 'e37cc441-a4f2-402c-8bdb-fc2413cbbaff',
+      version: '6.2.6',
       host: 'localhost',
       port: 6379,
       name: 'localhost',
@@ -124,6 +124,7 @@ beforeEach(() => {
     },
     {
       id: 'b83a3932-e95f-4f09-9d8a-55079f400186',
+      version: '6.2.6',
       host: 'localhost',
       port: 5005,
       name: 'sentinel',

--- a/redisinsight/ui/src/telemetry/telemetryUtils.ts
+++ b/redisinsight/ui/src/telemetry/telemetryUtils.ts
@@ -16,6 +16,7 @@ import {
 } from 'uiSrc/telemetry/interfaces'
 import { apiService } from 'uiSrc/services'
 import { store } from 'uiSrc/slices/store'
+import { getInstanceInfo } from 'uiSrc/services/database/instancesService'
 import { AdditionalRedisModule } from 'apiSrc/modules/database/models/additional.redis.module'
 import { IRedisModulesSummary, MatchType, RedisModules } from './interfaces'
 import { TelemetryEvent } from './events'
@@ -237,7 +238,28 @@ const getModuleSummaryToSent = (
   version: module.version,
   semanticVersion: module.semanticVersion,
 })
+const getRedisInfoSummary = async (id: string) => {
+  let infoData: any = {}
+  try {
+    const info = await getInstanceInfo(id)
+    infoData = {
+      redis_version: info?.version,
+      uptime_in_days: info?.stats?.uptime_in_days,
+      used_memory: info?.usedMemory,
+      connected_clients: info?.connectedClients,
+      maxmemory_policy: info?.stats?.maxmemory_policy,
+      instantaneous_ops_per_sec: info?.stats?.instantaneous_ops_per_sec,
+      instantaneous_input_kbps: info?.stats?.instantaneous_input_kbps,
+      instantaneous_output_kbps: info?.stats?.instantaneous_output_kbps,
+      numberOfKeysRange: info?.stats?.numberOfKeysRange,
+      totalKeys: info?.totalKeys,
+    }
+  } catch (e) {
+    // continue regardless of error
+  }
 
+  return infoData
+}
 const getRedisModulesSummary = (
   modules: AdditionalRedisModule[] = [],
 ): IRedisModulesSummary => {
@@ -279,4 +301,5 @@ export {
   getMatchType,
   getRedisModulesSummary,
   getFreeDbFlag,
+  getRedisInfoSummary,
 }


### PR DESCRIPTION
Add data to: `CONFIG_DATABASES_OPEN_DATABASE`

Data fields added: 
  - redis_version
  - uptime_in_days
  - used_memory
  - connected_clients
  - maxmemory_policy
  - instantaneous_ops_per_sec
  - instantaneous_input_kbps:
  - instantaneous_output_kbps
  - totalKeys
  - numberOfKeysRange