### PR TITLE
RI-000: add possibility to run multiple UI

### DIFF
--- a/redisinsight/ui/vite.config.mjs
+++ b/redisinsight/ui/vite.config.mjs
@@ -86,7 +86,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 8080,
+    port: parseInt(process.env.RI_UI_DEV_PORT, 10) || 8080,
     fs: {
       allow: ['..', '../../node_modules/monaco-editor', 'static', 'defaults'],
     },


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Just tech changes. Added possibility to run UI on specified port via env variable. So we can run both UI and API from different folders at the same time when each will live on own ports
# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows running multiple UI instances or customizing the dev port.
> 
> - Updates `vite.config.mjs` to set `server.port` from `RI_UI_DEV_PORT` with fallback to `8080`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8ead74ed7f4fb176ce224e2c32f3b59c51ff4ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->