### PR TITLE
RED-177232: Fix label for column sorting

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -394,7 +394,7 @@ const KeysHeader = (props: Props) => {
                               className={styles.checkbox}
                             />
                           </FlexItem>
-                          <FlexItem grow>
+                          <FlexItem>
                             <RiTooltip
                               content="Hide the key size to avoid performance issues when working with large keys."
                               position="top"


### PR DESCRIPTION
# What

The label should be `Key size`, not `Key`.

# Testing

| Before    | After |
| -------- | ------- |
| <img width="238" height="139" alt="Screenshot 2025-11-25 at 13 24 14" src="https://github.com/user-attachments/assets/9d4203bc-75ab-45a8-8a98-60c36669f39c" /> |  <img width="238" height="139" alt="Screenshot 2025-11-25 at 13 23 50" src="https://github.com/user-attachments/assets/9562e835-63e9-46fb-866e-b9eea3652764" /> |