### PR TITLE
CI: Fix binaries paths for MAS universal build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -42,6 +42,12 @@
     "hardenedRuntime": false,
     "asarUnpack": ["node_modules"],
     "provisioningProfile": "embedded.provisionprofile",
+    "binaries": [
+      "Contents/Resources/app-x64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app-arm64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app-arm64.asar.unpacked/node_modules/keytar/build/Release/keytar.node",
+      "Contents/Resources/app-x64.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
+    ],
     "artifactName": "Redis-Insight-${os}-${arch}-mas.${ext}"
   },
   "masDev": {
@@ -52,6 +58,12 @@
     "hardenedRuntime": false,
     "asarUnpack": ["node_modules"],
     "provisioningProfile": "dev.provisionprofile",
+    "binaries": [
+      "Contents/Resources/app-x64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app-arm64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node",
+      "Contents/Resources/app-arm64.asar.unpacked/node_modules/keytar/build/Release/keytar.node",
+      "Contents/Resources/app-x64.asar.unpacked/node_modules/keytar/build/Release/keytar.node"
+    ],
     "artifactName": "Redis-Insight-${os}-${arch}-masDev.${ext}"
   },
   "dmg": {


### PR DESCRIPTION
The explicit binaries config in `electron-builder.json` used incorrect paths for the MAS universal build. With `mergeASARs: false`, electron-builder creates separate asar files per architecture (`app-x64.asar` and `app-arm64.asar`) instead of a single `app.asar`.

The old config expected:
  `app.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node`

But the actual structure is:
- `app-x64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node`
- `app-arm64.asar.unpacked/node_modules/sqlite3/build/Release/node_sqlite3.node`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update MAS/MASDev `electron-builder.json` to use arch-specific `app-*.asar.unpacked` paths for `sqlite3` and `keytar` binaries.
> 
> - **Build config (electron-builder.json)**
>   - **MAS / MASDev**:
>     - Replace single `app.asar.unpacked` binary paths with arch-specific paths:
>       - `Contents/Resources/app-x64.asar.unpacked/...`
>       - `Contents/Resources/app-arm64.asar.unpacked/...`
>     - Applies to native modules: `sqlite3` and `keytar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e6c3cb89ea97aa16493639b1f292b4b9449758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->