### PR TITLE
ci: refactor test workflow to support release branches and reduce duplication

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,19 +73,37 @@ jobs:
             desktop:
               - 'redisinsight/desktop/**'
 
+  # Check common conditions that trigger all test suites
+  should-run-all-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.check.outputs.result }}
+    steps:
+      - id: check
+        run: |
+          RESULT=$(cat <<EOF
+          ${{ inputs.pre_release == true ||
+              github.event_name == 'workflow_dispatch' ||
+              startsWith(github.ref_name, 'feature/') ||
+              startsWith(github.ref_name, 'bugfix/') ||
+              startsWith(github.ref_name, 'ric/') ||
+              startsWith(github.ref_name, 'release/') ||
+              github.ref_name == 'latest' ||
+              contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
+          EOF
+          )
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
   lint:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   frontend-tests:
-    needs: [changes, lint]
+    needs: [changes, lint, should-run-all-tests]
     if: |
+      needs.should-run-all-tests.outputs.result == 'true' ||
       startsWith(github.ref_name, 'fe/') ||
       startsWith(github.ref_name, 'fe-be/') ||
-      startsWith(github.ref_name, 'feature/') ||
-      startsWith(github.ref_name, 'bugfix/') ||
-      startsWith(github.ref_name, 'ric/') ||
-      contains(github.event.pull_request.labels.*.name, 'run-all-tests') ||
       contains(github.event.pull_request.labels.*.name, 'run-frontend-tests')
     uses: ./.github/workflows/tests-frontend.yml
     secrets: inherit
@@ -99,14 +117,11 @@ jobs:
       type: unit
 
   backend-tests:
-    needs: [changes, lint]
+    needs: [changes, lint, should-run-all-tests]
     if: |
+      needs.should-run-all-tests.outputs.result == 'true' ||
       startsWith(github.ref_name, 'be/') ||
       startsWith(github.ref_name, 'fe-be/') ||
-      startsWith(github.ref_name, 'feature/') ||
-      startsWith(github.ref_name, 'bugfix/') ||
-      startsWith(github.ref_name, 'ric/') ||
-      contains(github.event.pull_request.labels.*.name, 'run-all-tests') ||
       contains(github.event.pull_request.labels.*.name, 'run-backend-tests')
     uses: ./.github/workflows/tests-backend.yml
     secrets: inherit
@@ -120,14 +135,11 @@ jobs:
       type: unit
 
   integration-tests:
-    needs: [changes, lint]
+    needs: [changes, lint, should-run-all-tests]
     if: |
+      needs.should-run-all-tests.outputs.result == 'true' ||
       startsWith(github.ref_name, 'be/') ||
       startsWith(github.ref_name, 'fe-be/') ||
-      startsWith(github.ref_name, 'feature/') ||
-      startsWith(github.ref_name, 'bugfix/') ||
-      startsWith(github.ref_name, 'ric/') ||
-      contains(github.event.pull_request.labels.*.name, 'run-all-tests') ||
       contains(github.event.pull_request.labels.*.name, 'run-integration-tests')
     uses: ./.github/workflows/tests-integration.yml
     secrets: inherit


### PR DESCRIPTION
# What

Refactored the test workflow to fix an issue where tests were being skipped on `release/*` branches and to reduce code duplication.

**Changes:**
- Added `release/*` and `latest` branches to test triggers
- Extracted common branch conditions into a reusable `should-run-all-tests` job
- Added support for `workflow_dispatch` and `workflow_call` with `pre_release` input
- Reduced duplication by centralizing common conditions (feature/, bugfix/, ric/, release/*, latest, run-all-tests)

**Before:** Common conditions were duplicated across frontend-tests, backend-tests, and integration-tests jobs. `workflow_dispatch` and `workflow_call` did not work at all.

**After:** Common conditions are evaluated once in `should-run-all-tests` job and reused across all test jobs. `workflow_dispatch` and `workflow_call` work.

# Testing

- Verify tests run on `release/*` branches
- Verify tests run on `latest` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that primarily affect when CI jobs run; main risk is unintentionally broadening/narrowing test execution due to the new shared condition logic.
> 
> **Overview**
> Refactors `.github/workflows/tests.yml` to centralize the “run all test suites” gating logic into a new `should-run-all-tests` job and reuses its output in `frontend-tests`, `backend-tests`, and `integration-tests`.
> 
> Expands the common trigger conditions to include `release/*`, `latest`, `workflow_dispatch`, and a `workflow_call` `pre_release` input, reducing duplicated branch/label checks and preventing tests from being skipped on release branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a874a54640c65119b59df30d061da8b57bc73a09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->