### PR TITLE
RI-7781: fix copy module name test to verify clipboard functionality

### DIFF
--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.spec.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.spec.tsx
@@ -4,7 +4,7 @@ import {
   RedisDefaultModules,
   DATABASE_LIST_MODULES_TEXT,
 } from 'uiSrc/slices/interfaces'
-import { fireEvent, render, act } from 'uiSrc/utils/test-utils'
+import { fireEvent, render } from 'uiSrc/utils/test-utils'
 import { AdditionalRedisModule } from 'apiSrc/modules/database/models/additional.redis.module'
 import { DatabaseListModules } from './DatabaseListModules'
 import { DatabaseListModulesProps } from './DatabaseListModules.types'
@@ -33,27 +33,22 @@ describe('DatabaseListModules', () => {
     ).toBeTruthy()
   })
 
-  it('copy module name', async () => {
+  it('should copy module name to clipboard when clicked', async () => {
+    const writeTextMock = jest.fn()
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock },
+    })
+
     const { queryByTestId } = render(
       <DatabaseListModules {...instance(mockedProps)} modules={modulesMock} />,
     )
 
     const term = DATABASE_LIST_MODULES_TEXT[RedisDefaultModules.Search]
-
     const module = queryByTestId(`${term}_module`)
+    expect(module).toBeInTheDocument()
 
-    await act(async () => {
-      module && fireEvent.click(module)
-    })
+    fireEvent.click(module!)
 
-    // queryByTestId
-    expect(
-      render(
-        <DatabaseListModules
-          {...instance(mockedProps)}
-          modules={modulesMock}
-        />,
-      ),
-    ).toBeTruthy()
+    expect(writeTextMock).toHaveBeenCalledWith(term)
   })
 })


### PR DESCRIPTION
Previous test did not actually test anything related to copying

# What

Fix the `DatabaseListModules` test that was supposed to verify copy-to-clipboard functionality but wasn't actually testing it.

# Testing

1. Run the test:
  redisinsight/ui/src/components/database-list-modules/DatabaseListModules.spec.tsx
   2. Verify both tests pass:
   - `should render`
   - `should copy module name to clipboard when clicked`

References: #RI-7781

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates DatabaseListModules test to mock clipboard and assert module click copies the correct name.
> 
> - **Tests**:
>   - `redisinsight/ui/src/components/database-list-modules/DatabaseListModules.spec.tsx`:
>     - Mock `navigator.clipboard.writeText` and assert it’s called with the selected module’s term.
>     - Rename test to clarify behavior: copy module name on click.
>     - Remove unnecessary `act` usage and redundant render/assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e9d0a9e77894d3c787a6a5f9b72f864acda0579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->