### PR TITLE
Expose router history

### DIFF
--- a/redisinsight/ui/src/Router.tsx
+++ b/redisinsight/ui/src/Router.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { BrowserRouter } from 'react-router-dom'
+import { Router as ReactRouter } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
 
 interface Props {
   children: React.ReactElement
@@ -13,8 +14,10 @@ if (RIPROXYPATH !== '') {
   MOUNT_PATH = RIPROXYPATH
 }
 
+export const history = createBrowserHistory({ basename: MOUNT_PATH })
+
 const Router = ({ children }: Props) => (
-  <BrowserRouter basename={MOUNT_PATH}>{children}</BrowserRouter>
+  <ReactRouter history={history}>{children}</ReactRouter>
 )
 
 export default Router

--- a/redisinsight/ui/src/slices/store.ts
+++ b/redisinsight/ui/src/slices/store.ts
@@ -1,4 +1,3 @@
-import { createBrowserHistory } from 'history'
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
 
 import { getConfig } from 'uiSrc/config'
@@ -58,8 +57,6 @@ import appDbSettingsReducer from './app/db-settings'
 import tagsReducer from './instances/tags'
 
 const riConfig = getConfig()
-
-export const history = createBrowserHistory()
 
 export const rootReducer = combineReducers({
   app: combineReducers({
@@ -149,7 +146,9 @@ const store = configureStore({
   devTools: riConfig.app.env !== 'production',
 })
 
-export { store }
+const dispatch = store.dispatch
+
+export { store, dispatch }
 
 export type ReduxStore = typeof store
 export type RootState = ReturnType<typeof rootReducer>

--- a/redisinsight/ui/src/utils/test-store.ts
+++ b/redisinsight/ui/src/utils/test-store.ts
@@ -1,11 +1,8 @@
-import { createBrowserHistory } from 'history'
-
 import type { ReduxStore } from 'uiSrc/slices/store'
 
 // Re-export all types and exports from the real store to avoid circular dependencies during tests
 
 export type { RootState, AppDispatch, ReduxStore } from 'uiSrc/slices/store'
-export const history = createBrowserHistory()
 
 // Lazy reference to avoid circular dependencies
 // The store will be set by the store module itself after it's created


### PR DESCRIPTION
## Description 

Issue:
We currently cannot navigate outside of react lifecycle/hooks. E.g. if we want to navigate from a method, we need to call `const history = useHistory()` in a component and somehow pass the history as a prop.
Use case - we have a lot of cells in a table and we don't want to call useHistory for each one of them if we can access the object directly.

Solution:
- [BrowserRouter](https://v5.reactrouter.com/web/api/BrowserRouter) is wrapper over ReactRouter that sets up history under the hook, so the new implementation should behave identically, only we have access to the history object outside of react hooks
- history from the store and test-store was not used, so I removed those