### PR TITLE
DEV: set typescript-react formatter to prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
# What

To overwrite in case user settings are set to different formatter. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures Prettier as the default formatter for TypeScript React files in `.vscode/settings.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53f2980e60e1035475e56dd2754ffc59f4747016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->