### PR TITLE
RI-7663 Split setup for the supported commands by the monaco editor

### DIFF
--- a/redisinsight/ui/src/components/monaco-editor/components/dedicated-editor/DedicatedEditor.tsx
+++ b/redisinsight/ui/src/components/monaco-editor/components/dedicated-editor/DedicatedEditor.tsx
@@ -210,10 +210,17 @@ const DedicatedEditor = (props: Props) => {
         selectedLang.completionProvider?.(keywords, functions)!,
       ).dispose
 
-    monaco.languages.setMonarchTokensProvider(
-      selectedLang.language,
-      selectedLang.tokensProvider?.(keywords, functions)!,
-    )
+    try {
+      monaco.languages.setMonarchTokensProvider(
+        selectedLang.language,
+        selectedLang.tokensProvider?.(keywords, functions)!,
+      )
+    } catch (exception) {
+      console.error(
+        `Monaco ${selectedLang.language} language setup error: `,
+        exception,
+      )
+    }
   }
 
   const onChangeLanguageSelect = (id: string) => {

--- a/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
+++ b/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
@@ -72,12 +72,17 @@ const MonacoLanguages = () => {
         MonacoLanguage.RediSearch,
         getRediSearchSubRedisMonarchTokensProvider(REDIS_SEARCH_COMMANDS),
       )
+    } catch (exception) {
+      console.error('Monaco RediSearch language setup error: ', exception)
+    }
+
+    try {
       monaco.languages.setMonarchTokensProvider(
         MonacoLanguage.Redis,
         getRedisMonarchTokensProvider(REDIS_COMMANDS),
       )
     } catch (exception) {
-      console.error('Monaco languages setup error: ', exception)
+      console.error('Monaco Redis language setup error: ', exception)
     }
   }
 


### PR DESCRIPTION
# Description

Split the setup for the different commands supported by the Monaco editor, in case only one of them fails for some reason, so it does not affect the other, as advised [here](https://github.com/redis/RedisInsight/pull/5095#discussion_r2447569302).

