### PR TITLE
fix: enable dual-stack IPv4/IPv6 support in ioredis connections

### DIFF
--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
@@ -52,6 +52,7 @@ export class IoredisRedisConnectionStrategy extends RedisConnectionStrategy {
       port,
       username,
       password,
+      family: 0, // Enable dual-stack IPv4/IPv6 (auto-detect)
       connectTimeout: timeout,
       db: isNumber(clientMetadata.db) ? clientMetadata.db : db,
       connectionName:


### PR DESCRIPTION
## Description

This PR fixes Redis connection failures in IPv6-only network environments by enabling dual-stack (IPv4/IPv6) support in ioredis connection options.

## Problem

RedisInsight currently sets no explicit `family` option when creating ioredis connections, which defaults to `family: 4` (IPv4 only). This causes connection failures in:
- IPv6-only Kubernetes clusters
- Dual-stack environments where the Redis server is only accessible via IPv6
- Cloud environments using IPv6 networking

Users see connection timeouts or "ECONNREFUSED" errors even when the Redis server is healthy and accessible.

## Solution

Set `family: 0` in the ioredis connection options to enable auto-detection of the appropriate address family. This allows ioredis to:
- Try both IPv4 and IPv6 addresses
- Connect successfully in IPv6-only, IPv4-only, or dual-stack environments
- Maintain backwards compatibility with existing IPv4 deployments

## Changes

- Added `family: 0` to `RedisOptions` in `ioredis.redis.connection.strategy.ts`

## Testing

Tested in an IPv6-only Kubernetes cluster (K3s on Hetzner) where:
- Before: Connection timeout errors
- After: Successful connection to Redis via IPv6

## Related Issues

- Fixes #3992 - IPv6 support
- Related to #1429 - Connection issues in containerized environments

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] The change is minimal and focused on the specific issue
- [x] No breaking changes to existing functionality
- [x] Backwards compatible with IPv4-only environments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enable dual-stack networking for Redis connections**
> 
> - Adds `family: 0` to `RedisOptions` in `ioredis.redis.connection.strategy.ts` so ioredis auto-detects IPv4/IPv6
> - Affects standalone, cluster, and sentinel clients via shared `getRedisOptions` flow
> - Improves connectivity in IPv6-only and dual-stack setups without breaking IPv4
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 084b7644714bd428225458564db098c5a90bc6b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->