### PR TITLE
RI-7635 Added feature flag for the search tab in the navigation

### DIFF
--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { Props as HighlightedFeatureProps } from 'uiSrc/components/hightlighted-feature/HighlightedFeature'
 import { ANALYTICS_ROUTES } from 'uiSrc/components/main-router/constants/sub-routes'
 import {
+  appFeatureFlagsFeaturesSelector,
   appFeaturePagesHighlightingSelector,
   removeFeatureFromHighlighting,
 } from 'uiSrc/slices/app/features'
@@ -47,6 +48,9 @@ export function useNavigation() {
     connectedRdiInstanceSelector,
   )
   const highlightedPages = useSelector(appFeaturePagesHighlightingSelector)
+  const { [FeatureFlags.vectorSearch]: vectorSearchFeature } = useSelector(
+    appFeatureFlagsFeaturesSelector,
+  )
 
   const isRdiWorkspace = workspace === AppWorkspace.RDI
 
@@ -95,7 +99,7 @@ export function useNavigation() {
       iconType: BrowserIcon,
       onboard: ONBOARDING_FEATURES.BROWSER_PAGE,
     },
-    {
+    vectorSearchFeature?.flag && {
       tooltipText: 'Search',
       pageName: PageNames.vectorSearch,
       ariaLabel: 'Search',
@@ -139,7 +143,7 @@ export function useNavigation() {
       onboard: ONBOARDING_FEATURES.PUB_SUB_PAGE,
       featureFlag: FeatureFlags.envDependent,
     },
-  ]
+  ].filter((tab) => !!tab) as INavigations[]
 
   const privateRdiRoutes: INavigations[] = [
     {


### PR DESCRIPTION
# Description

Add a feature flag to toggle the presence of the Search tab in the main navigation.

_PS: Currently, it's disabled._

<img width="916" height="743" alt="2025-10-13_12-44" src="https://github.com/user-attachments/assets/af5a05a4-d3f4-47a8-9f97-046a87848845" />

# How it was tested

1. Open Redis Insight
2. Go to **Databases** and open a connection to an existing database instance, or create a new one

Check the main navigation, the **Search** page shouldn't be there.

If you want to disable the feature flag, you can simply toggle its value in SQLite, manually:

1. GO to `features_config` table
2. Toggle the flag
```
"vectorSearch":{
  "flag": false,"
  perc": [[0,100]]
}
```