### PR TITLE
Bump version to v3.0.2

### DIFF
--- a/.github/build/release-docker.sh
+++ b/.github/build/release-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 HELP="Args:
--v - Semver (3.0.1)
+-v - Semver (3.0.2)
 -d - Build image repository (Ex: -d redisinsight)
 -r - Target repository (Ex: -r redis/redisinsight)
 "

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -107,7 +107,7 @@ export default {
       : true,
     buildType: process.env.RI_BUILD_TYPE || 'DOCKER_ON_PREMISE',
     appType: process.env.RI_APP_TYPE,
-    appVersion: process.env.RI_APP_VERSION || '3.0.1',
+    appVersion: process.env.RI_APP_VERSION || '3.0.2',
     requestTimeout: parseInt(process.env.RI_REQUEST_TIMEOUT, 10) || 25000,
     excludeRoutes: [],
     excludeAuthRoutes: [],

--- a/redisinsight/api/config/swagger.ts
+++ b/redisinsight/api/config/swagger.ts
@@ -5,7 +5,7 @@ const SWAGGER_CONFIG: Omit<OpenAPIObject, 'paths'> = {
   info: {
     title: 'Redis Insight Backend API',
     description: 'Redis Insight Backend API',
-    version: '3.0.1',
+    version: '3.0.2',
   },
   tags: [],
 };

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redisinsight-api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Redis Insight API",
   "private": true,
   "author": {

--- a/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
+++ b/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
@@ -7,7 +7,7 @@ const ICON_PATH = app.isPackaged
   : path.join(__dirname, '../resources', 'icon.png')
 
 const appVersionPrefix = config.isEnterprise ? 'Enterprise - ' : ''
-const appVersion = app.getVersion() || '3.0.1'
+const appVersion = app.getVersion() || '3.0.2'
 const appVersionSuffix = !config.isProduction
   ? `-dev-${process.getCreationTime()}`
   : ''

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -3,7 +3,7 @@
   "appName": "Redis Insight",
   "productName": "RedisInsight",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Redis Insight",
   "main": "./dist/main/main.js",
   "author": {


### PR DESCRIPTION
# What

Prepare a new release version. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares v3.0.2 release by updating version references across app, API, and metadata.
> 
> - Bumps `version` to `3.0.2` in `redisinsight/package.json` and `api/package.json`
> - Updates `server.appVersion` default to `3.0.2` in `api/config/default.ts`
> - Sets Swagger `info.version` to `3.0.2` in `api/config/swagger.ts`
> - Updates desktop About panel fallback `appVersion` to `3.0.2`
> - Refreshes release script help text with new semver example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9fb06472fddcaebdcfffa430add2f747d1cd0ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->