### PR TITLE
Update @redis-ui components and table versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,10 +251,10 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "34.6.0",
-    "@redis-ui/components": "^42.0.0",
+    "@redis-ui/components": "^42.8.0",
     "@redis-ui/icons": "^6.7.0",
     "@redis-ui/styles": "^14.6.0",
-    "@redis-ui/table": "^3.4.1",
+    "@redis-ui/table": "^3.5.1",
     "@reduxjs/toolkit": "^1.6.2",
     "@stablelib/snappy": "^1.0.2",
     "@types/json-dup-key-validator": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,6 +2139,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.2.tgz#83f415c4425f21e3d27914c12b3272a32e3dae65"
   integrity sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==
 
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
 "@radix-ui/react-arrow@1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.6.tgz#4b460fdbc1ac097a4964e04ca404c25c2f6d7d3f"
@@ -2183,6 +2188,16 @@
     "@radix-ui/react-context" "1.1.2"
     "@radix-ui/react-primitive" "2.1.2"
     "@radix-ui/react-slot" "1.2.2"
+
+"@radix-ui/react-collection@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
+  integrity sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
 
 "@radix-ui/react-compose-refs@1.1.2":
   version "1.1.2"
@@ -2348,6 +2363,13 @@
   dependencies:
     "@radix-ui/react-slot" "1.2.2"
 
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
+
 "@radix-ui/react-progress@^1.1.0":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.6.tgz#bec8368fffe28446895be48a4b85f71eb91709f6"
@@ -2414,10 +2436,34 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-slider@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.3.6.tgz#409453110b8f34ca00972750b80cd792f0b23a8c"
+  integrity sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==
+  dependencies:
+    "@radix-ui/number" "1.1.1"
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-slot@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.2.tgz#18e6533e778a2051edc2ad0773da8e22f03f626a"
   integrity sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
@@ -2556,10 +2602,10 @@
     "@react-hook/latest" "^1.0.2"
     "@react-hook/passive-layout-effect" "^1.2.0"
 
-"@redis-ui/components@^42.0.0":
-  version "42.0.0"
-  resolved "https://registry.yarnpkg.com/@redis-ui/components/-/components-42.0.0.tgz#3a0015ae8c11ee1ac729bff2b6e5f13192deff03"
-  integrity sha512-uJDhBpu+ZIQADSwA3EHrMjgsqO3ugoqU94TXqNz19b9KVZ7+zuePFTVqyLkQWIFpZ7sIDEsdVyuxgeILOC5qUw==
+"@redis-ui/components@^42.5.1", "@redis-ui/components@^42.8.0":
+  version "42.8.0"
+  resolved "https://registry.yarnpkg.com/@redis-ui/components/-/components-42.8.0.tgz#583ade7d155e722b2169d5f385a22b81678afb49"
+  integrity sha512-VQl6aeuM/VVVP46CJd9x2ng3lDLZnz1MsqgmC+f/zUYWVFzpV9oPKisFnjJj8e++8hKzdb6Hx5I8GsKicoHbsA==
   dependencies:
     "@radix-ui/react-checkbox" "^1.0.3"
     "@radix-ui/react-collapsible" "^1.0.3"
@@ -2570,6 +2616,7 @@
     "@radix-ui/react-progress" "^1.1.0"
     "@radix-ui/react-radio-group" "^1.1.2"
     "@radix-ui/react-select" "^2.1.0"
+    "@radix-ui/react-slider" "^1.3.6"
     "@radix-ui/react-switch" "^1.1.2"
     "@radix-ui/react-tabs" "^1.0.3"
     "@radix-ui/react-toggle" "^1.0.3"
@@ -2583,10 +2630,10 @@
     type-fest "^3.13.1"
     virtua "^0.36.3"
 
-"@redis-ui/icons@^6.6.0", "@redis-ui/icons@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@redis-ui/icons/-/icons-6.7.0.tgz#7f53cb6ca2aeeb569bc355f8a87420fcdf3879c4"
-  integrity sha512-XcEV6oVk/ZntgdNyqeuMAs5cU1jqFZzWZWMpfCLU48boSEQM3/Ox1qHkkSFm2m2ObiQSI90z61vAhkZkKReweA==
+"@redis-ui/icons@^6.7.0", "@redis-ui/icons@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@redis-ui/icons/-/icons-6.7.1.tgz#e1fc3bb041429319b982fd880b3cbfa86d12a8d7"
+  integrity sha512-Ht1lDSN53W0Z72k0j+L8LoYP113S/3wBdoXHuCwk2r7akiofmcu5zGdwjgOjAsHZYrlzj2jci5k8zrbB3oBwNg==
 
 "@redis-ui/styles@^14.6.0":
   version "14.6.0"
@@ -2596,13 +2643,13 @@
     color-alpha "^2.0.0"
     polished "^4.3.1"
 
-"@redis-ui/table@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@redis-ui/table/-/table-3.4.1.tgz#5c881bb9f0e2ed26d78039efaf0dbee2b294e066"
-  integrity sha512-sDF4qriLdtEotnjzUPv0ncOin9bsaPp6U9X0QvRdXuM207TITvLP8TlK3zSUm7N0aUH6ATJTxr5wczuHYATmqw==
+"@redis-ui/table@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@redis-ui/table/-/table-3.5.1.tgz#955c63349fdb52d49f7748b3c40a96c2da897f37"
+  integrity sha512-UxmWd9JJNAwo63mv4Qbbxbw5YYqmrmSlK+2wkaycwwJ18EJaTzpadsapML0bWzylG4dB5RCYOMk7X45emXy1Uw==
   dependencies:
-    "@redis-ui/components" "^42.0.0"
-    "@redis-ui/icons" "^6.6.0"
+    "@redis-ui/components" "^42.5.1"
+    "@redis-ui/icons" "^6.7.1"
     "@tanstack/react-table" "^8.9.8"
     type-fest "^3.13.1"
 


### PR DESCRIPTION
# What

Updated dependencies:
  - @redis-ui/components: 42.8.0
  - @redis-ui/table: 3.5.1

# Testing

There are no breaking changes introduced in the new versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps with no application logic changes; risk is limited to potential UI regressions from updated transitive components.
> 
> **Overview**
> Updates UI dependency versions by bumping `@redis-ui/components` to `42.8.0` and `@redis-ui/table` to `3.5.1`, with corresponding `yarn.lock` refresh.
> 
> The lockfile changes pull in newer transitive Radix UI packages (including adding `@radix-ui/react-slider`) and update `@redis-ui/icons` to `6.7.1` to satisfy the updated table/components dependency graph.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7073ecc0074ec3c73077c5eb5978d746a1cdc17e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->