### PR TITLE
RI-7834 Workbench toggle result icon

### DIFF
--- a/redisinsight/ui/src/packages/clients-list/public/json_view_icon_dark.svg
+++ b/redisinsight/ui/src/packages/clients-list/public/json_view_icon_dark.svg
@@ -1,11 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;stroke:#DFE5EF;stroke-linecap:round;}
-</style>
-<path class="st0" d="M3.9,3.7C3.5,3.7,2.6,4,2.6,5.1s0,1.7,0,1.8c0,0.5-0.4,1.4-1.8,1.4c0.6,0,1.8,0.2,1.8,0.9s0,1.8,0,2.3
-	s0.3,1.4,1.4,1.4"/>
-<path class="st0" d="M12.1,3.7c0.5,0,1.4,0.3,1.4,1.4s0,1.7,0,1.8c0,0.5,0.4,1.4,1.8,1.4c-0.6,0-1.8,0.2-1.8,0.9s0,1.8,0,2.3
-	s-0.3,1.4-1.4,1.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M3.9,3.7C3.5,3.7,2.6,4,2.6,5.1s0,1.7,0,1.8c0,0.5-0.4,1.4-1.8,1.4c0.6,0,1.8,0.2,1.8,0.9s0,1.8,0,2.3s0.3,1.4,1.4,1.4" fill="none" stroke="#DFE5EF" stroke-linecap="round"/>
+  <path d="M12.1,3.7c0.5,0,1.4,0.3,1.4,1.4s0,1.7,0,1.8c0,0.5,0.4,1.4,1.8,1.4c-0.6,0-1.8,0.2-1.8,0.9s0,1.8,0,2.3s-0.3,1.4-1.4,1.4" fill="none" stroke="#DFE5EF" stroke-linecap="round"/>
 </svg>

--- a/redisinsight/ui/src/packages/clients-list/public/json_view_icon_light.svg
+++ b/redisinsight/ui/src/packages/clients-list/public/json_view_icon_light.svg
@@ -1,11 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;stroke:#728baf;stroke-linecap:round;}
-</style>
-<path class="st0" d="M3.9,3.7C3.5,3.7,2.6,4,2.6,5.1s0,1.7,0,1.8c0,0.5-0.4,1.4-1.8,1.4c0.6,0,1.8,0.2,1.8,0.9s0,1.8,0,2.3
-	s0.3,1.4,1.4,1.4"/>
-<path class="st0" d="M12.1,3.7c0.5,0,1.4,0.3,1.4,1.4s0,1.7,0,1.8c0,0.5,0.4,1.4,1.8,1.4c-0.6,0-1.8,0.2-1.8,0.9s0,1.8,0,2.3
-	s-0.3,1.4-1.4,1.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M3.9,3.7C3.5,3.7,2.6,4,2.6,5.1s0,1.7,0,1.8c0,0.5-0.4,1.4-1.8,1.4c0.6,0,1.8,0.2,1.8,0.9s0,1.8,0,2.3s0.3,1.4,1.4,1.4" fill="none" stroke="#728baf" stroke-linecap="round"/>
+  <path d="M12.1,3.7c0.5,0,1.4,0.3,1.4,1.4s0,1.7,0,1.8c0,0.5,0.4,1.4,1.8,1.4c-0.6,0-1.8,0.2-1.8,0.9s0,1.8,0,2.3s-0.3,1.4-1.4,1.4" fill="none" stroke="#728baf" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
# What

Fix the button for toggling the result view mode (Text or JSON) in the Workbench.

We use the generic `RiIcon` component, but when the icon is not found in the registry, we use a regular image as a fallback. And we weren't applying the size constraints to it, so now this should be fixed.

# Testing

Note: It can be verified only on the desktop build, so make sure you run the following commands in advance:
```bash
yarn build:statics
yarn dev:desktop
```

1. Open Redis Insight and go to the Databases tab
2. Open existing database connection or create a new one
3. Go to Workbench tab
4. Execute `set hello 'world'` to make sure there are keys in the database
5. Execute `get hello` command

Now, from the list with the results, you should be able to toggle the view mode of the result (Text or JSON).
And the icon should look ok for both modes.

| Before | After |
| - | - |
<img width="328" height="184" alt="Screenshot 2025-11-25 at 14 56 37" src="https://github.com/user-attachments/assets/3991e49b-8ffe-4b17-bfac-10783797f603" />|<img width="328" height="184" alt="Screenshot 2025-11-25 at 14 55 50" src="https://github.com/user-attachments/assets/436a3d9d-ab38-4cef-bc43-c1cc9ad27afa" />
