### PR TITLE
RI-7139: Fix json editor styles

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -123,11 +123,15 @@ const RejsonDetailsWrapper = (props: Props) => {
   const shouldShowTextEditor =
     !isUndefined(updatedData) && editorType === EditorType.Text
 
+  const keyDetailsBodyName = shouldShowDefaultEditor
+    ? 'key-details-body'
+    : 'key-details-body-monaco-editor'
+
   return (
     <div className="fluid flex-column relative">
       <KeyDetailsHeader {...props} key="key-details-header" />
 
-      <div className="key-details-body" key="key-details-body">
+      <div className={keyDetailsBodyName} key={keyDetailsBodyName}>
         <div className="flex-column" style={{ flex: '1', height: '100%' }}>
           <div data-testid="json-details" className={styles.container}>
             {loading && (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
@@ -39,7 +39,11 @@ const MonacoEditor = (props: BaseProps) => {
   }
 
   return (
-    <div className={styles.jsonData} id="jsonData" data-testid="json-data">
+    <div
+      className={styles.monacoEditorJsonData}
+      id="monaco-editor-json-data"
+      data-testid="monaco-editor-json-data"
+    >
       <Editor
         language="json"
         value={value}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
@@ -58,14 +58,22 @@
   font-family: "Inconsolata", monospace !important;
   letter-spacing: 0.15px;
   flex-grow: 1;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
 
   input {
     width: 100%;
     min-width: 140px;
   }
+}
+
+.monacoEditorJsonData {
+  font-size: 14px;
+  line-height: 25px;
+  font-family: "Inconsolata", monospace !important;
+  letter-spacing: 0.15px;
+  flex-grow: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .defaultFont {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/styles.module.scss
@@ -33,10 +33,15 @@
   border-bottom-width: 1px !important;
 }
 
-// 115px is the key details header height
 :global(.key-details-body) {
   position: relative;
-  height: calc(100% - 115px);
+  height: calc(100% - 144px);
+}
+
+// 108px is the key details header height
+:global(.key-details-body-monaco-editor) {
+  position: relative;
+  height: calc(100% - 108px);
 }
 
 :global(.key-details-footer) {


### PR DESCRIPTION
With this PR https://github.com/RedisInsight/RedisInsight/commit/fe7b8af51b26991ffc945dba5e9a471a2714b05f, I've broken the styles a bit.

Generally, there are a few magics in the JSON editor HTML + CSS structure, like `calc(100%—X)`, `:global()`, or `position: absolute` on elements, that can be aligned without changing their position property. Cleaning this up properly would require a larger refactor. So for now, this PR introduces separate classes for the two editors to apply different styles as a workaround.

Note: header height changed from 115 to 108