### PR TITLE
RI-7405: remove Nightly workflow

### DIFF
--- a/redisinsight/api/src/modules/auth/window-auth/middleware/window.auth.middleware.ts
+++ b/redisinsight/api/src/modules/auth/window-auth/middleware/window.auth.middleware.ts
@@ -13,8 +13,6 @@ export class WindowAuthMiddleware implements NestMiddleware {
 
   async use(req: Request, res: Response, next: NextFunction): Promise<any> {
     const { windowId } = WindowAuthMiddleware.getWindowIdFromReq(req);
-    next()
-    return
 
     const isAuthorized = await this.windowAuthService.isAuthorized(windowId);
 


### PR DESCRIPTION
### Description

Original PR: https://github.com/redis/RedisInsight/pull/4883
Removing the whole workflow because "Error No event triggers defined in `on`" https://github.com/redis/RedisInsight/actions/runs/17121232343

Nightly workflows are apparently broken and have been so ever since, mostly due to failing e2e tests. Source - [Nightly jobs · Workflow runs · redis/RedisInsight](https://github.com/redis/RedisInsight/actions/workflows/nightly.yml) 

This PR disables them for the time being, until we need them again or decide on another strategy.