### PR TITLE
RI-7456 Hide "getting started" button when Redis version is not compatible

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/no-data-message/NoDataMessage.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/no-data-message/NoDataMessage.spec.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
-import { render, screen } from 'uiSrc/utils/test-utils'
+import { cleanup, render, screen } from 'uiSrc/utils/test-utils'
 import NoDataMessage, { NoDataMessageProps } from './NoDataMessage'
 import { NO_DATA_MESSAGES, NoDataMessageKeys } from './data'
+import useRedisInstanceCompatibility from '../../create-index/hooks/useRedisInstanceCompatibility'
+
+jest.mock('../../create-index/hooks/useRedisInstanceCompatibility', () =>
+  jest.fn(),
+)
 
 const mockDefaultNoDataMessageVariant = NoDataMessageKeys.ManageIndexes
 
@@ -14,6 +19,19 @@ const renderNoDataMessageComponent = (props?: NoDataMessageProps) => {
 }
 
 describe('NoDataMessage', () => {
+  const mockUseRedisInstanceCompatibility =
+    useRedisInstanceCompatibility as jest.Mock
+
+  beforeEach(() => {
+    cleanup()
+
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: false,
+      hasRedisearch: true,
+      hasSupportedVersion: true,
+    })
+  })
+
   it('should render correctly', () => {
     renderNoDataMessageComponent()
 
@@ -29,9 +47,41 @@ describe('NoDataMessage', () => {
     const icon = screen.getByAltText(
       NO_DATA_MESSAGES[mockDefaultNoDataMessageVariant].title,
     )
+    const gettingStartedButton = screen.queryByRole('button', {
+      name: /Get started/i,
+    })
 
     expect(title).toBeInTheDocument()
     expect(description).toBeInTheDocument()
     expect(icon).toBeInTheDocument()
+    expect(gettingStartedButton).toBeInTheDocument()
+  })
+
+  it('should not render "Get started" button when Redis version is unsupported', () => {
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: false,
+      hasRedisearch: false,
+      hasSupportedVersion: false,
+    })
+
+    renderNoDataMessageComponent()
+
+    const container = screen.getByTestId('no-data-message')
+    expect(container).toBeInTheDocument()
+
+    // Check title and description are rendered
+    const title = screen.getByText(
+      NO_DATA_MESSAGES[mockDefaultNoDataMessageVariant].title,
+    )
+    const description = screen.getByText(
+      NO_DATA_MESSAGES[mockDefaultNoDataMessageVariant].description,
+    )
+
+    expect(title).toBeInTheDocument()
+    expect(description).toBeInTheDocument()
+
+    // Check "Get started" button is not rendered, because Redis is older than 7.2
+    const button = screen.queryByRole('button', { name: /Get started/i })
+    expect(button).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/vector-search/components/no-data-message/NoDataMessage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/no-data-message/NoDataMessage.tsx
@@ -6,6 +6,7 @@ import { Text } from 'uiSrc/components/base/text'
 import useStartWizard from '../../hooks/useStartWizard'
 import { StyledContainer, StyledImage } from './NoDataMessage.styles'
 import { NO_DATA_MESSAGES, NoDataMessageKeys } from './data'
+import useRedisInstanceCompatibility from '../../create-index/hooks/useRedisInstanceCompatibility'
 
 export interface NoDataMessageProps {
   variant: NoDataMessageKeys
@@ -13,6 +14,7 @@ export interface NoDataMessageProps {
 
 const NoDataMessage = ({ variant }: NoDataMessageProps) => {
   const start = useStartWizard()
+  const { loading, hasSupportedVersion } = useRedisInstanceCompatibility()
   const { title, description, icon } = NO_DATA_MESSAGES[variant]
 
   return (
@@ -24,9 +26,11 @@ const NoDataMessage = ({ variant }: NoDataMessageProps) => {
         <Text size="S">{description}</Text>
       </Col>
 
-      <Button variant="secondary-invert" onClick={start}>
-        Get started
-      </Button>
+      {loading === false && hasSupportedVersion === true && (
+        <Button variant="secondary-invert" onClick={start}>
+          Get started
+        </Button>
+      )}
     </StyledContainer>
   )
 }


### PR DESCRIPTION
# Description 

Hide the "**Getting Started**" button (leading to the "**Create Index**" wizard) from the "**No Results**", "**Manage Indexes**", and "**Saved Queries**"  panels on the **Vector Search** page when the Redis version is older than 7.2 and doesn't support Vector Sets.

<img width="2516" height="1780" alt="image" src="https://github.com/user-attachments/assets/4272ed94-4c51-480a-8872-0c3b15fc656c" />


# How it was tested

1. First, you need an older Redis instance without support for Vector Sets (older than 7.2)

_Note: You can use the following command to create a Docker container with such an instance_
```bash
docker run -d --name redis6-redismod -p 6404:6379 redislabs/redismod:latest
```

4. Go to **Databases** page and connect to the instance
5. Go to **Search** page (from the main navbar)

You'll see the search page, but with a banner to let you know that you can't use the full functionalities.

Respectively, the "**Getting started**" button will no longer be visible in the "**No Results**", "**Manage Indexes**" and "**Saved Queries**" panels.

| Before | After |
|-|-|
<img width="2508" height="1784" alt="image" src="https://github.com/user-attachments/assets/a38064d5-93a1-4c21-be9c-8f779fc4f418" />|<img width="1263" height="891" alt="image" src="https://github.com/user-attachments/assets/2d73e586-916b-4232-90a3-81b0b88c08ca" />
<img width="2510" height="1784" alt="image" src="https://github.com/user-attachments/assets/42905cfa-28f7-467f-82c2-ad5a7d9d6e97" />|<img width="1260" height="890" alt="image" src="https://github.com/user-attachments/assets/94fcd0bd-9c6e-4503-9ac0-21f17e6d9955" />

## Note

The "**Getting Started**" button is still there, when you use a newer Redis version that supports Vector Sets.

<img width="1065" height="869" alt="image" src="https://github.com/user-attachments/assets/280deca7-ca66-4657-be82-dab47efa61fd" />

