### PR TITLE
RI-7504: fix alignment of redis icon

### DIFF
--- a/redisinsight/ui/src/components/base/icons/iconRegistry.tsx
+++ b/redisinsight/ui/src/components/base/icons/iconRegistry.tsx
@@ -156,6 +156,7 @@ export {
   GoogleSigninIcon,
   SsoIcon,
   GithubIcon,
+  RedisLogoDarkMinIcon,
 } from '@redis-ui/icons/multicolor'
 
 // Common icons

--- a/redisinsight/ui/src/components/base/layout/sidebar/SideBarItemIcon.tsx
+++ b/redisinsight/ui/src/components/base/layout/sidebar/SideBarItemIcon.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 
 import { RiSideBarItemIconProps, StyledIcon } from './sidebar-item-icon.styles'
 
-export const SideBarItemIcon = (props: RiSideBarItemIconProps) => (
-  <StyledIcon {...props} />
+export const SideBarItemIcon = ({centered, ...props}: RiSideBarItemIconProps) => (
+  <StyledIcon {...props} $centered={centered} />
 )

--- a/redisinsight/ui/src/components/base/layout/sidebar/sidebar-item-icon.styles.ts
+++ b/redisinsight/ui/src/components/base/layout/sidebar/sidebar-item-icon.styles.ts
@@ -1,5 +1,5 @@
 import { SideBar } from '@redis-ui/components'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 export type RiSideBarItemIconProps = Omit<
   React.ComponentProps<typeof SideBar.Item.Icon>,
@@ -7,13 +7,20 @@ export type RiSideBarItemIconProps = Omit<
 > & {
   width?: string
   height?: string
+  centered?: boolean
 }
 
-export const StyledIcon = styled(SideBar.Item.Icon)<RiSideBarItemIconProps>`
-  ${({ width = 'inherit' }) => css`
+export const StyledIcon = styled(SideBar.Item.Icon)<RiSideBarItemIconProps & {
+  $centered?: boolean
+}>`
+  ${({ width = 'inherit' }) => `
     width: ${width};
   `}
-  ${({ height = 'inherit' }) => css`
+  ${({ height = 'inherit' }) => `
     height: ${height};
+  `}
+  ${({ $centered }) => $centered && `
+    justify-content: center;
+    align-items: center;
   `}
 `

--- a/redisinsight/ui/src/components/navigation-menu/components/redis-logo/RedisLogo.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/redis-logo/RedisLogo.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import React from 'react'
 import { useSelector } from 'react-redux'
 
@@ -12,12 +11,24 @@ import {
 import { getRouterLinkProps } from 'uiSrc/services'
 import { Pages } from 'uiSrc/constants'
 import { Link } from 'uiSrc/components/base/link/Link'
-import LogoSVG from 'uiSrc/assets/img/logo_small.svg?react'
-import styles from '../../styles.module.scss'
+import { RedisLogoDarkMinIcon } from 'uiSrc/components/base/icons'
+import styled from 'styled-components'
 
 type Props = {
   isRdiWorkspace: boolean
 }
+
+const RedisLogoIcon = styled.span`
+  height: 60px;
+  width: 100%;
+  @media only screen and (min-width: 768px) {
+    height: 72px;
+  }
+  svg {
+    width: 30px;
+    height: 34px;
+  }
+`
 
 export const RedisLogo = ({ isRdiWorkspace }: Props) => {
   const { envDependent } = useSelector(appFeatureFlagsFeaturesSelector)
@@ -25,9 +36,13 @@ export const RedisLogo = ({ isRdiWorkspace }: Props) => {
 
   if (!envDependent?.flag) {
     return (
-      <span className={cx(styles.iconNavItem, styles.homeIcon)}>
-        <SideBarItemIcon aria-label="Redis Insight Homepage" icon={LogoSVG} />
-      </span>
+      <RedisLogoIcon>
+        <SideBarItemIcon height="50px" width="50px"
+          aria-label="Redis Insight Homepage"
+          icon={RedisLogoDarkMinIcon}
+          centered
+        />
+      </RedisLogoIcon>
     )
   }
 
@@ -49,7 +64,7 @@ export const RedisLogo = ({ isRdiWorkspace }: Props) => {
         }}
         style={{ marginBlock: '2rem', marginInline: 'auto' }}
       >
-        <SideBarItemIcon icon={LogoSVG} />
+        <SideBarItemIcon icon={RedisLogoDarkMinIcon} />
       </SideBarItem>
     </Link>
   )


### PR DESCRIPTION
- removed usage of `css` helper in sidebar-item-icon.styles.ts (not needed unless accessing theme) 
- added centered option, to allow centering of the sidebar item's contents 
- use @redis-ui/icons RedisLogoDarkMinIcon icon

Before:
<img width="271" height="248" alt="image" src="https://github.com/user-attachments/assets/f8cf46de-c3e8-4bd2-9404-0bdcd4f77576" />



After:
<img width="318" height="387" alt="image" src="https://github.com/user-attachments/assets/3885e1eb-c394-40a2-84de-7b77ca5e32a5" />
