### PR TITLE
RI-7706 Refactor bulk actions status display

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.styles.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.styles.tsx
@@ -2,12 +2,6 @@ import styled from 'styled-components'
 import React from 'react'
 import { ColorText, Text } from 'uiSrc/components/base/text'
 import { Theme } from 'uiSrc/components/base/theme/types'
-import { getApproximatePercentage, Maybe } from 'uiSrc/utils'
-import { isUndefined } from 'lodash'
-import { isProcessedBulkAction } from 'uiSrc/pages/browser/components/bulk-actions/utils'
-import { Banner } from 'uiSrc/components/base/display'
-import { BulkActionsStatus } from 'uiSrc/constants'
-import { Props } from './BulkActionsInfo'
 
 export const BulkActionsInfoFilter = styled.div<{
   className?: string
@@ -33,8 +27,6 @@ export const BulkActionsInfoSearch = styled(ColorText).attrs({
   word-break: break-all;
 `
 
-export const BulkActionsProgress = styled(Banner)``
-
 export const BulkActionsProgressLine = styled.div<{
   children?: React.ReactNode
 }>`
@@ -57,57 +49,3 @@ export const BulkActionsContainer = styled.div<{ children: React.ReactNode }>`
   display: flex;
   flex-direction: column;
 `
-
-export const BulkActionsStatusDisplay = ({
-  status,
-  total,
-  scanned,
-}: {
-  status: Props['status']
-  total: Maybe<number>
-  scanned: Maybe<number>
-}) => {
-  if (!isUndefined(status) && !isProcessedBulkAction(status)) {
-    return (
-      <BulkActionsProgress
-        message={
-          <>
-            In progress:
-            <ColorText size="XS">{` ${getApproximatePercentage(total, scanned)}`}</ColorText>
-          </>
-        }
-        data-testid="bulk-status-progress"
-      />
-    )
-  }
-  if (status === BulkActionsStatus.Aborted) {
-    return (
-      <BulkActionsProgress
-        variant="danger"
-        message={<>Stopped: {getApproximatePercentage(total, scanned)}</>}
-        data-testid="bulk-status-stopped"
-      />
-    )
-  }
-
-  if (status === BulkActionsStatus.Completed) {
-    return (
-      <BulkActionsProgress
-        showIcon
-        variant="success"
-        message="Action completed"
-        data-testid="bulk-status-completed"
-      />
-    )
-  }
-  if (status === BulkActionsStatus.Disconnected) {
-    return (
-      <BulkActionsProgress
-        variant="danger"
-        message={`Connection Lost: ${getApproximatePercentage(total, scanned)}`}
-        data-testid="bulk-status-disconnected"
-      />
-    )
-  }
-  return null
-}

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsInfo/BulkActionsInfo.tsx
@@ -6,12 +6,13 @@ import { BulkActionsStatus, KeyTypes, RedisDataType } from 'uiSrc/constants'
 import GroupBadge from 'uiSrc/components/group-badge/GroupBadge'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
+
+import BulkActionsStatusDisplay from '../BulkActionsStatusDisplay'
 import {
   BulkActionsContainer,
   BulkActionsInfoFilter,
   BulkActionsInfoSearch,
   BulkActionsProgressLine,
-  BulkActionsStatusDisplay,
   BulkActionsTitle,
 } from './BulkActionsInfo.styles'
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/BulkActionsStatusDisplay.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/BulkActionsStatusDisplay.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import BulkActionsStatusDisplay, {
+  BulkActionsStatusDisplayProps,
+} from './BulkActionsStatusDisplay'
+import { faker } from '@faker-js/faker/locale/af_ZA'
+import { BulkActionsStatus } from 'uiSrc/constants'
+
+const renderBulkActionsStatusDisplay = (
+  props?: Partial<BulkActionsStatusDisplayProps>,
+) => {
+  const defaultProps: BulkActionsStatusDisplayProps = {
+    status: faker.helpers.enumValue(BulkActionsStatus),
+    total: faker.number.int({ min: 0, max: 1000 }),
+    scanned: faker.number.int({ min: 0, max: 1000 }),
+  }
+
+  return render(<BulkActionsStatusDisplay {...defaultProps} {...props} />)
+}
+
+describe('BulkActionsStatusDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render banner when status is in progress', () => {
+    const props: BulkActionsStatusDisplayProps = {
+      status: BulkActionsStatus.Running,
+      total: 200,
+      scanned: 50,
+    }
+
+    renderBulkActionsStatusDisplay(props)
+
+    const banner = screen.getByTestId('bulk-status-progress')
+
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('In progress: 25%')
+  })
+
+  it('should render banner when status is in Aborted', () => {
+    const props: BulkActionsStatusDisplayProps = {
+      status: BulkActionsStatus.Aborted,
+      total: 100,
+      scanned: 30,
+    }
+
+    renderBulkActionsStatusDisplay(props)
+
+    const banner = screen.getByTestId('bulk-status-stopped')
+
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Stopped: 30%')
+  })
+
+  it('should render banner when status is Completed', () => {
+    renderBulkActionsStatusDisplay({ status: BulkActionsStatus.Completed })
+
+    const banner = screen.getByTestId('bulk-status-completed')
+
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Action completed')
+  })
+
+  it('should render banner when status is Disconnected', () => {
+    const props: BulkActionsStatusDisplayProps = {
+      status: BulkActionsStatus.Disconnected,
+      total: 100,
+      scanned: 50,
+    }
+
+    renderBulkActionsStatusDisplay(props)
+
+    const banner = screen.getByTestId('bulk-status-disconnected')
+
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('Connection Lost: 50%')
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/BulkActionsStatusDisplay.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/BulkActionsStatusDisplay.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { isUndefined } from 'lodash'
+
+import { BulkActionsStatus } from 'uiSrc/constants'
+import { getApproximatePercentage, Maybe } from 'uiSrc/utils'
+import { ColorText } from 'uiSrc/components/base/text'
+
+import { isProcessedBulkAction } from '../utils'
+import { Props } from '../BulkActionsInfo/BulkActionsInfo'
+import { Banner } from 'uiSrc/components/base/display'
+
+export interface BulkActionsStatusDisplayProps {
+  status: Props['status']
+  total: Maybe<number>
+  scanned: Maybe<number>
+}
+
+export const BulkActionsStatusDisplay = ({
+  status,
+  total,
+  scanned,
+}: BulkActionsStatusDisplayProps) => {
+  if (!isUndefined(status) && !isProcessedBulkAction(status)) {
+    return (
+      <Banner
+        message={
+          <>
+            In progress:
+            <ColorText size="XS">{` ${getApproximatePercentage(total, scanned)}`}</ColorText>
+          </>
+        }
+        data-testid="bulk-status-progress"
+      />
+    )
+  }
+
+  if (status === BulkActionsStatus.Aborted) {
+    return (
+      <Banner
+        variant="danger"
+        message={<>Stopped: {getApproximatePercentage(total, scanned)}</>}
+        data-testid="bulk-status-stopped"
+      />
+    )
+  }
+
+  if (status === BulkActionsStatus.Completed) {
+    return (
+      <Banner
+        showIcon
+        variant="success"
+        message="Action completed"
+        data-testid="bulk-status-completed"
+      />
+    )
+  }
+
+  if (status === BulkActionsStatus.Disconnected) {
+    return (
+      <Banner
+        variant="danger"
+        message={`Connection Lost: ${getApproximatePercentage(total, scanned)}`}
+        data-testid="bulk-status-disconnected"
+      />
+    )
+  }
+
+  return null
+}
+
+export default BulkActionsStatusDisplay

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsStatusDisplay/index.ts
@@ -1,0 +1,3 @@
+import BulkActionsStatusDisplay from './BulkActionsStatusDisplay'
+
+export default BulkActionsStatusDisplay


### PR DESCRIPTION
# What

Export the component that we use to report the status of a Bulk Action
- move out the main component outside of the styles file
- added tests
    
# Testing

1. Open Redis Insight and go to the **Databases** tab
2. Open an existing database, or establish a new connection to a new database
3. Go to the **Browser** page
4. Click on the "**Bulk Actions**" button in the top right corner
5. Click on the "**Upload Data**" tab
6. Select a file with Redis commands

```
JSON.SET bike:1 $ '{"brand": "Zoomer", "price": 1328.16, "type": "Mountain", "specs": {"material": "carbon fiber", "weight": 7.2}, "description": "Designed for rugged terrain and off-road adventures.", "addons": ["GPS tracker", "phone mount"], "helmet_included": true, "condition": "new"}'
```

7. Click on the "**Upload**" button
8. Once you confirm the upload, you'll see a screen with results

Based on the result of the action, there are a few options to be dispalyed.

| Light | Dark |
| - | - |
<img width="1123" height="433" alt="image" src="https://github.com/user-attachments/assets/5340a94e-a3dc-43a4-bcf6-23635ea44ebf" />|<img width="1126" height="539" alt="Screenshot 2025-11-13 at 15 13 50" src="https://github.com/user-attachments/assets/8497d447-cba8-4b4b-acd4-c6b0ab2af8e5" />
<img width="1126" height="539" alt="Screenshot 2025-11-13 at 15 14 42" src="https://github.com/user-attachments/assets/f16206a2-9a63-4aa3-bc51-009ca1098a95" />|<img width="1126" height="539" alt="Screenshot 2025-11-13 at 15 14 37" src="https://github.com/user-attachments/assets/9dafa2b6-0c18-4591-9fbe-d745a7f7ee08" />
<img width="1126" height="539" alt="Screenshot 2025-11-13 at 15 14 52" src="https://github.com/user-attachments/assets/e659e0c7-9f41-48c6-ad58-b367fe2935ff" />|<img width="1126" height="539" alt="Screenshot 2025-11-13 at 15 14 58" src="https://github.com/user-attachments/assets/d794afbd-36ce-453b-a345-2b0cc5117715" />
