### PR TITLE
RI-7508: Fix compatibility resolving

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/create-index/hooks/useRedisInstanceCompatibility.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/create-index/hooks/useRedisInstanceCompatibility.spec.ts
@@ -25,6 +25,33 @@ describe('useRedisInstanceCompatibility', () => {
     jest.clearAllMocks()
   })
 
+  it('returns undefineds when loading is undefined (not initialized yet)', () => {
+    mockConnectedInstanceSelector.mockReturnValue({
+      loading: undefined,
+      modules: [{ name: 'search' }],
+      version: '7.2.0',
+    })
+
+    const hookResult = renderUseRedisInstanceCompatibility()
+    expect(hookResult.loading).toBeUndefined()
+    expect(hookResult.hasRedisearch).toBeUndefined()
+    expect(hookResult.hasSupportedVersion).toBeUndefined()
+  })
+
+  it('still returns hasRedisearch=undefined when modules is null even after init', () => {
+    mockConnectedInstanceSelector.mockReturnValue({
+      loading: false,
+      modules: null,
+      version: '7.2.0',
+    })
+
+    const hookResult = renderUseRedisInstanceCompatibility()
+    expect(hookResult.loading).toBe(false)
+    // preserve prior behavior: null => unknown, not false
+    expect(hookResult.hasRedisearch).toBeUndefined()
+    expect(hookResult.hasSupportedVersion).toBe(true)
+  })
+
   it('returns loading=true when connectedInstanceSelector returns loading=true', () => {
     mockConnectedInstanceSelector.mockReturnValue({
       loading: true,

--- a/redisinsight/ui/src/pages/vector-search/create-index/hooks/useRedisInstanceCompatibility.ts
+++ b/redisinsight/ui/src/pages/vector-search/create-index/hooks/useRedisInstanceCompatibility.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { REDISEARCH_MODULES } from 'uiSrc/slices/interfaces'
@@ -20,15 +21,18 @@ const useRedisInstanceCompatibility =
       version,
     } = useSelector(connectedInstanceSelector)
 
-    const hasRedisearch = modules?.some((m) =>
-      REDISEARCH_MODULE_SET.has(m.name),
+    const isInitialized = loading !== undefined
+
+    const redisearchPresent = useMemo(
+      () => modules?.some((m) => REDISEARCH_MODULE_SET.has(m.name)),
+      [modules],
     )
 
     return {
       loading,
-      hasRedisearch: !loading ? hasRedisearch : undefined,
+      hasRedisearch: isInitialized ? redisearchPresent : undefined,
       hasSupportedVersion:
-        !loading && version
+        isInitialized && version
           ? isRedisVersionSupported(version, MIN_SUPPORTED_REDIS_VERSION)
           : undefined,
     }


### PR DESCRIPTION
There is an edge case in this compatibility logic that returns `hasSupportedVersion` as undefined, and this PR addresses that.