### PR TITLE
RI-7022: Rename New Report to Analyze

### DIFF
--- a/redisinsight/ui/src/pages/database-analysis/components/empty-analysis-message/EmptyAnalysisMessage.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/empty-analysis-message/EmptyAnalysisMessage.tsx
@@ -15,7 +15,7 @@ interface Props {
 const emptyMessageContent: { [key in EmptyMessage]: Content } = {
   [EmptyMessage.Reports]: {
     title: 'No Reports found',
-    text: () => 'Run "New Analysis" to generate first report.',
+    text: () => 'Click "Analyze" to generate the first report.',
   },
   [EmptyMessage.Keys]: {
     title: 'No keys to display',

--- a/redisinsight/ui/src/pages/database-analysis/components/header/Header.spec.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/header/Header.spec.tsx
@@ -103,6 +103,7 @@ describe('DatabaseAnalysisHeader', () => {
 
     expect(screen.getByTestId('analysis-progress')).toBeInTheDocument()
   })
+
   it('should call "getDBAnalysis" action be called after click "start-database-analysis-btn"', () => {
     render(<Header {...instance(mockedProps)} />)
     fireEvent.click(screen.getByTestId('start-database-analysis-btn'))
@@ -110,6 +111,7 @@ describe('DatabaseAnalysisHeader', () => {
     const expectedActions = [getDBAnalysis()]
     expect(store.getActions()).toEqual(expectedActions)
   })
+
   it('should send telemetry event after click "new analysis" btn', async () => {
     const sendEventTelemetryMock = jest.fn()
 
@@ -129,6 +131,16 @@ describe('DatabaseAnalysisHeader', () => {
       },
     })
     ;(sendEventTelemetry as jest.Mock).mockRestore()
+  })
+
+  it('should show "Analyze" text on the start analysis button', async () => {
+    render(
+      <Header {...instance(mockedProps)} items={mockReports} progress={mockProgress} />,
+    )
+
+    const analizeButtonId = screen.getByTestId('start-database-analysis-btn')
+    expect(analizeButtonId).toBeInTheDocument()
+    expect(analizeButtonId).toHaveTextContent('Analyze')
   })
 
   it.skip('should call onChangeSelectedAnalysis after change selector', async () => {

--- a/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
@@ -161,7 +161,7 @@ const Header = (props: Props) => {
                 onClick={handleClick}
                 size="s"
               >
-                New Report
+                Analyze
               </EuiButton>
             </FlexItem>
             <FlexItem style={{ paddingLeft: 6 }}>


### PR DESCRIPTION
- Rename **New Report** to **Analyze**
- Change the empty message from **Run New Analysis...** to **Click Analyze** when no reports are generated:

old:
![image](https://github.com/user-attachments/assets/65123f2a-2ecf-47b1-8d10-368d585ab61f)

new:
![image](https://github.com/user-attachments/assets/8641a4c6-5db7-4382-b596-52d05b5a644e)
