### PR TITLE
RI-7431: Delete key popover layout

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import cx from 'classnames'
 import { KeyTypes, ModulesKeyTypes } from 'uiSrc/constants'
 import { formatLongName } from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
   DestructiveButton,
   IconButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { DeleteIcon } from 'uiSrc/components/base/icons'
-import { Text } from 'uiSrc/components/base/text'
+import { Text, Title } from 'uiSrc/components/base/text'
 import { RiPopover } from 'uiSrc/components/base'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
 
 export interface DeleteProps {
   nameString: string
@@ -24,6 +25,11 @@ export interface DeleteProps {
   onOpenPopover: (index: number, type: KeyTypes | ModulesKeyTypes) => void
 }
 
+const PopoverContentWrapper = styled(Col)`
+  word-break: break-all;
+  max-width: 300px;
+`
+
 export const DeleteKeyPopover = ({
   nameString,
   name,
@@ -33,40 +39,46 @@ export const DeleteKeyPopover = ({
   deleting,
   onDelete,
   onOpenPopover,
-}: DeleteProps) => (
-  <RiPopover
-    anchorClassName={cx('showOnHoverKey', { show: deletePopoverId === rowId })}
-    anchorPosition="leftUp"
-    isOpen={deletePopoverId === rowId}
-    closePopover={() => onOpenPopover(-1, type)}
-    panelPaddingSize="l"
-    button={
-      <IconButton
-        icon={DeleteIcon}
-        onClick={() => onOpenPopover(rowId, type)}
-        aria-label="Delete Key"
-        data-testid={`delete-key-btn-${nameString}`}
-      />
-    }
-    onClick={(e) => e.stopPropagation()}
-  >
-    <>
-      <Text size="m" component="div">
-        <h4 style={{ wordBreak: 'break-all' }}>
-          <b>{formatLongName(nameString)}</b>
-        </h4>
-        <Text size="s">will be deleted.</Text>
-      </Text>
-      <Spacer size="m" />
-      <DestructiveButton
-        size="small"
-        icon={DeleteIcon}
-        disabled={deleting}
-        onClick={() => onDelete(name)}
-        data-testid="submit-delete-key"
-      >
-        Delete
-      </DestructiveButton>
-    </>
-  </RiPopover>
-)
+}: DeleteProps) => {
+  const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation()
+    onOpenPopover(rowId, type)
+  }
+
+  return (
+    <RiPopover
+      anchorClassName={cx('showOnHoverKey', {
+        show: deletePopoverId === rowId,
+      })}
+      anchorPosition="leftCenter"
+      isOpen={deletePopoverId === rowId}
+      closePopover={() => onOpenPopover(-1, type)}
+      panelPaddingSize="l"
+      button={
+        <IconButton
+          icon={DeleteIcon}
+          onClick={onClick}
+          aria-label="Delete Key"
+          data-testid={`delete-key-btn-${nameString}`}
+        />
+      }
+      onClick={(e) => e.stopPropagation()}
+    >
+      <PopoverContentWrapper gap="l">
+        <Title size="S">{formatLongName(nameString)}</Title>
+        <Text size="m">will be deleted.</Text>
+        <Row>
+          <DestructiveButton
+            size="small"
+            icon={DeleteIcon}
+            disabled={deleting}
+            onClick={() => onDelete(name)}
+            data-testid="submit-delete-key"
+          >
+            Delete
+          </DestructiveButton>
+        </Row>
+      </PopoverContentWrapper>
+    </RiPopover>
+  )
+}


### PR DESCRIPTION
Fixed behavior when clicking on trash button results into selecting row and fetching key details
Also fixed popover layout

|Before|After|
|-|-|
<img width="272" height="165" alt="Screenshot 2025-09-17 at 15 19 55" src="https://github.com/user-attachments/assets/2c0bfe6d-5ce1-42a5-816a-3d9446cd8766" />|<img width="322" height="216" alt="Screenshot 2025-09-17 at 15 20 34" src="https://github.com/user-attachments/assets/bddc4b37-c7c6-49a7-803e-d588829ebe3a" />

