### PR TITLE
RI-8071: run staging and production release workflows in parallel

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,12 +1,9 @@
 name: ❗ Release (prod)
 
 on:
-  workflow_call:
-    inputs:
-      release_ref:
-        description: 'Branch to release from'
-        required: true
-        type: string
+  push:
+    branches:
+      - 'release/**'
 
 jobs:
   tests-prod:
@@ -23,8 +20,8 @@ jobs:
     needs: tests-prod
     secrets: inherit
     with:
-      environment: "production"
-      target: "all"
+      environment: 'production'
+      target: 'all'
 
   virustotal-prod:
     name: Virustotal

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -3,7 +3,7 @@ name: 📖 Release (stage)
 on:
   push:
     branches:
-      - "release/**"
+      - 'release/**'
 
 jobs:
   tests:
@@ -20,8 +20,8 @@ jobs:
     needs: tests
     secrets: inherit
     with:
-      environment: "staging"
-      target: "all"
+      environment: 'staging'
+      target: 'all'
 
   aws:
     uses: ./.github/workflows/aws-upload-dev.yml
@@ -42,26 +42,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Remove all artifacts
         uses: ./.github/actions/remove-artifacts # Remove artifacts from github actions
-
-  approve-production-release:
-    name: Approve production release
-    needs: [tests, builds, aws, remove-artifacts]
-    if: |
-      always() &&
-      needs.tests.result == 'success' &&
-      needs.builds.result == 'success' &&
-      needs.aws.result == 'success' &&
-      needs.remove-artifacts.result == 'success'
-    runs-on: ubuntu-latest
-    environment: 'production-approve'
-    steps:
-      - name: Approval for production release
-        run: echo "Production release approved for branch ${{ github.ref_name }}"
-
-  release-prod:
-    name: Release to production
-    needs: [approve-production-release]
-    uses: ./.github/workflows/release-prod.yml
-    secrets: inherit
-    with:
-      release_ref: ${{ github.ref_name }}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Remove sequential dependency between release-stage and release-prod workflows. Both now trigger independently on push to release/** branches.

| Before | After |
| --- | --- |
| <img width="491" height="727" alt="image" src="https://github.com/user-attachments/assets/3d2f51ac-6fed-4f72-8744-c35045f95351" /> | <img width="808" height="569" alt="image" src="https://github.com/user-attachments/assets/2e0c1e61-7a77-440b-9988-199a154528c9" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

During release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the production release pipeline wiring and triggers, including removing the separate stage→approval→prod handoff, which could affect when/if production deployments run on `release/**` pushes.
> 
> **Overview**
> Consolidates the previously separate `release-stage.yml` and `release-prod.yml` workflows into a single `release.yml` that triggers on pushes to `release/**`.
> 
> Staging and production build/release chains now run *in parallel* after a shared `tests` job, with staging uploading to dev AWS and production running VirusTotal, uploading to prod S3, and publishing to stores; the old production approval gate and `workflow_call` handoff are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d43e37f21b5afba4d82655b20b305022d801f130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->