### PR TITLE
RI-7496 Diff executed commands telemetry by their type (Workbench/Search)

### DIFF
--- a/redisinsight/api/src/constants/telemetry-events.ts
+++ b/redisinsight/api/src/constants/telemetry-events.ts
@@ -61,6 +61,7 @@ export enum TelemetryEvents {
 
   // Events for search tool
   SearchCommandExecuted = 'SEARCH_COMMAND_EXECUTED',
+  SearchIndexInfoSubmitted = 'SEARCH_INDEX_INFO_SUBMITTED',
   SearchCommandErrorReceived = 'SEARCH_COMMAND_ERROR_RECEIVED',
 
   // Custom tutorials

--- a/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.spec.ts
+++ b/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.spec.ts
@@ -118,6 +118,7 @@ describe('WorkbenchCommandsExecutor', () => {
         expect(mockAnalyticsService.sendIndexInfoEvent).toHaveBeenCalledWith(
           mockSessionMetadata,
           mockWorkbenchClientMetadata.databaseId,
+          CommandExecutionType.Workbench,
           mockFtInfoAnalyticsData,
         );
       });

--- a/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.ts
+++ b/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.ts
@@ -88,6 +88,7 @@ export class WorkbenchCommandsExecutor {
         this.analyticsService.sendIndexInfoEvent(
           client.clientMetadata.sessionMetadata,
           client.clientMetadata.databaseId,
+          dto.type,
           getAnalyticsDataFromIndexInfo(response as string[]),
         );
       }

--- a/redisinsight/api/src/modules/workbench/workbench.analytics.spec.ts
+++ b/redisinsight/api/src/modules/workbench/workbench.analytics.spec.ts
@@ -82,10 +82,15 @@ describe('WorkbenchAnalytics', () => {
   });
 
   describe('sendIndexInfoEvent', () => {
-    it('should emit index info event', async () => {
-      service.sendIndexInfoEvent(mockSessionMetadata, instanceId, {
-        any: 'fields',
-      });
+    it('should emit index info event for Workbench commands', async () => {
+      service.sendIndexInfoEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Workbench,
+        {
+          any: 'fields',
+        },
+      );
 
       expect(sendEventMethod).toHaveBeenCalledWith(
         mockSessionMetadata,
@@ -96,8 +101,32 @@ describe('WorkbenchAnalytics', () => {
         },
       );
     });
+    it('should emit index info event for Search commands', async () => {
+      service.sendIndexInfoEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Search,
+        {
+          any: 'fields',
+        },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.SearchIndexInfoSubmitted,
+        {
+          databaseId: instanceId,
+          any: 'fields',
+        },
+      );
+    });
     it('should not fail and should not emit when no data to send', async () => {
-      service.sendIndexInfoEvent(mockSessionMetadata, instanceId, null);
+      service.sendIndexInfoEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Workbench,
+        null,
+      );
 
       expect(sendEventMethod).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
# Description

Differentiate the executed commands telemetry by their type (Workbench/Search).
Currently, when running commands from the Search page, you see logged telemetry related to the Workbench page.

| Before | After |
| - | - |
<img alt="image" src="https://github.com/user-attachments/assets/6d1ea041-7db0-4fbf-888b-14e960f9dc19" />|<img alt="2025-10-09_10-27" src="https://github.com/user-attachments/assets/6517306a-5292-4e7b-8576-495e7925dc92" />

# How it was tested

1. Open Redis Insight 
2. Go to **Databases** and open a connection to an existing database instance, or create a new one
3. Go to the **Search** tab from the main navbar
4. Type in a query in the editor, like FT._LIST, and execute it via the “Run” button 

There should be telemetry events related to Vector Search only.

<img width="1096" height="510" alt="2025-10-09_10-27" src="https://github.com/user-attachments/assets/e749e3f9-daf5-4ac3-983c-8021133709f6" />

## Notes

### Update other telemetry events as well

The same logic applies to a few more custom telemetry events that we collect, so the same change applies to them as well.

| Before | After |
| - | - |
<img width="1120" height="232" alt="2025-10-09_13-27" src="https://github.com/user-attachments/assets/1958b250-f9d9-428d-b3e4-16f662e417bb" />|<img width="1092" height="234" alt="2025-10-09_13-31" src="https://github.com/user-attachments/assets/e5c5ae38-da07-4c74-ab70-d60dbf2174a5" />


### Workbench is still operational

It still works fine from the Workbench page as well.

<img width="1026" height="360" alt="2025-10-09_10-28" src="https://github.com/user-attachments/assets/7fdecb61-b4d3-466a-adeb-74b40eb478cd" />
