### PR TITLE
RI-7638 Set default delay for all tooltips

### DIFF
--- a/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
@@ -21,7 +21,7 @@ export const RiTooltip = ({
   title,
   content,
   position,
-  delay,
+  delay = 250,
   anchorClassName,
   ...props
 }: RiTooltipProps) => (


### PR DESCRIPTION
# Description

Set default delay for all tooltips.

_Note: Using the delay that is used by default in EUI._ ([ref](https://github.com/elastic/eui/blob/d788096bb2cc8dc40a9827b1503679f270ceb7d4/packages/eui/src/components/tool_tip/tool_tip.tsx#L37))

## Before

https://github.com/user-attachments/assets/1a99c245-7bf5-40dd-9d09-6797cd636c79

## After
https://github.com/user-attachments/assets/1e7b4ef4-2581-4b91-8289-445cd07f1417

# How it was tested

1. Go to **Databases** and open an existing database, or establish connection to a new database instance
2. Scroll over the keys in the **Browser**
3. Go to **Workbench** and hover over the actions in the Commands Results

All tooltips should appear slightly slower compared to previously.