### PR TITLE
RI-7971 Add DEL fallback for bulk delete on Redis 3.x

### DIFF
--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -6,6 +6,7 @@ export enum BrowserToolKeysCommands {
   Expire = 'expire',
   Persist = 'persist',
   Del = 'del',
+  Unlink = 'unlink',
   Rename = 'rename',
   RenameNX = 'renamenx',
   MemoryUsage = 'memory usage',

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/delete.bulk-action.simple.runner.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/delete.bulk-action.simple.runner.ts
@@ -1,8 +1,9 @@
+import { BrowserToolKeysCommands } from 'src/modules/browser/constants/browser-tool-commands';
 import { AbstractBulkActionSimpleRunner } from 'src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner';
 import { RedisClientCommand } from 'src/modules/redis/client';
 
 export class DeleteBulkActionSimpleRunner extends AbstractBulkActionSimpleRunner {
   prepareCommands(keys: Buffer[]): RedisClientCommand[] {
-    return keys.map((key) => ['del', key]);
+    return keys.map((key) => [BrowserToolKeysCommands.Del, key]);
   }
 }

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/unlink.bulk-action.simple.runner.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/unlink.bulk-action.simple.runner.spec.ts
@@ -4,10 +4,12 @@ import {
   mockCreateBulkActionDto,
   mockStandaloneRedisClient,
 } from 'src/__mocks__';
+import { BrowserToolKeysCommands } from 'src/modules/browser/constants/browser-tool-commands';
 import { UnlinkBulkActionSimpleRunner } from 'src/modules/bulk-actions/models/runners/simple/unlink.bulk-action.simple.runner';
 import { BulkAction } from 'src/modules/bulk-actions/models/bulk-action';
 import { RedisDataType } from 'src/modules/browser/keys/dto';
 import { BulkActionFilter } from 'src/modules/bulk-actions/models/bulk-action-filter';
+import { RedisFeature } from 'src/modules/redis/client';
 
 const mockBulkActionFilter = Object.assign(new BulkActionFilter(), {
   count: 10_000,
@@ -32,24 +34,78 @@ describe('UnlinkBulkActionSimpleRunner', () => {
   let unlinkRunner: UnlinkBulkActionSimpleRunner;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     unlinkRunner = new UnlinkBulkActionSimpleRunner(bulkAction, client);
   });
 
-  it('prepareCommands 3 commands', () => {
-    const commands = unlinkRunner.prepareCommands([
-      mockKeyBuffer,
-      mockKeyBuffer,
-      mockKeyBuffer,
-    ]);
-    expect(commands).toEqual([
-      ['unlink', mockKeyBuffer],
-      ['unlink', mockKeyBuffer],
-      ['unlink', mockKeyBuffer],
-    ]);
+  describe('prepareCommands', () => {
+    it('should use UNLINK command when Redis supports it (Redis 4.0.0+)', () => {
+      // Default behavior - UNLINK is supported
+      const commands = unlinkRunner.prepareCommands([
+        mockKeyBuffer,
+        mockKeyBuffer,
+        mockKeyBuffer,
+      ]);
+      expect(commands).toEqual([
+        [BrowserToolKeysCommands.Unlink, mockKeyBuffer],
+        [BrowserToolKeysCommands.Unlink, mockKeyBuffer],
+        [BrowserToolKeysCommands.Unlink, mockKeyBuffer],
+      ]);
+    });
+
+    it('should return empty array for 0 commands', () => {
+      const commands = unlinkRunner.prepareCommands([]);
+      expect(commands).toEqual([]);
+    });
   });
 
-  it('prepareCommands 0 commands', () => {
-    const commands = unlinkRunner.prepareCommands([]);
-    expect(commands).toEqual([]);
+  describe('prepareToStart', () => {
+    it('should use UNLINK when Redis version supports it (4.0.0+)', async () => {
+      client.isFeatureSupported.mockResolvedValueOnce(true);
+      client.sendCommand.mockResolvedValueOnce('100'); // getTotalKeys mock
+
+      await unlinkRunner.prepareToStart();
+
+      expect(client.isFeatureSupported).toHaveBeenCalledWith(
+        RedisFeature.UnlinkCommand,
+      );
+
+      const commands = unlinkRunner.prepareCommands([mockKeyBuffer]);
+      expect(commands).toEqual([
+        [BrowserToolKeysCommands.Unlink, mockKeyBuffer],
+      ]);
+    });
+
+    it('should fall back to DEL when Redis version does not support UNLINK (< 4.0.0)', async () => {
+      client.isFeatureSupported.mockResolvedValueOnce(false);
+      client.sendCommand.mockResolvedValueOnce('100'); // getTotalKeys mock
+
+      await unlinkRunner.prepareToStart();
+
+      expect(client.isFeatureSupported).toHaveBeenCalledWith(
+        RedisFeature.UnlinkCommand,
+      );
+
+      const commands = unlinkRunner.prepareCommands([mockKeyBuffer]);
+      expect(commands).toEqual([[BrowserToolKeysCommands.Del, mockKeyBuffer]]);
+    });
+
+    it('should use DEL for multiple keys when UNLINK is not supported', async () => {
+      client.isFeatureSupported.mockResolvedValueOnce(false);
+      client.sendCommand.mockResolvedValueOnce('100'); // getTotalKeys mock
+
+      await unlinkRunner.prepareToStart();
+
+      const commands = unlinkRunner.prepareCommands([
+        mockKeyBuffer,
+        mockKeyBuffer,
+        mockKeyBuffer,
+      ]);
+      expect(commands).toEqual([
+        [BrowserToolKeysCommands.Del, mockKeyBuffer],
+        [BrowserToolKeysCommands.Del, mockKeyBuffer],
+        [BrowserToolKeysCommands.Del, mockKeyBuffer],
+      ]);
+    });
   });
 });

--- a/redisinsight/api/src/modules/bulk-actions/models/runners/simple/unlink.bulk-action.simple.runner.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/runners/simple/unlink.bulk-action.simple.runner.ts
@@ -1,8 +1,29 @@
+import { BrowserToolKeysCommands } from 'src/modules/browser/constants/browser-tool-commands';
 import { AbstractBulkActionSimpleRunner } from 'src/modules/bulk-actions/models/runners/simple/abstract.bulk-action.simple.runner';
-import { RedisClientCommand } from 'src/modules/redis/client';
+import { RedisClientCommand, RedisFeature } from 'src/modules/redis/client';
 
 export class UnlinkBulkActionSimpleRunner extends AbstractBulkActionSimpleRunner {
+  private useDelFallback = false;
+
+  /**
+   * @inheritDoc
+   * Check if UNLINK command is supported, fall back to DEL if not
+   */
+  async prepareToStart(): Promise<void> {
+    await super.prepareToStart();
+
+    // Check if UNLINK is supported (Redis 4.0.0+)
+    // If not, fall back to DEL command for Redis 3.x compatibility
+    const isUnlinkSupported = await this.node.isFeatureSupported(
+      RedisFeature.UnlinkCommand,
+    );
+    this.useDelFallback = !isUnlinkSupported;
+  }
+
   prepareCommands(keys: Buffer[]): RedisClientCommand[] {
-    return keys.map((key) => ['unlink', key]);
+    const command = this.useDelFallback
+      ? BrowserToolKeysCommands.Del
+      : BrowserToolKeysCommands.Unlink;
+    return keys.map((key) => [command, key]);
   }
 }

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -54,6 +54,7 @@ export type RedisClientCommandReply =
 
 export enum RedisFeature {
   HashFieldsExpiration = 'HashFieldsExpiration',
+  UnlinkCommand = 'UnlinkCommand',
 }
 
 export abstract class RedisClient extends EventEmitter2 {
@@ -166,6 +167,14 @@ export abstract class RedisClient extends EventEmitter2 {
         try {
           const redisVersion = await this.getRedisVersion();
           return redisVersion && semverCompare('7.3', redisVersion) < 1;
+        } catch (e) {
+          return false;
+        }
+      case RedisFeature.UnlinkCommand:
+        try {
+          const redisVersion = await this.getRedisVersion();
+          // UNLINK command was introduced in Redis 4.0.0
+          return redisVersion && semverCompare('4.0.0', redisVersion) < 1;
         } catch (e) {
           return false;
         }


### PR DESCRIPTION
# What

Implement fallback to DEL command when UNLINK is unavailable (Redis < 4.0.0). This restores backwards compatibility with Redis 3.x for bulk delete operations.

**Changes:**
- Add `UnlinkCommand` to `RedisFeature` enum
- Implement version check in `isFeatureSupported()` (Redis >= 4.0.0)
- Modify `UnlinkBulkActionSimpleRunner` to check UNLINK support and fall back to DEL
- Add tests for both UNLINK and DEL code paths

# Testing

1. Connect to a Redis 3.x instance (e.g., Redis 3.2.12)
2. Create some test keys
3. Use bulk delete - should work using DEL command
4. Connect to Redis 4.0.0+ instance
5. Use bulk delete - should use UNLINK command

---

Closes #RI-7971
References #4658

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bulk deletion command selection based on detected Redis version; failures would impact key deletion behavior across supported Redis versions.
> 
> **Overview**
> Bulk delete via `UnlinkBulkActionSimpleRunner` now **detects Redis support for `UNLINK`** at startup and **falls back to `DEL`** when running against Redis < 4.0.0.
> 
> This introduces a new `RedisFeature.UnlinkCommand` with semver-based gating in `RedisClient.isFeatureSupported()`, adds `Unlink` to `BrowserToolKeysCommands`, standardizes delete runners to use these command enums, and expands unit tests to cover both the `UNLINK` and `DEL` paths (plus empty input).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a437f1e25b966f5aed8dc5bc1533aa7bbdd9f293. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->