### PR TITLE
RI-7784: update add db buttons styles

### DIFF
--- a/redisinsight/ui/src/pages/home/components/database-list-header/DatabaseListHeader.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-header/DatabaseListHeader.tsx
@@ -27,6 +27,7 @@ import {
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
+  EmptyButton,
   PrimaryButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
@@ -111,22 +112,22 @@ const DatabaseListHeader = ({ onAddInstance }: Props) => {
       <PrimaryButton
         onClick={handleClickFreeCloudDb}
         data-testid={`${CREATE_CLOUD_DB_ID}-button`}
-        icon={PlusIcon}
       >
-        Create Free Cloud database
+        Create free Cloud database
       </PrimaryButton>
     </FeatureFlagComponent>
   )
 
   const AddLocalInstanceButton = () => (
     <FeatureFlagComponent name={FeatureFlags.databaseManagement}>
-      <SecondaryButton
+      <EmptyButton
+        variant="primary"
         onClick={handleOnAddDatabase}
         data-testid="add-redis-database-short"
         icon={PlusIcon}
       >
         Connect existing database
-      </SecondaryButton>
+      </EmptyButton>
     </FeatureFlagComponent>
   )
 


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Updates text/styles for add db buttons to match new design.

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

| Before | After | 
| --- | --- |
| <img width="553" height="208" alt="Screenshot 2025-11-27 at 10 49 07" src="https://github.com/user-attachments/assets/ac12e750-f205-4451-91e8-45cc5d6bb8bf" /> | <img width="552" height="206" alt="Screenshot 2025-11-27 at 10 29 31" src="https://github.com/user-attachments/assets/4fa3c63b-9719-41e3-b6e6-744e9b5052d8" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tweaks add-database buttons: updates Cloud button text/removes icon and switches local connect button to `EmptyButton` (primary variant).
> 
> - **UI (Database list header `DatabaseListHeader.tsx`)**:
>   - **Cloud CTA**: Change label to `Create free Cloud database`; remove `PlusIcon` from `PrimaryButton`.
>   - **Local connect CTA**: Replace `SecondaryButton` with `EmptyButton` (`variant="primary"`) for `Connect existing database` (keeps `PlusIcon`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a01886a1a7e8dd1b18bffe46914e2e55d58df008. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->