### PR TITLE
RI-7843: Remove workbench panel space

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/wb-results/WBResults/styles.module.scss
+++ b/redisinsight/ui/src/pages/workbench/components/wb-results/WBResults/styles.module.scss
@@ -1,12 +1,10 @@
 .wrapper {
   flex: 1;
-  height: calc(100% - var(--border-radius-medium));
   width: 100%;
+  height: 100%;
   background-color: var(--euiColorEmptyShade);
   border: 1px solid var(--euiColorLightShade);
   border-radius: var(--border-radius-medium);
-  // HACK: to fix rectangle like view in rounded borders wrapper
-  padding-bottom: var(--border-radius-medium);
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# What

Remove additional space in the workbench bottom panel

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

| Before | After |
| --- | --- |
| <img width="1520" height="918" alt="image" src="https://github.com/user-attachments/assets/b8f7204a-78cd-4dfd-9192-a9bf040a9994" /> | <img width="3050" height="1882" alt="image" src="https://github.com/user-attachments/assets/2fe0499a-055d-4393-b839-bf476860b940" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `WBResults` `.wrapper` to `height: 100%` and remove padding/height hacks to eliminate extra space.
> 
> - **UI Styles (Workbench Results)**
>   - Update `redisinsight/ui/src/pages/workbench/components/wb-results/WBResults/styles.module.scss`:
>     - Set `.wrapper` `height` to `100%`.
>     - Remove `height: calc(100% - var(--border-radius-medium))`.
>     - Remove extra `padding-bottom` on `.wrapper`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac0081f0d0b0cc7b7dacb7e441a9fe49f2aa2555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->