### PR TITLE
fix: update Docker Hub and Snapcraft release pipelines

### DIFF
--- a/.github/workflows/publish-stores.yml
+++ b/.github/workflows/publish-stores.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download Docker images
         run: |
           mkdir release
-          aws s3 cp s3://${AWS_BUCKET_NAME}/public/latest/docker ./release --recursive
+          aws s3 cp s3://${AWS_BUCKET_NAME}/public/latest-v3/docker ./release --recursive
 
       - name: Publish docker
         env:
@@ -60,7 +60,7 @@ jobs:
         id: snap
         run: |
           mkdir release
-          aws s3 cp s3://${AWS_BUCKET_NAME}/public/latest/${SNAPCRAFT_FILE_NAME} ./release
+          aws s3 cp s3://${AWS_BUCKET_NAME}/public/latest-v3/${SNAPCRAFT_FILE_NAME} ./release
           echo "snap-path=$(readlink -e ./release/${SNAPCRAFT_FILE_NAME})" >> "$GITHUB_OUTPUT"
 
       - uses: snapcore/action-publish@v1


### PR DESCRIPTION
# What

Make sure the release pipeline for Docker Hub and Snapcraft uses `latest-v3` for the binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release workflows to fetch artifacts from `latest-v3`.
> 
> - In `.github/workflows/publish-stores.yml`, change S3 download paths for Docker images and Snapcraft (`Redis-Insight-linux-amd64.snap`) from `public/latest` to `public/latest-v3`
> - Publishing steps and credentials remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bab71cd7829a4368c1b5e424dc006702d02c4bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->