### PR TITLE
Added more branch options to enforce-branch-name-rules.yml

### DIFF
--- a/.github/workflows/enforce-branch-name-rules.yml
+++ b/.github/workflows/enforce-branch-name-rules.yml
@@ -17,6 +17,9 @@ jobs:
                 "${{ github.head_ref }}" != release/* && \
                 "${{ github.head_ref }}" != dependabot/* && \
                 "${{ github.head_ref }}" != latest && \
+                "${{ github.head_ref }}" != fe && \
+                "${{ github.head_ref }}" != be && \
+                "${{ github.head_ref }}" != e2e && \
                 "${{ github.head_ref }}" != ric/* ]]; then
             echo "❌ Pull requests to 'main' are only allowed from 'feature/**', 'bugfix/**', 'release/**', 'dependabot/**', 'latest' or 'ric/**' branches."
             exit 1


### PR DESCRIPTION
I think it makes sense to support also
fe - for just front end changes (recently had something like that for an RDI fix) in which cases there is no point in running the BE and integrations tests be - for just api changes. It also happens from time to time and it doesn't make sense to run all of our FE tests, especially how flaky they are. e2e - just for e2e tests. No point in wasting a lot of time (physical and github) to run all of the other tests