### PR TITLE
RI-7760: update margins for empty pub/sub table

### DIFF
--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/EmptyMessagesList/EmptyMessagesList.styles.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/EmptyMessagesList/EmptyMessagesList.styles.tsx
@@ -17,6 +17,7 @@ export const InnerContainer = styled(Col)`
 `
 
 export const Wrapper = styled(FlexItem)`
-  margin: ${({ theme }) => theme.core.space.space500};
+  margin: ${({ theme }) =>
+    `${theme.core.space.space050} ${theme.core.space.space200}`};
   height: 100%;
 `


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Margin updates for empty pub/sub table to keep layout similar to rest of the pages

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

| Before | After |
| --- | --- |
| <img width="1142" height="848" alt="Screenshot 2025-11-27 at 15 05 34" src="https://github.com/user-attachments/assets/fab72038-61af-4011-b65b-9d3b3045d38b" /> | <img width="1137" height="821" alt="Screenshot 2025-11-27 at 15 05 04" src="https://github.com/user-attachments/assets/5ee84e24-2448-4f3d-ae6a-e8ada67bc155" /> |

## Before

https://github.com/user-attachments/assets/4da46e15-5b35-4420-9986-9677b49cee86

## After  

https://github.com/user-attachments/assets/6b3fdd25-c338-4016-ac79-4a777eaf087a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tweaks `Wrapper` margins in `EmptyMessagesList.styles.tsx` to use `${space050} ${space200}` for better layout consistency.
> 
> - **UI (Pub/Sub)**:
>   - **Empty Messages List**: Update `Wrapper` margins in `redisinsight/ui/src/pages/pub-sub/components/messages-list/EmptyMessagesList/EmptyMessagesList.styles.tsx` from `space500` to `${space050} ${space200}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85dc8c12235dd4644be7fa6639edb8495e8a0547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->