### PR TITLE
RI-000: bump version to 3.2.0

### DIFF
--- a/.github/build/release-docker.sh
+++ b/.github/build/release-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 HELP="Args:
--v - Semver (3.0.3)
+-v - Semver (3.2.0)
 -d - Build image repository (Ex: -d redisinsight)
 -r - Target repository (Ex: -r redis/redisinsight)
 "

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -107,7 +107,7 @@ export default {
       : true,
     buildType: process.env.RI_BUILD_TYPE || 'DOCKER_ON_PREMISE',
     appType: process.env.RI_APP_TYPE,
-    appVersion: process.env.RI_APP_VERSION || '3.0.3',
+    appVersion: process.env.RI_APP_VERSION || '3.2.0',
     requestTimeout: parseInt(process.env.RI_REQUEST_TIMEOUT, 10) || 25000,
     excludeRoutes: [],
     excludeAuthRoutes: [],

--- a/redisinsight/api/config/swagger.ts
+++ b/redisinsight/api/config/swagger.ts
@@ -5,7 +5,7 @@ const SWAGGER_CONFIG: Omit<OpenAPIObject, 'paths'> = {
   info: {
     title: 'Redis Insight Backend API',
     description: 'Redis Insight Backend API',
-    version: '3.0.3',
+    version: '3.2.0',
   },
   tags: [],
 };

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redisinsight-api",
-  "version": "3.0.3",
+  "version": "3.2.0",
   "description": "Redis Insight API",
   "private": true,
   "author": {

--- a/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
+++ b/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
@@ -7,7 +7,7 @@ const ICON_PATH = app.isPackaged
   : path.join(__dirname, '../resources', 'icon.png')
 
 const appVersionPrefix = config.isEnterprise ? 'Enterprise - ' : ''
-const appVersion = app.getVersion() || '3.0.3'
+const appVersion = app.getVersion() || '3.2.0'
 const appVersionSuffix = !config.isProduction
   ? `-dev-${process.getCreationTime()}`
   : ''

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -3,7 +3,7 @@
   "appName": "Redis Insight",
   "productName": "RedisInsight",
   "private": true,
-  "version": "3.0.3",
+  "version": "3.2.0",
   "description": "Redis Insight",
   "main": "./dist/main/main.js",
   "author": {


### PR DESCRIPTION
# What

Bump minor version to reflect the addition of the Microsoft Entra ID authentication feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure version-string bumps across build/docs/UI metadata with no functional logic changes; low risk aside from potential packaging/release labeling mismatches if any reference was missed.
> 
> **Overview**
> Bumps RedisInsight version references from `3.0.3` to `3.2.0` across the repo.
> 
> Updates the API package/version reporting (`redisinsight/api/package.json`, default config `RI_APP_VERSION`, and Swagger `info.version`), the desktop About panel fallback version, the top-level app `package.json`, and the release Docker script help text to reflect `3.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09e9699543d6995495c0ceef30a12480426bd9be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->