### PR TITLE
RI-7687: adjust RDI pipeline statuses

### DIFF
--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/current-pipeline-status/CurrentPipelineStatus.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/current-pipeline-status/CurrentPipelineStatus.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
 import { PipelineState } from 'uiSrc/slices/interfaces'
 import { formatLongName, Maybe } from 'uiSrc/utils'
-import { AllIconsType, RiIcon } from 'uiSrc/components/base/icons/RiIcon'
-import { IconProps } from 'uiSrc/components/base/icons'
+import { Icon, IconProps } from 'uiSrc/components/base/icons'
 import { Title } from 'uiSrc/components/base/text/Title'
 import { Loader } from 'uiSrc/components/base/display'
 import { RiTooltip } from 'uiSrc/components'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
+import {
+  IndicatorSyncingIcon,
+  IndicatorSyncedIcon,
+  IndicatorSyncstoppedIcon,
+  IndicatorSyncerrorIcon,
+} from '@redis-ui/icons'
+import { IconType } from 'uiSrc/components/base/forms/buttons'
 
 export interface Props {
   pipelineState?: PipelineState
@@ -24,31 +30,31 @@ const CurrentPipelineStatus = ({
     pipelineState: Maybe<PipelineState>,
   ): {
     label: string
-    icon: AllIconsType
+    icon: IconType
     iconColor: IconProps['color']
   } => {
     switch (pipelineState) {
       case PipelineState.InitialSync:
         return {
-          icon: 'IndicatorSyncingIcon',
+          icon: IndicatorSyncingIcon,
           iconColor: 'success300',
           label: 'Initial sync',
         }
       case PipelineState.CDC:
         return {
-          icon: 'IndicatorSyncedIcon',
-          iconColor: 'success300',
+          icon: IndicatorSyncedIcon,
+          iconColor: 'success500',
           label: 'Streaming',
         }
       case PipelineState.NotRunning:
         return {
-          icon: 'IndicatorXIcon',
+          icon: IndicatorSyncstoppedIcon,
           iconColor: 'attention500',
           label: 'Not running',
         }
       default:
         return {
-          icon: 'IndicatorErrorIcon',
+          icon: IndicatorSyncerrorIcon,
           iconColor: 'danger500',
           label: 'Error',
         }
@@ -60,7 +66,9 @@ const CurrentPipelineStatus = ({
   return (
     <Row align="center" gap="m">
       <FlexItem>
-        <Title size="XS">Pipeline state:</Title>
+        <Title size="XS" color="primary">
+          Pipeline state
+        </Title>
       </FlexItem>
       <FlexItem>
         {headerLoading ? (
@@ -70,13 +78,9 @@ const CurrentPipelineStatus = ({
             content={errorTooltipContent}
             anchorClassName={statusError}
           >
-            <Row data-testid="pipeline-state-badge" gap="s">
-              <RiIcon
-                type={stateInfo.icon}
-                color={stateInfo.iconColor}
-                size="m"
-              />
-              <Text size="s">{stateInfo.label}</Text>
+            <Row data-testid="pipeline-state-badge" gap="s" align="center">
+              <Icon icon={stateInfo.icon} color={stateInfo.iconColor} />
+              <Text>{stateInfo.label}</Text>
             </Row>
           </RiTooltip>
         )}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Adjusted RDI pipeline statuses:
- changed text size/color
- icons, sizes, colors

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->
|Before|After|
|-|-|
<img width="286" height="107" alt="Screenshot 2025-11-07 at 12 20 28" src="https://github.com/user-attachments/assets/56fd2194-0ad6-4fa3-84cb-7d98c5107cc4" />|<img width="220" height="99" alt="Screenshot 2025-11-07 at 12 14 35" src="https://github.com/user-attachments/assets/64b12c11-844a-4074-a815-713b4e28b89a" />
<img width="290" height="88" alt="Screenshot 2025-11-07 at 12 20 45" src="https://github.com/user-attachments/assets/290413db-607a-474f-b3ce-76067f48e09c" />|<img width="289" height="123" alt="Screenshot 2025-11-07 at 12 14 59" src="https://github.com/user-attachments/assets/31b0739b-a459-4e36-8c26-8c6446956232" />
<img width="286" height="93" alt="Screenshot 2025-11-07 at 12 20 37" src="https://github.com/user-attachments/assets/7052f82a-1edd-4831-acd1-0473cd78b48e" />|<img width="282" height="109" alt="Screenshot 2025-11-07 at 12 14 47" src="https://github.com/user-attachments/assets/624d8547-13c5-4cb2-afde-fca5b4ceea1b" />
<img width="285" height="93" alt="Screenshot 2025-11-07 at 12 20 53" src="https://github.com/user-attachments/assets/14cd5212-de73-4bb0-ba9c-e32ba47cda33" />|<img width="301" height="118" alt="Screenshot 2025-11-07 at 12 15 08" src="https://github.com/user-attachments/assets/79985616-4bc8-4fdb-90d7-cf29a830073e" />


