### PR TITLE
RI-7006: fix handle direction to horizontal

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBView/WBView.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBView/WBView.tsx
@@ -221,6 +221,7 @@ const WBView = (props: Props) => {
             </ResizablePanel>
 
             <ResizablePanelHandle
+              direction="horizontal"
               data-test-subj="resize-btn-scripting-area-and-results"
             />
 


### PR DESCRIPTION
Fixing Workbench Page, which was not displayed correctly because the handle direction was not set to horizontal and it defaults to vertical. 