### PR TITLE
RI-7531: Error handling for "payload too large"

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -112,6 +112,14 @@ export default {
     excludeRoutes: [],
     excludeAuthRoutes: [],
     databaseManagement: process.env.RI_DATABASE_MANAGEMENT !== 'false',
+    maxPayloadSize: process.env.RI_MAX_PAYLOAD_SIZE || '512MB',
+    cors: {
+      origin: process.env.RI_CORS_ORIGIN
+        ? process.env.RI_CORS_ORIGIN
+        : '*',
+      credentials:
+        process.env.RI_CORS_CREDENTIALS === 'true',
+    },
   },
   statics: {
     initDefaults: process.env.RI_STATICS_INIT_DEFAULTS

--- a/redisinsight/api/src/common/middlewares/body-parser.middleware.ts
+++ b/redisinsight/api/src/common/middlewares/body-parser.middleware.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express';
+import { PayloadTooLargeException, HttpStatus } from '@nestjs/common';
+import { Config, get } from 'src/utils';
+
+const serverConfig = get('server') as Config['server'];
+
+interface BodyParserError extends Error {
+  type?: 'entity.too.large';
+}
+
+export default (
+  err: BodyParserError,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (err.type === 'entity.too.large') {
+    const exception = new PayloadTooLargeException(
+      `The request is too large. Maximum allowed size is ${serverConfig.maxPayloadSize}`,
+    );
+
+    return res
+      .status(HttpStatus.PAYLOAD_TOO_LARGE)
+      .set('Access-Control-Allow-Origin', serverConfig.cors.origin)
+      .set('Access-Control-Allow-Credentials', `${serverConfig.cors.credentials}`)
+      .json(exception.getResponse());
+  }
+
+  next(err);
+};

--- a/redisinsight/api/src/main.ts
+++ b/redisinsight/api/src/main.ts
@@ -10,6 +10,7 @@ import {
   NestApplicationOptions,
 } from '@nestjs/common';
 import * as bodyParser from 'body-parser';
+import bodyParserMiddleware from 'src/common/middlewares/body-parser.middleware';
 import { GlobalExceptionFilter } from 'src/exceptions/global-exception.filter';
 import { get, Config } from 'src/utils';
 import { migrateHomeFolder, removeOldFolders } from 'src/init-helper';
@@ -59,8 +60,12 @@ export default async function bootstrap(apiPort?: number): Promise<IApp> {
   app.useGlobalFilters(new GlobalExceptionFilter(app.getHttpAdapter()));
   // set qs as parser to support nested objects in the query string
   app.set('query parser', qs.parse);
-  app.use(bodyParser.json({ limit: '512mb' }));
-  app.use(bodyParser.urlencoded({ limit: '512mb', extended: true }));
+  app.use(bodyParser.json({ limit: serverConfig.maxPayloadSize }));
+  app.use(bodyParser.urlencoded({
+    limit: serverConfig.maxPayloadSize,
+    extended: true,
+  }));
+  app.use(bodyParserMiddleware);
   app.enableCors();
 
   if (


### PR DESCRIPTION
Adds handler for body-parser "payload too large" error to be returned with 413 http status code and with proper error message (cors part of this PR)

|Before|After|
|-|-|
<img width="686" height="132" alt="Screenshot 2025-09-29 at 12 36 49" src="https://github.com/user-attachments/assets/a5bfe181-06c6-400a-8ce3-d3b81c3da863" />|<img width="679" height="124" alt="Screenshot 2025-09-29 at 12 37 18" src="https://github.com/user-attachments/assets/70180f75-0abf-4e26-a422-bb091f39620a" />
