### PR TITLE
Bugfix/deb build script

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -93,7 +93,6 @@
     "allowToChangeInstallationDirectory": true
   },
   "linux": {
-    "executableName": "redisinsight",
     "icon": "./resources/icons",
     "target": [
       {

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -27,8 +27,9 @@ exports.default = async function afterPack(context) {
   } else if (electronPlatformName === 'win32') {
     electronBinaryPath = path.join(appOutDir, `${productFilename}.exe`);
   } else {
-    // Linux
-    electronBinaryPath = path.join(appOutDir, productFilename);
+    // Linux - the actual executable is 'redisinsight' (lowercase, no space)
+    // electron-builder sanitizes productName for the binary name
+    electronBinaryPath = path.join(appOutDir, 'redisinsight');
   }
 
   console.log(`Flipping Electron fuses for: ${electronBinaryPath}`);


### PR DESCRIPTION
# What

Fix Linux deb package upgrade issues by:

1. **`scripts/deb-before-remove.sh`**: Check the `$1` argument to determine the action type. Only perform directory cleanup during `remove`/`purge` operations, not during `upgrade`. Previously, the script was deleting the installation directory during upgrades, causing the app to disappear.

2. **`scripts/afterPack.js`**: Use the actual Linux executable name `'redisinsight'` (lowercase, no space) instead of `productFilename` which returns `"Redis Insight"` (with space). This fixes the `ENOENT: no such file or directory` error during Linux builds when flipping Electron fuses.

| Before | After |
|--------|-------|
| `deb-before-remove.sh` deletes `/opt/redisinsight/` during package upgrade, causing app to disappear. `afterPack.js` looks for `Redis Insight` binary which doesn't exist. | `deb-before-remove.sh` only cleans up directories on actual removal. `afterPack.js` correctly finds the `redisinsight` binary. |

# Testing

1. **Build verification**: Run `yarn build:statics && yarn package:prod --linux deb` and verify the build completes without "ENOENT: no such file or directory" errors.

2. **Script behavior verification**: Full deb lifecycle test (on Linux VM):
Install the deb package: `sudo dpkg -i Redis-Insight-linux-x64.deb`
Verify installation: `ls -la /opt/redisinsight/`
Upgrade (reinstall same package): `sudo dpkg -i Redis-Insight-linux-x64.deb`
Verify app still exists after upgrade: `/opt/redisinsight/redisinsight --version`
Remove: `sudo dpkg -r redisinsight`
Verify cleanup: `ls /opt/redisinsight/` should not exist
   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves Linux packaging/build issues and prevents app removal during deb upgrades.
> 
> - In `scripts/afterPack.js`, use Linux executable `redisinsight` (not `productFilename`) when flipping Electron fuses
> - Refactor `scripts/deb-before-remove.sh` to always stop running instances, and only remove symlink and install dirs on `remove|purge`; skip directory removal on `upgrade`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 641092b517c97b2d80b1b41f7fa3a15544e49afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->