### PR TITLE
Bump Node version in Docker

### DIFF
--- a/.github/build/build.Dockerfile
+++ b/.github/build/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.14-alpine
+FROM node:22.12.0-alpine
 
 # runtime args and environment variables
 ARG DIST=Redis-Insight.tar.gz

--- a/redisinsight/api/test/test-runs/test.Dockerfile
+++ b/redisinsight/api/test/test-runs/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.14-alpine as test
+FROM node:22.12.0-alpine as test
 
 RUN apk update && apk add bash libsecret dbus-x11 gnome-keyring
 RUN dbus-uuidgen > /var/lib/dbus/machine-id


### PR DESCRIPTION
# What

Related to https://github.com/redis/RedisInsight/issues/5492 and https://github.com/redis/RedisInsight/issues/5500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated Docker image version bump; main risk is runtime/dependency incompatibilities when building or running under Node 22.
> 
> **Overview**
> Updates the Docker base image for both the production build (`.github/build/build.Dockerfile`) and API test runner (`redisinsight/api/test/test-runs/test.Dockerfile`) from Node 20.14 Alpine to Node 22.12.0 Alpine to align container builds/tests with the newer Node runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7416c48b3b517d146d60ba3e0ccde981e6c0695c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->