### PR TITLE
RI-7945 Explain and Profile queries on Vector Search page

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.constants.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.constants.ts
@@ -21,5 +21,5 @@ export const TOOLTIP_EXPLAIN =
   "Shows how your query will run (execution plan) to understand what's used. Acts on FT.SEARCH or FT.AGGREGATE."
 export const TOOLTIP_PROFILE =
   'Profiles your query to show where time is spent and spot bottlenecks. Acts on FT.SEARCH or FT.AGGREGATE.'
-export const TOOLTIP_DISABLED_NO_QUERY = ' Disabled: no query identified.'
-export const TOOLTIP_DISABLED_LOADING = ' Disabled: query is running.'
+export const TOOLTIP_DISABLED_NO_QUERY = 'Disabled: no query identified.'
+export const TOOLTIP_DISABLED_LOADING = 'Disabled: query is running.'

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/VectorSearchActions.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/VectorSearchActions.spec.tsx
@@ -1,7 +1,19 @@
 import React from 'react'
-import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitForRiTooltipVisible,
+} from 'uiSrc/utils/test-utils'
 
 import { QueryEditorContextProvider } from 'uiSrc/components/query'
+import {
+  TOOLTIP_EXPLAIN,
+  TOOLTIP_PROFILE,
+  TOOLTIP_DISABLED_NO_QUERY,
+  TOOLTIP_DISABLED_LOADING,
+} from './QueryEditor.constants'
 import { VectorSearchActions } from './VectorSearchActions'
 
 const mockOnSubmit = jest.fn()
@@ -95,6 +107,51 @@ describe('VectorSearchActions', () => {
       fireEvent.click(screen.getByTestId('btn-explain'))
       expect(mockOnSubmit).toHaveBeenCalledWith('FT.EXPLAIN idx "*" LIMIT 0 10')
     })
+
+    it('should show disabled reason in tooltip when no valid query', async () => {
+      renderComponent({ query: '' })
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId('btn-explain'))
+      })
+      await waitForRiTooltipVisible()
+
+      expect(screen.getAllByText(TOOLTIP_EXPLAIN)[0]).toBeInTheDocument()
+      expect(
+        screen.getAllByText(TOOLTIP_DISABLED_NO_QUERY)[0],
+      ).toBeInTheDocument()
+    })
+
+    it('should show loading reason in tooltip when query is running', async () => {
+      renderComponent({ query: 'FT.SEARCH idx "*"', isLoading: true })
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId('btn-explain'))
+      })
+      await waitForRiTooltipVisible()
+
+      expect(screen.getAllByText(TOOLTIP_EXPLAIN)[0]).toBeInTheDocument()
+      expect(
+        screen.getAllByText(TOOLTIP_DISABLED_LOADING)[0],
+      ).toBeInTheDocument()
+    })
+
+    it('should show only base tooltip when enabled', async () => {
+      renderComponent({ query: 'FT.SEARCH idx "*"' })
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId('btn-explain'))
+      })
+      await waitForRiTooltipVisible()
+
+      expect(screen.getAllByText(TOOLTIP_EXPLAIN)[0]).toBeInTheDocument()
+      expect(
+        screen.queryByText(TOOLTIP_DISABLED_NO_QUERY),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(TOOLTIP_DISABLED_LOADING),
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe('Profile button', () => {
@@ -132,6 +189,34 @@ describe('VectorSearchActions', () => {
       expect(mockOnSubmit).toHaveBeenCalledWith(
         'FT.PROFILE idx AGGREGATE QUERY "*" GROUPBY 1 @field',
       )
+    })
+
+    it('should show disabled reason in tooltip when no valid query', async () => {
+      renderComponent({ query: '' })
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId('btn-profile'))
+      })
+      await waitForRiTooltipVisible()
+
+      expect(screen.getAllByText(TOOLTIP_PROFILE)[0]).toBeInTheDocument()
+      expect(
+        screen.getAllByText(TOOLTIP_DISABLED_NO_QUERY)[0],
+      ).toBeInTheDocument()
+    })
+
+    it('should show only base tooltip when enabled', async () => {
+      renderComponent({ query: 'FT.SEARCH idx "*"' })
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId('btn-profile'))
+      })
+      await waitForRiTooltipVisible()
+
+      expect(screen.getAllByText(TOOLTIP_PROFILE)[0]).toBeInTheDocument()
+      expect(
+        screen.queryByText(TOOLTIP_DISABLED_NO_QUERY),
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/VectorSearchActions.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/VectorSearchActions.tsx
@@ -36,11 +36,11 @@ export const VectorSearchActions = () => {
   const hasValidCommand = !!parsed
   const isExplainEnabled = hasValidCommand && !isLoading
 
-  const getDisabledSuffix = () => {
+  const disabledReason = useMemo(() => {
     if (!hasValidCommand) return TOOLTIP_DISABLED_NO_QUERY
     if (isLoading) return TOOLTIP_DISABLED_LOADING
-    return ''
-  }
+    return undefined
+  }, [hasValidCommand, isLoading])
 
   const handleExplain = () => {
     if (!parsed) return
@@ -56,7 +56,8 @@ export const VectorSearchActions = () => {
     <S.ActionsBar data-testid="vector-search-actions">
       <RiTooltip
         position="top"
-        content={`${TOOLTIP_EXPLAIN}${getDisabledSuffix()}`}
+        title={TOOLTIP_EXPLAIN}
+        content={disabledReason}
         data-testid="explain-tooltip"
       >
         <EmptyButton
@@ -70,7 +71,8 @@ export const VectorSearchActions = () => {
       </RiTooltip>
       <RiTooltip
         position="top"
-        content={`${TOOLTIP_PROFILE}${getDisabledSuffix()}`}
+        title={TOOLTIP_PROFILE}
+        content={disabledReason}
         data-testid="profile-tooltip"
       >
         <EmptyButton


### PR DESCRIPTION
# What

Make it easier for the people using the new **Vector Search** page to actually learn more about the queries they run:
- `EXPLAIN` - see details for the way the query is handled and executed
- `PROFILE` - learn more about the performance impact of your query

_Note: In this PR, we simply amend the tooltip texts, because the actual functionality was already introduced in previous iterations._

<img width="993" height="391" alt="image" src="https://github.com/user-attachments/assets/135e05dd-d64f-4df5-99d1-c7bde0962f66" />


# Testing

_Note: You ned to manually enable the dev-vectorSearch feature flag in order to see the page._

Navigate to the **Search** page > Click on **Query** button for a particular index (if you don't have any indexes, you should create one first)

## Disabled state 

Tooltip should show the base text **and** "Disabled: no query identified." on a separate line, if:
- the Code Editor is blank, you just landed on the page
- you didn't type in a command that supports profiling/explaining
- you have more than a single query in the editor 

| Explain | Profile |
| - | - |
<img width="987" height="398" alt="Screenshot 2026-02-23 at 15 32 37" src="https://github.com/user-attachments/assets/2f680dee-cb34-495a-b4da-52a507a57eb9" />|<img width="987" height="398" alt="Screenshot 2026-02-23 at 15 32 41" src="https://github.com/user-attachments/assets/50095af3-4543-4350-a1f7-45791b24732d" />

## Explain command

Type in the following command in the **Query Editor** and hit the **Explain** button.

```
FT.SEARCH  'idx:bikes_vss' "@price:[1000 1200]"
```

| Light | Dark |
| - | - |
<img width="987" height="752" alt="Screenshot 2026-02-23 at 15 34 28" src="https://github.com/user-attachments/assets/36b44985-c4e8-4b9a-8083-ffa6e282e9ef" />|<img width="987" height="752" alt="Screenshot 2026-02-23 at 15 34 47" src="https://github.com/user-attachments/assets/9d0ea95c-2f84-481f-a619-90ffd33dd521" />

## Profile command

Type in the following command in the **Query Editor** and hit the **Profile** button.

```
FT.SEARCH  'idx:bikes_vss' "@price:[1000 1200]"
```

| Light | Dark |
| - | - |
<img width="987" height="1001" alt="Screenshot 2026-02-23 at 15 36 59" src="https://github.com/user-attachments/assets/50328739-f235-47bc-af9e-56f74dce1545" />|<img width="987" height="1001" alt="Screenshot 2026-02-23 at 15 36 30" src="https://github.com/user-attachments/assets/bbc75af4-20e6-491b-9628-fb23f49dbb6a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip behavior change plus additional unit tests; no data/auth logic modified.
> 
> **Overview**
> Updates Vector Search Explain/Profile tooltips to show the base help text as a `title` and (when disabled) a separate `content` line explaining *why* the action is disabled (no valid query vs query running), rather than concatenating strings.
> 
> Cleans up tooltip disabled-message constants and expands `VectorSearchActions` tests to assert the correct tooltip text appears for disabled/loading/enabled states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cbc1a8de6999539998bafb5201a8a917dbcb05f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->