### PR TITLE
fix RiAccordion.tsx to work with latest redis-ui components

### DIFF
--- a/redisinsight/ui/src/components/base/display/accordion/RiAccordion.tsx
+++ b/redisinsight/ui/src/components/base/display/accordion/RiAccordion.tsx
@@ -5,11 +5,10 @@ export type RiAccordionProps = Omit<ComponentProps<typeof Section>, 'label'> & {
   label: ReactNode
   actions?: ReactNode
   collapsible?: SectionProps['collapsible']
-  actionButtonText?: SectionProps['actionButtonText']
-  collapsedInfo?: SectionProps['collapsedInfo']
+  actionButtonText?: ReactNode
   content?: SectionProps['content']
   children?: SectionProps['content']
-  onAction?: SectionProps['onAction']
+  onAction?: () => void
 }
 
 const RiAccordionLabel = ({ label }: Pick<RiAccordionProps, 'label'>) => {
@@ -38,7 +37,7 @@ const RiAccordionActions = ({
       {actionButtonText}
     </Section.Header.ActionButton>
     {actions}
-    <Section.Header.CollapseIndicator />
+    <Section.Header.CollapseButton />
   </Section.Header.Group>
 )
 
@@ -48,7 +47,6 @@ export const RiAccordion = ({
   label,
   onAction,
   actionButtonText,
-  collapsedInfo,
   children,
   actions,
   collapsible = true,
@@ -61,7 +59,6 @@ export const RiAccordion = ({
     collapsible={collapsible}
   >
     <Section.Header.Compose
-      collapsedInfo={collapsedInfo}
       id={`ri-accordion-${id}`}
       data-testid={`ri-accordion-header-${id}`}
     >
@@ -76,9 +73,8 @@ export const RiAccordion = ({
         data-testid={`ri-accordion-actions-${id}`}
       />
     </Section.Header.Compose>
-    <Section.Body
-      content={children ?? content}
-      data-testid={`ri-accordion-body-${id}`}
-    />
+    <Section.Body data-testid={`ri-accordion-body-${id}`}>
+      {children ?? content}
+    </Section.Body>
   </Section.Compose>
 )


### PR DESCRIPTION
# What

Update RiAccordion to follow the pattern for Section in redis-ui

# Testing

Run the app, go to place where accordion is used, verify it still does work. For example settings or tutrorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `RiAccordion` with the latest `@redis-ui/components` `Section` API.
> 
> - Replace `Section.Header.CollapseIndicator` with `Section.Header.CollapseButton`; remove `collapsedInfo` usage
> - Render `Section.Body` via children instead of `content` prop (`{children ?? content}` as body children)
> - Update prop types: `actionButtonText` now `ReactNode`; `onAction` now `() => void`
> - Preserve header/label composition and test IDs while keeping `collapsible` support
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1068fcb903950c32fe6528fcf350020f0e85f0bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->