### PR TITLE
RI-7530 Update visuals of the Commands Helper filter in the cli panel

### DIFF
--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/CHSearchFilter.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/CHSearchFilter.tsx
@@ -6,7 +6,7 @@ import { GROUP_TYPES_DISPLAY } from 'uiSrc/constants'
 import { appRedisCommandsSelector } from 'uiSrc/slices/app/redis-commands'
 import { cliSettingsSelector } from 'uiSrc/slices/cli/cli-settings'
 import { Text } from 'uiSrc/components/base/text'
-
+import { Row } from 'uiSrc/components/base/layout/flex'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import styles from './styles.module.scss'
@@ -79,13 +79,13 @@ const CHSearchFilter = ({ submitFilter, isLoading }: Props) => {
         options={options}
         allowReset
         placeholder={
-          <div role="presentation">
+          <Row role="presentation">
             <RiIcon
               type="FilterIcon"
               data-testid="filter-option--group-type-default"
               className={styles.controlsIcon}
             />
-          </div>
+          </Row>
         }
         value={typeSelected}
         data-testid="select-filter-group-type"

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/styles.module.scss
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/styles.module.scss
@@ -1,45 +1,5 @@
 .container {
   height: 36px;
-  width: 180px;
-
-  :global {
-    .euiFormControlLayout {
-      .euiSuperSelectControl {
-        height: 36px !important;
-        padding: 0 8px !important;
-        background-color: var(--euiColorLightShade) !important;
-        border-color: var(--euiColorLightShade) !important;
-        box-shadow: none !important;
-
-        .euiHealth {
-          margin-top: 10px;
-          margin-left: -5px;
-        }
-
-        &.euiSuperSelect--isOpen__button {
-          background-color: var(--euiColorLightShade) !important;
-        }
-        &:focus {
-          background-color: var(--euiColorLightShade) !important;
-        }
-      }
-    }
-
-    .euiPopover:not(.euiSuperSelect) {
-      position: absolute;
-      z-index: 10;
-      top: 7px;
-      right: 88px;
-
-      svg {
-        width: 24px !important;
-        height: 24px !important;
-      }
-    }
-    .euiFormControlLayoutIcons {
-      right: 80px;
-    }
-  }
 }
 
 .filterKeyType {
@@ -49,9 +9,9 @@
 
 .controlsIcon {
   cursor: pointer;
-  margin-left: 3px;
   height: 20px !important;
   width: 20px !important;
+  
   &:global(svg) {
     color: var(--inputTextColor) !important;
   }


### PR DESCRIPTION
# Description

Update the visuals of the **Filter** select in the **Commands Helper** panel to look more like the previous version before the EUI replacement:
- align the icons
- make the **Filter** select width shorter to make more room for the **Search** input

| No FIlter | With Filter |
| - | - |
<img width="358" height="269" alt="image" src="https://github.com/user-attachments/assets/dac7a2b7-0649-4392-979a-102bae0b5d1d" />|<img width="358" height="269" alt="image" src="https://github.com/user-attachments/assets/3a025b62-99a5-4e08-8b05-c9328973b120" />

# How it was tested

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Open the **Command Helper** from the bottom of the screen

Now, you can see the **Filter** select and the **Search** input, and how they fill the spacing together

_Note: You can also open the CLI and the Profiler alongside it, to see how they blend together_

| Old | Before | After |
| - | - | - |
| No FIlter | - | - |
<img alt="Screenshot 2025-10-02 at 9 13 58" src="https://github.com/user-attachments/assets/59441d5a-e5b0-4b58-9711-22df7095b287" />|<img alt="image" src="https://github.com/user-attachments/assets/15109fb2-1ac2-42bd-b215-223db1b7ef31" />|<img alt="image" src="https://github.com/user-attachments/assets/ca1ed5d6-97e2-442d-a66e-c92682c06272" />
| With FIlter | - | - |
<img alt="Screenshot 2025-10-02 at 9 16 01" src="https://github.com/user-attachments/assets/86616e6c-066a-45c2-badc-cc63562db14d" />|<img alt="Screenshot 2025-10-02 at 9 16 33" src="https://github.com/user-attachments/assets/3486cee8-b11b-47ec-84e6-255d8b0ab666" />|<img alt="image" src="https://github.com/user-attachments/assets/08b914df-96ce-495c-98d6-96264a347a90" />
