### PR TITLE
RI-7776 Fix cloud discovery search and notifications

### DIFF
--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResult.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResult.tsx
@@ -58,7 +58,7 @@ const RedisCloudDatabaseListResult = ({
         item.subscriptionId?.toString()?.indexOf(value) !== -1 ||
         item.subscriptionName?.toLowerCase().indexOf(value) !== -1 ||
         item.databaseId?.toString()?.indexOf(value) !== -1 ||
-        item.statusAdded?.toLowerCase()?.indexOf(value) !== -1,
+        (item.statusAdded || '').toLowerCase().indexOf(value) !== -1,
     )
 
     if (!itemsTemp.length) {

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResult.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResult.tsx
@@ -57,7 +57,8 @@ const RedisCloudDatabaseListResult = ({
         (item.publicEndpoint || '')?.toLowerCase().indexOf(value) !== -1 ||
         item.subscriptionId?.toString()?.indexOf(value) !== -1 ||
         item.subscriptionName?.toLowerCase().indexOf(value) !== -1 ||
-        item.databaseId?.toString()?.indexOf(value) !== -1,
+        item.databaseId?.toString()?.indexOf(value) !== -1 ||
+        item.statusAdded?.toLowerCase()?.indexOf(value) !== -1,
     )
 
     if (!itemsTemp.length) {

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.spec.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.spec.tsx
@@ -1,46 +1,192 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
+import { faker } from '@faker-js/faker'
 import {
   RedisCloudSubscription,
   RedisCloudSubscriptionStatus,
   RedisCloudSubscriptionType,
 } from 'uiSrc/slices/interfaces'
-import { render } from 'uiSrc/utils/test-utils'
+import { fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
 import RedisCloudSubscriptions, { Props } from './RedisCloudSubscriptions'
 
 const mockedProps = mock<Props>()
 
-describe('RedisCloudSubscriptions', () => {
-  it('should render', () => {
-    const columnsMock = [
-      {
-        id: 'subscriptionId',
-        accessorKey: 'subscriptionId',
-        header: 'Subscription ID',
-        enableSorting: true,
-      },
-    ]
+const columnsMock = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: 'Name',
+    enableSorting: true,
+  },
+  {
+    id: 'id',
+    accessorKey: 'id',
+    header: 'Subscription ID',
+    enableSorting: true,
+  },
+]
 
-    const subscriptionsMock: RedisCloudSubscription[] = [
-      {
-        id: 123,
-        name: 'name',
-        numberOfDatabases: 123,
-        provider: 'provider',
-        region: 'region',
+const createSubscription = (
+  overrides?: Partial<RedisCloudSubscription>,
+): RedisCloudSubscription => ({
+  id: faker.number.int(),
+  name: faker.company.name(),
+  numberOfDatabases: faker.number.int({ min: 1, max: 10 }),
+  provider: faker.helpers.arrayElement(['AWS', 'GCP', 'Azure']),
+  region: faker.helpers.arrayElement(['us-east-1', 'eu-west-1', 'ap-south-1']),
+  status: RedisCloudSubscriptionStatus.Active,
+  type: RedisCloudSubscriptionType.Fixed,
+  free: faker.datatype.boolean(),
+  ...overrides,
+})
+
+describe('RedisCloudSubscriptions', () => {
+  const defaultProps: Partial<Props> = {
+    columns: columnsMock,
+    subscriptions: [],
+    selection: [],
+    loading: false,
+    account: null,
+    error: '',
+    onClose: jest.fn(),
+    onBack: jest.fn(),
+    onSubmit: jest.fn(),
+    onSelectionChange: jest.fn(),
+  }
+
+  const renderComponent = (propsOverride?: Partial<Props>) => {
+    const props = { ...defaultProps, ...propsOverride } as Props
+    return render(
+      <RedisCloudSubscriptions {...instance(mockedProps)} {...props} />,
+    )
+  }
+
+  it('should render', () => {
+    const subscriptionsMock: RedisCloudSubscription[] = [createSubscription()]
+    expect(renderComponent({ subscriptions: subscriptionsMock })).toBeTruthy()
+  })
+
+  describe('search functionality', () => {
+    const subscriptions: RedisCloudSubscription[] = [
+      createSubscription({
+        id: 111,
+        name: 'Production Database',
+        provider: 'AWS',
+        region: 'us-east-1',
+        status: RedisCloudSubscriptionStatus.Active,
+        type: RedisCloudSubscriptionType.Flexible,
+      }),
+      createSubscription({
+        id: 222,
+        name: 'Staging Environment',
+        provider: 'GCP',
+        region: 'eu-west-1',
         status: RedisCloudSubscriptionStatus.Active,
         type: RedisCloudSubscriptionType.Fixed,
-        free: false,
-      },
+      }),
+      createSubscription({
+        id: 333,
+        name: 'Development',
+        provider: 'Azure',
+        region: 'ap-south-1',
+        status: RedisCloudSubscriptionStatus.Error,
+        type: RedisCloudSubscriptionType.Fixed,
+      }),
     ]
-    expect(
-      render(
-        <RedisCloudSubscriptions
-          {...instance(mockedProps)}
-          columns={columnsMock}
-          subscriptions={subscriptionsMock}
-        />,
-      ),
-    ).toBeTruthy()
+
+    it('should filter by name', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'Production' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Production Database')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Staging Environment'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should filter by id', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: '222' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Staging Environment')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Production Database'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should filter by provider', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'AWS' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Production Database')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Staging Environment'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should filter by region', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'eu-west' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Staging Environment')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Production Database'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should filter by status', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'error' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Development')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Production Database'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should filter by type', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'flexible' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Production Database')).toBeInTheDocument()
+        expect(
+          screen.queryByText('Staging Environment'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('should be case-insensitive', async () => {
+      renderComponent({ subscriptions })
+
+      const searchInput = screen.getByTestId('search')
+      fireEvent.change(searchInput, { target: { value: 'PRODUCTION' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('Production Database')).toBeInTheDocument()
+      })
+    })
   })
 })

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.tsx
@@ -75,12 +75,15 @@ const RedisCloudSubscriptions = ({
     }
   }, [subscriptions, loading])
 
-  const countStatusActive = items.filter(
-    ({ status, numberOfDatabases }: RedisCloudSubscription) =>
-      status === RedisCloudSubscriptionStatus.Active && numberOfDatabases !== 0,
-  )?.length
+  // Calculate counts from original subscriptions to prevent notification re-triggering on search
+  const countStatusActive =
+    subscriptions?.filter(
+      ({ status, numberOfDatabases }: RedisCloudSubscription) =>
+        status === RedisCloudSubscriptionStatus.Active &&
+        numberOfDatabases !== 0,
+    )?.length || 0
 
-  const countStatusFailed = items.length - countStatusActive
+  const countStatusFailed = (subscriptions?.length || 0) - countStatusActive
 
   const handleSubmit = () => {
     onSubmit(
@@ -106,7 +109,11 @@ const RedisCloudSubscriptions = ({
       subscriptions?.filter(
         (item: RedisCloudSubscription) =>
           item.name?.toLowerCase()?.indexOf(value) !== -1 ||
-          item.id?.toString()?.toLowerCase().indexOf(value) !== -1,
+          item.id?.toString()?.indexOf(value) !== -1 ||
+          item.type?.toLowerCase()?.indexOf(value) !== -1 ||
+          item.provider?.toLowerCase()?.indexOf(value) !== -1 ||
+          item.region?.toLowerCase()?.indexOf(value) !== -1 ||
+          item.status?.toLowerCase()?.indexOf(value) !== -1,
       ) ?? []
 
     if (!itemsTemp?.length) {


### PR DESCRIPTION
# What

Fixes two issues in the cloud database discovery flow:

1. **Multiple notifications bug**: The "Successfully discovered database(s)..." notification was showing multiple times when interacting with the search field
2. **Limited search**: Search in subscriptions table only worked for name and id fields

### Root Cause

When search filtered items, the notification counts were recalculated from filtered data. This caused the `variant` prop to change (e.g., from "attention" to "success" when filtered results had no failures), which triggered the MessageBar's useEffect to show a new toast.

### Solution

- Calculate notification counts from original `subscriptions` prop instead of filtered `items` state
- Expand search fields to include all relevant columns:
  - Subscriptions: name, id, type, provider, region, status
  - Database results: added statusAdded (success/fail)

# Testing

1. Navigate to Redis Cloud database discovery
2. Verify the summary notification appears only once when data loads
3. Type in the search field - notification should NOT reappear
4. Search by different fields (provider, region, status) - should filter correctly

---

Fixes #RI-7776

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes notifications by deriving counts from original data and broadens search across subscriptions and database results, with tests added for search behavior.
> 
> - **UI (Cloud Discovery)**:
>   - **Notifications**: Compute `countStatusActive`/`countStatusFailed` from `subscriptions` (not filtered `items`) in `RedisCloudSubscriptions.tsx` to avoid re-triggering toasts on search.
>   - **Search Enhancements**:
>     - `RedisCloudSubscriptions.tsx`: Search now matches `name`, `id`, `type`, `provider`, `region`, `status`.
>     - `RedisCloudDatabasesResult.tsx`: Search now includes `statusAdded` in addition to existing fields.
> - **Tests**:
>   - `RedisCloudSubscriptions.spec.tsx`: Add comprehensive search tests (name, id, provider, region, status, type; case-insensitive) and test scaffolding with `faker`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f8edbc0ac7b409b9b28da2ff6f6797550bc450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->