### PR TITLE
RI-7275 Create e2e tests for "Vector Search" page

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
@@ -44,7 +44,10 @@ const VectorSearchPage = () => {
 
   if (!hasRedisearch) {
     return (
-      <VectorSearchPageWrapper>
+      <VectorSearchPageWrapper
+        as="div"
+        data-testid="vector-search-page--rqe-not-available"
+      >
         <RqeNotAvailableCard />
       </VectorSearchPageWrapper>
     )

--- a/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
+++ b/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
@@ -11,6 +11,15 @@ export class VectorSearchPage extends BasePage {
     // SELECTORS
     public readonly vectorSearchPage: Locator
     public readonly searchTab: Locator
+    public readonly cloudLoginModal: Locator
+
+    // VECTOR SET NOT AVAILABLE BANNER
+    public readonly vectorSetNotAvailableBanner: Locator
+    public readonly freeRedisCloudDatabaseButton: Locator
+
+    // RQE NOT AVAILABLE CARD
+    public readonly rqeNotAvailableCard: Locator
+    public readonly createRedisCloudDatabaseButton: Locator
 
     // EDITOR
     public readonly editorContainer: Locator
@@ -32,6 +41,7 @@ export class VectorSearchPage extends BasePage {
     // BUTTONS
     public readonly getStartedButton: Locator
     public readonly clearCommandsResultsButton: Locator
+    public readonly startWizardButton: Locator
 
     constructor(page: Page) {
         super(page)
@@ -43,6 +53,25 @@ export class VectorSearchPage extends BasePage {
         // CONTAINERS
         this.vectorSearchPage = page.getByTestId('vector-search-page')
         this.searchTab = page.getByRole('tab', { name: 'Search' })
+        this.cloudLoginModal = page.getByTestId('social-oauth-dialog')
+
+        // VECTOR SET NOT AVAILABLE BANNER
+        this.vectorSetNotAvailableBanner = page.getByTestId(
+            'vector-set-not-available-banner',
+        )
+        this.freeRedisCloudDatabaseButton =
+            this.vectorSetNotAvailableBanner.getByRole('button', {
+                name: 'Free Redis Cloud DB',
+            })
+
+        // RQE NOT AVAILABLE CARD
+        this.rqeNotAvailableCard = page.getByTestId(
+            'vector-search-page--rqe-not-available',
+        )
+        this.createRedisCloudDatabaseButton =
+            this.rqeNotAvailableCard.getByRole('button', {
+                name: 'Get Started For Free',
+            })
 
         // EDITOR
         this.editorContainer = page.getByTestId('vector-search-query-editor')
@@ -80,6 +109,7 @@ export class VectorSearchPage extends BasePage {
             })
         this.clearCommandsResultsButton =
             this.commandsResults.getByTestId('clear-history-btn')
+        this.startWizardButton = page.getByTestId('start-wizard-button')
     }
 
     async navigateToVectorSearchPage(): Promise<void> {

--- a/tests/playwright/tests/vector-search/version-compatibility.spec.ts
+++ b/tests/playwright/tests/vector-search/version-compatibility.spec.ts
@@ -1,0 +1,94 @@
+import { VectorSearchPage } from '../../pageObjects/pages/vector-search/vector-search-page'
+import { test } from '../../fixtures/test'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../helpers/utils'
+import { ossStandaloneConfig, ossStandaloneV6Config } from '../../helpers/conf'
+import { ossStandaloneV5Config } from '../../helpers/conf'
+
+test.describe('Vector Search - Query', () => {
+    let searchPage: VectorSearchPage
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page }) => {
+        searchPage = new VectorSearchPage(page)
+    })
+
+    test.afterEach(async () => {
+        await cleanupInstance()
+    })
+
+    test('should open Vector Search page', async ({
+        page,
+        api: { databaseService },
+    }) => {
+        // Init database instance that supports vector search
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+            ossStandaloneV6Config,
+        )
+
+        await navigateToStandaloneInstance(page, ossStandaloneV6Config)
+        await searchPage.navigateToVectorSearchPage()
+
+        // Verify that Vector Search page is opened and the start wizard button is visible
+        await searchPage.waitForLocatorVisible(searchPage.startWizardButton)
+    })
+
+    test('should not open Vector Search page if Redis Query Engine module is not enabled', async ({
+        page,
+        api: { databaseService },
+    }) => {
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+            ossStandaloneV5Config,
+        )
+
+        await navigateToStandaloneInstance(page, ossStandaloneV5Config)
+        await searchPage.searchTab.click()
+
+        // Verify that Vector Search page is opened and the start wizard button is visible
+        await searchPage.waitForLocatorVisible(searchPage.rqeNotAvailableCard)
+
+        // Verify that "Get Started For Free" button is visible
+        await searchPage.waitForLocatorVisible(
+            searchPage.createRedisCloudDatabaseButton,
+        )
+        await searchPage.createRedisCloudDatabaseButton.click()
+
+        // Verify that Cloud Login modal is opened
+        await searchPage.waitForLocatorVisible(searchPage.cloudLoginModal)
+    })
+
+    test('should open Vector Search page, but show a message if Redis version does not support Vector Sets', async ({
+        page,
+        api: { databaseService },
+    }) => {
+        // Init database instance that supports vector search
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+            ossStandaloneConfig,
+        )
+
+        await navigateToStandaloneInstance(page, ossStandaloneConfig)
+        await searchPage.navigateToVectorSearchPage()
+
+        // Verify that Vector Search page is opened and banner with information about Vector Sets is visible
+        await searchPage.waitForLocatorVisible(
+            searchPage.vectorSetNotAvailableBanner,
+        )
+
+        // Verify that "Free Redis Cloud DB" button is visible
+        await searchPage.waitForLocatorVisible(
+            searchPage.freeRedisCloudDatabaseButton,
+        )
+        await searchPage.freeRedisCloudDatabaseButton.click()
+
+        // Verify that Cloud Login modal is opened
+        await searchPage.waitForLocatorVisible(searchPage.cloudLoginModal)
+    })
+})


### PR DESCRIPTION
# Description

Created e2e tests to verify the availability of the "**Vector Search**" page:
- it should open the page when all requirements are met
- it should open a fallback message when the Redis Query Engine module is not enabled
- it should show a fallback message when Redis version doesn't support vector sets

## How the tests work

- We have page objects that define selectors for all the main elements we need to use in our tests. These page object classes also provide helper utilities that we can use in our test cases to keep them concise yet informative about what’s happening. They serve as a layer of abstraction.
- In each test case, we have a setup step that initializes the environment and prepares a Redis instance suitable for it. Then, we open the correct page (navigate through the UI) until we reach it.
- After that, we execute some test steps using the browser page helpers.

# How to run the tests

You can always refer to the README, but simply running the following commands should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web vector-search/version-compatibility

# Then, check the detailed report and all the video recordings
yarn playwright show-report
``` 

<img width="995" height="289" alt="image" src="https://github.com/user-attachments/assets/32a08bf3-9e5b-459c-9eed-def35bb2bee3" />