### PR TITLE
RI-7138: fix suggested tag values list

### DIFF
--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
@@ -91,4 +91,17 @@ describe('TagSuggestions', () => {
 
     expect(tagElements.length).toBe(7)
   })
+
+  it('should display correct number of value suggestions when duplicated tag keys are present', () => {
+    mockSelector.mockReturnValue({
+      data: presetTagSuggestions,
+    })
+
+    renderComponent({
+      targetKey: 'environment',
+    })
+    const tagElements = screen.getAllByRole('option')
+
+    expect(tagElements.length).toBe(3)
+  })
 })

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.tsx
@@ -22,7 +22,9 @@ export const TagSuggestions = ({
   const { data: allTags } = useSelector(tagsSelector)
   const tagsSuggestions: EuiSelectableOption<{ value: string }>[] =
     useMemo(() => {
-      const options = uniqBy(presetTagSuggestions.concat(allTags), 'key')
+      const options = uniqBy(presetTagSuggestions.concat(allTags), (tag) =>
+        targetKey ? tag.value : tag.key,
+      )
         .filter(({ key, value }) => {
           if (targetKey !== undefined) {
             return (


### PR DESCRIPTION
## Description

Issue: having selected a tag key, up to one suggested value is present in the list, even if there are more

| Before  | After |
| ------------- | ------------- |
|  <img width="835" alt="Screenshot 2025-05-20 at 10 21 37" src="https://github.com/user-attachments/assets/9df086e3-a9a0-466c-8031-7be16f81e5aa" /> | <img width="829" alt="Screenshot 2025-05-20 at 10 21 12" src="https://github.com/user-attachments/assets/f9ebc1ad-3aad-4a9d-9765-344ef2571e25" /> |