### PR TITLE
ci (POC): run staging and production release workflows in parallel

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,12 +1,9 @@
 name: ❗ Release (prod)
 
 on:
-  workflow_call:
-    inputs:
-      release_ref:
-        description: 'Branch to release from'
-        required: true
-        type: string
+  push:
+    branches:
+      - 'release/**'
 
 jobs:
   tests-prod:
@@ -23,8 +20,8 @@ jobs:
     needs: tests-prod
     secrets: inherit
     with:
-      environment: "production"
-      target: "all"
+      environment: 'production'
+      target: 'all'
 
   virustotal-prod:
     name: Virustotal

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -3,7 +3,7 @@ name: 📖 Release (stage)
 on:
   push:
     branches:
-      - "release/**"
+      - 'release/**'
 
 jobs:
   tests:
@@ -20,8 +20,8 @@ jobs:
     needs: tests
     secrets: inherit
     with:
-      environment: "staging"
-      target: "all"
+      environment: 'staging'
+      target: 'all'
 
   aws:
     uses: ./.github/workflows/aws-upload-dev.yml
@@ -42,26 +42,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Remove all artifacts
         uses: ./.github/actions/remove-artifacts # Remove artifacts from github actions
-
-  approve-production-release:
-    name: Approve production release
-    needs: [tests, builds, aws, remove-artifacts]
-    if: |
-      always() &&
-      needs.tests.result == 'success' &&
-      needs.builds.result == 'success' &&
-      needs.aws.result == 'success' &&
-      needs.remove-artifacts.result == 'success'
-    runs-on: ubuntu-latest
-    environment: 'production-approve'
-    steps:
-      - name: Approval for production release
-        run: echo "Production release approved for branch ${{ github.ref_name }}"
-
-  release-prod:
-    name: Release to production
-    needs: [approve-production-release]
-    uses: ./.github/workflows/release-prod.yml
-    secrets: inherit
-    with:
-      release_ref: ${{ github.ref_name }}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Remove sequential dependency between release-stage and release-prod workflows. Both now trigger independently on push to release/** branches.

| Before | After |
| --- | --- |
| <img width="491" height="727" alt="image" src="https://github.com/user-attachments/assets/3d2f51ac-6fed-4f72-8744-c35045f95351" /> | <img width="808" height="569" alt="image" src="https://github.com/user-attachments/assets/2e0c1e61-7a77-440b-9988-199a154528c9" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

During release