### PR TITLE
Add AI-Made label requirement to PR guidelines

### DIFF
--- a/.ai/rules/pull-requests.md
+++ b/.ai/rules/pull-requests.md
@@ -6,6 +6,10 @@ alwaysApply: true
 
 ## Creating a PR
 
+### Labels
+
+When creating PRs with AI assistance, always add the **"AI-Made"** label.
+
 ### PR Title
 
 Include issue number at the start:


### PR DESCRIPTION
# What

Add a rule requiring the "AI-Made" label when creating PRs with AI assistance.

# Testing

N/A - documentation change only.

---

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guideline to label AI-assisted PRs with the "AI-Made" label in `.ai/rules/pull-requests.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5361f508b3555efee29d1778fc2521d87ed02638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->