### PR TITLE
RI-7431: fix tooltip position

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/key-row-name/KeyRowName.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-row-name/KeyRowName.tsx
@@ -43,7 +43,6 @@ const KeyRowName = (props: Props) => {
           <RiTooltip
             title="Key Name"
             className={styles.tooltip}
-            anchorClassName="truncateText"
             position="bottom"
             content={nameTooltipContent}
           >


### PR DESCRIPTION
|Before|After|
|-|-|
<img width="975" height="143" alt="Screenshot 2025-09-17 at 17 37 00" src="https://github.com/user-attachments/assets/c297eb42-f2ad-48dd-ae02-3754bd472cb4" />|<img width="1000" height="130" alt="Screenshot 2025-09-17 at 17 35 57" src="https://github.com/user-attachments/assets/f8d6f74b-648c-4c91-b3e7-95df5d71ecd6" />

