### PR TITLE
RI-8080: rollback default env changes since copilot won't work on the…

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -345,11 +345,12 @@ export default {
   },
   cloud: {
     apiUrl:
-      process.env.RI_CLOUD_API_URL || 'https://app-qa.qa.redislabs.com/api/v1',
+      process.env.RI_CLOUD_API_URL ||
+      'https://app-sm.k8s-cloudapi.sm-qa.qa.redislabs.com/api/v1',
     apiToken: process.env.RI_CLOUD_API_TOKEN || 'token',
     capiUrl:
       process.env.RI_CLOUD_CAPI_URL ||
-      'https://capi.k8s-dev-uirefresh.sm-qa.qa.redislabs.com/v1',
+      'https://api-k8s-cloudapi.qa.redislabs.com/v1',
     capiKeyName: process.env.RI_CLOUD_CAPI_KEY_NAME || 'RedisInsight',
     freeSubscriptionName:
       process.env.RI_CLOUD_FREE_SUBSCRIPTION_NAME || 'My free subscription',


### PR DESCRIPTION
… new qa env

# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that alters default external endpoints; risk is limited to QA/default environment behavior if the new URLs are incorrect or unavailable.
> 
> **Overview**
> Updates `redisinsight/api/config/default.ts` to change the fallback `cloud.apiUrl` and `cloud.capiUrl` values used when `RI_CLOUD_API_URL`/`RI_CLOUD_CAPI_URL` are unset, redirecting default QA traffic to different Cloud API/CAPI hosts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c900fce3ccba27239f90439c5d0315c717acaee9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->