### PR TITLE
DEV: Remove ui/src/packages ESLint overrides as this part is ignored

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -381,22 +381,6 @@ module.exports = {
         // 'no-template-curly-in-string': 'off',
       },
     },
-    // Temporary disable some rules for UI packages
-    {
-      // In order to lint just UI packages
-      // make sure there's no override on 'redisinsight/ui'
-      // a.k.a. comment the above section
-      files: ['redisinsight/ui/src/packages/**/*.ts*'],
-      rules: {
-        'import/extensions': 'off',
-        'react/prop-types': 'off',
-        'react-hooks/rules-of-hooks': 'off',
-        'sonarjs/cognitive-complexity': 'off',
-        'max-len': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
-        'prefer-destructuring': 'off',
-      },
-    },
   ],
   parserOptions: {
     project: './tsconfig.json',


### PR DESCRIPTION
# What

If you take a look at the `.eslintrc.js` file inside the `ignorePatterns`, there's a `'redisinsight/ui/src/packages/**'`, so these rules are applied to that ignored part of the code. No point in having them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up ESLint config by deleting a redundant override for `redisinsight/ui/src/packages/**` that was never applied due to `ignorePatterns` excluding that path.
> 
> - Removes the UI packages-specific rules block from `.eslintrc.js`
> - No other lint rules or paths changed; behavior unchanged for linted files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae8667a1407cf60fb97627930323545825bdbf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->