### PR TITLE
[RI-7366] Vector Search - Saved Queries not opening for electron builds

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.spec.tsx
@@ -95,12 +95,12 @@ describe('VectorSearchCreateIndex', () => {
     renderVectorSearchCreateIndexComponent({ initialStep: 2 })
 
     // Effect should dispatch success notification and navigate
-    expect(pushMock).toHaveBeenCalledWith(
-      Pages.vectorSearch(INSTANCE_ID_MOCK),
-      {
-        defaultSavedQueriesIndex: PresetDataType.BIKES,
-      },
-    )
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: Pages.vectorSearch(INSTANCE_ID_MOCK),
+      search: `?defaultSavedQueriesIndex=${encodeURIComponent(
+        PresetDataType.BIKES,
+      )}`,
+    })
   })
 
   it('should dispatch error notification on error', () => {

--- a/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
+++ b/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
@@ -97,8 +97,11 @@ export const VectorSearchCreateIndex = ({
     } else if (success) {
       dispatch(addMessageNotification(successMessages.CREATE_INDEX()))
 
-      history.push(Pages.vectorSearch(instanceId), {
-        defaultSavedQueriesIndex: createSearchIndexParameters.indexName,
+      history.push({
+        pathname: Pages.vectorSearch(instanceId),
+        search: `?defaultSavedQueriesIndex=${encodeURIComponent(
+          createSearchIndexParameters.indexName,
+        )}`,
       })
     }
   }, [success, error])

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
@@ -10,13 +10,13 @@ import { VectorSearchPageWrapper } from './../styles'
 type Params = {
   instanceId: string
 }
-type LocationState = {
-  defaultSavedQueriesIndex?: string
-}
 
 const VectorSearchPage = () => {
   const { instanceId } = useParams<Params>()
-  const { state } = useLocation<LocationState | undefined>()
+  const { search } = useLocation()
+  const defaultSavedQueriesIndex =
+    new URLSearchParams(search).get('defaultSavedQueriesIndex') || undefined
+
   usePageViewTelemetry({
     page: TelemetryPageView.VECTOR_SEARCH_PAGE,
   })
@@ -30,7 +30,7 @@ const VectorSearchPage = () => {
     <VectorSearchPageWrapper>
       <VectorSearchQuery
         instanceId={instanceId}
-        defaultSavedQueriesIndex={state?.defaultSavedQueriesIndex}
+        defaultSavedQueriesIndex={defaultSavedQueriesIndex}
       />
     </VectorSearchPageWrapper>
   )


### PR DESCRIPTION
## Description

After creating an index, the user should be navigated to the root Vector Search page and have his Saved Queries for this index opened.

It seems that using react router's state param does not work for electron in this case. I have replaced it with query params solution and seems to be working fine across builds