### PR TITLE
DEV: Update the ESLint caching mechanism

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,19 +3,12 @@ name: Lint
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
-    types: [labeled]
   push:
     branches:
       - main
 
 jobs:
   lint:
-    if: |
-      github.event_name == 'workflow_call' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-lint'))
     runs-on: ubuntu-latest
     name: ESLint
     steps:


### PR DESCRIPTION
# What

The `restore-keys` is the fallback mechanism. When running on a branch like `feature/RI-123/something`:

- First looks for exact match: `eslint-Linux-feature/RI-123/something` cache
- If not found, falls back to any cache starting with `eslint-Linux-` (which includes `eslint-Linux-main`)

So what happens if we change `.eslintrc.js`? - That makes ESLint ignore the cache, lint all the files, and create a new cache.

The problem comes because the GitHub action doesn't update the cache if it has the same name (the action step returns: `Post job cleanup. Cache hit occurred on the primary key eslint-Linux-feature-.... not saving cache.`

There's a hack to do it manually - Go to [Actions -> Caches](https://github.com/redis/RedisInsight/actions/caches) and delete the old one, then after the first run, the cache will be OK. But this is manual work, so this PR solves this problem.

# Another thing

For the sake of automation, now every merge in `main` would trigger the linter to prepare the cache. If that PR didn't update anything ESLint-related, it will reuse the cache, and it will be a very quick one.

Added `workflow_dispatch` as well, in case we want to run it manually.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves ESLint workflow reliability and automation.
> 
> - Adds `push` on `main` and `workflow_dispatch` triggers to run `lint` automatically and on-demand
> - Updates cache `key`/`restore-keys` to include `hashFiles('.eslintrc.js')` and `github.ref_name`, ensuring cache invalidates on ESLint config changes while retaining branch-specific reuse
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d17909660007a0cdf3cdbc2e753b2a5f0cf0be06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->