### PR TITLE
RI-7894: Implement sorting function for last connection dates in databases list

### DIFF
--- a/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.config.tsx
+++ b/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.config.tsx
@@ -98,6 +98,20 @@ export const BASE_COLUMNS: ColumnDef<Instance>[] = [
     accessorKey: DatabaseListColumn.LastConnection,
     header: COLUMN_FIELD_NAME_MAP.get(DatabaseListColumn.LastConnection),
     enableSorting: true,
+    sortingFn: (rowA, rowB) => {
+      const conn1 = rowA.original.lastConnection
+      const conn2 = rowB.original.lastConnection
+      if (conn1 && conn2) {
+        return new Date(conn2).getTime() - new Date(conn1).getTime()
+      }
+      if (conn1 && !conn2) {
+        return -1
+      }
+      if (!conn1 && conn2) {
+        return 1
+      }
+      return 0
+    },
     cell: DatabasesListCellLastConnection,
   },
   {


### PR DESCRIPTION
# What

Fixed default sorting for the "Last Connection" column in the databases list. Added a custom `sortingFn` that properly handles null/undefined connection dates by placing databases with connection history above those that have never been connected.
It also correctly converts data to dates before sorting (the data comes as date strings)

References: #5383 

# Testing

1. Navigate to the Home page with the databases list
3. Ensure you have multiple databases - with different last connection dates
3. Verify that:
   - Databases with connection history appear at the top (sorted by most recent first)
6. Click to change the sort order and verify the behavior works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves databases list sorting for connection history.
> 
> - Adds a custom `sortingFn` for `LastConnection` in `DatabasesList.config.tsx` that parses date strings, sorts by most recent first, and pushes null/undefined dates below entries with history
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9017babb8278d866058e9062d8aea7651971854a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->