### PR TITLE
DEV: Ignore stories files for ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,12 @@ module.exports = {
     node: true,
     browser: true,
   },
-  extends: ['airbnb-typescript', 'prettier', 'plugin:prettier/recommended', 'plugin:storybook/recommended'],
+  extends: [
+    'airbnb-typescript',
+    'prettier',
+    'plugin:prettier/recommended',
+    'plugin:storybook/recommended',
+  ],
   plugins: ['@typescript-eslint', 'import', 'prettier'],
   parser: '@typescript-eslint/parser',
   rules: {
@@ -429,5 +434,6 @@ module.exports = {
     'electron-builder-mas.js',
     'jest-resolver.js',
     'resources/resources.d.ts',
+    'stories/**',
   ],
 };


### PR DESCRIPTION
# What

ESLint runs on these files, but tsconfig isn't configured yet for them, so the execution results in an error:

```
Parsing error: ESLint was configured to run on `<tsconfigRootDir>/stories/playground/Playground.stories.tsx` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
```

# Testing

`yarn lint` in the root of the repo