### PR TITLE
RI-7727: fix instance not opening for electron

### DIFF
--- a/redisinsight/ui/src/Router.tsx
+++ b/redisinsight/ui/src/Router.tsx
@@ -14,7 +14,17 @@ if (RIPROXYPATH !== '') {
   MOUNT_PATH = RIPROXYPATH
 }
 
-export const history = createBrowserHistory({ basename: MOUNT_PATH })
+const history = createBrowserHistory({ basename: MOUNT_PATH })
+
+export const navigate = (path: string) => {
+  if (window.location.hash) {
+    // Electron (HashRouter)
+    window.location.hash = `#${path}`
+  } else {
+    // Web (BrowserRouter)
+    history.push(path)
+  }
+}
 
 const Router = ({ children }: Props) => (
   <ReactRouter history={history}>{children}</ReactRouter>

--- a/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.spec.ts
+++ b/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.spec.ts
@@ -59,7 +59,7 @@ jest.mock('uiSrc/slices/app/context', () => ({
 
 const mockHistoryPush = jest.fn()
 jest.mock('uiSrc/Router', () => ({
-  history: { push: jest.fn((...args) => mockHistoryPush(...args)) },
+  navigate: jest.fn((...args) => mockHistoryPush(...args)),
 }))
 
 const mockLocalStorageSet = jest.fn()

--- a/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.ts
+++ b/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.ts
@@ -13,14 +13,14 @@ import { appContextSelector, resetRdiContext } from 'uiSrc/slices/app/context'
 import { BrowserStorageItem, Pages } from 'uiSrc/constants'
 import { store, dispatch } from 'uiSrc/slices/store'
 import { SortingState } from 'uiSrc/components/base/layout/table'
-import { history } from 'uiSrc/Router'
+import { navigate } from 'uiSrc/Router'
 import { localStorageService } from 'uiSrc/services'
 
 const connectToInstance = (id: string) => {
   dispatch(resetRdiContext())
   dispatch(setConnectedInstanceId(id))
 
-  history.push(Pages.browser(id))
+  navigate(Pages.browser(id))
 }
 
 export const handleCheckConnectToInstance = async (instance: Instance) => {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Electron uses hash based routing so using the browser history object (outside of react dom hook) does not work.
This navigation method is first used here and was exposed in this PR: https://github.com/redis/RedisInsight/pull/5118

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->
Start electron app. Try to open an instance (new databases list ui)