### PR TITLE
RI-000: remove e2e

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -24,36 +24,6 @@ jobs:
       environment: "production"
       target: "all"
 
-  e2e-docker-tests-smoke:
-    name: "E2E: Smoke (Docker)"
-    needs: builds-prod
-    uses: ./.github/workflows/tests-e2e-docker-smoke.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-docker-tests-critical-path:
-    name: "E2E: Critical Path (Docker)"
-    needs: builds-prod
-    uses: ./.github/workflows/tests-e2e-docker-critical-path.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-docker-tests-regression:
-    name: "E2E: Regression (Docker)"
-    needs: builds-prod
-    uses: ./.github/workflows/tests-e2e-docker-regression.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-appimage-tests:
-    name: E2E AppImage tests
-    needs: builds-prod
-    uses: ./.github/workflows/tests-e2e-appimage.yml
-    secrets: inherit
-
   virustotal-prod:
     name: Virustotal
     uses: ./.github/workflows/virustotal.yml
@@ -78,14 +48,7 @@ jobs:
   # Remove artifacts from github actions
   remove-artifacts:
     name: Remove artifacts
-    needs:
-      [
-        aws-upload-prod,
-        e2e-docker-tests-smoke,
-        e2e-docker-tests-critical-path,
-        e2e-docker-tests-regression,
-        e2e-appimage-tests,
-      ]
+    needs: [aws-upload-prod]
     if: always()
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -31,46 +31,10 @@ jobs:
     with:
       pre-release: true
 
-  e2e-docker-tests-smoke:
-    name: "E2E: Smoke (Docker)"
-    needs: builds
-    uses: ./.github/workflows/tests-e2e-docker-smoke.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-docker-tests-critical-path:
-    name: "E2E: Critical Path (Docker)"
-    needs: builds
-    uses: ./.github/workflows/tests-e2e-docker-critical-path.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-docker-tests-regression:
-    name: "E2E: Regression (Docker)"
-    needs: builds
-    uses: ./.github/workflows/tests-e2e-docker-regression.yml
-    secrets: inherit
-    with:
-      debug: ${{ inputs.debug || false }}
-
-  e2e-appimage-tests:
-    needs: builds
-    uses: ./.github/workflows/tests-e2e-appimage.yml
-    secrets: inherit
-
   # Remove artifacts from github actions
   remove-artifacts:
     name: Remove artifacts
-    needs:
-      [
-        aws,
-        e2e-docker-tests-smoke,
-        e2e-docker-tests-critical-path,
-        e2e-docker-tests-regression,
-        e2e-appimage-tests,
-      ]
+    needs: [aws]
     if: always()
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes E2E test jobs from prod/stage release workflows and updates remove-artifacts to depend only on AWS upload.
> 
> - **CI/CD (GitHub Actions)**:
>   - **Release (prod)**:
>     - Remove E2E jobs (`e2e-docker-tests-*`, `e2e-appimage-tests`).
>     - Update `remove-artifacts` to `needs: [aws-upload-prod]`.
>   - **Release (stage)**:
>     - Remove E2E jobs (`e2e-docker-tests-*`, `e2e-appimage-tests`).
>     - Update `remove-artifacts` to `needs: [aws]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16f99333fd9dd9607c1afb7a1524f03ae5d2e71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->