### PR TITLE
#5359 Add IPv6 dual-stack tests and node-redis support

### DIFF
--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
@@ -218,6 +218,18 @@ describe('IoredisRedisConnectionStrategy', () => {
         .then(fail)
         .catch(checkError(done));
     });
+    it('should include family: 0 for dual-stack IPv4/IPv6 support', (done) => {
+      service
+        .createStandaloneClient(mockClientMetadata, mockDatabase, {})
+        .then(() => {
+          expect(spyRedis).toHaveBeenCalledWith(
+            expect.objectContaining({ family: 0 }),
+          );
+          done();
+        });
+
+      process.nextTick(() => mockIoredisNativeClient.emit('ready'));
+    });
   });
 
   describe('createClusterClient', () => {

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
@@ -1,0 +1,65 @@
+import { Test } from '@nestjs/testing';
+import * as redis from 'redis';
+import {
+  mockClientMetadata,
+  mockDatabase,
+  mockSshTunnelProvider,
+} from 'src/__mocks__';
+import { SshTunnelProvider } from 'src/modules/ssh/ssh-tunnel.provider';
+import { NodeRedisConnectionStrategy } from 'src/modules/redis/connection/node.redis.connection.strategy';
+import { StandaloneNodeRedisClient } from 'src/modules/redis/client/node-redis/standalone.node-redis.client';
+
+jest.mock('redis', () => ({
+  ...jest.requireActual('redis'),
+  createClient: jest.fn(),
+}));
+
+describe('NodeRedisConnectionStrategy', () => {
+  let service: NodeRedisConnectionStrategy;
+  let createClientSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        NodeRedisConnectionStrategy,
+        {
+          provide: SshTunnelProvider,
+          useFactory: mockSshTunnelProvider,
+        },
+      ],
+    }).compile();
+
+    service = module.get(NodeRedisConnectionStrategy);
+
+    createClientSpy = jest.spyOn(redis, 'createClient');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createStandaloneClient', () => {
+    it('should include family: 0 in socket options for dual-stack IPv4/IPv6 support', async () => {
+      const mockClient = {
+        on: jest.fn().mockReturnThis(),
+        connect: jest.fn().mockResolvedValue(undefined),
+      };
+      createClientSpy.mockReturnValue(mockClient);
+
+      const result = await service.createStandaloneClient(
+        mockClientMetadata,
+        mockDatabase,
+        {},
+      );
+
+      expect(result).toBeInstanceOf(StandaloneNodeRedisClient);
+      expect(createClientSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          socket: expect.objectContaining({
+            family: 0,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
@@ -57,6 +57,7 @@ export class NodeRedisConnectionStrategy extends RedisConnectionStrategy {
       socket: {
         host,
         port,
+        family: 0, // Enable dual-stack IPv4/IPv6 (auto-detect)
         connectTimeout: timeout,
         ...tlsOptions,
         reconnectStrategy: options?.useRetry


### PR DESCRIPTION
# What

Follow-up to #5359 - adds tests and extends dual-stack IPv4/IPv6 support to node-redis.

- Add `family: 0` to `NodeRedisConnectionStrategy` for dual-stack support
- Add unit test for ioredis connection strategy verifying `family: 0` config
- Add new test file for node-redis connection strategy

# Testing

`yarn test:api` - all tests pass

---

Closes #5359

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends dual-stack IPv4/IPv6 support and verifies it across clients.
> 
> - Adds `family: 0` to `NodeRedisConnectionStrategy` socket options in `node.redis.connection.strategy.ts`
> - Adds unit test in `ioredis.redis.connection.strategy.spec.ts` asserting `family: 0` is passed to `ioredis`
> - Introduces `node.redis.connection.strategy.spec.ts` to verify `socket.family: 0` and successful client creation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c70ef9a2069bec4284a85b581223a678c68bd135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->