### PR TITLE
RI-7592: add field type tag badge variants

### DIFF
--- a/redisinsight/ui/src/components/base/display/badge/RiBadge.tsx
+++ b/redisinsight/ui/src/components/base/display/badge/RiBadge.tsx
@@ -1,5 +1,5 @@
-import { Badge } from '@redis-ui/components'
 import React from 'react'
+import { Badge, BadgeVariants } from '@redis-ui/components'
 
 type RiBadgeProps = Omit<React.ComponentProps<typeof Badge>, 'label'> & {
   children?: React.ReactNode
@@ -13,3 +13,5 @@ export const RiBadge = ({ children, label, ...rest }: RiBadgeProps) => {
   // Redis-UI badge accepts `string` as label, however in implementation it just renders it out, so any valid node will work
   return <Badge {...rest} label={internalLabel as string} />
 }
+
+export type { BadgeVariants }

--- a/redisinsight/ui/src/components/new-index/create-index-step/field-box/FieldTag.tsx
+++ b/redisinsight/ui/src/components/new-index/create-index-step/field-box/FieldTag.tsx
@@ -2,14 +2,18 @@ import React from 'react'
 import { Badge } from '@redis-ui/components'
 import { FIELD_TYPE_OPTIONS } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
 import { FieldTagProps } from './FieldTag.types'
+import { FIELD_TYPE_BADGE_VARIANT_MAP } from './constants'
 
-// TODO: Add colors mapping for tags when @redis-ui/components v38.6.0 is released
 export const FieldTag = ({ tag, dataTestId }: FieldTagProps) => {
   const tagLabel = FIELD_TYPE_OPTIONS.find(
     (option) => option.value === tag,
   )?.text
 
   return tagLabel ? (
-    <Badge label={tagLabel} data-testid={dataTestId ?? 'field-tag'} />
+    <Badge
+      label={tagLabel}
+      data-testid={dataTestId ?? 'field-tag'}
+      variant={FIELD_TYPE_BADGE_VARIANT_MAP[tag]}
+    />
   ) : null
 }

--- a/redisinsight/ui/src/components/new-index/create-index-step/field-box/constants.ts
+++ b/redisinsight/ui/src/components/new-index/create-index-step/field-box/constants.ts
@@ -1,0 +1,10 @@
+import { BadgeVariants } from 'uiSrc/components/base/display/badge/RiBadge'
+import { FieldTypes } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+
+export const FIELD_TYPE_BADGE_VARIANT_MAP: Record<FieldTypes, BadgeVariants> = {
+  [FieldTypes.TAG]: 'notice',
+  [FieldTypes.TEXT]: 'informative',
+  [FieldTypes.NUMERIC]: 'attention',
+  [FieldTypes.VECTOR]: 'success',
+  [FieldTypes.GEO]: 'default',
+}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Add variants to the badges used for the types of the field tags. 

| Light theme | Dark theme | 
| -- | -- |
| <img width="465" height="188" alt="image" src="https://github.com/user-attachments/assets/4d70c2cf-24db-44ed-949b-3268b2c5cb31" /> | <img width="465" height="188" alt="image" src="https://github.com/user-attachments/assets/1caf4024-fcc8-43ef-bf9f-30b85946f4ca" /> |



# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only styling change that adds a variant mapping and a type re-export; minimal behavioral impact aside from badge appearance.
> 
> **Overview**
> Field type badges in the create-index UI now render with distinct `variant` styles based on the field type via a new `FIELD_TYPE_BADGE_VARIANT_MAP`.
> 
> `RiBadge` now re-exports `BadgeVariants` from `@redis-ui/components` so shared code can type these variant mappings cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d58fd61963a91868b17548290ba7f94b25dfacb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->