### PR TITLE
RI-7814 Always show monaco editor code suggestions

### DIFF
--- a/redisinsight/ui/src/constants/monaco/monaco.ts
+++ b/redisinsight/ui/src/constants/monaco/monaco.ts
@@ -51,6 +51,7 @@ export const defaultMonacoOptions: monacoEditor.editor.IStandaloneEditorConstruc
     automaticLayout: true,
     formatOnPaste: false,
     glyphMargin: true,
+    fixedOverflowWidgets: true,
     bracketPairColorization: {
       enabled: true,
       independentColorPoolPerBracketType: true,


### PR DESCRIPTION
# What

When typing commands like `JSON.GET` and continuing to type, the suggestion tooltip would appear above the line (when there wasn't enough space below) and get clipped/cut off, making it impossible to read the suggestions.

### Root Cause
The Monaco Editor's overflow widgets (suggestion tooltips, parameter hints) were being rendered relative to the editor container. When positioned above the cursor line, these widgets would be clipped by parent containers with CSS overflow restrictions.

### Solution
Added the `fixedOverflowWidgets: true` option to the default Monaco Editor configuration.

This option ensures that overflow widgets are rendered in a fixed position at the document root level rather than relative to the editor container, preventing them from being clipped by parent elements' CSS overflow properties.

# Testing

1. Open Redis Insight and go to the **Databases** tab
2. Open existing database connection or create a new one
3. Open **Workbench** tab
4. Type a command like `JSON.GET` followed by additional text
5. Verify that suggestion tooltips are fully visible whether they appear above or below the cursor line
6. Verify that long suggestion lists are fully accessible

| Before | After |
| - | - |
<img alt="image" src="https://github.com/user-attachments/assets/9a660dd2-f212-45a4-b5a5-4a3b8211e33a" />|<img  alt="image" src="https://github.com/user-attachments/assets/a1d58b0f-8ac5-457e-b348-c6e1e6291444" />

