### PR TITLE
DEV: Use storybook ESLint preset just for storybook files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -234,6 +234,7 @@ module.exports = {
     // Storybook files only
     {
       files: [
+        '.storybook/**/*.@(ts|tsx|js|jsx)',
         'stories/**/*.@(ts|tsx|js|jsx)',
         '**/*.stories.@(ts|tsx|js|jsx)',
         '**/*.story.@(ts|tsx|js|jsx)',


### PR DESCRIPTION
# What

No need to parse them for rest of the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes Storybook ESLint rules to Storybook-only files instead of the whole project.
> 
> - Removes `plugin:storybook/recommended` from root `extends` in `.eslintrc.js`
> - Adds an `overrides` block applying `plugin:storybook/recommended` to `**/*.stories.@(ts|tsx|js|jsx)`, `**/*.story.@(ts|tsx|js|jsx)`, `.storybook/**`, and `stories/**`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c40d4c423dd4b53593c7174d109b45f4e7b92c58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->