### PR TITLE
Escape special characters in Monaco tokens and fix black screen in application

### DIFF
--- a/redisinsight/ui/src/utils/monaco/monacoRedisMonarchTokensProvider.ts
+++ b/redisinsight/ui/src/utils/monaco/monacoRedisMonarchTokensProvider.ts
@@ -5,6 +5,8 @@ import { IRedisCommand } from 'uiSrc/constants'
 
 const STRING_DOUBLE = 'string.double'
 
+const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 export const getRedisMonarchTokensProvider = (
   commands: IRedisCommand[],
 ): monacoEditor.languages.IMonarchLanguage => {
@@ -12,8 +14,8 @@ export const getRedisMonarchTokensProvider = (
   const searchCommands = remove(commandRedisCommands, ({ token }) =>
     token?.startsWith(ModuleCommandPrefix.RediSearch),
   )
-  const COMMON_COMMANDS_REGEX = `^\\s*(\\d+\\s+)?(${commandRedisCommands.map(({ token }) => token).join('|')})\\b`
-  const SEARCH_COMMANDS_REGEX = `^\\s*(\\d+\\s+)?(${searchCommands.map(({ token }) => token).join('|')})\\b`
+  const COMMON_COMMANDS_REGEX = `^\\s*(\\d+\\s+)?(${commandRedisCommands.map(({ token }) => escapeRegex(token || '')).join('|')})\\b`
+  const SEARCH_COMMANDS_REGEX = `^\\s*(\\d+\\s+)?(${searchCommands.map(({ token }) => escapeRegex(token || '')).join('|')})\\b`
 
   return {
     defaultToken: '',

--- a/redisinsight/ui/src/utils/monaco/monarchTokens/redisearchTokensTemplates.ts
+++ b/redisinsight/ui/src/utils/monaco/monarchTokens/redisearchTokensTemplates.ts
@@ -3,6 +3,9 @@ import { curryRight } from 'lodash'
 import { Maybe } from 'uiSrc/utils'
 import { IRedisCommand } from 'uiSrc/constants'
 
+// Escape special regex characters in tokens
+const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const appendToken = (token: string, name: Maybe<string>) =>
   name ? `${token}.${name}` : token
 export const generateQuery = (
@@ -17,7 +20,7 @@ export const generateQuery = (
   ): languages.IMonarchLanguageRule =>
     args?.length
       ? [
-          `(${args?.map(({ token }) => token).join('|')})\\b`,
+          `(${args?.map(({ token }) => escapeRegex(token || '')).join('|')})\\b`,
           { token: 'function', next: appendTokenName(tokenName) },
         ]
       : [/_/, '']

--- a/redisinsight/ui/src/utils/monaco/redisearch/utils.ts
+++ b/redisinsight/ui/src/utils/monaco/redisearch/utils.ts
@@ -5,6 +5,8 @@ import { generateQuery } from 'uiSrc/utils/monaco/monarchTokens/redisearchTokens
 import { ICommandTokenType, IRedisCommand } from 'uiSrc/constants'
 import { DefinedArgumentName } from 'uiSrc/pages/workbench/constants'
 
+const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 export const generateKeywords = (commands: IRedisCommand[]) =>
   commands.map(({ name }) => name)
 export const generateTokens = (
@@ -153,7 +155,7 @@ export const getBlockTokens = (
 
     if (tokensWithNextExpression.length) {
       result.push([
-        `(${tokensWithNextExpression.map(({ token }) => token).join('|')})\\b`,
+        `(${tokensWithNextExpression.map(({ token }) => escapeRegex(token || '')).join('|')})\\b`,
         {
           token: `argument.block.${lvl}.${name}`,
           next: '@query',
@@ -163,7 +165,7 @@ export const getBlockTokens = (
 
     if (restTokens.length) {
       result.push([
-        `(${restTokens.map(({ token }) => token).join('|')})\\b`,
+        `(${restTokens.map(({ token }) => escapeRegex(token || '')).join('|')})\\b`,
         { token: `argument.block.${lvl}.${name}`, next: '@root' },
       ])
     }


### PR DESCRIPTION
An `escapeRegex` utility has been added and applied to all locations where command tokens are used to generate regex patterns in Monaco's token providers.
This prevents issues with tokens containing special regex characters.

Additionally, this fix prevents the application from displaying a black screen when accessed.

Related issues reporting the issue:

* [[#5080](https://github.com/redis/RedisInsight/issues/5080)](https://github.com/redis/RedisInsight/issues/5080)
* [[#5081](https://github.com/redis/RedisInsight/issues/5081)](https://github.com/redis/RedisInsight/issues/5081)
* [[#5082](https://github.com/redis/RedisInsight/issues/5082)](https://github.com/redis/RedisInsight/issues/5082)
* [[#5083](https://github.com/redis/RedisInsight/issues/5083)](https://github.com/redis/RedisInsight/issues/5083)
* [[#5084](https://github.com/redis/RedisInsight/issues/5084)](https://github.com/redis/RedisInsight/issues/5084)
