### PR TITLE
RI-6953: Use correct telemetry event for Monaco edits

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
@@ -41,7 +41,7 @@ const MonacoEditor = (props: BaseProps) => {
   const { switchEditorType } = useChangeEditorType()
 
   const submitUpdate = () => {
-    dispatch(setReJSONDataAction(selectedKey, ROOT_PATH, value, false, length))
+    dispatch(setReJSONDataAction(selectedKey, ROOT_PATH, value, true, length))
   }
 
   return (


### PR DESCRIPTION
Monaco editor used in this context always edits JSONs, so the proper invocation of `setReJSONDataAction` is with `isEditMode` = `true`.