### PR TITLE
add "Enforce Branch Name Rules" workflow

### DIFF
--- a/.github/workflows/enforce-branch-name-rules.yml
+++ b/.github/workflows/enforce-branch-name-rules.yml
@@ -15,7 +15,8 @@ jobs:
           if [[ "${{ github.head_ref }}" != feature/* && \
                 "${{ github.head_ref }}" != bugfix/* && \
                 "${{ github.head_ref }}" != release/* && \
+                "${{ github.head_ref }}" != dependabot/* && \
                 "${{ github.head_ref }}" != ric/* ]]; then
-            echo "❌ Pull requests to 'main' are only allowed from 'feature/**', 'bugfix/**', 'release/**', or 'ric/**' branches."
+            echo "❌ Pull requests to 'main' are only allowed from 'feature/**', 'bugfix/**', 'release/**', 'dependabot/**', or 'ric/**' branches."
             exit 1
           fi


### PR DESCRIPTION
## Description

Adds a workflow that prevents merging to main if the source branch name doesn't the rules