### PR TITLE
RI-7449: show cluster node host

### DIFF
--- a/redisinsight/ui/src/pages/cluster-details/components/cluser-nodes-table/ClusterNodesTable.tsx
+++ b/redisinsight/ui/src/pages/cluster-details/components/cluser-nodes-table/ClusterNodesTable.tsx
@@ -49,7 +49,7 @@ const ClusterNodesTable = ({
       enableSorting: true,
       cell: ({
         row: {
-          original: { letter, port, color },
+          original: { letter, port, color, host },
         },
       }) => (
         <>
@@ -63,7 +63,7 @@ const ClusterNodesTable = ({
               {letter}
             </span>
             <span>
-              {letter}:{port}
+              {host}:{port}
             </span>
           </div>
         </>


### PR DESCRIPTION
### Description

| Before | After |
| --- | --- |
| <img width="198" height="123" alt="Screenshot 2025-10-20 at 17 30 08" src="https://github.com/user-attachments/assets/6b082ada-7dc6-415c-be92-a9ef34812f25" /> |  <img width="214" height="138" alt="Screenshot 2025-10-20 at 17 30 37" src="https://github.com/user-attachments/assets/2493c837-85ce-4445-a65b-350333a46a6e" /> |