### PR TITLE
Update pr-plan command to auto-detect planner tool

### DIFF
--- a/.ai/commands/pr-plan.md
+++ b/.ai/commands/pr-plan.md
@@ -62,6 +62,14 @@ Use `sequential-thinking` tool for complex analysis. Break down into thoughts:
 
 Create a comprehensive Markdown document and save it to `docs/pr-plan-{ticket-id}-{brief-description}.md` using the `write` tool.
 
+**IMPORTANT: Planner Detection**
+- Detect which AI tool is being used (Cursor, Augment, or other)
+- Set the **Planner** field to:
+  - "Cursor Agent" if running in Cursor
+  - "Augment Agent" if running in Augment
+  - "[Tool Name] Agent" for other tools
+- You can infer the tool from context, user messages, or environment
+
 **The document structure MUST include all sections below:**
 
 ```markdown
@@ -71,7 +79,7 @@ Create a comprehensive Markdown document and save it to `docs/pr-plan-{ticket-id
 **Epic:** [EPIC-XXX](link) (if applicable)
 **Parent:** [PARENT-XXX](link) (if applicable)
 **Plan Date:** [Date]
-**Planner:** Augment Agent
+**Planner:** [Detect and set: Cursor Agent / Augment Agent / [Tool Name] Agent]
 
 ---
 


### PR DESCRIPTION
# What

Update the `pr-plan` command template to automatically detect which AI tool is being used (Cursor, Augment, or other) and set the planner field accordingly instead of hardcoding the value.

The planner will now be dynamically set to:
- `Cursor Agent` when running in Cursor
- `Augment Agent` when running in Augment  
- `[Tool Name] Agent` for other tools

# Testing

1. Run `/pr-plan` command in Cursor - verify planner shows "Cursor Agent"
2. Run `/pr-plan` command in Augment - verify planner shows "Augment Agent"
3. Check generated plan documents have correct planner value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `pr-plan` now detects the running tool (Cursor/Augment/other) and sets the Planner field dynamically in the generated plan document.
> 
> - **Command template updates (`.ai/commands/pr-plan.md`)**
>   - Add planner auto-detection logic (Cursor, Augment, or other) with guidance to infer from context/environment.
>   - Update plan document template to use dynamic `Planner` value instead of hardcoded entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff706877b7ca58eebcedbe1664ff904962bcbac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->