### PR TITLE
RI:7728: Support semantic colors in Indicator

### DIFF
--- a/redisinsight/ui/src/components/base/text/text.styles.ts
+++ b/redisinsight/ui/src/components/base/text/text.styles.ts
@@ -92,19 +92,10 @@ const getAlignValue = (align?: MapProps['$align']) => {
 export const StyledColorText = styled(Typography.Body)<MapProps>`
   ${useColorTextStyles}
 `
+
 export const StyledText = styled(Typography.Body)<MapProps>`
   ${useColorTextStyles};
   ${({ $align }) => getAlignValue($align)};
-`
-export const Indicator = styled.div<
-  {
-    $color: ColorType
-  } & CommonProps
->`
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 50%;
-  background-color: ${({ $color }) => $color || 'inherit'};
 `
 
 const useStatusColorStyles = ({ $color }: MapProps = {}) => {
@@ -113,6 +104,8 @@ const useStatusColorStyles = ({ $color }: MapProps = {}) => {
 
   const getColorValue = (color?: ColorType) => {
     switch (color) {
+      case 'informative':
+        return colors.text.informative400
       case 'danger':
         return colors.text.danger500
       case 'warning':
@@ -129,16 +122,17 @@ const useStatusColorStyles = ({ $color }: MapProps = {}) => {
   `
 }
 
-export const StatusIndicator = styled.div<
+export const Indicator = styled.div<
   {
     $color: ColorType
   } & CommonProps
 >`
-  ${useStatusColorStyles};
-  width: 1rem;
-  height: 1rem;
+  width: 0.8rem;
+  height: 0.8rem;
   border-radius: 50%;
+  ${useStatusColorStyles};
 `
+
 export const mapSize = (size: TextSizeType): BodyProps['size'] => {
   if (size === 'm') {
     return 'M'

--- a/redisinsight/ui/src/pages/rdi/statistics/target-connections/TargetConnections.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/target-connections/TargetConnections.tsx
@@ -12,7 +12,7 @@ import {
   StyledRdiAnalyticsTable,
   StyledRdiStatisticsSectionBody,
 } from 'uiSrc/pages/rdi/statistics/styles'
-import { StatusIndicator } from 'uiSrc/components/base/text/text.styles'
+import { Indicator } from 'uiSrc/components/base/text/text.styles'
 import { Row } from 'uiSrc/components/base/layout/flex'
 
 type ConnectionData = {
@@ -49,7 +49,7 @@ const columns: ColumnDefinition<ConnectionData>[] = [
     }) => (
       <Row align="center" justify="center">
         <RiTooltip content={status}>
-          <StatusIndicator $color={getStatusColor(status)} />
+          <Indicator $color={getStatusColor(status)} />
         </RiTooltip>
       </Row>
     ),


### PR DESCRIPTION
# What

This PR serves as a prerequisite for upcoming changes. It removes the `StatusIndicator` component since we can achieve the same functionality using `Indicator` with a minor update to support semantic colors (danger, warning, success, etc.).

In addition to adding color support, another key consideration is the size difference:

- The existing Indicator defaults to 0.8rem (≈8px)
- The removed StatusIndicator uses 1rem (≈10px)
- The RDI pages (upcoming PR) rely on a 6px reference

a.k.a. 8px vs 10px vs 6px, so this PR also helps unify these sizes, which was the original goal behind this change.

# Testing

## No regression on the `Indicator` component

| Before    | After |
| -------- | ------- |
| <img width="154" height="322" alt="Screenshot 2025-11-12 at 16 00 44" src="https://github.com/user-attachments/assets/b3ea5681-e763-46d1-9db7-85e9d7bb9d9d" /> |  <img width="214" height="345" alt="Screenshot 2025-11-12 at 16 00 17" src="https://github.com/user-attachments/assets/68501cd1-0ddf-4f8b-8d36-e9c60d1ba056" /> |

## Using the new size in RDI statistics

| Before    | After |
| -------- | ------- |
| <img width="234" height="244" alt="Screenshot 2025-11-12 at 16 01 00" src="https://github.com/user-attachments/assets/f03b3f3f-b834-411e-afa0-46d377fa5712" /> |  <img width="199" height="237" alt="Screenshot 2025-11-12 at 16 01 12" src="https://github.com/user-attachments/assets/5a91193b-dee9-4c99-afe8-6e3bb80a92a0" /> |
