### PR TITLE
RI-6570 Verify edit string key operations for in the browsers module

### DIFF
--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -1693,4 +1693,29 @@ export class BrowserPage extends BasePage {
         expect(displayedTTL).toContain('TTL:')
         expect(displayedTTL).not.toContain('No limit')
     }
+
+    async cancelStringKeyValueEdit(newValue: string): Promise<void> {
+        await this.editKeyValueButton.click()
+        await this.stringKeyValueInput.clear()
+        await this.stringKeyValueInput.fill(newValue)
+        await this.keyDetailsHeader.click()
+    }
+
+    async waitForKeyLengthToUpdate(expectedLength: string): Promise<void> {
+        await expect
+            .poll(async () => {
+                const keyLength = await this.getKeyLength()
+                return keyLength
+            })
+            .toBe(expectedLength)
+    }
+
+    async waitForStringValueToUpdate(expectedValue: string): Promise<void> {
+        await expect
+            .poll(async () => {
+                const currentValue = await this.getStringKeyValue()
+                return currentValue
+            })
+            .toContain(expectedValue)
+    }
 }

--- a/tests/playwright/tests/browser/keys-edit/edit-string-key.spec.ts
+++ b/tests/playwright/tests/browser/keys-edit/edit-string-key.spec.ts
@@ -1,0 +1,95 @@
+import { faker } from '@faker-js/faker'
+
+import { BrowserPage } from '../../../pageObjects/browser-page'
+import { test, expect } from '../../../fixtures/test'
+import { ossStandaloneConfig } from '../../../helpers/conf'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../../helpers/utils'
+
+test.describe('Browser - Edit Key Operations - String Key Editing', () => {
+    let browserPage: BrowserPage
+    let keyName: string
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page, api: { databaseService } }) => {
+        browserPage = new BrowserPage(page)
+        keyName = faker.string.alphanumeric(10)
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+        )
+
+        await navigateToStandaloneInstance(page)
+    })
+
+    test.afterEach(async ({ api: { keyService } }) => {
+        // Clean up: delete the key if it exists
+        try {
+            await keyService.deleteKeyByNameApi(
+                keyName,
+                ossStandaloneConfig.databaseName,
+            )
+        } catch (error) {
+            // Key might already be deleted in test, ignore error
+        }
+
+        await cleanupInstance()
+    })
+
+    test('should edit string key value successfully', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a string key
+        const originalValue = faker.lorem.words(3)
+        const newValue = faker.lorem.words(4)
+
+        await keyService.addStringKeyApi(
+            { keyName, value: originalValue },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and verify original value
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+
+        const displayedOriginalValue = await browserPage.getStringKeyValue()
+        expect(displayedOriginalValue).toContain(originalValue)
+
+        // Edit the key value
+        await browserPage.editStringKeyValue(newValue)
+
+        // Wait for value and length to update
+        await browserPage.waitForStringValueToUpdate(newValue)
+        await browserPage.waitForKeyLengthToUpdate(newValue.length.toString())
+    })
+
+    test('should cancel string key value edit operation', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a string key
+        const originalValue = faker.lorem.words(3)
+        const attemptedNewValue = faker.lorem.words(4)
+
+        await keyService.addStringKeyApi(
+            { keyName, value: originalValue },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and verify original value
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+
+        const displayedOriginalValue = await browserPage.getStringKeyValue()
+        expect(displayedOriginalValue).toContain(originalValue)
+
+        // Start editing but cancel
+        await browserPage.cancelStringKeyValueEdit(attemptedNewValue)
+
+        // Verify the original value is still displayed
+        const displayedValueAfterCancel = await browserPage.getStringKeyValue()
+        expect(displayedValueAfterCancel).toContain(originalValue)
+        expect(displayedValueAfterCancel).not.toContain(attemptedNewValue)
+    })
+})


### PR DESCRIPTION
# Description

Add new E2E tests to check the update functionalities for string key types in the Browsers module. These tests make sure that when you click on a key, you can update all of its details in the Details Panel.

<img width="762" height="652" alt="image" src="https://github.com/user-attachments/assets/acad5ea1-d890-47ee-8a4b-cb572ae52945" />

### How the tests work

- First, prepare the data for the test using the Redis API (it's easier and faster and also, the UI flow for creating keys is already covered in another test suite)
- Then we open the Details Panel by clicking on the key we just added (in the table in the UI)
- After that, we go and update the values, depending on the field type (and verify the change)

Note: Once [PR: 4723](https://github.com/redis/RedisInsight/pull/4723) is merged, make sure to update the target branch of this pull request to lead to [feature/RI-6570/PlayWright](https://github.com/redis/RedisInsight/tree/feature/RI-6570/PlayWright) branch.

## Code Changes

* Extend browser page locators to provide helpers for dealing with the state of the keys and their values in details drawer
* Add e2e tests to verify that you can edit all the information related to the various key types displayed in the details drawer

# How to run the tests

You can always refer to the README, but simply running the following command should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web browser/keys-edit 

# The, check the detailed report an all the video recordings
yarn playwright show-report
``` 


### Edit String Key

```
yarn test:chromium:local-web browser/keys-edit/edit-string-key
```

<img width="1005" height="265" alt="image" src="https://github.com/user-attachments/assets/32835cf1-ad9f-48c6-bb80-f35197f5b582" />
