### PR TITLE
RI-7871: Enable the temporarily disabled publish to docker and snapcraft

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -37,12 +37,11 @@ jobs:
     needs: virustotal-prod
     secrets: inherit
 
-  # Temporal disable publish to docker and snapcraft
-  # publish-stores:
-  #   name: Publish to stores
-  #   uses: ./.github/workflows/publish-stores.yml
-  #   needs: aws-upload-prod
-  #   secrets: inherit
+  publish-stores:
+    name: Publish to stores
+    uses: ./.github/workflows/publish-stores.yml
+    needs: aws-upload-prod
+    secrets: inherit
 
   # Remove artifacts from github actions
   remove-artifacts:


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

In order to achieve gradual rollout, we had disabled the release to docker and snapcraft in this PR - https://github.com/redis/RedisInsight/pull/5219

Removing the commented out block for the prod release. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the `publish-stores` job in the prod release workflow to publish to Docker and Snapcraft after AWS upload.
> 
> - **CI/CD**
>   - **Prod release workflow** (`.github/workflows/release-prod.yml`):
>     - Restores `publish-stores` job (uses `./.github/workflows/publish-stores.yml`) with dependency on `aws-upload-prod` to publish to Docker/Snapcraft.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff8a1077ce05e554fe24ef849a85e51459c243b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->