### PR TITLE
RI-7838 removed icons from bulk actions

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsTabs/BulkActionsTabs.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsTabs/BulkActionsTabs.tsx
@@ -14,8 +14,6 @@ import { DEFAULT_SEARCH_MATCH } from 'uiSrc/constants/api'
 import { keysSelector } from 'uiSrc/slices/browser/keys'
 import { TabInfo } from 'uiSrc/components/base/layout/tabs'
 import { Text } from 'uiSrc/components/base/text'
-import { RiIcon } from 'uiSrc/components/base/icons'
-import { Row } from 'uiSrc/components/base/layout/flex'
 
 import { StyledTabs } from './BulkActionsTabs.styles'
 
@@ -56,22 +54,12 @@ const BulkActionsTabs = (props: Props) => {
     () => [
       {
         value: BulkActionsType.Delete,
-        label: (
-          <Row align="center" gap="m" grow={false}>
-            <RiIcon type="DeleteIcon" />
-            <Text size="XS">Delete Keys</Text>
-          </Row>
-        ),
+        label: <Text size="S">Delete Keys</Text>,
         content: null,
       },
       {
         value: BulkActionsType.Upload,
-        label: (
-          <Row align="center" gap="m" grow={false}>
-            <RiIcon type="BulkUploadIcon" size="M" />
-            <Text size="XS">Upload Data</Text>
-          </Row>
-        ),
+        label: <Text size="S">Upload Data</Text>,
         content: null,
       },
     ],


### PR DESCRIPTION
# What

Removed action items and increased text to match visual

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies Bulk Actions tabs by removing icons and increasing label text size for Delete and Upload.
> 
> - **UI (Browser > Bulk Actions)**:
>   - In `redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsTabs/BulkActionsTabs.tsx`:
>     - Remove icon and layout wrappers from tab labels.
>     - Increase label text size to `S` and keep labels as plain text: `Delete Keys`, `Upload Data`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2174ffd8fc130c4f9faecdf027bb44567bad05ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->