### PR TITLE
RI-8103: Disable connection fields when cloning Azure databases

### DIFF
--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -1342,7 +1342,7 @@ describe('InstanceForm', () => {
       expect(screen.getByTestId('password')).toBeDisabled()
     })
 
-    it('should not disable connection fields when cloning Azure database', () => {
+    it('should disable connection fields when cloning Azure database', () => {
       render(
         <ManualConnectionForm
           {...instance(mockedProps)}
@@ -1356,11 +1356,10 @@ describe('InstanceForm', () => {
         />,
       )
 
-      // In clone mode, all fields should be shown and enabled
-      expect(screen.getByTestId('host')).not.toBeDisabled()
-      expect(screen.getByTestId('port')).not.toBeDisabled()
-      expect(screen.getByTestId('username')).not.toBeDisabled()
-      expect(screen.getByTestId('password')).not.toBeDisabled()
+      expect(screen.getByTestId('host')).toBeDisabled()
+      expect(screen.getByTestId('port')).toBeDisabled()
+      expect(screen.getByTestId('username')).toBeDisabled()
+      expect(screen.getByTestId('password')).toBeDisabled()
     })
 
     it('should not disable connection fields for non-Azure database in edit mode', () => {

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -44,9 +44,8 @@ const EditConnection = (props: Props) => {
     buildType,
   } = props
 
-  // For Azure databases in edit mode (not clone)
-  const readOnlyFields =
-    isFromAzure && isEditMode && !isCloneMode ? AZURE_READONLY_FIELDS : []
+  // For Azure databases in edit/clone mode, disable connection fields
+  const readOnlyFields = isFromAzure && isEditMode ? AZURE_READONLY_FIELDS : []
 
   return (
     <form


### PR DESCRIPTION
# What

Disable connection fields (host, port, username, password) when cloning Azure databases.

# Preview

<img width="852" height="216" alt="Screenshot 2026-02-20 at 11 14 47" src="https://github.com/user-attachments/assets/cfd16d87-264f-405f-b715-258f0a87cf7d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to Azure edit/clone forms, backed by an updated unit test; low likelihood of affecting other connection types.
> 
> **Overview**
> Disables Azure connection fields (host/port/username/password) when **cloning** an Azure database, aligning clone behavior with Azure edit-mode restrictions.
> 
> Updates the `ManualConnectionForm` test to assert these fields are disabled during Azure clone, and simplifies `EditConnection` to apply `AZURE_READONLY_FIELDS` for Azure in edit mode regardless of `isCloneMode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16cc723cec5579b5a6786cc71012eff98e4b488d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->