### PR TITLE
RI-7782: don't show notifications when masters array is empty

### DIFF
--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.stories.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.stories.tsx
@@ -222,3 +222,18 @@ export const Empty: Story = {
     countSuccessAdded: 0,
   },
 }
+
+export const NoNotificationWhenMastersAreNotProvided: Story = {
+  args: {
+    columns: colFactory(
+      action('onChangedInput'),
+      action('onAddInstance'),
+      false,
+      0,
+      0,
+    ),
+    masters: [],
+    onBack: action('onBack'),
+    countSuccessAdded: 2,
+  },
+}

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.tsx
@@ -45,7 +45,9 @@ const SentinelDatabasesResult = ({
 
   const { loading } = useSelector(sentinelSelector)
 
-  const countFailAdded = masters?.length - countSuccessAdded
+  const countFailAdded = masters?.length
+    ? masters.length - countSuccessAdded
+    : 0
 
   useEffect(() => {
     if (masters.length) {
@@ -105,19 +107,21 @@ const SentinelDatabasesResult = ({
             />
           )}
         </DatabaseWrapper>
-        <MessageBar
-          opened={!!countSuccessAdded || !!countFailAdded}
-          variant={
-            !!countFailAdded
-              ? riToast.Variant.Attention
-              : riToast.Variant.Success
-          }
-        >
-          <SummaryText
-            countSuccessAdded={countSuccessAdded}
-            countFailAdded={countFailAdded}
-          />
-        </MessageBar>
+        {!!masters?.length && (
+          <MessageBar
+            opened={!!countSuccessAdded || !!countFailAdded}
+            variant={
+              !!countFailAdded
+                ? riToast.Variant.Attention
+                : riToast.Variant.Success
+            }
+          >
+            <SummaryText
+              countSuccessAdded={countSuccessAdded}
+              countFailAdded={countFailAdded}
+            />
+          </MessageBar>
+        )}
       </DatabaseContainer>
       <Footer>
         <Row justify="end">


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Because of redux we might have a situation when masters array is empty when successfully added master groups is > 0. For such cases I've enhanced checks to not show notifications at all

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

Added storybook scenario, it could be verified there 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide MessageBar and compute failure count safely when `masters` is empty; add Storybook case to verify no notification is shown.
> 
> - **UI (`SentinelDatabasesResult.tsx`)**
>   - Safely compute `countFailAdded` when `masters` is empty.
>   - Show `MessageBar` only when `masters.length > 0`.
> - **Storybook**
>   - Add `NoNotificationWhenMastersAreNotProvided` scenario to validate no notification with empty `masters`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8731d1887c6063350d91cdeb6b77a2e56f28b02b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->