### PR TITLE
DEV: Rename Azure FF to dev

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -126,7 +126,7 @@
       "flag": true,
       "perc": [[0, 100]]
     },
-    "azureEntraId": {
+    "dev-azureEntraId": {
       "flag": false,
       "perc": [[0, 100]]
     }

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -33,7 +33,7 @@ export enum KnownFeatures {
   DatabaseManagement = 'databaseManagement',
   VectorSearch = 'vectorSearch',
   DatabasesListV2 = 'databasesListV2',
-  AzureEntraId = 'azureEntraId',
+  AzureEntraId = 'dev-azureEntraId',
 }
 
 export interface IFeatureFlag {

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -12,5 +12,5 @@ export enum FeatureFlags {
   databaseManagement = 'databaseManagement',
   vectorSearch = 'vectorSearch',
   databasesListV2 = 'databasesListV2',
-  azureEntraId = 'azureEntraId',
+  azureEntraId = 'dev-azureEntraId',
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk string-rename of a feature flag, but misalignment with any external flag management/rollout config could unintentionally disable/enable the Azure Entra ID-gated path.
> 
> **Overview**
> Renames the Azure Entra ID feature flag key from `azureEntraId` to `dev-azureEntraId` across the remote feature config and both API/UI feature-flag enums, effectively gating Azure Entra ID–related UI/behavior behind a dev-scoped flag name.
> 
> No functional logic changes beyond the identifier rename; existing references to `FeatureFlags.azureEntraId`/`KnownFeatures.AzureEntraId` now resolve to the new string value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e09f05a733d5c9ed4b46a5b688058eea494aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->