### PR TITLE
chore(ci): upgrade CodeQL action from v1 to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/config.yml
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
v1 was deprecated on January 18th, 2023. Also upgrade actions/checkout from v2 to v4.

# What
I noticed that we have failing tasks here: https://github.com/redis/RedisInsight/actions/runs/20341218220, so I updated them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps GitHub Actions in `/.github/workflows/codeql-analysis.yml`: `actions/checkout` to v4 and all `github/codeql-action/*` steps to v3.
> 
> - **CI / GitHub Actions** (`.github/workflows/codeql-analysis.yml`):
>   - Upgrade `actions/checkout` from `v2` → `v4`.
>   - Upgrade CodeQL actions from `v1` → `v3`:
>     - `github/codeql-action/init@v3`
>     - `github/codeql-action/autobuild@v3`
>     - `github/codeql-action/analyze@v3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e35b3d3b218a4af27e6b2fb32abe2f1ed7f3411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->