### PR TITLE
RI-7826: RDI data streams statistics table

### DIFF
--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.config.ts
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.config.ts
@@ -1,0 +1,78 @@
+import { ColumnDef } from 'uiSrc/components/base/layout/table'
+import { DataStreamsData } from './DataStreams.types'
+import { LastArrivalCell, StreamNameCell } from './components'
+
+const columns: ColumnDef<DataStreamsData>[] = [
+  {
+    header: 'Stream name',
+    id: 'name',
+    accessorKey: 'name',
+    enableSorting: true,
+    cell: StreamNameCell,
+  },
+  {
+    header: 'Total',
+    id: 'total',
+    accessorKey: 'total',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Pending',
+    id: 'pending',
+    accessorKey: 'pending',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Inserted',
+    id: 'inserted',
+    accessorKey: 'inserted',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Updated',
+    id: 'updated',
+    accessorKey: 'updated',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Deleted',
+    id: 'deleted',
+    accessorKey: 'deleted',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Filtered',
+    id: 'filtered',
+    accessorKey: 'filtered',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Rejected',
+    id: 'rejected',
+    accessorKey: 'rejected',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Deduplicated',
+    id: 'deduplicated',
+    accessorKey: 'deduplicated',
+    enableSorting: true,
+    size: 100,
+  },
+  {
+    header: 'Last arrival',
+    id: 'lastArrival',
+    accessorKey: 'lastArrival',
+    enableSorting: true,
+    cell: LastArrivalCell,
+  },
+]
+
+export default columns

--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.tsx
@@ -1,104 +1,20 @@
 import React from 'react'
 
 import { IDataStreams } from 'uiSrc/slices/interfaces'
-import { formatLongName } from 'uiSrc/utils'
-import { FormatedDate, RiTooltip } from 'uiSrc/components'
-import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
+import { Table } from 'uiSrc/components/base/layout/table'
 import { Section } from '@redis-ui/components'
 import {
   StyledRdiAnalyticsTable,
   StyledRdiStatisticsSectionBody,
 } from 'uiSrc/pages/rdi/statistics/styles'
-
-type DataStreamsData = {
-  name: string
-  total: number
-  pending: number
-  inserted: number
-  updated: number
-  deleted: number
-  filtered: number
-  rejected: number
-  deduplicated: number
-  lastArrival?: string
-}
+import { DataStreamsData } from './DataStreams.types'
+import columns from './DataStreams.config'
 
 interface Props {
   data: IDataStreams
 }
 
-const columns: ColumnDefinition<DataStreamsData>[] = [
-  {
-    header: 'Stream name',
-    id: 'name',
-    accessorKey: 'name',
-    enableSorting: true,
-    cell: ({ getValue }) => (
-      <RiTooltip content={getValue<string>()}>
-        <span>{formatLongName(getValue<string>(), 30, 0, '...')}</span>
-      </RiTooltip>
-    ),
-  },
-  {
-    header: 'Total',
-    id: 'total',
-    accessorKey: 'total',
-    enableSorting: true,
-  },
-  {
-    header: 'Pending',
-    id: 'pending',
-    accessorKey: 'pending',
-    enableSorting: true,
-  },
-  {
-    header: 'Inserted',
-    id: 'inserted',
-    accessorKey: 'inserted',
-    enableSorting: true,
-  },
-  {
-    header: 'Updated',
-    id: 'updated',
-    accessorKey: 'updated',
-    enableSorting: true,
-  },
-  {
-    header: 'Deleted',
-    id: 'deleted',
-    accessorKey: 'deleted',
-    enableSorting: true,
-  },
-  {
-    header: 'Filtered',
-    id: 'filtered',
-    accessorKey: 'filtered',
-    enableSorting: true,
-  },
-  {
-    header: 'Rejected',
-    id: 'rejected',
-    accessorKey: 'rejected',
-    enableSorting: true,
-  },
-  {
-    header: 'Deduplicated',
-    id: 'deduplicated',
-    accessorKey: 'deduplicated',
-    enableSorting: true,
-  },
-  {
-    header: 'Last arrival',
-    id: 'lastArrival',
-    accessorKey: 'lastArrival',
-    enableSorting: true,
-    cell: ({ getValue }) => <FormatedDate date={getValue<string>()} />,
-  },
-]
-
-const DataStreams = ({
-  data,
-}: Props) => {
+const DataStreams = ({ data }: Props) => {
   const dataStreams: DataStreamsData[] = Object.keys(data?.streams || {}).map(
     (key) => {
       const dataStream = data.streams[key]

--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.types.ts
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/DataStreams.types.ts
@@ -1,0 +1,12 @@
+export type DataStreamsData = {
+  name: string
+  total: number
+  pending: number
+  inserted: number
+  updated: number
+  deleted: number
+  filtered: number
+  rejected: number
+  deduplicated: number
+  lastArrival?: string
+}

--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/LastArrivalCell.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/LastArrivalCell.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { CellContext } from 'uiSrc/components/base/layout/table'
+import { DataStreamsData } from 'uiSrc/pages/rdi/statistics/data-streams/DataStreams.types'
+import { FormatedDate } from 'uiSrc/components'
+
+export const LastArrivalCell = ({
+  getValue,
+}: CellContext<DataStreamsData, unknown>) => (
+  <FormatedDate date={getValue<string>()} />
+)

--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/StreamNameCell.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/StreamNameCell.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { CellContext } from 'uiSrc/components/base/layout/table'
+import { DataStreamsData } from 'uiSrc/pages/rdi/statistics/data-streams/DataStreams.types'
+import { RiTooltip } from 'uiSrc/components'
+import { formatLongName } from 'uiSrc/utils'
+
+export const StreamNameCell = ({
+  getValue,
+}: CellContext<DataStreamsData, unknown>) => (
+  <RiTooltip content={getValue<string>()}>
+    <span>{formatLongName(getValue<string>(), 30, 0, '...')}</span>
+  </RiTooltip>
+)

--- a/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/index.ts
+++ b/redisinsight/ui/src/pages/rdi/statistics/data-streams/components/index.ts
@@ -1,0 +1,2 @@
+export { LastArrivalCell } from './LastArrivalCell'
+export { StreamNameCell } from './StreamNameCell'


### PR DESCRIPTION
# What

Fixed RDI data streams statistics table by updating column configuration.

**Key changes:**
- Added `DataStreams.config.ts` with column definitions
- Created `DataStreams.types.ts` with TypeScript interfaces for data streams data
- Implemented `LastArrivalCell.tsx` and  `StreamNameCell.tsx`

| Before | After |
|--------|-------|
| <img width="1503" height="561" alt="image" src="https://github.com/user-attachments/assets/57ab7c3c-53d3-4a6d-ba62-51e48cff1e5d" /> | <img width="1503" height="561" alt="image" src="https://github.com/user-attachments/assets/c019218d-0820-46a4-9c01-c868bdb2880e" /> |

# Testing

To verify the changes:
1. Navigate to the RDI page
2. Open a configuration
3. Click `Analytics`
4. Ensure all columns are fully visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the RDI data streams statistics table to use a dedicated column config and typed data with custom cells, adds a totals row, and sets default sorting.
> 
> - **RDI Analytics — Data Streams Table**
>   - **Column config**: Extracted to `DataStreams.config.ts` using `ColumnDef`, added fixed widths for numeric columns, and custom cells for `name` and `lastArrival`.
>   - **Types**: Added `DataStreams.types.ts` defining `DataStreamsData`.
>   - **Cells**: New `StreamNameCell` (tooltip + truncated name) and `LastArrivalCell` (formatted date) under `components/` with index export.
>   - **Table setup**: `DataStreams.tsx` now imports config/types, appends a computed `totalsRow`, and applies default sorting by `name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 485d7aec1d8a728eedbfc7bf2dde0b16ff44cacd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->