### PR TITLE
RI-000: bump version to 3.0.3

### DIFF
--- a/.github/build/release-docker.sh
+++ b/.github/build/release-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 HELP="Args:
--v - Semver (3.0.2)
+-v - Semver (3.0.3)
 -d - Build image repository (Ex: -d redisinsight)
 -r - Target repository (Ex: -r redis/redisinsight)
 "

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -107,7 +107,7 @@ export default {
       : true,
     buildType: process.env.RI_BUILD_TYPE || 'DOCKER_ON_PREMISE',
     appType: process.env.RI_APP_TYPE,
-    appVersion: process.env.RI_APP_VERSION || '3.0.2',
+    appVersion: process.env.RI_APP_VERSION || '3.0.3',
     requestTimeout: parseInt(process.env.RI_REQUEST_TIMEOUT, 10) || 25000,
     excludeRoutes: [],
     excludeAuthRoutes: [],

--- a/redisinsight/api/config/swagger.ts
+++ b/redisinsight/api/config/swagger.ts
@@ -5,7 +5,7 @@ const SWAGGER_CONFIG: Omit<OpenAPIObject, 'paths'> = {
   info: {
     title: 'Redis Insight Backend API',
     description: 'Redis Insight Backend API',
-    version: '3.0.2',
+    version: '3.0.3',
   },
   tags: [],
 };

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redisinsight-api",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Redis Insight API",
   "private": true,
   "author": {

--- a/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
+++ b/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
@@ -7,7 +7,7 @@ const ICON_PATH = app.isPackaged
   : path.join(__dirname, '../resources', 'icon.png')
 
 const appVersionPrefix = config.isEnterprise ? 'Enterprise - ' : ''
-const appVersion = app.getVersion() || '3.0.2'
+const appVersion = app.getVersion() || '3.0.3'
 const appVersionSuffix = !config.isProduction
   ? `-dev-${process.getCreationTime()}`
   : ''

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -3,7 +3,7 @@
   "appName": "Redis Insight",
   "productName": "RedisInsight",
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Redis Insight",
   "main": "./dist/main/main.js",
   "author": {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps across build/config metadata; low risk aside from potential mismatched version strings affecting release packaging/display.
> 
> **Overview**
> Bumps RedisInsight version references from `3.0.2` to `3.0.3` across the desktop app, API package metadata, and generated Swagger/OpenAPI docs.
> 
> Updates the Docker release helper script’s help text and the backend `appVersion` default used when `RI_APP_VERSION` is not set, keeping displayed/reported versions consistent for the `3.0.3` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d29bc571d13fd59efdb35b9889dd50d9ef2bcd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->