### PR TITLE
RI-7859 Load config when switching database

### DIFF
--- a/redisinsight/ui/src/components/config/Config.tsx
+++ b/redisinsight/ui/src/components/config/Config.tsx
@@ -34,7 +34,7 @@ import { fetchCustomTutorials } from 'uiSrc/slices/workbench/wb-custom-tutorials
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 import { fetchContentRecommendations } from 'uiSrc/slices/recommendations/recommendations'
 import { fetchGuideLinksAction } from 'uiSrc/slices/content/guide-links'
-import { setCapability } from 'uiSrc/slices/app/context'
+import { setCapability, setDbConfig } from 'uiSrc/slices/app/context'
 
 import { fetchProfile } from 'uiSrc/slices/oauth/cloud'
 import { fetchDBSettings } from 'uiSrc/slices/app/db-settings'
@@ -99,6 +99,8 @@ const Config = () => {
               BrowserStorageItem.dbConfig + payload.id,
               payload.data,
             )
+            // Update Redux state with the fetched config
+            dispatch(setDbConfig(payload.data))
           },
         ),
       )
@@ -201,7 +203,9 @@ const Config = () => {
     const appliedConsents = config?.agreements
     dispatch(
       setSettingsPopupState(
-        config?.acceptTermsAndConditionsOverwritten ? false : isDifferentConsentsExists(specConsents, appliedConsents),
+        config?.acceptTermsAndConditionsOverwritten
+          ? false
+          : isDifferentConsentsExists(specConsents, appliedConsents),
       ),
     )
   }


### PR DESCRIPTION
# What

Ensure that we load the config in Redux, so it loads correctly when changing databases using the switcher (not just from the database list).

References https://github.com/redis/RedisInsight/issues/5315

# Testing

As a prerequisite, start with at least two databases, with different configurations for the default delimiter.
And, make sure it loads properly when you change the active database from the switcher in the top left corner.

### Before

https://github.com/user-attachments/assets/d21b7d65-5308-454f-a701-735794bc9c14

### After

https://github.com/user-attachments/assets/e107c4c4-7f7b-4c2e-8d01-91c561f81c1d




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Dispatches `setDbConfig` after `fetchDBSettings` so database-specific config loads correctly when switching databases.
> 
> - **Config component (`ui/src/components/config/Config.tsx`)**:
>   - After fetching DB settings via `fetchDBSettings`, dispatches `setDbConfig(payload.data)` to update Redux with the active database configuration.
>   - Adds import for `setDbConfig` from `uiSrc/slices/app/context`.
>   - Minor formatting tweak in `setSettingsPopupState` call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 847d8471c7c31c83204b906955d92c446d73ddf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->