### PR TITLE
RI-7687: fix huge error messages issue

### DIFF
--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -10,7 +10,6 @@ import { ToastOptions as RcToastOptions } from 'react-toastify'
 import { CommonProps } from 'uiSrc/components/base/theme/types'
 import { ColorText, Text } from 'uiSrc/components/base/text'
 import { ColorType } from 'uiSrc/components/base/text/text.styles'
-import { Spacer } from '../../layout'
 
 type RiToastProps = React.ComponentProps<typeof Toast>
 export const RiToast = (props: RiToastProps) => <Toast {...props} />
@@ -35,7 +34,6 @@ export const riToast = (
     toastContent.message = (
       <Text size="M" variant="semiBold">
         <ColorText color={color}>{message}</ColorText>
-        <Spacer size="s" />
       </Text>
     )
   } else {

--- a/redisinsight/ui/src/components/notifications/constants.ts
+++ b/redisinsight/ui/src/components/notifications/constants.ts
@@ -2,3 +2,4 @@ export const defaultContainerId = 'default'
 
 export const IMContainerId = 'InfiniteMessages'
 export const ONE_HOUR = 3_600_000
+export const NotificationTextLengthThreshold = 400

--- a/redisinsight/ui/src/components/notifications/error-messages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/error-messages.spec.tsx
@@ -1,0 +1,291 @@
+import React from 'react'
+import { handleDownloadButton } from 'uiSrc/utils'
+import { NotificationTextLengthThreshold } from 'uiSrc/components/notifications/constants'
+import ERROR_MESSAGES from './error-messages'
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  handleDownloadButton: jest.fn(),
+}))
+
+describe('ERROR_MESSAGES', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('DEFAULT', () => {
+    it('should return error notification with correct data-testid', () => {
+      const result = ERROR_MESSAGES.DEFAULT('Error text')
+
+      expect(result['data-testid']).toBe('toast-error')
+    })
+
+    it('should return error notification with default title', () => {
+      const result = ERROR_MESSAGES.DEFAULT('Error text')
+
+      expect(result.message).toBe('Error')
+    })
+
+    it('should return error notification with custom title', () => {
+      const customTitle = 'Custom Error Title'
+      const result = ERROR_MESSAGES.DEFAULT('Error text', () => {}, customTitle)
+
+      expect(result.message).toBe(customTitle)
+    })
+
+    it('should have customIcon property', () => {
+      const result = ERROR_MESSAGES.DEFAULT('Error text')
+
+      expect(result.customIcon).toBeDefined()
+    })
+
+    it('should have description for short messages', () => {
+      const shortText = 'Short error message'
+      const result = ERROR_MESSAGES.DEFAULT(shortText)
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should not have description for long messages', () => {
+      const longText = 'a'.repeat(NotificationTextLengthThreshold + 1)
+      const result = ERROR_MESSAGES.DEFAULT(longText)
+
+      expect(result.description).toBeUndefined()
+    })
+
+    it('should have description for non-string text', () => {
+      const objectText = { error: 'some error' }
+      const result = ERROR_MESSAGES.DEFAULT(objectText)
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should have download button action for long messages', () => {
+      const longText = 'a'.repeat(NotificationTextLengthThreshold + 1)
+      const result = ERROR_MESSAGES.DEFAULT(longText)
+
+      expect(result.actions.secondary).toBeDefined()
+      expect(result.actions.secondary?.label).toBe('Download full log')
+      expect(result.actions.secondary?.closes).toBe(true)
+    })
+
+    it('should not have download button action for short messages', () => {
+      const shortText = 'Short error message'
+      const result = ERROR_MESSAGES.DEFAULT(shortText)
+
+      expect(result.actions.secondary).toBeUndefined()
+    })
+
+    it('should call handleDownloadButton when download action is clicked', () => {
+      const longText = 'a'.repeat(NotificationTextLengthThreshold + 1)
+      const onClose = jest.fn()
+      const result = ERROR_MESSAGES.DEFAULT(longText, onClose)
+
+      result.actions.secondary?.onClick?.()
+
+      expect(handleDownloadButton).toHaveBeenCalledWith(
+        longText,
+        'error-log.txt',
+        onClose,
+      )
+    })
+
+    it('should handle onClick when it is undefined', () => {
+      const longText = 'a'.repeat(NotificationTextLengthThreshold + 1)
+      const result = ERROR_MESSAGES.DEFAULT(longText)
+
+      expect(result.actions.secondary?.onClick).toBeDefined()
+    })
+  })
+
+  describe('ENCRYPTION', () => {
+    it('should return encryption error notification with correct data-testid', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result['data-testid']).toBe('toast-error-encryption')
+    })
+
+    it('should return encryption error notification with correct message', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result.message).toBe('Unable to decrypt')
+    })
+
+    it('should have customIcon property', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result.customIcon).toBeDefined()
+    })
+
+    it('should have showCloseButton set to false', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result.showCloseButton).toBe(false)
+    })
+
+    it('should have description defined', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should work with instanceId parameter', () => {
+      const instanceId = 'test-instance-123'
+      const result = ERROR_MESSAGES.ENCRYPTION(() => {}, instanceId)
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should work with default parameters', () => {
+      const result = ERROR_MESSAGES.ENCRYPTION()
+
+      expect(result.description).toBeDefined()
+      expect(result.showCloseButton).toBe(false)
+    })
+  })
+
+  describe('CLOUD_CAPI_KEY_UNAUTHORIZED', () => {
+    it('should return cloud capi unauthorized error with correct data-testid', () => {
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message: 'Unauthorized' },
+        {},
+        () => {},
+      )
+
+      expect(result['data-testid']).toBe(
+        'toast-error-cloud-capi-key-unauthorized',
+      )
+    })
+
+    it('should have customIcon property', () => {
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message: 'Unauthorized' },
+        {},
+        () => {},
+      )
+
+      expect(result.customIcon).toBeDefined()
+    })
+
+    it('should have showCloseButton set to false', () => {
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message: 'Unauthorized' },
+        {},
+        () => {},
+      )
+
+      expect(result.showCloseButton).toBe(false)
+    })
+
+    it('should return error notification with title', () => {
+      const title = 'Unauthorized Error'
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message: 'Unauthorized', title },
+        {},
+        () => {},
+      )
+
+      expect(result.message).toBe(title)
+    })
+
+    it('should have description defined', () => {
+      const message = 'Unauthorized access'
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message },
+        {},
+        () => {},
+      )
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should work with resourceId in additionalInfo', () => {
+      const message = 'Unauthorized access'
+      const resourceId = 'resource-123'
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message },
+        { resourceId },
+        () => {},
+      )
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should handle JSX Element as message', () => {
+      const jsxMessage = <span>Custom JSX Error</span>
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message: jsxMessage },
+        {},
+        () => {},
+      )
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should work without title', () => {
+      const message = 'Unauthorized access'
+      const result = ERROR_MESSAGES.CLOUD_CAPI_KEY_UNAUTHORIZED(
+        { message },
+        {},
+        () => {},
+      )
+
+      expect(result.message).toBeUndefined()
+    })
+  })
+
+  describe('RDI_DEPLOY_PIPELINE', () => {
+    it('should return rdi deploy error with correct data-testid', () => {
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE(
+        { message: 'Deploy failed' },
+        () => {},
+      )
+
+      expect(result['data-testid']).toBe('toast-error-deploy')
+    })
+
+    it('should have customIcon property', () => {
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE(
+        { message: 'Deploy failed' },
+        () => {},
+      )
+
+      expect(result.customIcon).toBeDefined()
+    })
+
+    it('should return error notification with title', () => {
+      const title = 'Deployment Error'
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE(
+        { title, message: 'Deploy failed' },
+        () => {},
+      )
+
+      expect(result.message).toBe(title)
+    })
+
+    it('should pass onClose callback', () => {
+      const onClose = jest.fn()
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE(
+        { message: 'Deploy failed' },
+        onClose,
+      )
+
+      expect(result.onClose).toBe(onClose)
+    })
+
+    it('should have description defined', () => {
+      const message = 'Deploy failed'
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE({ message }, () => {})
+
+      expect(result.description).toBeDefined()
+    })
+
+    it('should work without title', () => {
+      const message = 'Deploy failed'
+      const result = ERROR_MESSAGES.RDI_DEPLOY_PIPELINE({ message }, () => {})
+
+      expect(result.message).toBeUndefined()
+      expect(result.description).toBeDefined()
+    })
+  })
+})

--- a/redisinsight/ui/src/components/notifications/error-messages.tsx
+++ b/redisinsight/ui/src/components/notifications/error-messages.tsx
@@ -5,21 +5,33 @@ import { InfoIcon, ToastDangerIcon } from 'uiSrc/components/base/icons'
 import RdiDeployErrorContent from './components/rdi-deploy-error-content'
 import { EncryptionErrorContent, DefaultErrorContent } from './components'
 import CloudCapiUnAuthorizedErrorContent from './components/cloud-capi-unauthorized'
+import { NotificationTextLengthThreshold } from 'uiSrc/components/notifications/constants'
+import { handleDownloadButton } from 'uiSrc/utils'
 
 export default {
-  DEFAULT: (text: any, onClose = () => {}, title: string = 'Error') => ({
-    'data-testid': 'toast-error',
-    customIcon: ToastDangerIcon,
-    message: title,
-    description: <DefaultErrorContent text={text} />,
-    actions: {
-      primary: {
-        label: 'OK',
-        closes: true,
-        onClick: onClose,
+  DEFAULT: (text: any, onClose = () => {}, title: string = 'Error') => {
+    const isSafeMessage =
+      text.length < NotificationTextLengthThreshold || typeof text !== 'string'
+
+    return {
+      'data-testid': 'toast-error',
+      customIcon: ToastDangerIcon,
+      message: title,
+      description: isSafeMessage ? (
+        <DefaultErrorContent text={text} />
+      ) : undefined,
+      actions: {
+        secondary: !isSafeMessage
+          ? {
+              label: 'Download full log',
+              closes: true,
+              onClick: () =>
+                handleDownloadButton(text, 'error-log.txt', onClose),
+            }
+          : undefined,
       },
-    },
-  }),
+    }
+  },
   ENCRYPTION: (onClose = () => {}, instanceId = '') => ({
     'data-testid': 'toast-error-encryption',
     customIcon: InfoIcon,

--- a/redisinsight/ui/src/utils/events/handleDownloadButton.ts
+++ b/redisinsight/ui/src/utils/events/handleDownloadButton.ts
@@ -1,0 +1,32 @@
+/**
+ * Triggers a client-side download of a text file containing the provided data.
+ *
+ * This function creates a temporary Blob from the given string data, generates
+ * a download link programmatically, and simulates a click event to prompt
+ * the browser to download the file with the specified filename.
+ *
+ * It automatically cleans up the created object URL after use to free memory.
+ * Optionally, a callback (`onSuccess`) can be executed once the download
+ * process has been initiated successfully.
+ *
+ * @param data - The string content to be saved in the downloaded file.
+ * @param filename - The desired name (with extension) of the downloaded file.
+ * @param onSuccess - Optional callback executed after the download trigger completes.
+ */
+export const handleDownloadButton = (data: string, filename: string, onSuccess?: () => void) => {
+  try {
+    const blob = new Blob([data], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+
+    URL.revokeObjectURL(url)
+
+    onSuccess?.()
+  } catch (e) {
+    // ignore error
+  }
+}

--- a/redisinsight/ui/src/utils/events/index.ts
+++ b/redisinsight/ui/src/utils/events/index.ts
@@ -1,4 +1,5 @@
 import handlePasteHostName from './handlePasteHostName'
 import selectOnFocus from './selectOnFocus'
+export * from './handleDownloadButton'
 
 export { handlePasteHostName, selectOnFocus }

--- a/redisinsight/ui/src/utils/tests/events/handleDownloadButton.spec.ts
+++ b/redisinsight/ui/src/utils/tests/events/handleDownloadButton.spec.ts
@@ -1,0 +1,187 @@
+import { handleDownloadButton } from 'uiSrc/utils/events/handleDownloadButton'
+
+describe('handleDownloadButton', () => {
+  let createObjectURLMock: jest.SpyInstance
+  let revokeObjectURLMock: jest.SpyInstance
+  let createElementMock: jest.SpyInstance
+  let mockAnchor: HTMLAnchorElement
+
+  beforeEach(() => {
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    createObjectURLMock = jest
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('mock-url')
+    revokeObjectURLMock = jest
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {})
+
+    // Mock document.createElement
+    mockAnchor = {
+      href: '',
+      download: '',
+      click: jest.fn(),
+    } as unknown as HTMLAnchorElement
+
+    createElementMock = jest
+      .spyOn(document, 'createElement')
+      .mockReturnValue(mockAnchor)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should create a blob with the provided data', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: data.length,
+        type: 'text/plain',
+      }),
+    )
+  })
+
+  it('should create an anchor element', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(createElementMock).toHaveBeenCalledWith('a')
+  })
+
+  it('should set the href attribute to the blob URL', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(mockAnchor.href).toBe('mock-url')
+  })
+
+  it('should set the download attribute to the filename', () => {
+    const data = 'test data'
+    const filename = 'test-file.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(mockAnchor.download).toBe(filename)
+  })
+
+  it('should trigger click on the anchor element', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(mockAnchor.click).toHaveBeenCalled()
+  })
+
+  it('should revoke the object URL after use', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('mock-url')
+  })
+
+  it('should call onSuccess callback when provided', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+    const onSuccess = jest.fn()
+
+    handleDownloadButton(data, filename, onSuccess)
+
+    expect(onSuccess).toHaveBeenCalled()
+  })
+
+  it('should not call onSuccess callback when not provided', () => {
+    const data = 'test data'
+    const filename = 'test.txt'
+
+    expect(() => handleDownloadButton(data, filename)).not.toThrow()
+  })
+
+  it('should handle errors gracefully without crashing', () => {
+    createObjectURLMock.mockImplementation(() => {
+      throw new Error('Test error')
+    })
+
+    const data = 'test data'
+    const filename = 'test.txt'
+    const onSuccess = jest.fn()
+
+    expect(() => handleDownloadButton(data, filename, onSuccess)).not.toThrow()
+  })
+
+  it('should not call onSuccess callback if an error occurs', () => {
+    createObjectURLMock.mockImplementation(() => {
+      throw new Error('Test error')
+    })
+
+    const data = 'test data'
+    const filename = 'test.txt'
+    const onSuccess = jest.fn()
+
+    handleDownloadButton(data, filename, onSuccess)
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('should handle empty data', () => {
+    const data = ''
+    const filename = 'empty.txt'
+
+    expect(() => handleDownloadButton(data, filename)).not.toThrow()
+    expect(mockAnchor.click).toHaveBeenCalled()
+  })
+
+  it('should handle special characters in filename', () => {
+    const data = 'test data'
+    const filename = 'test-file (1) [copy].txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(mockAnchor.download).toBe(filename)
+  })
+
+  it('should handle large data strings', () => {
+    const data = 'a'.repeat(10000)
+    const filename = 'large.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(createObjectURLMock).toHaveBeenCalled()
+    expect(mockAnchor.click).toHaveBeenCalled()
+    expect(revokeObjectURLMock).toHaveBeenCalled()
+  })
+
+  it('should handle multiline data', () => {
+    const data = 'line1\nline2\nline3'
+    const filename = 'multiline.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'text/plain',
+      }),
+    )
+    expect(mockAnchor.click).toHaveBeenCalled()
+  })
+
+  it('should handle data with special characters', () => {
+    const data = 'Special chars: ñ, é, ü, 中文, 🎉'
+    const filename = 'special.txt'
+
+    handleDownloadButton(data, filename)
+
+    expect(mockAnchor.click).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
- covered cases when we receive big string error message. we will suggest to download full log and show title only
- removed ok button from error notifications

Note: these changes applied to "default" error notifications only. Custom/separate handled notifications are not touched

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->