### PR TITLE
DEV: Install API dependencies with root level install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "package:mac": "yarn build:prod && electron-builder build --mac -p never",
     "package:mac:arm": "yarn build:prod && electron-builder build --mac --arm64 -p never",
     "package:linux": "yarn build:prod && electron-builder build --linux -p never",
-    "preinstall": "yarn --cwd redisinsight/api install",
+    "preinstall": "test -d redisinsight/api && yarn --cwd redisinsight/api install || true",
     "postinstall": "patch-package && vite optimize -c ./redisinsight/ui/vite.config.mjs && skip-postinstall || yarn-deduplicate yarn.lock",
     "test": "jest ./redisinsight/ui -w 1",
     "test:api": "yarn --cwd redisinsight/api test",


### PR DESCRIPTION
# What

When `yarn install` is run on root level, it will go and install `redisinsight/api` dependencies as well (first API, then root ones).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes install-time scripting, with no runtime logic impact; main risk is longer installs or failures on environments where `test`/shell semantics differ (e.g., Windows).
> 
> **Overview**
> Root-level `yarn install` now runs a `preinstall` step that installs dependencies in `redisinsight/api` (when that directory exists) before proceeding with the main install.
> 
> This is implemented as a best-effort command (`... || true`) to avoid blocking installs when the API folder is missing or the sub-install fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab243fcba74bf98332ac475603a2c003580b42e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->