### PR TITLE
Fix universal configuration for binaries

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -46,10 +46,8 @@
     "asarUnpack": ["node_modules"],
     "provisioningProfile": "embedded.provisionprofile",
     "binaries": [
-      "Contents/Resources/app-x64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
-      "Contents/Resources/app-arm64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
-      "Contents/Resources/app-arm64.asar.unpacked/node_modules/keytar/build/Release/keytar.node",
-      "Contents/Resources/app-x64.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
+      "Contents/Resources/app.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
     ],
     "artifactName": "Redis-Insight-${os}-${arch}-mas.${ext}"
   },
@@ -62,10 +60,8 @@
     "asarUnpack": ["node_modules"],
     "provisioningProfile": "dev.provisionprofile",
     "binaries": [
-      "Contents/Resources/app-x64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
-      "Contents/Resources/app-arm64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
-      "Contents/Resources/app-arm64.asar.unpacked/node_modules/keytar/build/Release/keytar.node",
-      "Contents/Resources/app-x64.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
+      "Contents/Resources/app.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
     ],
     "artifactName": "Redis-Insight-${os}-${arch}-masDev.${ext}"
   },


### PR DESCRIPTION
Not sure why exactly, but it looks like universal builds work with a single `app.asar.unpacked` instead of architecture-specific ones.