### PR TITLE
RI-7874: make link and text inline and same size

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndex.tsx
+++ b/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndex.tsx
@@ -88,8 +88,6 @@ const CreateRedisearchIndex = ({ onClosePanel, onCreateIndex }: Props) => {
     initialFieldValue(fieldTypeOptions),
   ])
 
-
-
   const lastAddedIdentifier = useRef<HTMLInputElement>(null)
   const prevCountFields = useRef<number>(0)
 
@@ -180,10 +178,10 @@ const CreateRedisearchIndex = ({ onClosePanel, onCreateIndex }: Props) => {
       interactive
       position="top"
       content={
-        <>
+        <Text>
           <Link
             variant="inline"
-            size="S"
+            size="M"
             href={getUtmExternalLink(
               'https://redis.io/commands/ft.create/#SCHEMA',
               {
@@ -198,7 +196,7 @@ const CreateRedisearchIndex = ({ onClosePanel, onCreateIndex }: Props) => {
           {keyTypeSelected === RedisearchIndexKeyType.HASH
             ? 'Enter a hash field name.'
             : 'Enter a JSON path expression.'}
-        </>
+        </Text>
       }
     >
       <IconButton


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Surround the link and regular text with Text so display inline on the link takes place. Add size M to the link so it is the same as the text. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

| Before | After |
| --- | --- | 
| <img width="337" height="168" alt="image" src="https://github.com/user-attachments/assets/0b0f117d-55e4-4fc1-b6fb-848af9c67f37" /> | <img width="337" height="168" alt="image" src="https://github.com/user-attachments/assets/db646faf-66a8-4c76-8555-31e6e6c72bc3" /> |
| <img width="337" height="168" alt="image" src="https://github.com/user-attachments/assets/0e0d282f-6ed1-4985-9866-22c97625e893" /> | <img width="337" height="168" alt="image" src="https://github.com/user-attachments/assets/193eed9f-e7ce-43c4-87bb-46d2904f7201" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap tooltip content in `Text` and set `Link` size to `M` in `CreateRedisearchIndex.tsx` so the link and surrounding text render inline consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c17684f306639b2b423a1f7f58e0ffa0e83cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->