### PR TITLE
RI-7833 Remove icon from cloud database tooltip

### DIFF
--- a/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
+++ b/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
@@ -12,9 +12,8 @@ import {
   TelemetryEvent,
 } from 'uiSrc/telemetry'
 import { RiTooltip } from 'uiSrc/components'
-import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { Indicator } from 'uiSrc/components/base/text/text.styles'
-import { Row } from 'uiSrc/components/base/layout/flex'
+import { Col } from 'uiSrc/components/base/layout/flex'
 import {
   CHECK_CLOUD_DATABASE,
   WARNING_WITH_CAPABILITY,
@@ -127,12 +126,7 @@ const WarningTooltipContent = (props: WarningTooltipProps) => {
     },
   })
 
-  return (
-    <Row gap="l">
-      <RiIcon type="AlarmIcon" customSize="50px" />
-      <div>{content}</div>
-    </Row>
-  )
+  return <Col>{content}</Col>
 }
 
 export default DbStatus


### PR DESCRIPTION
# What

Remove the additional icon from the tooltips shown for the cloud databases on the database list.

# Testing

In order to see this tooltip, you need the following prerequisites.

1. You should import a FREE remote database from Redis Cloud
2. Wait 3 days without connecting to it to see a warning that it might get deleted if there is no activity
3. Wait 16 days without connecting to it to see the other message, as it might be deleted already

Or simply bypass the checks in the code [here](https://github.com/redis/RedisInsight/blob/main/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx#L86) and [there](https://github.com/redis/RedisInsight/blob/main/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx#L93) to force the tooltip

| Before | After |
| - | - |
<img width="422" height="262" alt="Screenshot 2025-12-01 at 10 37 30" src="https://github.com/user-attachments/assets/7a28e7a7-4628-4e7c-93b2-8160173acd74" />|<img width="422" height="262" alt="Screenshot 2025-12-01 at 10 33 48" src="https://github.com/user-attachments/assets/69955041-334a-45d5-887b-556d0595374a" />
<img width="422" height="262" alt="Screenshot 2025-12-01 at 10 37 46" src="https://github.com/user-attachments/assets/24299e04-cd83-451c-819f-614bfe312313" />|<img width="422" height="262" alt="Screenshot 2025-12-01 at 10 34 17" src="https://github.com/user-attachments/assets/740030c5-669e-4ad4-a04b-31f5ca0f213b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the additional icon from cloud database warning tooltips and replaces the row layout with a column.
> 
> - **UI (DbStatus)**:
>   - Remove `RiIcon` (AlarmIcon) from warning tooltip content.
>   - Replace `Row` layout with `Col` for tooltip content rendering.
>   - Adjust imports accordingly in `redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c408796d8be55ae3221327e2807e6a8fb995d3ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->