### PR TITLE
docs: add specific frontend test commands to testing docs

### DIFF
--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -30,6 +30,19 @@ describe('FeatureService', () => {
 
 ## Frontend Testing (Jest + Testing Library)
 
+### Running Specific Tests
+
+```bash
+# Run a specific test file
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/path/to/Component.spec.tsx' -c 'jest.config.cjs'
+
+# Run a specific test by name (use -t flag)
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/path/to/Component.spec.tsx' -c 'jest.config.cjs' -t 'test name pattern'
+
+# Example:
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/slices/tests/browser/keys.spec.ts' -c 'jest.config.cjs' -t 'refreshKeyInfoAction'
+```
+
 ### CRITICAL: Always Use Shared `renderComponent` Helper
 
 **Create a `renderComponent` helper for each component test file**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,19 @@ yarn test:api          # Run all API tests
 yarn --cwd tests/e2e test
 ```
 
+### Run Specific Frontend Tests
+
+```bash
+# Run a specific test file
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/path/to/Component.spec.tsx' -c 'jest.config.cjs'
+
+# Run a specific test by name (use -t flag)
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/path/to/Component.spec.tsx' -c 'jest.config.cjs' -t 'test name pattern'
+
+# Example:
+node 'node_modules/.bin/jest' 'redisinsight/ui/src/slices/tests/browser/keys.spec.ts' -c 'jest.config.cjs' -t 'refreshKeyInfoAction'
+```
+
 ### Before Committing
 
 **ALWAYS run these before committing:**


### PR DESCRIPTION
# What

Adds documentation for running specific frontend tests using Jest CLI commands.

This helps developers (and AI agents) run targeted tests instead of the entire test suite, which is useful for:
- Testing a specific file during development
- Running a specific test by name using the `-t` flag

# Testing

N/A - documentation only change.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Jest CLI examples for running specific frontend tests to `.ai/rules/testing.md` and `AGENTS.md`.
> 
> - **Docs**:
>   - **Testing rules** (`.ai/rules/testing.md`): Add "Running Specific Tests" with Jest commands to run a specific file and test name (`-t`), plus an example path.
>   - **AI Agent guide** (`AGENTS.md`): Add "Run Specific Frontend Tests" with the same Jest commands and example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 405c317c26c51c4b3c24306d5a561108aaa931a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->