### PR TITLE
RI-7981: Add azureEntraId feature flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -125,6 +125,10 @@
     "databasesListV2": {
       "flag": true,
       "perc": [[0, 100]]
+    },
+    "azureEntraId": {
+      "flag": false,
+      "perc": [[0, 100]]
     }
   }
 }

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -33,6 +33,7 @@ export enum KnownFeatures {
   DatabaseManagement = 'databaseManagement',
   VectorSearch = 'vectorSearch',
   DatabasesListV2 = 'databasesListV2',
+  AzureEntraId = 'azureEntraId',
 }
 
 export interface IFeatureFlag {

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -66,4 +66,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DatabasesListV2,
     storage: FeatureStorage.Database,
   },
+  [KnownFeatures.AzureEntraId]: {
+    name: KnownFeatures.AzureEntraId,
+    storage: FeatureStorage.Database,
+  },
 };

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -95,6 +95,10 @@ export class FeatureFlagProvider {
       KnownFeatures.DatabasesListV2,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
+    this.strategies.set(
+      KnownFeatures.AzureEntraId,
+      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
+    );
   }
 
   getStrategy(name: string): FeatureFlagStrategy {

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -12,4 +12,5 @@ export enum FeatureFlags {
   databaseManagement = 'databaseManagement',
   vectorSearch = 'vectorSearch',
   databasesListV2 = 'databasesListV2',
+  azureEntraId = 'azureEntraId',
 }

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -65,6 +65,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.databasesListV2]: {
         flag: false,
       },
+      [FeatureFlags.azureEntraId]: {
+        flag: false,
+      },
     },
   },
 }


### PR DESCRIPTION
# What

Adds a new `azureEntraId` feature flag to support upcoming Azure Entra ID integration for autodiscovery and database connections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only registers a new disabled-by-default feature flag across config, API, and UI state, without changing auth/connection behavior yet.
> 
> **Overview**
> Introduces a new `azureEntraId` feature flag and wires it through the feature-flag system end-to-end.
> 
> Adds the flag to the server `KnownFeatures`/`knownFeatures`, registers it with a `CommonFlagStrategy`, includes it in `features-config.json` (default `false`), and exposes it on the UI via `FeatureFlags` and the Redux initial feature state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea3d492c2e53748e1925bc95af72feb4408e9ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->