### PR TITLE
RI-7789: prevent content jumping in tree view

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/VirtualTree.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/VirtualTree.tsx
@@ -279,7 +279,8 @@ const VirtualTree = (props: Props) => {
                 <ProgressBarLoader
                   color="primary"
                   data-testid="progress-key-tree"
-                  style={{ width }}
+                  absolute
+                  style={{ width, zIndex: 1 }}
                 />
               )}
               <Tree


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Make loader absolute + set z-index to be visible for tree view

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

https://github.com/user-attachments/assets/b1376d85-c704-40a1-809a-0508fb85b3e9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `ProgressBarLoader` in `VirtualTree` absolute with z-index to overlay content and avoid layout shifts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f65daaa3d636f7c8a338b24d18e6dacf4b20a49d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->