### PR TITLE
RI-7094: Recalculate provider on db connect

### DIFF
--- a/redisinsight/api/src/modules/database/database-connection.service.spec.ts
+++ b/redisinsight/api/src/modules/database/database-connection.service.spec.ts
@@ -115,7 +115,7 @@ describe('DatabaseConnectionService', () => {
 
     it('should recalculate provider if not available in the list of providers', async () => {
       const testHost = 'localhost';
-      repository.get = jest.fn().mockResolvedValue({
+      repository.get.mockResolvedValue({
         host: testHost,
         provider: 'not-in-providers-enum',
       });

--- a/redisinsight/api/src/modules/database/database-connection.service.spec.ts
+++ b/redisinsight/api/src/modules/database/database-connection.service.spec.ts
@@ -25,6 +25,10 @@ import { DatabaseConnectionService } from 'src/modules/database/database-connect
 import { RECOMMENDATION_NAMES } from 'src/constants';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { FeatureService } from 'src/modules/feature/feature.service';
+import { getHostingProvider } from 'src/utils/hosting-provider-helper';
+import { HostingProvider } from 'src/modules/database/entities/database.entity';
+
+jest.mock('src/utils/hosting-provider-helper');
 
 describe('DatabaseConnectionService', () => {
   let service: DatabaseConnectionService;
@@ -32,6 +36,7 @@ describe('DatabaseConnectionService', () => {
   let recommendationService: MockType<DatabaseRecommendationService>;
   let databaseInfoProvider: MockType<DatabaseInfoProvider>;
   let featureService: MockType<FeatureService>;
+  let repository: MockType<DatabaseRepository>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -76,6 +81,7 @@ describe('DatabaseConnectionService', () => {
     recommendationService = module.get(DatabaseRecommendationService);
     databaseInfoProvider = module.get(DatabaseInfoProvider);
     featureService = module.get(FeatureService);
+    repository = module.get(DatabaseRepository);
 
     featureService.getByName.mockResolvedValue({
       flag: false,
@@ -104,6 +110,33 @@ describe('DatabaseConnectionService', () => {
           RECOMMENDATION_NAMES.BIG_AMOUNT_OF_CONNECTED_CLIENTS,
         ],
         mockRedisGeneralInfo,
+      );
+    });
+
+    it('should recalculate provider if not available in the list of providers', async () => {
+      const testHost = 'localhost';
+      repository.get = jest.fn().mockResolvedValue({
+        host: testHost,
+        provider: 'not-in-providers-enum',
+      });
+
+      (getHostingProvider as jest.Mock).mockResolvedValue(
+        HostingProvider.REDIS_STACK,
+      );
+
+      await service.connect(mockCommonClientMetadata);
+
+      expect(getHostingProvider).toHaveBeenCalledWith(
+        expect.any(Object),
+        testHost,
+      );
+
+      expect(repository.update).toHaveBeenCalledWith(
+        mockCommonClientMetadata.sessionMetadata,
+        mockCommonClientMetadata.databaseId,
+        expect.objectContaining({
+          provider: HostingProvider.REDIS_STACK,
+        }),
       );
     });
 

--- a/redisinsight/api/src/modules/database/database-connection.service.ts
+++ b/redisinsight/api/src/modules/database/database-connection.service.ts
@@ -48,7 +48,7 @@ export class DatabaseConnectionService {
       version: await this.databaseInfoProvider.determineDatabaseServer(client),
     };
 
-    let { host, provider } = await this.repository.get(
+    const { host, provider } = await this.repository.get(
       clientMetadata.sessionMetadata,
       clientMetadata.databaseId,
     );

--- a/redisinsight/api/src/modules/database/database-connection.service.ts
+++ b/redisinsight/api/src/modules/database/database-connection.service.ts
@@ -55,7 +55,6 @@ export class DatabaseConnectionService {
 
     if (!HostingProvider[provider]) {
       toUpdate.provider = await getHostingProvider(client, host);
-      console.log('provider after,', toUpdate.provider);
     }
 
     const connectionType = client?.getConnectionType();

--- a/redisinsight/api/src/modules/database/database-connection.service.ts
+++ b/redisinsight/api/src/modules/database/database-connection.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { RECOMMENDATION_NAMES } from 'src/constants';
 import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 import { DatabaseAnalytics } from 'src/modules/database/database.analytics';
+import { HostingProvider } from 'src/modules/database/entities/database.entity';
 import { DatabaseInfoProvider } from 'src/modules/database/providers/database-info.provider';
 import { DatabaseRecommendationService } from 'src/modules/database-recommendation/database-recommendation.service';
 import { Database } from 'src/modules/database/models/database';
@@ -13,6 +14,7 @@ import {
 } from 'src/modules/redis/client';
 import { FeatureService } from 'src/modules/feature/feature.service';
 import { KnownFeatures } from 'src/modules/feature/constants';
+import { getHostingProvider } from 'src/utils/hosting-provider-helper';
 
 @Injectable()
 export class DatabaseConnectionService {
@@ -28,7 +30,8 @@ export class DatabaseConnectionService {
   ) {}
 
   /**
-   * Connects to database and updates modules list and last connected time
+   * Connects to database and updates modules list, last connected time
+   * and provider if not available in the list of providers
    * @param clientMetadata
    */
   async connect(clientMetadata: ClientMetadata): Promise<void> {
@@ -44,6 +47,16 @@ export class DatabaseConnectionService {
       modules: await this.databaseInfoProvider.determineDatabaseModules(client),
       version: await this.databaseInfoProvider.determineDatabaseServer(client),
     };
+
+    let { host, provider } = await this.repository.get(
+      clientMetadata.sessionMetadata,
+      clientMetadata.databaseId,
+    );
+
+    if (!HostingProvider[provider]) {
+      toUpdate.provider = await getHostingProvider(client, host);
+      console.log('provider after,', toUpdate.provider);
+    }
 
     const connectionType = client?.getConnectionType();
     // Update cluster nodes db record


### PR DESCRIPTION
Currently, the provider is recalculated when a database is created or edited. However, instances that were added before this logic was introduced still have outdated or missing provider values.

This PR enhances the “connect database” logic to handle those legacy instances. When a user connects to such a database, the system will:
- Check if the stored provider is part of the current Host Provider list.
- If not, recalculate the provider to align it with the recognized list.
- Update the database instance with the new provider value.

This recalculation happens only once per instance, the first time it is connected after this logic is deployed.

Notes
- This ensures backward compatibility and smooth transition for older instances.
- Helps maintain consistency in provider metadata across all database entries.