### PR TITLE
RI-7798: report with deleted keys only

### DIFF
--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.spec.ts
@@ -277,7 +277,7 @@ describe('AbstractBulkActionSimpleRunner', () => {
       deleteRunner.processIterationResults(keys, results);
 
       expect(addProcessedSpy).toHaveBeenCalledWith(3);
-      expect(addKeysSpy).toHaveBeenCalledWith(keys);
+      expect(addKeysSpy).toHaveBeenCalledWith([keys[0], keys[2]]);
 
       expect(addSuccessSpy).toHaveBeenNthCalledWith(1, 1); // first call
       expect(addSuccessSpy).toHaveBeenNthCalledWith(2, 1); // second call

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner.ts
@@ -82,11 +82,11 @@ export abstract class AbstractBulkActionSimpleRunner extends AbstractBulkActionR
    * @param res
    */
   processIterationResults(
-    keys,
+    keys: Buffer[],
     res: [Error | null, RedisClientCommandReply][],
   ) {
     this.summary.addProcessed(res.length);
-    this.summary.addKeys(keys);
+    this.summary.addKeys(keys.filter((_, index) => !res[index][0]));
 
     const errors = [];
 


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Filtered keys processed by command result. In case of an error in results array we will filter out key from the keys array

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

https://github.com/user-attachments/assets/42cf4560-1c9b-4255-afa3-7f9d4f224de9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters processed keys to include only successful operations when updating the summary, adds explicit typing, and updates tests accordingly.
> 
> - **Backend**
>   - **Bulk Actions (Simple Runner)**:
>     - Update `processIterationResults(keys: Buffer[], res)` to add only successful `keys` to summary: `keys.filter((_, i) => !res[i][0])`.
>     - Add explicit typing for `keys: Buffer[]` in `processIterationResults`.
>   - **Tests**:
>     - Adjust spec to expect only successfully processed `keys` added to summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2871899f2e55a4ea77319047459aabf4f9c029cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->