### PR TITLE
RI-7799: Bulk delete in batches

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -451,4 +451,8 @@ export default {
     queryMaxNestedElements:
       parseInt(process.env.RI_AI_QUERY_MAX_NESTED_ELEMENTS, 10) || 25,
   },
+  bulk_actions: {
+    summaryKeysLimit:
+      parseInt(process.env.RI_BULK_ACTIONS_SUMMARY_KEYS_LIMIT, 10) || 10_000,
+  },
 };

--- a/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
@@ -176,12 +176,11 @@ describe('BulkImportService', () => {
     });
     it('should return all failed in case of global error', async () => {
       mockStandaloneRedisClient.sendPipeline.mockRejectedValueOnce(new Error());
-      expect(
-        await service['executeBatch'](
-          mockStandaloneRedisClient,
-          mockBatchCommands,
-        ),
-      ).toEqual({
+      const result = await service['executeBatch'](
+        mockStandaloneRedisClient,
+        mockBatchCommands,
+      );
+      expect(result.getOverview()).toEqual({
         ...mockSummary.getOverview(),
         succeed: 0,
         failed: mockSummary.getOverview().processed,

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action-summary.spec.ts
@@ -81,6 +81,98 @@ describe('BulkActionSummary', () => {
       expect(summary['errors']).toEqual(generateErrors(500));
     });
   });
+
+  describe('addKeys', () => {
+    it('should add keys when under limit', async () => {
+      const keys = [Buffer.from('key1'), Buffer.from('key2')];
+
+      summary.addKeys(keys);
+
+      expect(summary['keys']).toEqual(keys);
+      expect(summary['totalKeysProcessed']).toEqual(2);
+      expect(summary['hasMoreKeys']).toBe(false);
+    });
+
+    it('should limit stored keys when exceeding default limit', async () => {
+      // Create many keys to exceed the default limit of 10,000
+      const keys = Array.from({ length: 15000 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+
+      summary.addKeys(keys);
+
+      expect(summary['keys']).toHaveLength(10000); // Default limit
+      expect(summary['totalKeysProcessed']).toEqual(15000);
+      expect(summary['hasMoreKeys']).toBe(true);
+    });
+
+    it('should handle multiple addKeys calls with default limit', async () => {
+      // Add keys in batches that exceed the default limit
+      const batch1 = Array.from({ length: 8000 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+      const batch2 = Array.from({ length: 5000 }, (_, i) =>
+        Buffer.from(`key${i + 8000}`),
+      );
+
+      summary.addKeys(batch1);
+      expect(summary['keys']).toHaveLength(8000);
+      expect(summary['totalKeysProcessed']).toEqual(8000);
+      expect(summary['hasMoreKeys']).toBe(false);
+
+      summary.addKeys(batch2);
+      expect(summary['keys']).toHaveLength(10000); // Default limit
+      expect(summary['totalKeysProcessed']).toEqual(13000);
+      expect(summary['hasMoreKeys']).toBe(true);
+    });
+
+    it('should handle partial batch when approaching default limit', async () => {
+      // Add keys close to the limit
+      const batch1 = Array.from({ length: 9999 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+      const batch2 = [Buffer.from('key9999'), Buffer.from('key10000')];
+
+      summary.addKeys(batch1);
+      expect(summary['keys']).toHaveLength(9999);
+      expect(summary['totalKeysProcessed']).toEqual(9999);
+      expect(summary['hasMoreKeys']).toBe(false);
+
+      summary.addKeys(batch2);
+      expect(summary['keys']).toHaveLength(10000); // Default limit
+      expect(summary['totalKeysProcessed']).toEqual(10001);
+      expect(summary['hasMoreKeys']).toBe(true);
+    });
+
+    it('should use default limit from configuration', async () => {
+      expect(summary['maxStoredKeys']).toEqual(10_000);
+    });
+
+    it('should handle empty keys array', async () => {
+      summary.addKeys([]);
+
+      expect(summary['keys']).toEqual([]);
+      expect(summary['totalKeysProcessed']).toEqual(0);
+      expect(summary['hasMoreKeys']).toBe(false);
+    });
+
+    it('should handle large number of keys efficiently', async () => {
+      const largeKeySet = Array.from({ length: 15000 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+
+      summary.addKeys(largeKeySet);
+
+      expect(summary['keys']).toHaveLength(10000); // Default limit
+      expect(summary['totalKeysProcessed']).toEqual(15000);
+      expect(summary['hasMoreKeys']).toBe(true);
+
+      // Verify only first 10000 keys are stored
+      expect(summary['keys'][0]).toEqual(Buffer.from('key0'));
+      expect(summary['keys'][9999]).toEqual(Buffer.from('key9999'));
+    });
+  });
+
   describe('getOverview', () => {
     it('should get overview and clear errors', async () => {
       expect(summary['processed']).toEqual(0);
@@ -104,6 +196,59 @@ describe('BulkActionSummary', () => {
       expect(summary['succeed']).toEqual(500);
       expect(summary['failed']).toEqual(1000);
       expect(summary['errors']).toEqual([]);
+    });
+
+    it('should return only stored keys in overview (not internal fields)', async () => {
+      const keys = Array.from({ length: 15000 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+
+      summary.addKeys(keys);
+      summary.addProcessed(15000);
+      summary.addSuccess(15000);
+
+      const overview = summary.getOverview();
+
+      // Should only contain the interface fields, not internal tracking fields
+      expect(overview.processed).toEqual(15000);
+      expect(overview.succeed).toEqual(15000);
+      expect(overview.failed).toEqual(0);
+      expect(overview.errors).toEqual([]);
+      expect(overview.keys).toHaveLength(10000); // Default limit
+
+      // Internal fields should not be exposed
+      expect(overview).not.toHaveProperty('totalKeysProcessed');
+      expect(overview).not.toHaveProperty('hasMoreKeys');
+      expect(overview).not.toHaveProperty('maxStoredKeys');
+    });
+  });
+
+  describe('memory management integration', () => {
+    it('should maintain consistent state across operations', async () => {
+      const batch1 = Array.from({ length: 5000 }, (_, i) =>
+        Buffer.from(`key${i}`),
+      );
+      summary.addKeys(batch1);
+      summary.addProcessed(5000);
+      summary.addSuccess(5000);
+
+      // Add more keys that exceed default limit
+      const batch2 = Array.from({ length: 8000 }, (_, i) =>
+        Buffer.from(`key${i + 5000}`),
+      );
+      summary.addKeys(batch2);
+      summary.addProcessed(8000);
+      summary.addSuccess(7000);
+      summary.addFailed(1000);
+
+      const overview = summary.getOverview();
+
+      expect(overview.processed).toEqual(13000);
+      expect(overview.succeed).toEqual(12000);
+      expect(overview.failed).toEqual(1000);
+      expect(overview.keys).toHaveLength(10000); // Default limit
+      expect(summary['totalKeysProcessed']).toEqual(13000);
+      expect(summary['hasMoreKeys']).toBe(true);
     });
   });
 });


### PR DESCRIPTION
# What

The current bulk delete implementation keeps all deleted keys in memory. When the number grows large (e.g., around 1M keys), the backend eventually crashes.
This PR introduces batch processing to avoid that issue.

However, reports now only return the keys from the last processed batch, meaning the user can no longer see the complete list of deleted keys. So that's why I implemented https://github.com/redis/RedisInsight/pull/5257

# Testing

## Before

Fill a database with enough keys (depending on your RAM), and bulk delete them all.


https://github.com/user-attachments/assets/5efc348d-04ce-41ba-b0b6-4c16f38c7175



## After


https://github.com/user-attachments/assets/ef8a9404-5ec9-4bd7-9093-2b72154b4c85

