### PR TITLE
Fix theme color occurrences

### DIFF
--- a/redisinsight/ui/src/components/new-index/selection-box/SelectionBox.styles.tsx
+++ b/redisinsight/ui/src/components/new-index/selection-box/SelectionBox.styles.tsx
@@ -19,12 +19,12 @@ export const StyledText = styled(Text)`
 
 export const StyledDisabledBar = styled.div`
   padding: ${({ theme }) => theme.core.space.space025} 0;
-  background: ${({ theme }) => theme.color.dusk100};
-  color: ${({ theme }) => theme.color.dusk400};
+  background: ${({ theme }) => theme.semantic.color.background.secondary100};
+  color: ${({ theme }) => theme.semantic.color.text.secondary400};
   /* Theme adjustments TODO: add radii scale */
   border-radius: ${({ theme }) => theme.core.space.space025};
   /* Theme adjustments TODO: border width scale */
-  border-bottom: 1px solid ${({ theme }) => theme.color.gray500};
+  border-bottom: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 `

--- a/redisinsight/ui/src/components/triggers/insights-trigger/InsightsTrigger.styles.ts
+++ b/redisinsight/ui/src/components/triggers/insights-trigger/InsightsTrigger.styles.ts
@@ -17,7 +17,7 @@ export const BulbHighlighting = styled.span`
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  border: 1px solid ${({ theme }) => theme.color.gray100};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral100};
 `
 
 export const BulbIconButton = styled(IconButton)<

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.styles.ts
@@ -31,8 +31,8 @@ export const WarningBannerWrapper = styled(Row)`
   gap: ${({ theme }) => theme.core.space.space100};
   padding: 6px 12px;
   margin: ${({ theme }) => theme.core.space.space200};
-  border: 1px solid ${({ theme }) => theme.color.purple300};
-  background-color: ${({ theme }) => theme.color.purple100};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.notice300};
+  background-color: ${({ theme }) => theme.semantic.color.background.notice100};
   border-radius: ${({ theme }) => theme.core.space.space100};
 `
 

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const SuggestionsListWrapper = styled.div<{ children: React.ReactNode }>`
   position: absolute;
-  background: ${({ theme }) => theme.color.gray100};
+  background: ${({ theme }) => theme.semantic.color.background.neutral100};
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   border-radius: ${({ theme }) => theme.core.space.space050};
   overflow-y: auto;

--- a/redisinsight/ui/src/pages/home/components/db-status/DbStatus.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/db-status/DbStatus.styles.ts
@@ -11,6 +11,6 @@ export const InfoIcon = styled(RiIcon).attrs({
   size: 'S',
   color: 'custom',
 })`
-  color: ${({ theme }) => theme.color.orange500};
+  color: ${({ theme }) => theme.semantic.color.icon.attention500};
   margin-left: -1px;
 `

--- a/redisinsight/ui/src/pages/vector-search/components/commands-view/CommandsView/CommandsView.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/commands-view/CommandsView/CommandsView.styles.ts
@@ -23,7 +23,7 @@ export const StyledContainer = styled.div`
   flex: 1;
   width: 100%;
   overflow: auto;
-  color: ${({ theme }) => theme.color.gray700};
+  color: ${({ theme }) => theme.semantic.color.text.neutral700};
 `
 
 export const StyledHeader = styled.div`

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/styles.ts
@@ -9,7 +9,7 @@ export const Title = styled(Text)`
   margin-top: ${({ theme }) => theme.core?.space.space100};
   margin-bottom: ${({ theme }) => theme.core?.space.space100};
   font-weight: bold;
-  color: ${({ theme }) => theme.color.danger500};
+  color: ${({ theme }) => theme.semantic.color.text.danger500};
 `
 
 export const IconWrapper = styled.div`


### PR DESCRIPTION
# What

The new version of redis ui has different structure for the colors, so some usages needed to be replaced. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves multiple styled components to the new semantic color palette for consistency with the updated theme system.
> 
> - Updates colors/borders/backgrounds in `SelectionBox.styles.tsx`, `InsightsTrigger.styles.ts`, `ManageTagsModal.styles.ts`, `TagSuggestions.styles.ts`, `DbStatus.styles.ts`, `CommandsView.styles.ts`, and `vector-search/manage-indexes/styles.ts`
> - Replaces references like `theme.color.*` with `theme.semantic.color.*` for text, backgrounds, borders, and icons
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d5062dd230ebdf05de71984a2bad7be8a7bf579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->