### PR TITLE
AI assistant: update import pattern for styles import

### DIFF
--- a/.ai/rules/frontend.md
+++ b/.ai/rules/frontend.md
@@ -64,6 +64,23 @@ ComponentName/
 
 ### Import Pattern
 
+Keep all component styles in dedicated .style.ts files and import them with a namespace.
+
+#### ✅ Good
+
+```typescript
+import * as S from './Component.styles'
+
+return (
+  <S.Container>
+    <S.Title>Title</S.Title>
+    <S.Content>Content</S.Content>
+  </S.Container>
+)
+```
+
+#### ❌ Bad
+
 ```typescript
 import { Container, Title, Content } from './Component.styles'
 


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Adjusts the rule to the standard followed in [redis](https://github.com/redislabsdev/cloud-ui/blob/master/.augment/rules/style-guide/styling-themes.md#-good).
Previously, with sass we had the same thing (import styles).

Cons of the namespace pattern:
- Slightly More Verbose: S.Container vs just Container

Cons of the named imports pattern:
- Name Conflicts: Container could conflict with actual components
- Unclear Origin: Hard to tell if Container is a component or styled element
- Import Bloat: Long import lines with many styled components
- Refactoring Issues: Renaming requires updating both definition and import

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the frontend style guide to prefer namespace imports from `Component.styles` and discourage named imports, with examples.
> 
> - **Styled Components Rules**:
>   - **Import Pattern**: Keep styles in dedicated `.styles.ts` files and import them via namespace (`import * as S from './Component.styles'`).
>     - Adds “Good” example using `S.Container`, `S.Title`, `S.Content`.
>     - Marks named imports from `Component.styles` as “Bad”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b3996abf676fcbcacfae58b456242722dba082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->