### PR TITLE
RI-000: change default env for SSO (dev, stage)

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -345,12 +345,11 @@ export default {
   },
   cloud: {
     apiUrl:
-      process.env.RI_CLOUD_API_URL ||
-      'https://app-sm.k8s-cloudapi.sm-qa.qa.redislabs.com/api/v1',
+      process.env.RI_CLOUD_API_URL || 'https://app-qa.qa.redislabs.com/api/v1',
     apiToken: process.env.RI_CLOUD_API_TOKEN || 'token',
     capiUrl:
       process.env.RI_CLOUD_CAPI_URL ||
-      'https://api-k8s-cloudapi.qa.redislabs.com/v1',
+      'https://capi.k8s-dev-uirefresh.sm-qa.qa.redislabs.com/v1',
     capiKeyName: process.env.RI_CLOUD_CAPI_KEY_NAME || 'RedisInsight',
     freeSubscriptionName:
       process.env.RI_CLOUD_FREE_SUBSCRIPTION_NAME || 'My free subscription',


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-only change that only affects environments relying on these default URLs; main risk is accidental use of the wrong backend endpoints in QA/dev.
> 
> **Overview**
> Updates `redisinsight/api/config/default.ts` cloud defaults so `apiUrl` now targets `https://app-qa.qa.redislabs.com/api/v1` (instead of the previous `app-sm...` URL), and `capiUrl` now targets `https://capi.k8s-dev-uirefresh.sm-qa.qa.redislabs.com/v1` (instead of `api-k8s-cloudapi...`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e85140ff27de16e018e48a740a339c366e52c259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->