### PR TITLE
RI-7782: reset state for cloud data when modal closed

### DIFF
--- a/redisinsight/ui/src/pages/home/HomePage.tsx
+++ b/redisinsight/ui/src/pages/home/HomePage.tsx
@@ -21,6 +21,7 @@ import {
 import { Instance } from 'uiSrc/slices/interfaces'
 import {
   cloudSelector,
+  resetDataRedisCloud,
   resetSubscriptionsRedisCloud,
 } from 'uiSrc/slices/instances/cloud'
 import {
@@ -210,6 +211,7 @@ const HomePage = () => {
     dispatch(resetDataRedisCluster())
     dispatch(resetDataSentinel())
     dispatch(resetImportInstances())
+    dispatch(resetDataRedisCloud())
 
     setOpenDialog(null)
     dispatch(setEditedInstance(null))


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Clear state for cloud the same way as for other states when model has been closed

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reset Redis Cloud state when closing the database modal, aligning it with other state resets.
> 
> - **Frontend**
>   - `redisinsight/ui/src/pages/home/HomePage.tsx`
>     - Add `resetDataRedisCloud` import from `uiSrc/slices/instances/cloud`.
>     - Call `dispatch(resetDataRedisCloud())` in `handleClose` to clear cloud data when the modal is closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86a55cc58ec9207b6a4161c7caa288115383e870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->