### PR TITLE
RI-7932 Query Library cleanup

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
@@ -8,7 +8,11 @@ import {
   deleteRedisearchIndexAction,
   redisearchListSelector,
 } from 'uiSrc/slices/browser/redisearch'
+import { addMessageNotification } from 'uiSrc/slices/app/notifications'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { collectManageIndexesDeleteTelemetry } from 'uiSrc/pages/vector-search-deprecated/telemetry'
+import { QueryLibraryService } from 'uiSrc/services/query-library/QueryLibraryService'
+import { queryLibraryNotifications } from 'uiSrc/pages/vector-search/constants'
 
 import { IndexList } from '../../../../components/index-list'
 import { IndexListAction } from '../../../../components/index-list/IndexList.types'
@@ -21,6 +25,7 @@ export const ListContent = () => {
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const { data: rawIndexes } = useSelector(redisearchListSelector)
+  const { id: databaseId } = useSelector(connectedInstanceSelector)
   const indexes = useMemo(
     () => rawIndexes.map((index) => bufferToString(index)),
     [rawIndexes],
@@ -39,6 +44,22 @@ export const ListContent = () => {
     [history, instanceId],
   )
 
+  const cleanupQueryLibrary = useCallback(
+    async (indexName: string) => {
+      try {
+        if (databaseId) {
+          const queryLibraryService = new QueryLibraryService()
+          await queryLibraryService.deleteByIndex(databaseId, indexName)
+        }
+      } catch {
+        dispatch(
+          addMessageNotification(queryLibraryNotifications.cleanupFailed()),
+        )
+      }
+    },
+    [databaseId, dispatch],
+  )
+
   const handleDelete = useCallback((indexName: string) => {
     setPendingDeleteIndex(indexName)
   }, [])
@@ -46,18 +67,19 @@ export const ListContent = () => {
   const handleConfirmDelete = useCallback(() => {
     if (!pendingDeleteIndex) return
 
+    const indexName = pendingDeleteIndex
+
     dispatch(
       deleteRedisearchIndexAction(
-        { index: stringToBuffer(pendingDeleteIndex) },
-        () => {
-          collectManageIndexesDeleteTelemetry({
-            instanceId,
-          })
+        { index: stringToBuffer(indexName) },
+        async () => {
+          collectManageIndexesDeleteTelemetry({ instanceId })
+          await cleanupQueryLibrary(indexName)
         },
       ),
     )
     setPendingDeleteIndex(null)
-  }, [dispatch, instanceId, pendingDeleteIndex])
+  }, [dispatch, cleanupQueryLibrary, instanceId, pendingDeleteIndex])
 
   const actions: IndexListAction[] = useMemo(
     () => [{ name: 'Delete', callback: handleDelete }], // TODO: Add more actions later (e.g. Browse dataset and View index)

--- a/redisinsight/ui/src/services/query-library/QueryLibraryService.ts
+++ b/redisinsight/ui/src/services/query-library/QueryLibraryService.ts
@@ -96,6 +96,14 @@ export class QueryLibraryService {
     }
   }
 
+  async deleteByIndex(databaseId: string, indexName: string): Promise<void> {
+    const { error } = await this.database.deleteByIndex(databaseId, indexName)
+
+    if (error) {
+      store.dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+
   async seed(
     databaseId: string,
     items: SeedQueryLibraryItem[],

--- a/redisinsight/ui/src/services/query-library/database/QueryLibraryIndexedDB.ts
+++ b/redisinsight/ui/src/services/query-library/database/QueryLibraryIndexedDB.ts
@@ -135,6 +135,27 @@ export class QueryLibraryIndexedDB implements QueryLibraryDatabase {
     }
   }
 
+  async deleteByIndex(
+    databaseId: string,
+    indexName: string,
+  ): Promise<QueryLibraryResult> {
+    try {
+      const listResult = await this.getList(databaseId, { indexName })
+
+      if (!listResult.success || !listResult.data) {
+        return { success: false, error: listResult.error }
+      }
+
+      await Promise.all(
+        listResult.data.map((item) => queryLibraryStorage.remove(item.id)),
+      )
+
+      return { success: true }
+    } catch (exception) {
+      return { success: false, error: exception as Error }
+    }
+  }
+
   async seed(
     databaseId: string,
     items: SeedQueryLibraryItem[],

--- a/redisinsight/ui/src/services/query-library/database/QueryLibrarySQLite.ts
+++ b/redisinsight/ui/src/services/query-library/database/QueryLibrarySQLite.ts
@@ -111,6 +111,15 @@ export class QueryLibrarySQLite implements QueryLibraryDatabase {
     }
   }
 
+  // No-op: for SQLite, query library cleanup is handled automatically by the backend
+  // when an index is deleted (see redisearch.service.ts → deleteIndex).
+  async deleteByIndex(
+    _databaseId: string,
+    _indexName: string,
+  ): Promise<QueryLibraryResult> {
+    return { success: true }
+  }
+
   async seed(
     databaseId: string,
     items: SeedQueryLibraryItem[],

--- a/redisinsight/ui/src/services/query-library/database/interface.ts
+++ b/redisinsight/ui/src/services/query-library/database/interface.ts
@@ -43,4 +43,9 @@ export interface QueryLibraryDatabase {
     databaseId: string,
     items: SeedQueryLibraryItem[],
   ): Promise<QueryLibraryResult>
+
+  deleteByIndex(
+    databaseId: string,
+    indexName: string,
+  ): Promise<QueryLibraryResult>
 }


### PR DESCRIPTION
# What

When an index is deleted, any saved queries associated with it in the query library should be cleaned up.

This adds a `deleteByIndex` method to the `QueryLibraryDatabase` interface with two implementations:

- **IndexedDB** — removes all queries related to the index from local storage.
- **SQLite** — no-op, since the backend already handles query library cleanup automatically when an index is deleted (see `redisearch.service.ts` → `deleteIndex`).

# Testing

_Note: You ned to manually enable the `dev-vectorSearch` feature flag in order to see the page._

1. Open the **Search** page from the main nav 
2. Click on the 3 dots button in the table (if you don't have indexes, you should create one)
3. Click on the **Delete** index button and confirm.

## SQLite path

By default, we use SQLite to store the query library. You can use [Bruno](https://github.com/redis/RedisInsight/pull/5535) to seed some queries, and then verify they got deleted successfully, once the index is deleted from the UI.

Go and check `query_library` in your database.   

## IndexdDB

_Note: By default, SQLite will be used as a data source, but you can manually toggle it via the following command._

```
RI_FEATURES_ENV_DEPENDENT_DEFAULT_FLAG=false yarn dev:ui
```

Go and check `RI_QUERY_LIBRARY` in your browser (DevTools -> Applications -> IndexedDB).   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-layer delete path invoked during index deletion; failures could leave stale saved queries or surface new notifications, but the change is scoped to query-library storage cleanup.
> 
> **Overview**
> When a vector search index is deleted from the list page, the UI now also attempts to remove any saved queries in the query library associated with that index, and shows an error toast if cleanup fails.
> 
> This introduces `deleteByIndex` on the query-library database interface/service: IndexedDB implementation deletes all matching stored items, while the SQLite implementation is a no-op (cleanup is assumed to be handled server-side).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e20f4004b12f159710d0e3ccfe5c9def1888e2eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->