### PR TITLE
RI-8073: Fix ENOENT error when logs directory doesn't exist

### DIFF
--- a/redisinsight/api/config/logger.ts
+++ b/redisinsight/api/config/logger.ts
@@ -72,7 +72,7 @@ if (LOGGER_CONFIG.files) {
   } catch (error) {
     // Log to console but don't crash the app if file logging setup fails
     console.warn(
-      'Failed to initialize file logging, falling back to console only:',
+      'Failed to initialize file logging',
       error instanceof Error ? error.message : error,
     );
   }


### PR DESCRIPTION
# What

Fixes the startup crash on fresh installs when the `.redis-insight` directory doesn't exist.

The logger config now:
- Creates the logs directory with `{ recursive: true }` before initializing file transports
- Wraps file transport creation in try-catch for graceful error handling ⚠️ Logs won't be made, but the application will still run

Related to: https://github.com/redis/RedisInsight/issues/5394

# Error

<img width="502" height="414" alt="Screenshot 2026-02-20 at 12 48 55" src="https://github.com/user-attachments/assets/6d639786-3c5b-4149-9dee-3d4049e943b6" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to logger initialization; main risk is silently losing file logs if directory creation or transport setup fails.
> 
> **Overview**
> Prevents startup crashes when file logging is enabled but the logs directory is missing by creating the directory before initializing the `winston` `DailyRotateFile` transports.
> 
> File transport setup is now wrapped in a `try/catch`; on failure the app continues running and emits a `console.warn`, potentially running without file logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291c054fe369fde9930220938c51437680a90d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->