### PR TITLE
RI-7659: Enhance RDI connection testing with per-source error handling

### DIFF
--- a/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
+++ b/redisinsight/api/src/modules/rdi/client/api.rdi.client.ts
@@ -225,24 +225,40 @@ export class ApiRdiClient extends RdiClient {
       throw wrapRdiPipelineError(error);
     }
 
-    try {
-      const sourceConfigs = Object.keys(config.sources || {});
+    const sourceConfigs = Object.keys(config.sources || {});
 
-      if (sourceConfigs.length) {
-        await Promise.all(
-          sourceConfigs.map(async (source) => {
-            const response = await this.client.post(
-              RdiUrl.TestSourcesConnections,
-              { ...config.sources[source] },
-            );
-            sources[source] = response.data;
-          }),
-        );
-      }
-    } catch (error) {
-      // failing is expected on RDI version below 1.6.0 (1.4.3 for example)
-      this.logger.error('Failed to fetch sources', error);
+    if (sourceConfigs.length === 0) {
+      return { targets, sources };
     }
+
+    await Promise.all(
+      sourceConfigs.map(async (source) => {
+        try {
+          const response = await this.client.post(
+            RdiUrl.TestSourcesConnections,
+            { ...config.sources[source] },
+          );
+          sources[source] = response.data;
+        } catch (error: any) {
+          // Older versions of RDI (below 1.6.0) don't support testing sources connections
+          // RDI returns 405 Method Not Allowed for non existing endpoints
+          const status = error?.status;
+          if (status === 405) {
+            sources[source] = {
+              connected: false,
+              error:
+                'Testing source connections is not supported in your RDI version. Please upgrade to version 1.6.0 or later.',
+            };
+          } else {
+            // Something went wrong with testing source connection
+            sources[source] = {
+              connected: false,
+              error: 'Failed to test source connection.',
+            };
+          }
+        }
+      }),
+    );
 
     return { targets, sources };
   }


### PR DESCRIPTION
# Description

Currently, there’s a bug that causes the connection check to appear as `successful 0`.
The expected outcome is either `successful 1` or `failed 1` - i.e., one definitive result per source.

<img width="447" height="459" alt="Screenshot 2025-10-30 at 13 28 02" src="https://github.com/user-attachments/assets/cfcb91d1-7a00-463c-b367-e86dac07f6a3" />


The root cause is missing backward compatibility handling. Specifically, there are a few scenarios that need to be covered:

- Older RDI versions (below 1.6.0) that don’t support testing source connections - the API returns `405`.
- Runtime errors on the RDI side - unrelated to the actual connection status.

This PR addresses these cases by:

- Handling errors per source instead of failing the whole batch.
- Returning meaningful error messages for unsupported RDI versions (405) or when some other error occurred.
- Ensuring that successful sources are still reported correctly, even if others fail.

# After

<img width="418" height="423" alt="Screenshot 2025-10-30 at 13 37 03" src="https://github.com/user-attachments/assets/0ff59424-5c3c-48e0-94dc-a5e8a36f574b" />

- `source2` - is an expected connection problem, so it's properly reported as failing
- `source` - is handled by the changes here, as RDI has a problem reporting the connection status (a.k.a. runtime error)

