### PR TITLE
RI-7762 Allow add key/elements forms to expand vertically

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.styles.ts
@@ -3,5 +3,6 @@ import { Col } from 'uiSrc/components/base/layout/flex'
 
 export const ItemsWrapper = styled(Col)`
   overflow: auto;
-  max-height: 174px;
+  flex: 1;
+  min-height: 0;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
@@ -31,7 +31,7 @@ export const AddKeysContainer = styled.div<
   }
 `
 export const EntryContent = styled(Col)`
-  max-height: 234px;
+  max-height: calc(50vh - 100px);
   scroll-padding-bottom: 60px;
   overflow-y: auto;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -36,7 +36,7 @@ import {
   HashFieldDto,
 } from 'apiSrc/modules/browser/hash/dto'
 
-import styles from './styles.module.scss'
+import { EntryContent } from '../../common/AddKeysContainer.styled'
 
 export interface Props {
   isExpireFieldsAvailable?: boolean
@@ -165,7 +165,7 @@ const AddHashFields = (props: Props) => {
 
   return (
     <Col gap="m">
-      <div className={styles.container}>
+      <EntryContent>
         <AddMultipleFields
           items={fields}
           isClearDisabled={isClearDisabled}
@@ -231,7 +231,7 @@ const AddHashFields = (props: Props) => {
             </Row>
           )}
         </AddMultipleFields>
-      </div>
+      </EntryContent>
       <Row justify="end" gap="m">
         <FlexItem>
           <div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/styles.module.scss
@@ -1,4 +1,0 @@
-.container {
-  max-height: 234px;
-  scroll-padding-bottom: 60px;
-}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -30,7 +30,8 @@ import {
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
-import styles from './styles.module.scss'
+
+import { EntryContent } from '../../common/AddKeysContainer.styled'
 
 export interface Props {
   closePanel: (isCancelled?: boolean) => void
@@ -135,7 +136,7 @@ const AddSetMembers = (props: Props) => {
 
   return (
     <Col gap="m">
-      <div className={styles.container}>
+      <EntryContent>
         <AddMultipleFields
           items={members}
           isClearDisabled={isClearDisabled}
@@ -165,7 +166,7 @@ const AddSetMembers = (props: Props) => {
             </Row>
           )}
         </AddMultipleFields>
-      </div>
+      </EntryContent>
       <Row justify="end" gap="xl">
         <FlexItem>
           <SecondaryButton

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/styles.module.scss
@@ -1,4 +1,0 @@
-.container {
-  max-height: 234px;
-  scroll-padding-bottom: 60px;
-}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.styles.ts
@@ -10,6 +10,6 @@ export const TimeStampInfoIcon = styled(RiIcon).attrs({ type: 'InfoIcon' })`
 `
 
 export const StreamGroupContent = styled(Col)`
-  max-height: 234px;
+  max-height: calc(50vh - 100px);
   scroll-padding-bottom: 30px;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -26,7 +26,8 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
-import styles from './styles.module.scss'
+
+import { EntryContent } from '../../common/AddKeysContainer.styled'
 
 export interface Props {
   closePanel: (isCancelled?: boolean) => void
@@ -176,7 +177,7 @@ const AddZsetMembers = (props: Props) => {
 
   return (
     <Col gap="m">
-      <div className={styles.container}>
+      <EntryContent>
         <AddMultipleFields
           items={members}
           isClearDisabled={isClearDisabled}
@@ -225,7 +226,7 @@ const AddZsetMembers = (props: Props) => {
             </Row>
           )}
         </AddMultipleFields>
-      </div>
+      </EntryContent>
       <Row justify="end" gap="l">
         <FlexItem>
           <div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/styles.module.scss
@@ -1,5 +1,0 @@
-.container {
-  max-height: 234px;
-  scroll-padding-bottom: 60px;
-  padding: 18px;
-}


### PR DESCRIPTION
# What

Fix forms for adding multiple values (List, Hash, Set, ZSet, Stream) to expand vertically and fill available space instead of being limited to fixed heights.

**Changes:**
- `AddMultipleFields.styles.ts`: Changed max-height from 174px to `calc(100vh - 400px)` for new key forms
- `AddKeysContainer.styled.ts`: Changed max-height from 234px to `calc(50vh - 100px)` for existing key add panels
- `AddStreamGroup.styles.ts`: Updated to use dynamic max-height
- Migrated Hash, Set, ZSet add components from SCSS to use shared `EntryContent` styled component

# Screenshots

## Before (main branch)
<img width="2560" height="1276" alt="add-key-list-main-dark-20251204-155022" src="https://github.com/user-attachments/assets/511aa754-d022-4f1d-a83d-c81347288c0e" />
<img width="2560" height="1276" alt="add-key-list-main-light-20251204-155022" src="https://github.com/user-attachments/assets/aae16a6b-bd70-4168-99f7-59557b2bbf34" />

## After (this PR)
<img width="2560" height="1276" alt="add-key-list-feature-dark-20251204-160100" src="https://github.com/user-attachments/assets/b1689191-77cd-4e28-9e85-08d273bf66a7" />
<img width="2560" height="1276" alt="add-key-list-feature-light-20251204-160100" src="https://github.com/user-attachments/assets/3d23d17d-4e21-464b-9024-cf3868db4e2f" />


# Testing

1. Connect to any Redis database
2. Click "Add key" → select "List" type → add 5+ elements → verify form expands
3. Open existing List key → click "Add Elements" → add 5+ elements → verify panel expands
4. Repeat for Hash, Set, ZSet, Stream key types

---

Closes #RI-7762