### PR TITLE
RI-7663 Prevent the app from crashing when Redis commands are not parsable

### DIFF
--- a/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
+++ b/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
@@ -67,14 +67,18 @@ const MonacoLanguages = () => {
       name?.startsWith(ModuleCommandPrefix.RediSearch),
     )
 
-    monaco.languages.setMonarchTokensProvider(
-      MonacoLanguage.RediSearch,
-      getRediSearchSubRedisMonarchTokensProvider(REDIS_SEARCH_COMMANDS),
-    )
-    monaco.languages.setMonarchTokensProvider(
-      MonacoLanguage.Redis,
-      getRedisMonarchTokensProvider(REDIS_COMMANDS),
-    )
+    try {
+      monaco.languages.setMonarchTokensProvider(
+        MonacoLanguage.RediSearch,
+        getRediSearchSubRedisMonarchTokensProvider(REDIS_SEARCH_COMMANDS),
+      )
+      monaco.languages.setMonarchTokensProvider(
+        MonacoLanguage.Redis,
+        getRedisMonarchTokensProvider(REDIS_COMMANDS),
+      )
+    } catch (exception) {
+      console.error('Monaco languages setup error: ', exception)
+    }
   }
 
   return null


### PR DESCRIPTION
# Description 

Prevent the app from crashing when Redis commands are not parsable

| Before | After |
| - | - |
<img width="1468" height="830" alt="image" src="https://github.com/user-attachments/assets/6df12216-4320-48a5-8be0-25a919270264" />|<img width="1663" height="742" alt="image" src="https://github.com/user-attachments/assets/d32a267d-9cfc-4558-912d-7b36be021d92" />

# Root Cause Analysis

We fetch all the available Redis commands and provide autocomplete intelligence in the Monco editor on the Workbench page. And we do get all of this information from external sources. A recent change in the RediSearch repository caused our app to crash because we can't parse the new command properly. With this pull request, we aim to improve the handling of these commands and simply disable the autocomplete feature, instead of causing the whole application to crash.