### PR TITLE
RI-7691: Improve visual consistency in Profiler

### DIFF
--- a/redisinsight/ui/src/components/monitor/Monitor/styles.module.scss
+++ b/redisinsight/ui/src/components/monitor/Monitor/styles.module.scss
@@ -18,11 +18,6 @@
 
   z-index: 10;
   overflow: auto;
-
-  &.isRunning {
-    outline: 1px solid var(--euiColorPrimary);
-    border-top-color: transparent;
-  }
 }
 
 .listWrapper {


### PR DESCRIPTION
# What

Other windows (CLI, Commands, etc.) don’t use primary-colored borders. To maintain consistency, the Profiler’s border has been removed as well.

# Testing

1. Open the Profiler
2. Start it
3. Pay attention to the border color

## Screenshots

| Before    | After |
| -------- | ------- |
|  <img width="592" height="468" alt="Screenshot 2025-11-05 at 16 25 24" src="https://github.com/user-attachments/assets/065d7d64-716e-44d6-9367-151588054460" /> |  <img width="431" height="472" alt="Screenshot 2025-11-05 at 16 25 03" src="https://github.com/user-attachments/assets/f4571df1-d129-48d4-a0b5-a7fd6f63c10d" /> |
| <img width="551" height="486" alt="Screenshot 2025-11-05 at 16 30 46" src="https://github.com/user-attachments/assets/15bb07cd-5bab-41aa-aca1-68c68d7db00e" /> | <img width="584" height="487" alt="Screenshot 2025-11-05 at 16 30 26" src="https://github.com/user-attachments/assets/49d2da76-810f-4d91-92ef-e471697524df" /> |