### PR TITLE
RI-7853 Fix tutorials scroll on database list page

### DIFF
--- a/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.styles.ts
+++ b/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.styles.ts
@@ -22,4 +22,5 @@ export const PageWrapper = styled.div`
 
 export const ExplorePanelWrapper = styled.div`
   padding-bottom: ${({ theme }: { theme: Theme }) => theme.core.space.space200};
+  height: 100%;
 `


### PR DESCRIPTION
# What

Fix scroll issue where Y-axis scroll does not appear when tutorials exceed container height on database list page.

- Add `height: 100%` to `ExplorePanelWrapper` to ensure proper flex container chain
- Ensures height constraint chain is complete from `PageWrapper` → `ExplorePanelWrapper` → `ExplorePanelTemplate` → side panels
- Fixes scroll functionality on database list page while maintaining existing behavior on browser page

# Testing

1. Open database list page
2. Click lightbulb icon to open tutorials panel
3. Expand tutorials or add custom tutorials to make content exceed container height
4. Verify Y-axis scroll bar appears and works correctly
5. Verify all tutorial content is accessible via scrolling
6. **Regression test**: Open browser page, verify scroll still works (no regression)

| Before | After |
| --- | --- |
| <img width="1502" height="858" alt="image" src="https://github.com/user-attachments/assets/b6b4d88c-0dc6-4aea-a6e8-def463cc1479" /> | <img width="1454" height="852" alt="image" src="https://github.com/user-attachments/assets/202382bd-e446-4bb9-bb8d-d0c7adf7592e" /> |

# Technical Details

The issue was caused by an incomplete flex container height chain. The `ExplorePanelWrapper` component needed `height: 100%` to properly participate in the flex layout and maintain height constraints down to the scroll container in the `Navigation` component.

**Files Changed:**
- `redisinsight/ui/src/templates/home-page-template/HomePageTemplate.styles.ts`: Added `height: 100%` to `ExplorePanelWrapper`

---

Closes #RI-7853

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `height: 100%` to `ExplorePanelWrapper` to complete the flex height chain and enable Y-axis scrolling in the tutorials panel on the database list page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d53672aba82f75710a8b555048a1d09255bfd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->