### PR TITLE
RI-7902: add index field options type definitions

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/index-details/IndexDetails.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/index-details/IndexDetails.types.ts
@@ -3,11 +3,57 @@ import { RowSelectionState } from 'uiSrc/components/base/layout/table'
 
 export type IndexFieldValue = string | number
 
+export enum VectorAlgorithm {
+  FLAT = 'FLAT',
+  HNSW = 'HNSW',
+}
+
+export enum VectorDistanceMetric {
+  COSINE = 'COSINE',
+  L2 = 'L2',
+  IP = 'IP',
+}
+
+export enum VectorDataType {
+  FLOAT32 = 'FLOAT32',
+  FLOAT64 = 'FLOAT64',
+  FLOAT16 = 'FLOAT16',
+  BFLOAT16 = 'BFLOAT16',
+}
+
+export interface VectorFieldOptionsBase {
+  dimensions?: number
+  distanceMetric?: VectorDistanceMetric
+  dataType?: VectorDataType
+}
+
+export interface VectorFlatFieldOptions extends VectorFieldOptionsBase {
+  algorithm: VectorAlgorithm.FLAT
+}
+
+export interface VectorHnswFieldOptions extends VectorFieldOptionsBase {
+  algorithm: VectorAlgorithm.HNSW
+  maxEdges?: number
+  maxNeighbors?: number
+  candidateLimit?: number
+  epsilon?: number
+}
+
+export type VectorFieldOptions = VectorFlatFieldOptions | VectorHnswFieldOptions
+
+export interface TextFieldOptions {
+  weight?: number
+  phonetic?: string
+}
+
+export type IndexFieldOptions = VectorFieldOptions | TextFieldOptions
+
 export interface IndexField {
   id: string
   name: string
   value: IndexFieldValue
   type: FieldTypes
+  options?: IndexFieldOptions
 }
 
 export enum IndexDetailsMode {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Adds TypeScript type definitions for index field options to support the upcoming field type modal (add/edit index fields).

This introduces:
- Enums for vector configuration: `VectorAlgorithm` (FLAT, HNSW), `VectorDistanceMetric` (COSINE, L2, IP), `VectorDataType` (FLOAT32, FLOAT64, FLOAT16, BFLOAT16)
- Discriminated union interfaces for vector field options: `VectorFlatFieldOptions` and `VectorHnswFieldOptions` with a shared `VectorFieldOptionsBase`
- `TextFieldOptions` interface for text-specific options (weight, phonetic)
- `IndexFieldOptions` union type combining all field option types
- Extends `IndexField` with an optional `options` property

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

- No runtime behavior changes — type definitions only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes confined to UI type definitions; no runtime logic, API calls, or data handling behavior is modified.
> 
> **Overview**
> Adds TypeScript type definitions to represent per-field index options in the vector search Index Details UI, including enums for vector configuration and discriminated unions for FLAT vs HNSW vector parameters.
> 
> Extends `IndexField` with an optional `options?: IndexFieldOptions` to carry vector or text-specific settings (e.g., dimensions/distance/data type, HNSW tuning, text weight/phonetic).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bc1cd7c985a2e73a5ff9b0db7ffd780da6044a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->