### PR TITLE
RI-000: Remove compress images step

### DIFF
--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -8,6 +8,10 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
+    branches-ignore:
+      - 'latest'
+      - 'release/*'
+      - 'ric/*'
 jobs:
   build:
     # Only run on Pull Requests within the same repository, and not from forks.


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Edit the compress images action, which started failing when executed on release branches due to recently added branch push constraint by not triggering it when it is targeting `latest`, `release/*` and `ric/*`.  

Given our release flow, and that release branches are created from main, then release branches merged to latest, and latest to main, in the whole flow the new commits added could be bugfixes, which will not include images that will need compressing. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update image compression workflow to ignore PRs from specific branches.
> 
> - **CI/CD**:
>   - **GitHub Actions** (`.github/workflows/compress-images.yml`):
>     - Add `branches-ignore` for `latest`, `release/*`, and `ric/*` on `pull_request` trigger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89b2fc54f8c15504cdf5d1cd0e05c345343e0e15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->