### PR TITLE
RI-7557: fix rdi job name validation when schema is missing

### DIFF
--- a/redisinsight/ui/src/components/yaml-validator/validatePipeline.ts
+++ b/redisinsight/ui/src/components/yaml-validator/validatePipeline.ts
@@ -41,7 +41,7 @@ export const validatePipeline = ({
         validation.errors.forEach((error) => acc.jobsErrors[j.name].add(error))
       }
 
-      if (!jobNameValidation.valid) {
+      if (jobNameSchema && !jobNameValidation.valid) {
         jobNameValidation.errors.forEach((error) =>
           acc.jobsErrors[j.name].add(error),
         )


### PR DESCRIPTION
### Description

I have this [schema](https://gist.github.com/KrumTy/0616fa387e8401da010a8fd98429d4bd#file-rid-schema-json-L750), returned by RDI instance (v1.6.0)
It is missing `jobs.properties.name` prop, required for job name schema [here](https://github.com/redis/RedisInsight/blob/main/redisinsight/ui/src/slices/rdi/pipeline.ts#L437)
And thus it marked the job as invalid, since the schema is `null`.
Note: there is already a job name schema for validating in this rdi schema response that is being taken into account ([source](https://gist.github.com/KrumTy/0616fa387e8401da010a8fd98429d4bd#file-rid-schema-json-L926))

Solution: if schema is null, skip this job name check.

| Before | After |
| --- | --- |
| <img width="630" height="495" alt="Screenshot 2025-10-24 at 18 00 11" src="https://github.com/user-attachments/assets/6fdb577a-f404-4d48-97d6-db3f613d7e94" /> | <img width="557" height="409" alt="Screenshot 2025-10-24 at 17 59 59" src="https://github.com/user-attachments/assets/65d511a2-6ea1-4dd1-9ce0-80ad855d3ed4" /> |