### PR TITLE
RI-7752: persist pagination state for DB, RDI and Pub/Sub tables

### DIFF
--- a/redisinsight/ui/src/constants/storage.ts
+++ b/redisinsight/ui/src/constants/storage.ts
@@ -40,6 +40,7 @@ enum BrowserStorageItem {
   selectedAiChat = 'selectedAiChat',
   generalChatAgreements = 'generalChatAgreements',
   vectorSearchOnboarding = 'vectorSearchOnboarding',
+  tablePaginationState = 'tablePaginationState',
 }
 
 export default BrowserStorageItem
@@ -56,4 +57,10 @@ export enum CapabilityStorageItem {
 
 export enum AppStorageItem {
   returnUrl = 'returnUrl',
+}
+
+export enum TableStorageKey {
+  dbList = 'dbList',
+  rdiList = 'rdiList',
+  pubSubList = 'pubSubList',
 }

--- a/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.tsx
+++ b/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.tsx
@@ -3,7 +3,9 @@ import React, { memo } from 'react'
 import { Table } from 'uiSrc/components/base/layout/table'
 import {
   handleCheckConnectToInstance,
+  handlePaginationChange,
   handleSortingChange,
+  getDefaultPagination,
 } from './methods/handlers'
 import BulkItemsActions from './components/BulkItemsActions/BulkItemsActions'
 import { DEFAULT_SORTING } from './DatabasesList.config'
@@ -34,6 +36,8 @@ const DatabasesList = () => {
         onRowSelectionChange={setRowSelection}
         rowSelection={rowSelection}
         onSortingChange={handleSortingChange}
+        defaultPagination={getDefaultPagination()}
+        onPaginationChange={handlePaginationChange}
         defaultSorting={DEFAULT_SORTING}
         maxHeight="60rem" // this enables vertical scroll
       />

--- a/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.ts
+++ b/redisinsight/ui/src/pages/home/components/databases-list/methods/handlers.ts
@@ -12,9 +12,17 @@ import {
 import { appContextSelector, resetRdiContext } from 'uiSrc/slices/app/context'
 import { BrowserStorageItem, Pages } from 'uiSrc/constants'
 import { store, dispatch } from 'uiSrc/slices/store'
-import { SortingState } from 'uiSrc/components/base/layout/table'
+import {
+  SortingState,
+  PaginationState,
+} from 'uiSrc/components/base/layout/table'
 import { navigate } from 'uiSrc/Router'
-import { localStorageService } from 'uiSrc/services'
+import { TableStorageKey } from 'uiSrc/constants/storage'
+import {
+  getObjectStorageField,
+  localStorageService,
+  setObjectStorageField,
+} from 'uiSrc/services'
 
 const connectToInstance = (id: string) => {
   dispatch(resetRdiContext())
@@ -66,3 +74,16 @@ export const handleSortingChange = (sorting: SortingState) => {
     eventData: sort,
   })
 }
+
+export const handlePaginationChange = (paginationState: PaginationState) =>
+  setObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.dbList,
+    paginationState,
+  )
+
+export const getDefaultPagination = () =>
+  getObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.dbList,
+  )

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.config.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.config.tsx
@@ -1,5 +1,8 @@
 import { IMessage } from 'apiSrc/modules/pub-sub/interfaces/message.interface'
-import { ColumnDef } from 'uiSrc/components/base/layout/table'
+import { ColumnDef, PaginationState } from 'uiSrc/components/base/layout/table'
+import { BrowserStorageItem } from 'uiSrc/constants'
+import { TableStorageKey } from 'uiSrc/constants/storage'
+import { setObjectStorageField, getObjectStorageField } from 'uiSrc/services'
 import {
   PUB_SUB_TABLE_COLUMN_FIELD_NAME_MAP,
   PubSubTableColumn,
@@ -29,3 +32,16 @@ export const PUB_SUB_TABLE_COLUMNS: ColumnDef<IMessage>[] = [
     header: PUB_SUB_TABLE_COLUMN_FIELD_NAME_MAP.get(PubSubTableColumn.Message),
   },
 ]
+
+export const handlePaginationChange = (paginationState: PaginationState) =>
+  setObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.pubSubList,
+    paginationState,
+  )
+
+export const getDefaultPagination = () =>
+  getObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.pubSubList,
+  )

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.tsx
@@ -17,7 +17,11 @@ import SubscribeForm from '../../subscribe-form'
 import PatternsInfo from '../../patternsInfo'
 import { Wrapper } from './MessagesListTable.styles'
 import { Table } from 'uiSrc/components/base/layout/table'
-import { PUB_SUB_TABLE_COLUMNS } from './MessagesListTable.config'
+import {
+  getDefaultPagination,
+  handlePaginationChange,
+  PUB_SUB_TABLE_COLUMNS,
+} from './MessagesListTable.config'
 import { PubSubTableColumn } from './MessagesListTable.constants'
 
 const MessagesListTable = () => {
@@ -81,6 +85,8 @@ const MessagesListTable = () => {
             enableSorting
             paginationEnabled
             defaultSorting={[{ id: PubSubTableColumn.Timestamp, desc: true }]}
+            onPaginationChange={handlePaginationChange}
+            defaultPagination={getDefaultPagination()}
             emptyState="No messages published yet"
           />
         </div>

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.tsx
@@ -5,7 +5,9 @@ import { Table } from 'uiSrc/components/base/layout/table'
 import useRdiInstancesListData from './hooks/useRdiInstancesListData'
 import {
   handleCheckConnectToRdiInstance,
+  handlePaginationChange,
   handleSortingChange,
+  getDefaultPagination,
 } from './methods/handlers'
 import { getDefaultSorting } from './methods/sortingAdapters'
 import BulkItemsActions from './components/BulkItemsActions/BulkItemsActions'
@@ -36,6 +38,8 @@ const RdiInstancesList = () => {
         rowSelection={rowSelection}
         onSortingChange={handleSortingChange}
         defaultSorting={getDefaultSorting()}
+        onPaginationChange={handlePaginationChange}
+        defaultPagination={getDefaultPagination()}
         maxHeight="60rem"
       />
       <BulkItemsActions items={selectedInstances} onClose={resetRowSelection} />

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/methods/handlers.ts
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/methods/handlers.ts
@@ -1,12 +1,20 @@
-import { SortingState } from 'uiSrc/components/base/layout/table'
+import {
+  SortingState,
+  PaginationState,
+} from 'uiSrc/components/base/layout/table'
 import { BrowserStorageItem, Pages } from 'uiSrc/constants'
-import { localStorageService } from 'uiSrc/services'
+import {
+  getObjectStorageField,
+  localStorageService,
+  setObjectStorageField,
+} from 'uiSrc/services'
 import { dispatch } from 'uiSrc/slices/store'
 import { navigate } from 'uiSrc/Router'
 import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
 import { setAppContextConnectedRdiInstanceId } from 'uiSrc/slices/app/context'
 import { checkConnectToRdiInstanceAction } from 'uiSrc/slices/rdi/instances'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
+import { TableStorageKey } from 'uiSrc/constants/storage'
 
 import { sortingStateToPropertySort } from './sortingAdapters'
 
@@ -50,3 +58,16 @@ export const handleCopyUrl = (
     eventData: { id },
   })
 }
+
+export const handlePaginationChange = (paginationState: PaginationState) =>
+  setObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.rdiList,
+    paginationState,
+  )
+
+export const getDefaultPagination = () =>
+  getObjectStorageField(
+    BrowserStorageItem.tablePaginationState,
+    TableStorageKey.rdiList,
+  )


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Persists pagination state (number of items per page and current page) for DB, RDI and Pub/Sub tables by using local storage.

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->
1. Open  DB, RDI (make sure you have 15+ items) or Pub/Sub table
2. change the "Items per page" or current page setting
3. navigate away/reload the app
4. previous selection should be preserved

## Before
https://github.com/user-attachments/assets/42aeb20b-ed83-46c2-8169-eb0ef92138a0

## After
https://github.com/user-attachments/assets/d758f1b8-099f-4b97-a4b1-837b921d9503


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist and restore pagination (page and page size) for database, RDI instance, and Pub/Sub tables using local storage.
> 
> - **Storage**:
>   - Add `BrowserStorageItem.tablePaginationState` and `TableStorageKey` (`dbList`, `rdiList`, `pubSubList`) in `ui/src/constants/storage.ts`.
> - **Tables**:
>   - `ui/src/pages/home/components/databases-list/DatabasesList.tsx`
>     - Wire `defaultPagination={getDefaultPagination()}` and `onPaginationChange={handlePaginationChange}` to `Table`.
>   - `ui/src/pages/rdi/home/components/rdi-instances-list/RdiInstancesList.tsx`
>     - Wire `defaultPagination` and `onPaginationChange` similarly.
>   - `ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.tsx`
>     - Wire `defaultPagination` and `onPaginationChange` similarly.
> - **Handlers**:
>   - Databases: add `handlePaginationChange`/`getDefaultPagination` in `methods/handlers.ts` using `setObjectStorageField`/`getObjectStorageField` with `TableStorageKey.dbList`.
>   - RDI: add same in `methods/handlers.ts` with `TableStorageKey.rdiList`.
>   - Pub/Sub: add same in `MessagesListTable.config.tsx` with `TableStorageKey.pubSubList`.
>   - Import `PaginationState` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7144d086c64ac5bf8a194a6d1eb2cbf9629dad58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->