### PR TITLE
RI-7588: Fix UTM params in Cloud SSO flows

### DIFF
--- a/redisinsight/ui/src/slices/interfaces/cloud.ts
+++ b/redisinsight/ui/src/slices/interfaces/cloud.ts
@@ -122,5 +122,7 @@ export enum CloudSsoUtmCampaign {
   Copilot = 'copilot',
   UserProfile = 'user_account',
   Settings = 'settings',
+  NavigationMenu = 'navigation_menu',
+  AddDbForm = 'add_db_form',
   Unknown = 'other',
 }

--- a/redisinsight/ui/src/utils/oauth/cloudSsoUtm.tsx
+++ b/redisinsight/ui/src/utils/oauth/cloudSsoUtm.tsx
@@ -6,6 +6,7 @@ export const getCloudSsoUtmCampaign = (
 ): CloudSsoUtmCampaign => {
   switch (source) {
     case OAuthSocialSource.ListOfDatabases:
+    case OAuthSocialSource.DatabaseConnectionList:
       return CloudSsoUtmCampaign.ListOfDatabases
     case OAuthSocialSource.BrowserSearch:
       return CloudSsoUtmCampaign.BrowserSearch
@@ -32,6 +33,10 @@ export const getCloudSsoUtmCampaign = (
       return CloudSsoUtmCampaign.UserProfile
     case OAuthSocialSource.SettingsPage:
       return CloudSsoUtmCampaign.Settings
+    case OAuthSocialSource.NavigationMenu:
+      return CloudSsoUtmCampaign.NavigationMenu
+    case OAuthSocialSource.AddDbForm:
+      return CloudSsoUtmCampaign.AddDbForm
     default:
       return CloudSsoUtmCampaign.Unknown
   }

--- a/redisinsight/ui/src/utils/tests/oauth/cloudSsoUtm.spec.tsx
+++ b/redisinsight/ui/src/utils/tests/oauth/cloudSsoUtm.spec.tsx
@@ -3,6 +3,10 @@ import { CloudSsoUtmCampaign, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 
 const getCloudSsoUtmCampaignTestCases = [
   [OAuthSocialSource.ListOfDatabases, CloudSsoUtmCampaign.ListOfDatabases],
+  [
+    OAuthSocialSource.DatabaseConnectionList,
+    CloudSsoUtmCampaign.ListOfDatabases,
+  ],
   [OAuthSocialSource.BrowserSearch, CloudSsoUtmCampaign.BrowserSearch],
   [OAuthSocialSource.RediSearch, CloudSsoUtmCampaign.Workbench],
   [OAuthSocialSource.RedisJSON, CloudSsoUtmCampaign.Workbench],
@@ -14,6 +18,8 @@ const getCloudSsoUtmCampaignTestCases = [
   [OAuthSocialSource.WelcomeScreen, CloudSsoUtmCampaign.WelcomeScreen],
   [OAuthSocialSource.Tutorials, CloudSsoUtmCampaign.Tutorial],
   [OAuthSocialSource.Autodiscovery, CloudSsoUtmCampaign.AutoDiscovery],
+  [OAuthSocialSource.NavigationMenu, CloudSsoUtmCampaign.NavigationMenu],
+  [OAuthSocialSource.AddDbForm, CloudSsoUtmCampaign.AddDbForm],
   [null, CloudSsoUtmCampaign.Unknown],
   [undefined, CloudSsoUtmCampaign.Unknown],
 ]


### PR DESCRIPTION
# Fix UTM params in Cloud SSO flows

## Problem
When creating a cloud database from the following sources:

1. navigation menu
2. add db form
3. database connection list

| 1 | 2 |
| --- | --- |
| <img width="964" height="1360" alt="image" src="https://github.com/user-attachments/assets/7867c471-8d8e-4ff3-bb31-9f89e4d8f60f" /> | <img width="1286" height="994" alt="image" src="https://github.com/user-attachments/assets/ea2a65d2-e197-47b8-96b1-f9158b4850c2" /> |

The campaign is not set to the appropriate value to the source. We are getting 'other' (unknown). 

## Solution

The fix is applied so the following are set:

| source | campaign|
| --- | --- |
| database connection list | list_of_databases |
| navigation menu | navigation_menu |
| add db form | add_db_form |

## Test

1. Download and install this manual build https://github.com/redis/RedisInsight/actions/runs/18778738361, which include the changes in this branch + logging the campaign `params <campaign>`
2. Start SSO flow from one of the sources described above
3. This is logged during authentication, so be sure to log out after each create db flow
4. You may need to close the app and open again

_This is needed because SSO flow cannot be completed by local dev setup_