### PR TITLE
feat(fe): expand textarea for String key edit

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -64,6 +64,8 @@ import styles from './styles.module.scss'
 
 const MIN_ROWS = 8
 const APPROXIMATE_WIDTH_OF_SIGN = 8.6
+const APPROXIMATE_ROW_HEIGHT = 17
+const TEXTAREA_PADDING = 80
 const MAX_LENGTH = STRING_MAX_LENGTH + 1
 
 export interface Props {
@@ -103,7 +105,6 @@ const StringDetailsValue = (props: Props) => {
   )
 
   const textAreaRef: Ref<HTMLTextAreaElement> = useRef(null)
-  const viewValueRef: Ref<HTMLPreElement> = useRef(null)
   const containerRef: Ref<HTMLDivElement> = useRef(null)
 
   const dispatch = useDispatch()
@@ -164,7 +165,7 @@ const StringDetailsValue = (props: Props) => {
   }, [initialValue, viewFormatProp, compressor, length])
 
   useEffect(() => {
-    // Approximate calculation of textarea rows by initialValue
+    // Approximate calculation of textarea rows by areaValue
     if (!isEditItem || !textAreaRef.current || value === null) {
       return
     }
@@ -173,10 +174,16 @@ const StringDetailsValue = (props: Props) => {
       textAreaRef.current.clientWidth,
       APPROXIMATE_WIDTH_OF_SIGN,
     )
-    if (calculatedRows > MIN_ROWS) {
-      setRows(calculatedRows)
-    }
-  }, [viewValueRef, isEditItem])
+
+    // Calculate max rows based on container height
+    const containerHeight = containerRef.current?.clientHeight || 0
+    const availableHeight = containerHeight - TEXTAREA_PADDING
+    const maxRows = Math.floor(availableHeight / APPROXIMATE_ROW_HEIGHT)
+
+    // Clamp rows between MIN_ROWS and maxRows
+    const newRows = Math.max(MIN_ROWS, Math.min(calculatedRows, maxRows))
+    setRows(newRows)
+  }, [areaValue, isEditItem])
 
   useMemo(() => {
     if (isEditItem && initialValue) {
@@ -301,11 +308,7 @@ const StringDetailsValue = (props: Props) => {
               onChange={setAreaValue}
               disabled={loading}
               ref={textAreaRef}
-              style={{
-                maxHeight: containerRef.current
-                  ? containerRef.current?.clientHeight - 80
-                  : '100%',
-              }}
+              height="100%"
               data-testid="string-value"
             />
           </InlineItemEditor>


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Makes edit String key textarea expandable. It expands as you type and is scrollable (not visible from screenshots)

Note: the css alternative approach requires adding a lot of custom css to a lot of components in the tree

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

| Before | After |
| --- | --- |
| <img width="1014" height="903" alt="Screenshot 2026-02-09 at 15 16 17" src="https://github.com/user-attachments/assets/55fc8979-e8c9-4f39-961c-c79a8557f139" /> | <img width="1010" height="897" alt="Screenshot 2026-02-09 at 15 13 07" src="https://github.com/user-attachments/assets/d49774a1-2289-47d9-8c1b-a6cb19a53d56" /> |
| <img width="1014" height="902" alt="Screenshot 2026-02-09 at 15 16 30" src="https://github.com/user-attachments/assets/8679023f-069e-4fa3-a069-999b182efb14" /> | <img width="1001" height="894" alt="Screenshot 2026-02-09 at 15 12 54" src="https://github.com/user-attachments/assets/de5510d9-c1e6-4c1c-bbab-293944179c7f" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sizing logic changes; main risk is minor layout/scrolling regressions on different container sizes.
> 
> **Overview**
> Improves the String key edit experience by dynamically sizing the edit `TextArea` based on the current content and the available height of the enclosing details container.
> 
> Replaces the previous fixed `maxHeight` inline style with a rows-based clamp (min `MIN_ROWS`, max derived from container height) and recalculates rows on `areaValue` changes while editing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59a7d6ebed76d9628cf3f75778d9c02db4381b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->