### PR TITLE
RI-7618: make entry id input looks the same as other inputs on the form

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
@@ -149,7 +149,6 @@ const StreamEntryFields = (props: Props) => {
             onChange={handleEntryIdChange}
             onBlur={onEntryIdBlur}
             onFocus={() => setIsEntryIdFocused(true)}
-            valid={!entryIdError}
             autoComplete="off"
             data-testid={config.entryId.id}
           />


### PR DESCRIPTION
|Before|After|
|-|-|
<img width="926" height="758" alt="Screenshot 2025-10-07 at 16 36 22" src="https://github.com/user-attachments/assets/74fb3e43-ea45-4d74-b9ed-204ef11c3e1f" />|<img width="917" height="751" alt="Screenshot 2025-10-07 at 16 36 13" src="https://github.com/user-attachments/assets/3ef9df47-67a6-4891-bf77-882b3570c9e0" />
<img width="928" height="757" alt="Screenshot 2025-10-07 at 16 36 28" src="https://github.com/user-attachments/assets/be774bb4-845a-41ff-b6af-31622e138b71" />|<img width="924" height="759" alt="Screenshot 2025-10-07 at 16 36 06" src="https://github.com/user-attachments/assets/404fc486-2022-4dd5-a002-a0b146e72049" />

