### PR TITLE
RI-7740: Adjust instances navigation position

### DIFF
--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/InstancesNavigationPopover.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/InstancesNavigationPopover.tsx
@@ -113,7 +113,7 @@ const InstancesNavigationPopover = ({ name }: Props) => {
   return (
     <RiPopover
       ownFocus
-      anchorPosition="downRight"
+      anchorPosition="downLeft"
       panelPaddingSize="none"
       isOpen={isPopoverOpen}
       closePopover={() => showPopover()}


### PR DESCRIPTION
# What

Adjust popover positioning so it no longer sticks to the screen edge.

# Testing

| Before    | After |
| -------- | ------- |
| <img width="475" height="380" alt="Screenshot 2025-11-19 at 11 42 05" src="https://github.com/user-attachments/assets/89f9f927-941e-4442-8fb8-8b3104718573" />  |  <img width="654" height="366" alt="Screenshot 2025-11-19 at 11 41 53" src="https://github.com/user-attachments/assets/bc1f5e49-738d-4b0f-be96-9cd376f266dd" />    |
|  <img width="511" height="144" alt="Screenshot 2025-11-19 at 11 42 15" src="https://github.com/user-attachments/assets/b40357e4-c55c-43ef-af14-ae0af4354293" />  |  <img width="703" height="147" alt="Screenshot 2025-11-19 at 11 41 43" src="https://github.com/user-attachments/assets/94880668-3fb9-4e07-ba50-95b32dbb1e2f" />  |