### PR TITLE
RI-7771 Remove blue border from Analyze database tooltip

### DIFF
--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/popover-run-analyze/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/popover-run-analyze/styles.module.scss
@@ -21,8 +21,4 @@
 .panelPopover {
   width: 432px;
   padding: 16px 30px !important;
-  border: 1px solid var(--euiColorPrimary) !important;
-  :global(.euiPopover__panelArrow:before) {
-    border-top-color: var(--euiColorPrimary) !important;
-  }
 }


### PR DESCRIPTION
# What

Removes the unwanted blue/purple border styling from the "Analyze database" popover/tooltip in the Tips section to match the design of other tooltips in the application.

# Testing

1. Open any database instance
2. Click on the top right bulb icon to open Tutorials / Tips
3. Click on the "Tips" tab
4. Click on "Analyze Database" button
5. Verify the popover appears without the blue/purple border
6. Compare with other tooltips in the application to ensure consistent styling


| Before | After |
| --- | --- |
| <img width="480" height="217" alt="Screenshot 2025-12-02 at 13 54 33" src="https://github.com/user-attachments/assets/16d06e0c-ffa8-4e4f-8811-153ac04e0447" /> | <img width="492" height="223" alt="Screenshot 2025-12-02 at 13 39 43" src="https://github.com/user-attachments/assets/3aa20df4-8bc6-471d-9ba1-5ea3bcffae6c" /> |

---

Closes #RI-7771

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the blue primary border and arrow styling from the "Analyze database" popover for consistent tooltip appearance.
> 
> - **UI/Styles**:
>   - In `styles.module.scss`, remove `border` and popover arrow `border-top-color` from `.panelPopover` to eliminate the blue outline on the Analyze Database popover.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9edec6c91a3ec4ec281447aef0555f85af8aca1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->