### PR TITLE
fix(test): update deprecated docker image

### DIFF
--- a/tests/e2e/rte/oss-standalone-tls/Dockerfile
+++ b/tests/e2e/rte/oss-standalone-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/redis:6.0.8
+FROM bitnamilegacy/redis:6.0.8
 
 ENV ALLOW_EMPTY_PASSWORD yes
 


### PR DESCRIPTION
# Description

All `bitnami` Docker images were deprecated, so we do migrate temporarily to the `bitnamilegacy` namespace.

`target oss-standalone-tls: failed to solve: bitnami/redis:6.0.8: failed to resolve source metadata for docker.io/bitnami/redis:6.0.8: docker.io/bitnami/redis:6.0.8: not found`

# How it was tested

1. Go to `/tests/e2e/`
2. Run the following Docker container and expect it to start properly

```
docker-compose -f rte.regression.docker-compose.yml -f rte.networks.docker-compose.yml -f vpn.docker-compose.yml up
```