### PR TITLE
RI-7973 Enhance JSON parse to safely handle prototype pollution

### DIFF
--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.spec.ts
@@ -367,6 +367,69 @@ describe('JsonService', () => {
           data: JSON.stringify(testData),
         });
       });
+      it('should return data with "constructor" property (prototype pollution safe)', async () => {
+        const testData = {
+          constructor: 'hello',
+          name: 'test',
+        };
+        when(client.sendCommand)
+          .calledWith(
+            [BrowserToolRejsonRlCommands.JsonGet, testKey, testPath],
+            { replyEncoding: 'utf8' },
+          )
+          .mockReturnValue(JSON.stringify([testData]));
+
+        const result = await service.getJson(mockBrowserClientMetadata, {
+          keyName: testKey,
+          path: testPath,
+        });
+
+        expect(result).toEqual({
+          downloaded: true,
+          path: testPath,
+          data: JSON.stringify(testData),
+        });
+      });
+      it('should return data with "__proto__" property (prototype pollution safe)', async () => {
+        const testDataString = '{"__proto__":"polluted","name":"test"}';
+        when(client.sendCommand)
+          .calledWith(
+            [BrowserToolRejsonRlCommands.JsonGet, testKey, testPath],
+            { replyEncoding: 'utf8' },
+          )
+          .mockReturnValue(`[${testDataString}]`);
+
+        const result = await service.getJson(mockBrowserClientMetadata, {
+          keyName: testKey,
+          path: testPath,
+        });
+
+        expect(result).toEqual({
+          downloaded: true,
+          path: testPath,
+          data: testDataString,
+        });
+      });
+      it('should return array with "constructor" property in nested object', async () => {
+        const testData = [{ constructor: 'hello' }];
+        when(client.sendCommand)
+          .calledWith(
+            [BrowserToolRejsonRlCommands.JsonGet, testKey, testPath],
+            { replyEncoding: 'utf8' },
+          )
+          .mockReturnValue(JSON.stringify([testData]));
+
+        const result = await service.getJson(mockBrowserClientMetadata, {
+          keyName: testKey,
+          path: testPath,
+        });
+
+        expect(result).toEqual({
+          downloaded: true,
+          path: testPath,
+          data: JSON.stringify(testData),
+        });
+      });
       it('should return full json data when forceRetrieve is true', async () => {
         const testData = {
           someStr: 'field',

--- a/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/rejson-rl.service.ts
@@ -35,7 +35,12 @@ import { RedisClient } from 'src/modules/redis/client';
 import { DatabaseService } from 'src/modules/database/database.service';
 
 const MODULES_CONFIG = config.get('modules') as Config['modules'];
-const JSONbig = JSONBigInt();
+
+// Allow JSON keys named 'constructor' and '__proto__' to be preserved since RedisInsight displays arbitrary user data from Redis
+const JSONbig = JSONBigInt({
+  protoAction: 'preserve',
+  constructorAction: 'preserve',
+});
 
 @Injectable()
 export class RejsonRlService {


### PR DESCRIPTION
# What
 
Update JSON parser configuration to allow `constructor` and `__proto__` properties to be preserved during JSON parsing

_Note: Since RedisInsight displays arbitrary user data from Redis, is it safe to do so?_

Reference #5412

# Testing

1. Create a JSON key with such proprietary values
```
JSON.SET mykey $ '{"constructor":"example value"}'
```
2. Try to open the key on the Browser page

| Before | After |
| - | - |
<img alt="image" src="https://github.com/user-attachments/assets/73b9b74e-1777-4ae7-8a85-f6ae79ef76f1" />|<img alt="image" src="https://github.com/user-attachments/assets/7e0de50d-7f9c-4f0d-82c2-3e02551636e1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures JSON values with potentially dangerous property names are preserved when reading from RedisJSON.
> 
> - Configure `JSONBigInt` in `rejson-rl.service.ts` with `protoAction: 'preserve'` and `constructorAction: 'preserve'`
> - Add unit tests in `rejson-rl.service.spec.ts` verifying handling of `constructor`, `"__proto__"` (as raw string), and nested occurrences during `getJson`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ebeab3cdf0fa5961e54f2a48f902f78f7eca1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->