### PR TITLE
ci: upgrade CodeQL action from v3 to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/config.yml
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What

Upgrade CodeQL action from v3 to v4.

v3 will be deprecated in December 2026.
See: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

## Testing

CodeQL workflow should run successfully with v4.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `github/codeql-action` (`init`, `autobuild`, `analyze`) from v3 to v4 in `.github/workflows/codeql-analysis.yml`.
> 
> - **CI/CD**
>   - **CodeQL Workflow** (`.github/workflows/codeql-analysis.yml`):
>     - Update `github/codeql-action/init` to `v4`.
>     - Update `github/codeql-action/autobuild` to `v4`.
>     - Update `github/codeql-action/analyze` to `v4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ded3153d5f3b9728e75a5a1cc5c81afa5d900c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->