### PR TITLE
RI-7705: refactor RdiInstancesList

### DIFF
--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.config.ts
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.config.ts
@@ -1,9 +1,8 @@
-import React from 'react'
-
 import { ColumnDef, Table } from 'uiSrc/components/base/layout/table'
 import { RDI_COLUMN_FIELD_NAME_MAP, RdiListColumn } from 'uiSrc/constants'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
 
+import RdiInstancesListCellSelect from './components/RdiInstancesListCellSelect/RdiInstancesListCellSelect'
 import RdiInstancesListCellControls from './components/RdiInstancesListCellControls/RdiInstancesListCellControls'
 import RdiInstancesListCell from './components/RdiInstancesListCell/RdiInstancesListCell'
 
@@ -17,21 +16,14 @@ export const BASE_COLUMNS: ColumnDef<RdiInstance>[] = [
     isHeaderCustom: true,
     enableSorting: false,
     header: Table.HeaderMultiRowSelectionButton,
-    cell: (props) => (
-      <Table.RowSelectionButton
-        {...props}
-        onClick={(e: any) => e.stopPropagation()}
-      />
-    ),
+    cell: RdiInstancesListCellSelect,
   },
   {
     id: RdiListColumn.Name,
     accessorKey: RdiListColumn.Name,
     header: RDI_COLUMN_FIELD_NAME_MAP.get(RdiListColumn.Name),
     enableSorting: true,
-    cell: (props) => (
-      <RdiInstancesListCell {...props} field={RdiListColumn.Name} />
-    ),
+    cell: RdiInstancesListCell,
     sortingFn: (rowA, rowB) =>
       `${rowA.original.name?.toLowerCase()}`.localeCompare(
         `${rowB.original.name?.toLowerCase()}`,
@@ -42,9 +34,7 @@ export const BASE_COLUMNS: ColumnDef<RdiInstance>[] = [
     accessorKey: RdiListColumn.Url,
     header: RDI_COLUMN_FIELD_NAME_MAP.get(RdiListColumn.Url),
     enableSorting: true,
-    cell: (props) => (
-      <RdiInstancesListCell {...props} field={RdiListColumn.Url} withCopyIcon />
-    ),
+    cell: RdiInstancesListCell,
     sortingFn: (rowA, rowB) =>
       `${rowA.original.url?.toLowerCase()}`.localeCompare(
         `${rowB.original.url?.toLowerCase()}`,
@@ -55,18 +45,14 @@ export const BASE_COLUMNS: ColumnDef<RdiInstance>[] = [
     accessorKey: RdiListColumn.Version,
     header: RDI_COLUMN_FIELD_NAME_MAP.get(RdiListColumn.Version),
     enableSorting: true,
-    cell: (props) => (
-      <RdiInstancesListCell {...props} field={RdiListColumn.Version} />
-    ),
+    cell: RdiInstancesListCell,
   },
   {
     id: RdiListColumn.LastConnection,
     accessorKey: RdiListColumn.LastConnection,
     header: RDI_COLUMN_FIELD_NAME_MAP.get(RdiListColumn.LastConnection),
     enableSorting: true,
-    cell: (props) => (
-      <RdiInstancesListCell {...props} field={RdiListColumn.LastConnection} />
-    ),
+    cell: RdiInstancesListCell,
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.lastConnection
       const b = rowB.original.lastConnection

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.types.ts
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.types.ts
@@ -4,8 +4,5 @@ import type { CellContext } from 'uiSrc/components/base/layout/table'
 import type { RdiInstance } from 'uiSrc/slices/interfaces'
 
 export type IRdiListCell = (
-  props: CellContext<RdiInstance, unknown> & {
-    field?: keyof RdiInstance
-    withCopyIcon?: boolean
-  },
+  props: CellContext<RdiInstance, unknown>,
 ) => ReactElement<any, any> | null

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/components/RdiInstancesListCell/RdiInstancesListCell.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/components/RdiInstancesListCell/RdiInstancesListCell.tsx
@@ -5,26 +5,32 @@ import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { CopyIcon } from 'uiSrc/components/base/icons'
 import { Text } from 'uiSrc/components/base/text'
 import { lastConnectionFormat } from 'uiSrc/utils'
-import { RdiInstance } from 'uiSrc/slices/interfaces'
+import { RdiListColumn } from 'uiSrc/constants'
 
 import { handleCopyUrl } from '../../methods/handlers'
 import { IRdiListCell } from '../../RdiInstancesList.types'
 import { CellContainer } from './RdiInstancesListCell.styles'
 
-const RdiInstancesListCell: IRdiListCell = ({ row, field, withCopyIcon }) => {
-  const instance = row.original as RdiInstance
+const fieldCopyIcon: Record<string, boolean> = {
+  [RdiListColumn.Url]: true,
+}
 
-  if (!field) {
+const fieldFormatters: Record<string, (v: any) => string> = {
+  [RdiListColumn.LastConnection]: lastConnectionFormat,
+}
+
+const RdiInstancesListCell: IRdiListCell = ({ row, column }) => {
+  const item = row.original
+  const id = item.id
+  const field = column.id as keyof typeof item
+  const value = item[field]
+
+  if (!field || !value) {
     return null
   }
 
-  const id = instance.id
-  const value = instance[field]
-  const text =
-    // lastConnection is returned as a string
-    field === 'lastConnection'
-      ? lastConnectionFormat(value as any)
-      : value?.toString()
+  const text = fieldFormatters[field]?.(value) ?? value?.toString()
+  const withCopyIcon = fieldCopyIcon[field]
 
   return (
     <CellContainer

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/components/RdiInstancesListCellSelect/RdiInstancesListCellSelect.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/components/RdiInstancesListCellSelect/RdiInstancesListCellSelect.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Table } from 'uiSrc/components/base/layout/table'
+import { IRdiListCell } from '../../RdiInstancesList.types'
+
+const RdiInstancesListCellSelect: IRdiListCell = (props) => (
+  <Table.RowSelectionButton
+    {...props}
+    onClick={(e: any) => e.stopPropagation()}
+  />
+)
+
+export default RdiInstancesListCellSelect


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Some refactors that I had in mind but didn't do in the original PR. No functionality/visual changes.
1. Changes the config file from .tsx to .ts as should
2. RdiInstancesListCell - derives field name and configs from cell value as opposed to custom props

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->