### PR TITLE
RI-7249 - RDI---Connection-test-results-are-broken

### DIFF
--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-table/TestConnectionsTable.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-table/TestConnectionsTable.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
 
 import { IRdiConnectionResult } from 'uiSrc/slices/interfaces'
 
 import styles from './styles.module.scss'
+
+const PreWrapText = styled.div<React.HTMLAttributes<HTMLDivElement>>`
+  white-space: pre-wrap;
+`
 
 export interface Props {
   data: Array<IRdiConnectionResult>
@@ -32,9 +37,9 @@ const TestConnectionsTable = (props: Props) => {
           original: { target, error },
         },
       }) => (
-        <div data-testid={`table-result-${target}`}>
+        <PreWrapText data-testid={`table-result-${target}`}>
           {error || 'Successful'}
-        </div>
+        </PreWrapText>
       ),
     },
   ]

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-table/styles.module.scss
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-table/styles.module.scss
@@ -1,5 +1,6 @@
 .tableWrapper {
   max-height: calc(100vh - 282px);
+  padding: 1px;
   @include eui.scrollBar;
   overflow: auto;
 }


### PR DESCRIPTION
Updated from 
<img width="878" height="928" alt="image" src="https://github.com/user-attachments/assets/cfe99538-2554-4df1-b696-3d00a7ebe4ca" />

to 
<img width="521" height="460" alt="image" src="https://github.com/user-attachments/assets/034a6763-7cb8-4a1c-adaa-8f8684a4aa0a" />

fixed the white-space break and the border not showing. It now looks/behaves as it did with the current UX, just the new color theme and components