### PR TITLE
fix(ui): clear selected key on refresh 404 error

### DIFF
--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -875,6 +875,7 @@ export function refreshKeyInfoAction(key: RedisResponseBuffer) {
       if (status && isStatusNotFoundError(status)) {
         dispatch(resetKeyInfo())
         dispatch(deleteKeyFromList(key))
+        dispatch(setBrowserSelectedKey(null))
       }
     }
   }

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1502,6 +1502,34 @@ describe('keys slice', () => {
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })
+
+      it('should reset key info and clear selected key when key not found (404)', async () => {
+        // Arrange
+        const keyName = stringToBuffer('deletedKey')
+        const errorMessage = 'Key with this name does not exist.'
+        const responsePayload = {
+          response: {
+            status: 404,
+            data: { message: errorMessage },
+          },
+        }
+
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+
+        // Act
+        await store.dispatch<any>(refreshKeyInfoAction(keyName))
+
+        // Assert
+        const expectedActions = [
+          refreshKeyInfo(),
+          refreshKeyInfoFail(),
+          addErrorNotification(responsePayload as AxiosError),
+          resetKeyInfo(),
+          deletePatternKeyFromList(keyName),
+          setBrowserSelectedKey(null),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
     })
 
     describe('addHashKey', () => {


### PR DESCRIPTION
# What

Fixes a bug where clicking on a recreated key (with the same name as a previously deleted key) would not open the key details panel.

**Root cause:** When refreshing a key that no longer exists (404 error), `refreshKeyInfoAction` was calling `resetKeyInfo()` and `deleteKeyFromList()` but was NOT calling `setBrowserSelectedKey(null)`. This meant the Redux context still considered that key as "selected", so when the user clicked on the recreated key with the same name, the `selectKey` function saw that the key buffers were equal and skipped fetching the new key data.

**Fix:** Added `dispatch(setBrowserSelectedKey(null))` in the 404 error handler of `refreshKeyInfoAction`, consistent with how `fetchKeyInfo` handles 404 errors.

# Testing

1. Connect to a Redis database
2. Create a key (e.g., `SET mykey "hello"`)
3. Click on the key in RedisInsight to open it
4. Delete the key externally (e.g., via redis-cli: `DEL mykey`)
5. Click the refresh button on the key in RedisInsight
6. Verify the 404 error notification appears
7. Recreate the key externally (e.g., `SET mykey "new value"`)
8. Refresh the keys list in RedisInsight
9. Click on the recreated key
10. **Expected:** Key details panel opens showing the new value
11. **Before fix:** Key details panel would not update until clicking on a different key first

---

Closes #TBD

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clears the browser’s selected key when a refreshed key returns 404, and adds a unit test to validate the 404 flow.
> 
> - **Browser Keys Slice (`redisinsight/ui/src/slices/browser/keys.ts`)**:
>   - On `refreshKeyInfoAction` 404 error: dispatch `setBrowserSelectedKey(null)` in addition to `resetKeyInfo()` and `deleteKeyFromList()`.
> - **Tests (`redisinsight/ui/src/slices/tests/browser/keys.spec.ts`)**:
>   - Add test verifying 404 refresh behavior triggers `resetKeyInfo()`, `deletePatternKeyFromList()`, and `setBrowserSelectedKey(null)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b83762f8abac4a807ab737417294df4a8bb1649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->