### PR TITLE
Update 'Learn More' links in Menu and Tray

### DIFF
--- a/redisinsight/desktop/src/lib/menu/menu.ts
+++ b/redisinsight/desktop/src/lib/menu/menu.ts
@@ -216,7 +216,7 @@ export class MenuBuilder {
           label: 'Learn More',
           click() {
             shell.openExternal(
-              'https://redis.io/docs/ui/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
+              'https://redis.io/docs/latest/develop/tools/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
             )
           },
         },
@@ -339,7 +339,7 @@ export class MenuBuilder {
             label: 'Learn More',
             click() {
               shell.openExternal(
-                'https://redis.io/docs/ui/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
+                'https://redis.io/docs/latest/develop/tools/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
               )
             },
           },

--- a/redisinsight/desktop/src/lib/tray/tray.ts
+++ b/redisinsight/desktop/src/lib/tray/tray.ts
@@ -78,7 +78,7 @@ export class TrayBuilder {
         label: 'Learn More',
         click() {
           shell.openExternal(
-            'https://redis.io/docs/ui/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
+            'https://redis.io/docs/latest/develop/tools/insight/?utm_source=redisinsight&utm_medium=main&utm_campaign=learn_more',
           )
         },
       },


### PR DESCRIPTION
# What

Update **Learn More** links in Menu and Tray

<img width="2346" height="1492" alt="image" src="https://github.com/user-attachments/assets/ce986c56-37f0-4ddd-aa14-9a28ebaaa6d4" />

# Testing

1. Start the desktop application - `yarn dev:desktop`
2. Go to the **Help** menu 
3. Click on the **Learn More** option

You'll be navigated to the correct documentation page.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple URL changes to external documentation links; no functional logic, data, or security-sensitive behavior is modified.
> 
> **Overview**
> Updates the Desktop app’s **Help → Learn More** and tray menu **Learn More** actions to open the new Redis Insight documentation URL (`/docs/latest/develop/tools/insight/`) instead of the old `/docs/ui/insight/` page, keeping existing UTM parameters intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 449635d5c43bcf8bb8094093e5f4bdf05d6cb34e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->