### PR TITLE
RI-7431: Layout fixes. Fonts and colors in the number of keys scanned

### DIFF
--- a/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
+++ b/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
@@ -57,31 +57,29 @@ const KeysSummary = (props: Props) => {
           <Text size="xs" component="div">
             {!!scanned && (
               <>
-                <ColorText>
-                  <b>
-                    {'Results: '}
-                    <span data-testid="keys-number-of-results">
-                      {numberWithSpaces(resultsLength)}
-                    </span>
-                    {'. '}
-                  </b>
-                  <ColorText color="subdued">
-                    {'Scanned '}
-                    <span data-testid="keys-number-of-scanned">
-                      {notAccurateScanned}
-                      {numberWithSpaces(scannedDisplay)}
-                    </span>
-                    {' / '}
-                    <span data-testid="keys-total">
-                      {nullableNumberWithSpaces(totalItemsCount)}
-                    </span>
-                    <span
-                      className={cx([
-                        styles.loading,
-                        { [styles.loadingShow]: loading },
-                      ])}
-                    />
-                  </ColorText>
+                <ColorText variant="semiBold">
+                  {'Results: '}
+                  <span data-testid="keys-number-of-results">
+                    {numberWithSpaces(resultsLength)}
+                  </span>
+                  {'. '}
+                </ColorText>
+                <ColorText color="secondary">
+                  {'Scanned '}
+                  <span data-testid="keys-number-of-scanned">
+                    {notAccurateScanned}
+                    {numberWithSpaces(scannedDisplay)}
+                  </span>
+                  {' / '}
+                  <span data-testid="keys-total">
+                    {nullableNumberWithSpaces(totalItemsCount)}
+                  </span>
+                  <span
+                    className={cx([
+                      styles.loading,
+                      { [styles.loadingShow]: loading },
+                    ])}
+                  />
                 </ColorText>
                 {showScanMore && (
                   <ScanMore
@@ -99,11 +97,9 @@ const KeysSummary = (props: Props) => {
             )}
 
             {!scanned && (
-              <Text size="xs">
-                <b>
-                  {'Total: '}
-                  {nullableNumberWithSpaces(totalItemsCount)}
-                </b>
+              <Text size="s" variant="semiBold">
+                {'Total: '}
+                {nullableNumberWithSpaces(totalItemsCount)}
               </Text>
             )}
           </Text>


### PR DESCRIPTION
| Before | After |
| - | - |
<img width="900" height="312" alt="Screenshot 2025-09-15 at 09 43 23" src="https://github.com/user-attachments/assets/959f5d79-2f7d-4392-b4be-a81bd27de344" /> | <img width="899" height="332" alt="Screenshot 2025-09-15 at 09 43 01" src="https://github.com/user-attachments/assets/052901dc-c663-4481-ba9c-fd5f5d76d2de" />
| - | - |
<img width="896" height="306" alt="Screenshot 2025-09-15 at 09 43 31" src="https://github.com/user-attachments/assets/7b3a10ab-4290-47c8-86aa-684c2f3e354e" /> | <img width="898" height="323" alt="Screenshot 2025-09-15 at 09 43 10" src="https://github.com/user-attachments/assets/45b18fe0-16ec-4296-80bf-bd9bcd455efa" />

