### PR TITLE
RDI suggestion

### DIFF
--- a/redisinsight/api/src/modules/rdi/providers/rdi.client.factory.ts
+++ b/redisinsight/api/src/modules/rdi/providers/rdi.client.factory.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { RdiClient } from 'src/modules/rdi/client/rdi.client';
 import { Rdi, RdiClientMetadata } from 'src/modules/rdi/models';
 import { ApiRdiClient } from 'src/modules/rdi/client/api/v1/api.rdi.client';
@@ -6,25 +6,26 @@ import { ApiV2RdiClient } from 'src/modules/rdi/client/api/v2/api.v2.rdi.client'
 
 @Injectable()
 export class RdiClientFactory {
+  private readonly logger = new Logger('RdiClientFactory');
+
   async createClient(
     clientMetadata: RdiClientMetadata,
     rdi: Rdi,
   ): Promise<RdiClient> {
-    let rdiClientV2 = new ApiV2RdiClient(clientMetadata, rdi);
-    let info = null;
-
     try {
-      info = await rdiClientV2.getInfo();
-    } catch (error) {
-      // info endpoint is not available
-      // skip the error and continue without info
-    }
+      const rdiClientV2 = new ApiV2RdiClient(clientMetadata, rdi);
+      // Probe v2 API endpoint to detect version
+      const info = await rdiClientV2.getInfo();
 
-    // todo: properly verify version from info to determine which client to use
-    if (info) {
-      await rdiClientV2.connect();
-      await rdiClientV2.selectPipeline();
-      return rdiClientV2;
+      // todo: properly verify version from info to determine which client to use
+      if (info) {
+        await rdiClientV2.connect();
+        await rdiClientV2.selectPipeline();
+        return rdiClientV2;
+      }
+    } catch (error) {
+      // v2 info endpoint is not available, falling back to v1 client
+      this.logger.log('RDI API v2 not detected, falling back to v1 client');
     }
 
     const rdiClient = new ApiRdiClient(clientMetadata, rdi);

--- a/redisinsight/ui/src/mocks/factories/rdi/RdiStatistics.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/rdi/RdiStatistics.factory.ts
@@ -4,7 +4,6 @@ import {
   IStatisticsInfoSection,
   IStatisticsBlocksSection,
   IStatisticsTableSection,
-  IStatisticsColumn,
   RdiStatisticsViewType,
   StatisticsCellType,
 } from 'uiSrc/slices/interfaces'
@@ -44,13 +43,6 @@ export const StatisticsBlocksSectionFactory =
       faker.number.int({ min: 1, max: 7 }),
     ),
   }))
-
-export const StatisticsColumnFactory = Factory.define<IStatisticsColumn>(
-  () => ({
-    id: faker.string.alpha(10),
-    header: faker.lorem.word(),
-  }),
-)
 
 export const StatisticsTableSectionFactory =
   Factory.define<IStatisticsTableSection>(() => {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Change let to const for variables that aren't reassigned
- Move v2 client instantiation inside try block to avoid waste on fallback
- Add Logger for version detection fallback visibility
- Remove unused StatisticsColumnFactory from test factories

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is largely unchanged aside from logging on v2 detection failure; only test/mock code is removed in the UI.
> 
> **Overview**
> Improves RDI client version detection by instantiating the v2 client inside the probe `try` block and **logging** when the v2 `getInfo()` call fails and the factory falls back to the v1 client.
> 
> Cleans up UI test mocks by removing the unused `StatisticsColumnFactory` export and related unused interface import from `RdiStatistics.factory.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a78bbeb025e346b31e630b97e42fabf01585a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->