### PR TITLE
RI-7934: Add delete index confirmation modal

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { render, screen, userEvent } from 'uiSrc/utils/test-utils'
+
+import {
+  DeleteIndexConfirmation,
+  DeleteIndexConfirmationProps,
+} from './DeleteIndexConfirmation'
+
+const defaultProps: DeleteIndexConfirmationProps = {
+  isOpen: true,
+  onConfirm: jest.fn(),
+  onClose: jest.fn(),
+}
+
+const renderComponent = (
+  propsOverride?: Partial<DeleteIndexConfirmationProps>,
+) => {
+  const props = { ...defaultProps, ...propsOverride }
+  return render(<DeleteIndexConfirmation {...props} />)
+}
+
+describe('DeleteIndexConfirmation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should not render when isOpen is false', () => {
+    renderComponent({ isOpen: false })
+
+    expect(
+      screen.queryByTestId('delete-index-modal-message'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render modal when isOpen is true', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('delete-index-modal-message')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-index-modal-confirm')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-index-modal-cancel')).toBeInTheDocument()
+  })
+
+  it('should call onConfirm when Delete index button is clicked', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onConfirm = jest.fn()
+    renderComponent({ onConfirm })
+
+    await user.click(screen.getByTestId('delete-index-modal-confirm'))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onClose when Keep index button is clicked', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onClose = jest.fn()
+    renderComponent({ onClose })
+
+    await user.click(screen.getByTestId('delete-index-modal-cancel'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onClose when close icon is clicked', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onClose = jest.fn()
+    renderComponent({ onClose })
+
+    await user.click(screen.getByTestId('delete-index-modal-close'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { Modal } from 'uiSrc/components/base/display/modal'
+import { Text } from 'uiSrc/components/base/text'
+
+export const ModalContent = styled(Modal.Content.Compose)`
+  width: 600px;
+`
+
+export const Question = styled(Text)`
+  color: ${({ theme }) => theme.semantic.color.text.secondary600};
+`

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/delete-index-confirmation/DeleteIndexConfirmation.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+
+import { Modal } from 'uiSrc/components/base/display'
+import { Button, DestructiveButton } from 'uiSrc/components/base/forms/buttons'
+import { CancelIcon } from 'uiSrc/components/base/icons'
+import { Text } from 'uiSrc/components/base/text'
+
+import * as S from './DeleteIndexConfirmation.styles'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
+
+export interface DeleteIndexConfirmationProps {
+  isOpen: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+export const DeleteIndexConfirmation = ({
+  isOpen,
+  onConfirm,
+  onClose,
+}: DeleteIndexConfirmationProps) => {
+  if (!isOpen) return null
+
+  return (
+    <Modal.Compose open={isOpen}>
+      <S.ModalContent persistent onCancel={onClose}>
+        <Modal.Content.Close
+          icon={CancelIcon}
+          onClick={onClose}
+          data-testid="delete-index-modal-close"
+        />
+
+        <Modal.Content.Header.Compose>
+          <Modal.Content.Header.Title>Delete Index</Modal.Content.Header.Title>
+        </Modal.Content.Header.Compose>
+
+        <Col gap="m">
+          <S.Question data-testid="delete-index-modal-question">
+            Are you sure you want to delete this index?
+          </S.Question>
+          <Text
+            color="primary"
+            variant="semiBold"
+            data-testid="delete-index-modal-message"
+          >
+            Deleting the index will remove it from Search and Vector Search, but
+            will not delete your underlying data.
+          </Text>
+          <Spacer size="xl" />
+        </Col>
+
+        <Row justify="end" gap="m">
+          <Button
+            size="large"
+            variant="secondary-ghost"
+            onClick={onClose}
+            data-testid="delete-index-modal-cancel"
+          >
+            Keep index
+          </Button>
+          <DestructiveButton
+            size="large"
+            onClick={onConfirm}
+            data-testid="delete-index-modal-confirm"
+          >
+            Delete index
+          </DestructiveButton>
+        </Row>
+      </S.ModalContent>
+    </Modal.Compose>
+  )
+}


### PR DESCRIPTION
# What

Add a confirmation modal before deleting an index from the Vector Search index list. When the user clicks "Delete" from the actions menu, a modal asks for confirmation before dispatching the delete action. This prevents accidental deletions.

**Changes:**
- New `DeleteIndexConfirmation` modal component with "Keep index" / "Delete index" buttons

# Testing

| Light | Dark |
| --- | --- |
| <img width="619" height="298" alt="image" src="https://github.com/user-attachments/assets/ce1fce17-6891-464b-940e-7c61a2fe3d97" /> | <img width="619" height="298" alt="image" src="https://github.com/user-attachments/assets/cb08fcc0-21b2-46bb-990c-631bdef51d6c" /> |

---

References: #RI-7934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behavior change gating an existing delete action, plus tests and telemetry hook; low risk aside from potential modal state/interaction regressions.
> 
> **Overview**
> Will prevent accidental index removal by introducing a **delete confirmation modal** in the Vector Search index list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b2c659ea884fe73b4845b7b1cf5c53b1abaa85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->