### PR TITLE
fix: Parse ipv6 and other formats of addresses in parseNodesFromClusterInfoReply properly

### DIFF
--- a/redisinsight/api/src/__mocks__/redis-info.ts
+++ b/redisinsight/api/src/__mocks__/redis-info.ts
@@ -109,6 +109,11 @@ export const mockRedisClusterNodesResponse: string =
   '07c37dfeb235213a872192d90877d0cd55635b91 127.0.0.1:30004@31004 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 4 connected\n' +
   'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001 myself,master - 0 0 1 connected 0-16383';
 
+// eslint-disable-next-line max-len
+export const mockRedisClusterNodesResponseIPv6: string =
+  '07c37dfeb235213a872192d90877d0cd55635b91 2001:db8::1:7001@17001 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238317239 4 connected\n' +
+  'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 2001:db8::2:7002@17002 myself,master - 0 0 1 connected 0-16383';
+
 export const mockStandaloneRedisInfoReply: string = `${
   mockRedisServerInfoResponse
 }\r\n${mockRedisClientsInfoResponse}\r\n${mockRedisMemoryInfoResponse}\r\n${

--- a/redisinsight/api/src/modules/redis/utils/reply.util.spec.ts
+++ b/redisinsight/api/src/modules/redis/utils/reply.util.spec.ts
@@ -1,5 +1,6 @@
 import {
   mockRedisClusterNodesResponse,
+  mockRedisClusterNodesResponseIPv6,
   mockRedisServerInfoResponse,
 } from 'src/__mocks__';
 import { flatMap } from 'lodash';
@@ -37,6 +38,28 @@ const mockRedisClusterNodes: IRedisClusterNode[] = [
     slot: '0-16383',
   },
 ];
+
+// IPv6 expected results
+const mockRedisClusterNodesIPv6: IRedisClusterNode[] = [
+  {
+    id: '07c37dfeb235213a872192d90877d0cd55635b91',
+    host: '2001:db8::1',
+    port: 7001,
+    replicaOf: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca',
+    linkState: RedisClusterNodeLinkState.Connected,
+    slot: undefined,
+  },
+  {
+    id: 'e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca',
+    host: '2001:db8::2',
+    port: 7002,
+    replicaOf: undefined,
+    linkState: RedisClusterNodeLinkState.Connected,
+    slot: '0-16383',
+  },
+];
+
+
 
 const mockIncorrectString = '$6\r\nfoobar\r\n';
 
@@ -85,5 +108,12 @@ describe('parseNodesFromClusterInfoReply', () => {
     const result = parseNodesFromClusterInfoReply(mockIncorrectString);
 
     expect(result).toEqual([]);
+  });
+  it('should parse IPv6 addresses correctly', async () => {
+    const result = parseNodesFromClusterInfoReply(
+      mockRedisClusterNodesResponseIPv6,
+    );
+
+    expect(result).toEqual(mockRedisClusterNodesIPv6);
   });
 });

--- a/redisinsight/api/src/modules/redis/utils/reply.util.ts
+++ b/redisinsight/api/src/modules/redis/utils/reply.util.ts
@@ -86,8 +86,9 @@ export const convertMultilineReplyToObject = (
  * Parse and return all endpoints from the nodes list returned by "cluster info" command
  * @Input
  * ```
- * 08418e3514990489e48fa05d642efc33e205f5 172.31.100.211:6379@16379 myself,master - 0 1698694904000 1 connected 0-5460\n
- * d2dee846c715a917ec9a4963e8885b06130f9f 172.31.100.212:6379@16379 master - 0 1698694905285 2 connected 5461-10922\n
+ * 08418e3514990489e48fa05d642efc33e205f5 172.31.100.211:6379@16379 myself,master - 0 1698694904000 1 connected 0-5460
+ * d2dee846c715a917ec9a4963e8885b06130f9f 172.31.100.212:6379@16379 master - 0 1698694905285 2 connected 5461-10922
+ * 3e92457ab813ad7a62dacf768ec7309210feaf [2001:db8::1]:7001@17001 master - 0 1698694906000 3 connected 10923-16383
  * ```
  * @Output
  * ```
@@ -99,6 +100,10 @@ export const convertMultilineReplyToObject = (
  *   {
  *     host: "172.31.100.212",
  *     port: 6379
+ *   },
+ *   {
+ *     host: "2001:db8::1",
+ *     port: 7001
  *   }
  * ]
  * ```

--- a/redisinsight/api/src/modules/redis/utils/reply.util.ts
+++ b/redisinsight/api/src/modules/redis/utils/reply.util.ts
@@ -115,8 +115,12 @@ export const parseNodesFromClusterInfoReply = (
         // fields = [id, endpoint, flags, master, pingSent, pongRecv, configEpoch, linkState, slot]
         const fields = line.split(' ');
         const [id, endpoint, , master, , , , linkState, slot] = fields;
-        const host = endpoint.split(':')[0];
-        const port = endpoint.split(':')[1].split('@')[0];
+
+        const hostAndPort = endpoint.split('@')[0]
+        const lastColonIndex = hostAndPort.lastIndexOf(':');
+
+        const host = hostAndPort.substring(0, lastColonIndex);
+        const port = hostAndPort.substring(lastColonIndex + 1);
         nodes.push({
           id,
           host,


### PR DESCRIPTION
Previously, the code assumed that all hosts contained only 1 `:`, where the left side was the host and the right was the port. Unfortunately, this breaks for IPv6. Instead, this code will find the last `:` and have the host be the last side, port be right.

This is related to [this issue](https://github.com/RedisInsight/RedisInsight/issues/1429).

I've tested this on my local machine using docker compose set up in ipv6 only, as well as on my company's ipv6 only Kubernetes cluster. This is confirmed working on my end.