### PR TITLE
Add Figma MCP integration

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -71,7 +71,7 @@ This directory contains comprehensive development standards that are automatical
 
 ## MCP (Model Context Protocol) Setup
 
-AI tools can access external services (JIRA, Confluence, GitHub) via MCP configuration.
+AI tools can access external services (JIRA, Confluence, GitHub, Figma) via MCP configuration.
 
 ### Initial Setup
 
@@ -87,7 +87,10 @@ AI tools can access external services (JIRA, Confluence, GitHub) via MCP configu
    - Create a classic token by pressing the first "Create Token" button
    - Copy the token
 
-3. **Edit `.env.mcp` with your credentials**
+3. **Edit `.env.mcp` with your credentials:**
+
+   - Add your JIRA and Confluence API tokens
+   - Note: Figma MCP server uses OAuth authentication and doesn't require API keys
 
 4. **Verify your setup:**
 
@@ -95,7 +98,8 @@ AI tools can access external services (JIRA, Confluence, GitHub) via MCP configu
 
    - Restart Cursor to load the new MCP configuration
    - Ask the AI: "Can you list all available MCP tools and test them?"
-   - The AI should be able to access JIRA, Confluence, GitHub, and other configured services
+   - The AI should be able to access JIRA, Confluence, GitHub, Figma, and other configured services
+   - **For Figma**: On first use, you'll be prompted to authenticate via OAuth flow in your browser
 
    **For Augment users:**
 
@@ -116,7 +120,8 @@ The `mcp.json` file configures these services:
 - **memory** - Persistent context storage across sessions
 - **sequential-thinking** - Enhanced reasoning for complex tasks
 - **context-7** - Advanced context management
-- **atlassian** - JIRA (RI-XXX tickets) and Confluence integration
+- **atlassian** - JIRA (RI-XXX tickets) and Confluence integration (requires API tokens in `.env.mcp`)
+- **figma** - Figma design files, frames, and layers (uses OAuth authentication - no API key needed)
 
 ## Updating These Rules
 

--- a/mcp.json
+++ b/mcp.json
@@ -32,6 +32,10 @@
         "ghcr.io/sooperset/mcp-atlassian:latest"
       ],
       "description": "Atlassian MCP server for managing JIRA projects (RI-XXX tickets) and Confluence content"
+    },
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "description": "Figma MCP server for accessing design files, frames, and layers. Copy a Figma frame/layer link to provide design context in prompts."
     }
   }
 }


### PR DESCRIPTION
# What

Add Figma MCP server configuration to enable design context access.

- add Figma MCP server to mcp.json
- update .ai/README.md with Figma integration documentation

# Testing

Paste a Figma link in Cursor/Augment and wait for the MCP to redirect you to Figma and for OAuth authentication, no API key required. Then, the MCP will be able to "see" the designs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Figma MCP server and updates README to document Figma OAuth setup and availability alongside existing services.
> 
> - **MCP Configuration**:
>   - Add `figma` MCP server in `mcp.json` with hosted URL and description for accessing design files.
> - **Docs (.ai/README.md)**:
>   - Include Figma in MCP overview and available services.
>   - Add setup notes: OAuth-based auth (no API key) and first-use browser flow.
>   - Clarify `.env.mcp` editing (Atlassian tokens required) and verification steps including Figma access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6b1bf70fbacef9eedf28c9d10769322f4be61d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->