### PR TITLE
RI-7718: Fix cloud button alignment

### DIFF
--- a/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.tsx
+++ b/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.tsx
@@ -10,7 +10,7 @@ import { FeatureFlagComponent, OAuthUserProfile } from 'uiSrc/components'
 import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { CopilotTrigger, InsightsTrigger } from 'uiSrc/components/triggers'
 
-import { Flex, FlexItem } from 'uiSrc/components/base/layout/flex'
+import { FlexGroup, FlexItem } from 'uiSrc/components/base/layout/flex'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -33,27 +33,23 @@ const HomePageTemplate = (props: Props) => {
     <>
       <div className={styles.pageDefaultHeader}>
         <HomeTabs />
-        <Flex style={{ flexGrow: 0 }} gap="none" align="center">
+        <FlexGroup gap="s">
           {isAnyChatAvailable && (
             <FlexItem style={{ marginRight: 12 }}>
               <CopilotTrigger />
             </FlexItem>
           )}
-          <FlexItem grow>
+          <FlexItem>
             <InsightsTrigger source="home page" />
           </FlexItem>
           <FeatureFlagComponent
             name={[FeatureFlags.cloudSso, FeatureFlags.cloudAds]}
           >
-            <FlexItem
-              grow
-              style={{ marginLeft: 16 }}
-              data-testid="home-page-sso-profile"
-            >
+            <FlexItem data-testid="home-page-sso-profile">
               <OAuthUserProfile source={OAuthSocialSource.UserProfile} />
             </FlexItem>
           </FeatureFlagComponent>
-        </Flex>
+        </FlexGroup>
       </div>
       <div className={styles.pageWrapper}>
         <ExplorePanelTemplate panelClassName={styles.explorePanel}>


### PR DESCRIPTION
Adjust some styling so all buttons are in place and do not get out of the nav bar container

# What

Fix styling for the nav bar so cloud sign in button does not stick out the container when opened in desktop

# Testing

| Before | After |
| --- | --- |
| <img width="1296" height="866" alt="image" src="https://github.com/user-attachments/assets/37c47cfd-fe2b-4237-a0a5-8ddf93a9c299" /> | <img width="1296" height="866" alt="image" src="https://github.com/user-attachments/assets/c4b1090e-968b-42b9-9cbb-997d8f28b364" /> |
| <img width="1296" height="866" alt="image" src="https://github.com/user-attachments/assets/605b9828-12e4-459c-86db-8394df96b2a1" /> | <img width="1296" height="866" alt="image" src="https://github.com/user-attachments/assets/48b803da-d7c2-4b9f-9e17-52972a7c87f0" /> |