### PR TITLE
RI-8082 tags suggestions position

### DIFF
--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.styles.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components'
 
 export const SuggestionsListWrapper = styled.div<{ children: React.ReactNode }>`
   position: absolute;
+  top: calc(100% + ${({ theme }) => theme.core.space.space050});
+  z-index: 100;
   background: ${({ theme }) => theme.semantic.color.background.neutral100};
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   border-radius: ${({ theme }) => theme.core.space.space050};


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
Issue: Database tags suggestion list appears bellow the input areas

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Click on Manage Tags icon for a db in the list
2. type 3-4 random key-value pairs
3. delete the first one
4. observe how the suggestions appear bellow the text inputs

| Before | After |
| --- | --- |
| <img width="951" height="730" alt="Screenshot 2026-02-11 at 17 23 36" src="https://github.com/user-attachments/assets/1e9cfc66-4f04-49e5-9c10-08ed2bd17e83" /> | <img width="962" height="732" alt="Screenshot 2026-02-11 at 18 07 12" src="https://github.com/user-attachments/assets/86a95be3-fce5-40aa-a15e-2f3032080e8e" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only positioning change scoped to the tag suggestions dropdown; minimal functional risk aside from potential minor layout overlap in edge cases.
> 
> **Overview**
> Adjusts the Manage Tags modal tag-suggestions dropdown styling so the list is anchored just below the input (`top: calc(100% + …)`) and rendered above other elements via a higher `z-index`, preventing it from appearing below the input rows after edits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fab1365ed43f5a7345a7a0cfdf9af5d68e784c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->