### PR TITLE
RI-7431: Layout fixes. Autorefresh popover

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
-import { ChevronDownIcon, RefreshIcon } from 'uiSrc/components/base/icons'
+import { ChevronDownIcon, ResetIcon } from 'uiSrc/components/base/icons'
 import {
   errorValidateRefreshRateNumber,
   MIN_REFRESH_RATE,
@@ -233,7 +233,7 @@ const AutoRefresh = ({
       >
         <IconButton
           size={iconSize}
-          icon={RefreshIcon}
+          icon={ResetIcon}
           disabled={loading || disabled}
           onClick={handleRefreshClick}
           onMouseEnter={updateLastRefresh}
@@ -279,7 +279,6 @@ const AutoRefresh = ({
           <div className={styles.inputLabel}>Refresh rate:</div>
           {!editingRate && (
             <ColorText
-              color="subdued"
               className={styles.refreshRateText}
               onClick={() => setEditingRate(true)}
               data-testid={getDataTestid('refresh-rate')}
@@ -307,7 +306,7 @@ const AutoRefresh = ({
                   onApply={(value) => handleApplyAutoRefreshRate(value)}
                 />
               </div>
-              <ColorText color="subdued">{' s'}</ColorText>
+              <ColorText>{' s'}</ColorText>
             </>
           )}
         </div>

--- a/redisinsight/ui/src/components/auto-refresh/styles.module.scss
+++ b/redisinsight/ui/src/components/auto-refresh/styles.module.scss
@@ -16,8 +16,8 @@
   }
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
   }
 
   &.rolling svg {

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.styles.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.styles.tsx
@@ -68,7 +68,7 @@ export const ApplyButton = styled(IconButton).attrs({
   color: 'primary',
   'aria-label': 'Apply',
 })`
-  vertical-align: initial;
+  vertical-align: top;
   &:hover:not([class*='isDisabled']) {
     color: ${({ theme }: { theme: Theme }) =>
       theme.semantic.color.text.neutral500};
@@ -165,10 +165,12 @@ export const StyledTextInput = styled(TextInput)<{
   height: ${({ $height }) => $height || 'auto'};
   max-height: ${({ $height }) => $height || 'auto'};
   min-height: ${({ $height }) => $height || 'auto'};
+  padding: 0;
 
   // Target the actual input element inside
   input {
     width: 100%;
-    height: ${({ $height }) => $height || 'auto'};  
-  }  
+    height: ${({ $height }) => $height || 'auto'};
+    padding: 0 5px;
+  }
 `

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -89,7 +89,6 @@ const InlineItemEditor = (props: Props) => {
     children,
     expandable,
     isLoading,
-    isInvalid,
     disableEmpty,
     disableByValidation,
     validation,
@@ -241,7 +240,6 @@ const InlineItemEditor = (props: Props) => {
                         value={value}
                         onChange={handleChangeValue}
                         loading={isLoading}
-                        valid={!isInvalid}
                         data-testid="inline-item-editor"
                         autoComplete={autoComplete}
                         ref={inputRef}

--- a/redisinsight/ui/src/styles/base/_helpers.scss
+++ b/redisinsight/ui/src/styles/base/_helpers.scss
@@ -89,13 +89,11 @@
 }
 
 .popover-without-top-tail {
-  margin-top: -8px;
+  margin-top: -6px;
 
-  .euiPopover__panelArrow {
-    &::before,
-    &::after {
-      content: none !important;
-    }
+  // removes top arrow (it is always first child)
+  & > span:nth-child(1) * {
+    display: none
   }
 }
 


### PR DESCRIPTION
RI-7431: Change the “synchronization” icon to “refresh”
RI-7431: Control to set the auto-refresh rate (especially, the edit mode)

| Before | After |
| - | - |
<img width="287" height="168" alt="Screenshot 2025-09-15 at 08 58 28" src="https://github.com/user-attachments/assets/8f0c9fa1-1d12-4342-96f8-38408b033808" /> | <img width="282" height="164" alt="Screenshot 2025-09-15 at 08 57 27" src="https://github.com/user-attachments/assets/daf00627-71ec-476a-8381-37a596d1f053" />
| - | - |
<img width="286" height="185" alt="Screenshot 2025-09-15 at 08 58 34" src="https://github.com/user-attachments/assets/f0e2870e-cfad-4843-9060-3e54efa3ad17" /> | <img width="290" height="199" alt="Screenshot 2025-09-15 at 08 57 36" src="https://github.com/user-attachments/assets/aa6d48ac-f217-40e9-b655-87b2a638b0f8" />


