### PR TITLE
RI-7171: Rename Monaco editor workflow Cancel button to Close

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
@@ -68,7 +68,7 @@ const MonacoEditor = (props: BaseProps) => {
           size="s"
           data-testid="json-data-cancel-btn"
         >
-          Cancel
+          Close
         </EuiButton>
 
         <EuiButton


### PR DESCRIPTION
Why?
The current UX flow is as follows:

- The user opens the Monaco editor
- Makes their changes (edits, additions, deletions, etc.)
- Clicks Overwrite data to save their changes (since we overwrite the entire key value)
- Or clicks Close to exit the workflow

This PR renames the Cancel button to Close, making it clearer to users that it simply ends the workflow without saving.