### PR TITLE
RI-7405: disable Nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,8 @@
 name: Nightly jobs
-on:
-  schedule:
-    - cron: 0 0 * * *
+# Disabled nightly jobs until issues with individual jobs are resolved
+# on:
+#   schedule:
+#     - cron: 0 0 * * *
 
 jobs:
   # Integration tests


### PR DESCRIPTION
### Description

Nightly workflows are apparently broken and have been so ever since, mostly due to failing e2e tests. Source - [Nightly jobs · Workflow runs · redis/RedisInsight](https://github.com/redis/RedisInsight/actions/workflows/nightly.yml) 

This PR disables them for the time being, until we need them again or decide on another strategy.