### PR TITLE
RI-7794: Fix font sizes in Security tab of add database form

### DIFF
--- a/redisinsight/ui/src/pages/home/components/form/TlsDetails.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/TlsDetails.tsx
@@ -191,7 +191,8 @@ const TlsDetails = (props: Props) => {
             <Checkbox
               id={sslId}
               name="tls"
-              label={<Text>Use TLS</Text>}
+              label="Use TLS"
+              labelSize="M"
               checked={!!formik.values.tls}
               onChange={formik.handleChange}
               data-testid="tls"
@@ -207,6 +208,7 @@ const TlsDetails = (props: Props) => {
               <Checkbox
                 id={sni}
                 name="sni"
+                labelSize="M"
                 label="Use SNI"
                 checked={!!formik.values.sni}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -251,6 +253,7 @@ const TlsDetails = (props: Props) => {
                 id={verifyTlsId}
                 name="verifyServerTlsCert"
                 label="Verify TLS Certificate"
+                labelSize="M"
                 checked={!!formik.values.verifyServerTlsCert}
                 onChange={formik.handleChange}
                 data-testid="verify-tls-cert"
@@ -333,6 +336,7 @@ const TlsDetails = (props: Props) => {
               id={isTlsAuthId}
               name="tlsClientAuthRequired"
               label="Requires TLS Client Authentication"
+              labelSize="M"
               checked={!!formik.values.tlsClientAuthRequired}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 formik.setFieldValue('tlsClientAuthRequired', e.target.checked)


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Fix font sizes for checkboxes labels

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

|Before|After|
|-|-|
<img width="911" height="713" alt="Screenshot 2025-11-26 at 11 58 10" src="https://github.com/user-attachments/assets/b2082a7f-1cc4-4a39-b787-a9d3896c000d" />|<img width="911" height="713" alt="Screenshot 2025-11-26 at 11 56 38" src="https://github.com/user-attachments/assets/de8a751a-b768-471e-ad09-2978b1784330" />

