### PR TITLE
Test scripts were outputting to ./coverage/ but workflow expected ./test/test-runs/coverage/

### DIFF
--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -35,7 +35,7 @@
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js -d ./config/ormconfig.ts",
     "test:api": "cross-env NODE_ENV=test ts-mocha --paths --config ./test/api/.mocharc.yml",
     "test:api:cov": "nyc --reporter=html --reporter=text --reporter=text-summary yarn run test:api",
-    "test:api:ci:cov": "cross-env nyc -r text -r text-summary -r html yarn run test:api --reporter mocha-multi-reporters --reporter-options configFile=test/api/reporters.json && nyc merge .nyc_output ./coverage/test-run-coverage.json",
+    "test:api:ci:cov": "cross-env nyc -r text -r text-summary -r html yarn run test:api --reporter mocha-multi-reporters --reporter-options configFile=test/api/reporters.json && nyc merge .nyc_output ./test/test-runs/coverage/test-run-coverage.json",
     "typeorm:migrate": "cross-env NODE_ENV=staging yarn typeorm migration:generate ./migration/migration",
     "typeorm:run": "yarn typeorm migration:run",
     "typeorm:run:stage": "cross-env NODE_ENV=staging yarn typeorm migration:run"

--- a/redisinsight/api/test/api/reporters.json
+++ b/redisinsight/api/test/api/reporters.json
@@ -1,9 +1,9 @@
 {
   "reporterEnabled": "spec,@mochajs/json-file-reporter,mocha-junit-reporter",
   "mochajsJsonFileReporterReporterOptions": {
-    "output": "coverage/test-run-result.json"
+    "output": "test/test-runs/coverage/test-run-result.json"
   },
   "mochaJunitReporterReporterOptions": {
-    "mochaFile": "coverage/test-run-result.xml"
+    "mochaFile": "test/test-runs/coverage/test-run-result.xml"
   }
 }

--- a/redisinsight/api/test/test-runs/test-docker-entry.sh
+++ b/redisinsight/api/test/test-runs/test-docker-entry.sh
@@ -11,4 +11,7 @@ eval "$(echo "$GNOME_KEYRING_PASS" | gnome-keyring-daemon --unlock)"
 sleep 1
 eval "$(echo "$GNOME_KEYRING_PASS" | gnome-keyring-daemon --start)"
 
+# Create coverage directory before running tests
+mkdir -p test/test-runs/coverage
+
 exec "$@"


### PR DESCRIPTION
Integration tests are passing but the reports generation/parsing fails https://github.com/redis/RedisInsight/actions/runs/16147033387 it seems that we had 2 different paths