### PR TITLE
RI-0000 improving the navigation centering

### DIFF
--- a/redisinsight/ui/src/components/navigation-menu/app-navigation/AppNavigation.styles.ts
+++ b/redisinsight/ui/src/components/navigation-menu/app-navigation/AppNavigation.styles.ts
@@ -2,7 +2,9 @@ import styled from 'styled-components'
 import { Row } from 'uiSrc/components/base/layout/flex'
 import Tabs from 'uiSrc/components/base/layout/tabs'
 
-export const StyledAppNavigation = styled(Row)`
+export const StyledAppNavigation = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   background: ${({ theme }) =>
     theme.components.appBar.variants.default.bgColor};
   color: ${({ theme }) => theme.components.appBar.variants.default.color};
@@ -10,9 +12,7 @@ export const StyledAppNavigation = styled(Row)`
   z-index: ${({ theme }) => theme.core.zIndex.zIndex5};
   box-shadow: ${({ theme }) => theme.components.appBar.boxShadow};
   box-sizing: border-box;
-  > div:last-child {
-    margin-inline-start: auto;
-  }
+  align-items: center;
 `
 type NavContainerProps = React.ComponentProps<typeof Row> & {
   $borderLess?: boolean
@@ -20,7 +20,6 @@ type NavContainerProps = React.ComponentProps<typeof Row> & {
 export const StyledAppNavigationContainer = styled(Row)<NavContainerProps>`
   height: 100%;
   width: auto;
-  max-width: 50%;
   &:first-child {
     padding-inline-start: ${({ theme }) => theme.components.appBar.group.gap};
   }

--- a/redisinsight/ui/src/components/navigation-menu/app-navigation/AppNavigation.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/app-navigation/AppNavigation.tsx
@@ -54,37 +54,35 @@ const AppNavigation = ({ actions, onChange }: AppNavigationProps) => {
   return (
     <StyledAppNavigation>
       <AppNavigationContainer />
-      <AppNavigationContainer borderLess grow={false}>
-        <Row align="end">
-          <Tabs.Compose
-            value={activeTab?.pageName}
-            onChange={(tabValue) => {
-              const tabNavItem = privateRoutes.find(
-                (route) => route.pageName === tabValue,
+      <AppNavigationContainer borderLess grow={false} justify="center" style={{ paddingTop: '20px' }}>
+        <Tabs.Compose
+          value={activeTab?.pageName}
+          onChange={(tabValue) => {
+            const tabNavItem = privateRoutes.find(
+              (route) => route.pageName === tabValue,
+            )
+            if (tabNavItem) {
+              onChange?.(tabNavItem.pageName) // remove actions before navigation, displayed page, should set their own actions
+              tabNavItem.onClick()
+            }
+          }}
+        >
+          <Tabs.TabBar.Compose variant="default">
+            {navTabs.map(({ value, label, disabled }, index) => {
+              const key = `${value}-${index}`
+              return (
+                <Tabs.TabBar.Trigger.Compose
+                  value={value}
+                  disabled={disabled}
+                  key={key}
+                >
+                  <StyledAppNavTab>{label ?? value}</StyledAppNavTab>
+                  <Tabs.TabBar.Trigger.Marker />
+                </Tabs.TabBar.Trigger.Compose>
               )
-              if (tabNavItem) {
-                onChange?.(tabNavItem.pageName) // remove actions before navigation, displayed page, should set their own actions
-                tabNavItem.onClick()
-              }
-            }}
-          >
-            <Tabs.TabBar.Compose variant="default">
-              {navTabs.map(({ value, label, disabled }, index) => {
-                const key = `${value}-${index}`
-                return (
-                  <Tabs.TabBar.Trigger.Compose
-                    value={value}
-                    disabled={disabled}
-                    key={key}
-                  >
-                    <StyledAppNavTab>{label ?? value}</StyledAppNavTab>
-                    <Tabs.TabBar.Trigger.Marker />
-                  </Tabs.TabBar.Trigger.Compose>
-                )
-              })}
-            </Tabs.TabBar.Compose>
-          </Tabs.Compose>
-        </Row>
+            })}
+          </Tabs.TabBar.Compose>
+        </Tabs.Compose>
       </AppNavigationContainer>
       <AppNavigationContainer justify="end" align="center">
         {actions}


### PR DESCRIPTION
Currently the navigation is centered in the empty space on top. This means that when there are extra buttons for the browser, it shifts the navigation positioning. Which is annoying for the users (and different than than the previews). Here is the current behavior

https://github.com/user-attachments/assets/c352ff9e-4d2b-4a91-99bf-f9f786a1ccf7



Here is what this PR changes it to 

https://github.com/user-attachments/assets/17bac539-e70e-45e8-9aa4-1470bd0d5b9a



