### PR TITLE
RI-7450: make buttons inside file picker clickable

### DIFF
--- a/redisinsight/ui/src/components/base/forms/file-picker/RiFilePicker.tsx
+++ b/redisinsight/ui/src/components/base/forms/file-picker/RiFilePicker.tsx
@@ -2,10 +2,12 @@ import React, { InputHTMLAttributes, ReactNode, useRef, useState } from 'react'
 import cx from 'classnames'
 import { useGenerateId } from 'uiSrc/components/base/utils/hooks/generate-id'
 import { Loader } from 'uiSrc/components/base/display'
-import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
+import {
+  EmptyButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
 import { RiIcon } from 'uiSrc/components/base/icons'
 import {
-  FilePickerClearButton,
   FilePickerInput,
   FilePickerPrompt,
   FilePickerPromptText,
@@ -135,14 +137,14 @@ export const RiFilePicker = ({
       )
     } else {
       clearButton = (
-        <FilePickerClearButton
+        <EmptyButton
           aria-label="Remove selected files"
           className="RI-File-Picker__clearButton"
           size="small"
           onClick={removeFiles}
         >
           <ColorText color="default">Remove</ColorText>
-        </FilePickerClearButton>
+        </EmptyButton>
       )
     }
   } else {

--- a/redisinsight/ui/src/components/base/forms/file-picker/styles.tsx
+++ b/redisinsight/ui/src/components/base/forms/file-picker/styles.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-nested-template-literals */
 import styled, { css } from 'styled-components'
 import React, { forwardRef, InputHTMLAttributes } from 'react'
-import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
 import { Text } from 'uiSrc/components/base/text'
 
 type FilePickerWrapperProps = InputHTMLAttributes<HTMLDivElement> & {
@@ -79,8 +78,9 @@ export const FilePickerPrompt = styled.div<FilePickerWrapperProps>`
   ${promptPadding}
 
   ${({ $large }) => ($large ? promptLarge : promptDefault)}
-`
-
-export const FilePickerClearButton = styled(EmptyButton)`
-  pointer-events: auto; /* Undo the pointer-events: none applied to the enclosing prompt */
+  /* Ensure inner buttons are clickable above the FilePickerInput */
+  button {
+    pointer-events: auto;
+    z-index: 1;
+  }
 `


### PR DESCRIPTION
# Description

Issue: Current FilePicker component is invisible and spreads over the whole area, making inner child buttons unclickable

Solution: add z-index and pointer events to inner buttons

## Before

https://github.com/user-attachments/assets/669d079c-29e5-4cb4-8750-cc6798579668

## After

https://github.com/user-attachments/assets/2cd207f2-dc4d-4506-a515-6709831e8bae