### PR TITLE
RI-7941 Add dynamic command generation for RediSearch index creation

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.spec.ts
@@ -1,0 +1,487 @@
+import {
+  FieldTypes,
+  RedisearchIndexKeyType,
+} from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+
+import {
+  IndexField,
+  VectorAlgorithm,
+  VectorDataType,
+  VectorDistanceMetric,
+} from '../components/index-details/IndexDetails.types'
+import {
+  generateDynamicFtCreateCommand,
+  DynamicFtCreateParams,
+} from './generateDynamicFtCreateCommand'
+
+const buildParams = (
+  overrides?: Partial<DynamicFtCreateParams>,
+): DynamicFtCreateParams => ({
+  indexName: 'idx:test',
+  keyType: RedisearchIndexKeyType.HASH,
+  prefix: 'test:',
+  fields: [],
+  ...overrides,
+})
+
+describe('generateDynamicFtCreateCommand', () => {
+  describe('basic structure', () => {
+    it('should generate command with HASH key type', () => {
+      const result = generateDynamicFtCreateCommand(
+        buildParams({
+          indexName: 'idx:myindex',
+          keyType: RedisearchIndexKeyType.HASH,
+          prefix: 'myprefix:',
+        }),
+      )
+
+      expect(result).toContain('FT.CREATE idx:myindex')
+      expect(result).toContain('ON HASH')
+      expect(result).toContain('PREFIX 1 "myprefix:"')
+      expect(result).toContain('SCHEMA')
+    })
+
+    it('should generate command with JSON key type', () => {
+      const result = generateDynamicFtCreateCommand(
+        buildParams({
+          keyType: RedisearchIndexKeyType.JSON,
+          prefix: 'doc:',
+        }),
+      )
+
+      expect(result).toContain('ON JSON')
+      expect(result).toContain('PREFIX 1 "doc:"')
+    })
+
+    it('should generate command with empty fields', () => {
+      const result = generateDynamicFtCreateCommand(buildParams())
+
+      expect(result).toContain('FT.CREATE idx:test')
+      expect(result).toContain('SCHEMA')
+    })
+  })
+
+  describe('simple field types', () => {
+    it.each([
+      { type: FieldTypes.NUMERIC, expected: 'NUMERIC' },
+      { type: FieldTypes.GEO, expected: 'GEO' },
+      { type: FieldTypes.GEOSHAPE, expected: 'GEOSHAPE' },
+    ])('should generate $expected field for HASH key', ({ type, expected }) => {
+      const fields: IndexField[] = [
+        { id: 'f1', name: 'myfield', value: 'val', type },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain(`"myfield" ${expected}`)
+    })
+
+    it('should generate TAG field for HASH key', () => {
+      const fields: IndexField[] = [
+        { id: 'f1', name: 'myfield', value: 'val', type: FieldTypes.TAG },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"myfield" TAG')
+    })
+
+    it.each([
+      { type: FieldTypes.NUMERIC, expected: 'NUMERIC' },
+      { type: FieldTypes.GEO, expected: 'GEO' },
+      { type: FieldTypes.GEOSHAPE, expected: 'GEOSHAPE' },
+    ])(
+      'should generate $expected field with JSONPath alias for JSON key',
+      ({ type, expected }) => {
+        const fields: IndexField[] = [
+          { id: 'f1', name: 'myfield', value: 'val', type },
+        ]
+        const result = generateDynamicFtCreateCommand(
+          buildParams({ keyType: RedisearchIndexKeyType.JSON, fields }),
+        )
+
+        expect(result).toContain(`$.myfield AS myfield ${expected}`)
+      },
+    )
+
+    it('should generate TAG field for JSON key', () => {
+      const fields: IndexField[] = [
+        { id: 'f1', name: 'myfield', value: 'val', type: FieldTypes.TAG },
+      ]
+      const result = generateDynamicFtCreateCommand(
+        buildParams({ keyType: RedisearchIndexKeyType.JSON, fields }),
+      )
+
+      expect(result).toContain('$.myfield AS myfield TAG')
+    })
+  })
+
+  describe('TEXT fields', () => {
+    it('should generate TEXT field without WEIGHT when using default', () => {
+      const fields: IndexField[] = [
+        { id: 'title', name: 'title', value: 'hello', type: FieldTypes.TEXT },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"title" TEXT')
+      expect(result).not.toContain('WEIGHT')
+      expect(result).not.toContain('PHONETIC')
+    })
+
+    it('should generate TEXT field with non-default weight', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'title',
+          name: 'title',
+          value: 'hello',
+          type: FieldTypes.TEXT,
+          options: { weight: 2.5 },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"title" TEXT WEIGHT 2.5')
+    })
+
+    it('should generate TEXT field with phonetic', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'title',
+          name: 'title',
+          value: 'hello',
+          type: FieldTypes.TEXT,
+          options: { phonetic: 'dm:en' },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"title" TEXT PHONETIC dm:en')
+    })
+
+    it('should omit PHONETIC when set to none', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'title',
+          name: 'title',
+          value: 'hello',
+          type: FieldTypes.TEXT,
+          options: { phonetic: 'none' },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).not.toContain('PHONETIC')
+    })
+
+    it('should generate TEXT field with weight and phonetic', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'title',
+          name: 'title',
+          value: 'hello',
+          type: FieldTypes.TEXT,
+          options: { weight: 3, phonetic: 'dm:fr' },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"title" TEXT WEIGHT 3 PHONETIC dm:fr')
+    })
+  })
+
+  describe('VECTOR FLAT fields', () => {
+    it('should generate VECTOR FLAT with default options when none provided', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"embedding" VECTOR FLAT 6')
+      expect(result).toContain('TYPE FLOAT32')
+      expect(result).toContain('DIM 384')
+      expect(result).toContain('DISTANCE_METRIC COSINE')
+    })
+
+    it('should generate VECTOR FLAT with explicit options', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.FLAT,
+            dataType: VectorDataType.FLOAT64,
+            dimensions: 768,
+            distanceMetric: VectorDistanceMetric.L2,
+          },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"embedding" VECTOR FLAT 6')
+      expect(result).toContain('TYPE FLOAT64')
+      expect(result).toContain('DIM 768')
+      expect(result).toContain('DISTANCE_METRIC L2')
+    })
+
+    it('should generate VECTOR FLAT for JSON key type', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.FLAT,
+            dimensions: 8,
+            distanceMetric: VectorDistanceMetric.COSINE,
+          },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(
+        buildParams({ keyType: RedisearchIndexKeyType.JSON, fields }),
+      )
+
+      expect(result).toContain('$.embedding AS embedding VECTOR FLAT 6')
+      expect(result).toContain('TYPE FLOAT32')
+      expect(result).toContain('DIM 8')
+      expect(result).toContain('DISTANCE_METRIC COSINE')
+    })
+  })
+
+  describe('VECTOR HNSW fields', () => {
+    it('should generate VECTOR HNSW with all options', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.HNSW,
+            dataType: VectorDataType.FLOAT32,
+            dimensions: 512,
+            distanceMetric: VectorDistanceMetric.IP,
+            maxEdges: 32,
+            maxNeighbors: 400,
+            candidateLimit: 20,
+            epsilon: 0.05,
+          },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"embedding" VECTOR HNSW 14')
+      expect(result).toContain('TYPE FLOAT32')
+      expect(result).toContain('DIM 512')
+      expect(result).toContain('DISTANCE_METRIC IP')
+      expect(result).toContain('M 32')
+      expect(result).toContain('EF_CONSTRUCTION 400')
+      expect(result).toContain('EF_RUNTIME 20')
+      expect(result).toContain('EPSILON 0.05')
+    })
+
+    it('should generate VECTOR HNSW with only base options', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.HNSW,
+            dimensions: 256,
+            distanceMetric: VectorDistanceMetric.COSINE,
+          },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"embedding" VECTOR HNSW 6')
+      expect(result).toContain('TYPE FLOAT32')
+      expect(result).toContain('DIM 256')
+      expect(result).toContain('DISTANCE_METRIC COSINE')
+      expect(result).not.toMatch(/\bM \d/)
+      expect(result).not.toContain('EF_CONSTRUCTION')
+      expect(result).not.toContain('EF_RUNTIME')
+      expect(result).not.toContain('EPSILON')
+    })
+
+    it('should generate VECTOR HNSW with partial options', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.HNSW,
+            dimensions: 128,
+            distanceMetric: VectorDistanceMetric.L2,
+            maxEdges: 16,
+          },
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"embedding" VECTOR HNSW 8')
+      expect(result).toContain('M 16')
+      expect(result).not.toContain('EF_CONSTRUCTION')
+    })
+  })
+
+  describe('mixed fields', () => {
+    it('should generate command with multiple field types', () => {
+      const fields: IndexField[] = [
+        { id: 'title', name: 'title', value: 'test', type: FieldTypes.TEXT },
+        { id: 'genre', name: 'genre', value: 'comedy', type: FieldTypes.TAG },
+        { id: 'year', name: 'year', value: 2024, type: FieldTypes.NUMERIC },
+        { id: 'loc', name: 'location', value: '1,2', type: FieldTypes.GEO },
+        {
+          id: 'emb',
+          name: 'embedding',
+          value: '[1,2,3]',
+          type: FieldTypes.VECTOR,
+          options: {
+            algorithm: VectorAlgorithm.FLAT,
+            dimensions: 8,
+            distanceMetric: VectorDistanceMetric.COSINE,
+          },
+        },
+      ]
+
+      const result = generateDynamicFtCreateCommand(
+        buildParams({
+          indexName: 'idx:mixed',
+          prefix: 'item:',
+          fields,
+        }),
+      )
+
+      expect(result).toContain('FT.CREATE idx:mixed')
+      expect(result).toContain('PREFIX 1 "item:"')
+      expect(result).toContain('"title" TEXT')
+      expect(result).toContain('"genre" TAG')
+      expect(result).toContain('"year" NUMERIC')
+      expect(result).toContain('"location" GEO')
+      expect(result).toContain('"embedding" VECTOR FLAT 6')
+    })
+
+    it('should reorder fields by type to avoid keyword clashes', () => {
+      const fields: IndexField[] = [
+        { id: 'title', name: 'title', value: 'test', type: FieldTypes.TEXT },
+        { id: 'genre', name: 'genre', value: 'comedy', type: FieldTypes.TAG },
+        { id: 'year', name: 'year', value: 2024, type: FieldTypes.NUMERIC },
+      ]
+
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      const numericIdx = result.indexOf('"year" NUMERIC')
+      const tagIdx = result.indexOf('"genre" TAG')
+      const textIdx = result.indexOf('"title" TEXT')
+
+      expect(numericIdx).toBeLessThan(tagIdx)
+      expect(tagIdx).toBeLessThan(textIdx)
+    })
+
+    it('should generate JSON command with multiple field types', () => {
+      const fields: IndexField[] = [
+        { id: 'title', name: 'title', value: 'test', type: FieldTypes.TEXT },
+        { id: 'tags', name: 'tags', value: 'a,b', type: FieldTypes.TAG },
+        { id: 'year', name: 'year', value: 2024, type: FieldTypes.NUMERIC },
+      ]
+
+      const result = generateDynamicFtCreateCommand(
+        buildParams({
+          keyType: RedisearchIndexKeyType.JSON,
+          prefix: 'doc:',
+          fields,
+        }),
+      )
+
+      expect(result).toContain('ON JSON')
+      expect(result).toContain('$.title AS title TEXT')
+      expect(result).toContain('$.tags AS tags TAG')
+      expect(result).toContain('$.year AS year NUMERIC')
+    })
+  })
+
+  describe('reserved keyword field names', () => {
+    it('should place NUMERIC "weight" before TEXT fields via reordering', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'desc',
+          name: 'description',
+          value: 'hello',
+          type: FieldTypes.TEXT,
+        },
+        {
+          id: 'w',
+          name: 'weight',
+          value: '10',
+          type: FieldTypes.NUMERIC,
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      const weightIdx = result.indexOf('"weight" NUMERIC')
+      const descIdx = result.indexOf('"description" TEXT')
+
+      expect(weightIdx).toBeLessThan(descIdx)
+    })
+
+    it('should place TAG fields before TEXT to avoid "separator" clash', () => {
+      const fields: IndexField[] = [
+        {
+          id: 's',
+          name: 'separator',
+          value: ';',
+          type: FieldTypes.TEXT,
+        },
+        { id: 't', name: 'tags', value: 'a,b', type: FieldTypes.TAG },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      const tagIdx = result.indexOf('"tags" TAG')
+      const textIdx = result.indexOf('"separator" TEXT')
+
+      expect(tagIdx).toBeLessThan(textIdx)
+    })
+  })
+
+  describe('field name handling', () => {
+    it('should quote HASH field names with special characters', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'f1',
+          name: 'my-field',
+          value: 'val',
+          type: FieldTypes.TEXT,
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(buildParams({ fields }))
+
+      expect(result).toContain('"my-field" TEXT')
+    })
+
+    it('should generate JSONPath for JSON field names with special characters', () => {
+      const fields: IndexField[] = [
+        {
+          id: 'f1',
+          name: 'my_field',
+          value: 'val',
+          type: FieldTypes.TAG,
+        },
+      ]
+      const result = generateDynamicFtCreateCommand(
+        buildParams({ keyType: RedisearchIndexKeyType.JSON, fields }),
+      )
+
+      expect(result).toContain('$.my_field AS my_field TAG')
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.ts
+++ b/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.ts
@@ -1,0 +1,148 @@
+import {
+  FieldTypes,
+  RedisearchIndexKeyType,
+} from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+
+import {
+  IndexField,
+  VectorAlgorithm,
+  VectorFieldOptions,
+  VectorHnswFieldOptions,
+  TextFieldOptions,
+} from '../components/index-details/IndexDetails.types'
+import {
+  VECTOR_ALGORITHM_DEFAULT,
+  VECTOR_DATA_TYPE_DEFAULT,
+  VECTOR_DISTANCE_METRIC_DEFAULT,
+  VECTOR_CONSTRAINTS,
+  PHONETIC_NONE,
+} from '../components/field-type-modal/FieldTypeModal.constants'
+
+export interface DynamicFtCreateParams {
+  indexName: string
+  keyType: RedisearchIndexKeyType
+  prefix: string
+  fields: IndexField[]
+}
+
+export const generateDynamicFtCreateCommand = ({
+  indexName,
+  keyType,
+  prefix,
+  fields,
+}: DynamicFtCreateParams): string => {
+  const onClause = keyType === RedisearchIndexKeyType.JSON ? 'JSON' : 'HASH'
+
+  const fieldSchemas = sortFieldsByType(fields)
+    .map((field) => `    ${buildFieldSchema(field, keyType)}`)
+    .join('\n')
+
+  const parts = [
+    `FT.CREATE ${indexName}`,
+    `  ON ${onClause}`,
+    `    PREFIX 1 "${prefix}"`,
+    '  SCHEMA',
+  ]
+
+  if (fieldSchemas) {
+    parts.push(fieldSchemas)
+  }
+
+  return parts.join('\n')
+}
+
+const buildFieldSchema = (
+  field: IndexField,
+  keyType: RedisearchIndexKeyType,
+): string => {
+  const isJson = keyType === RedisearchIndexKeyType.JSON
+  const fieldRef = isJson
+    ? `$.${field.name} AS ${field.name}`
+    : `"${field.name}"`
+
+  if (field.type === FieldTypes.VECTOR) {
+    const vectorOptions = field.options as VectorFieldOptions | undefined
+    const algorithm = vectorOptions?.algorithm ?? VECTOR_ALGORITHM_DEFAULT
+    const params = getVectorParams(vectorOptions)
+    const numArgs = params.length * 2
+
+    const paramLines = params
+      .map(([key, value]) => `      ${key} ${value}`)
+      .join('\n')
+
+    return `${fieldRef} VECTOR ${algorithm} ${numArgs}\n${paramLines}`
+  }
+
+  if (field.type === FieldTypes.TEXT) {
+    const textOptions = field.options as TextFieldOptions | undefined
+    const parts = [fieldRef, 'TEXT']
+
+    if (textOptions?.weight !== undefined && textOptions.weight !== 1) {
+      parts.push('WEIGHT', String(textOptions.weight))
+    }
+
+    if (textOptions?.phonetic && textOptions.phonetic !== PHONETIC_NONE) {
+      parts.push('PHONETIC', textOptions.phonetic)
+    }
+
+    return parts.join(' ')
+  }
+
+  return `${fieldRef} ${field.type.toUpperCase()}`
+}
+
+const getVectorParams = (options?: VectorFieldOptions): [string, string][] => {
+  const algorithm = options?.algorithm ?? VECTOR_ALGORITHM_DEFAULT
+  const dataType = options?.dataType ?? VECTOR_DATA_TYPE_DEFAULT
+  const dimensions =
+    options?.dimensions ?? VECTOR_CONSTRAINTS.DIMENSIONS_DEFAULT
+  const distanceMetric =
+    options?.distanceMetric ?? VECTOR_DISTANCE_METRIC_DEFAULT
+
+  const params: [string, string][] = [
+    ['TYPE', dataType],
+    ['DIM', String(dimensions)],
+    ['DISTANCE_METRIC', distanceMetric],
+  ]
+
+  if (algorithm === VectorAlgorithm.HNSW) {
+    const hnsw = options as VectorHnswFieldOptions | undefined
+    if (hnsw?.maxEdges !== undefined) {
+      params.push(['M', String(hnsw.maxEdges)])
+    }
+    if (hnsw?.maxNeighbors !== undefined) {
+      params.push(['EF_CONSTRUCTION', String(hnsw.maxNeighbors)])
+    }
+    if (hnsw?.candidateLimit !== undefined) {
+      params.push(['EF_RUNTIME', String(hnsw.candidateLimit)])
+    }
+    if (hnsw?.epsilon !== undefined) {
+      params.push(['EPSILON', String(hnsw.epsilon)])
+    }
+  }
+
+  return params
+}
+
+/**
+ * RediSearch parses field modifiers greedily: after a field type, it keeps
+ * consuming tokens that match known modifier keywords (case-insensitive).
+ * A field *name* like "weight" after a TEXT field is consumed as the WEIGHT
+ * modifier, causing a parsing error.
+ *
+ * Ordering fields so that types with fewer/simpler modifiers come first
+ * (NUMERIC, GEO → TAG → TEXT → VECTOR) avoids most real-world clashes.
+ */
+const FIELD_TYPE_ORDER: Record<string, number> = {
+  [FieldTypes.NUMERIC]: 0,
+  [FieldTypes.GEO]: 1,
+  [FieldTypes.GEOSHAPE]: 2,
+  [FieldTypes.TAG]: 3,
+  [FieldTypes.TEXT]: 4,
+  [FieldTypes.VECTOR]: 5,
+}
+
+const sortFieldsByType = (fields: IndexField[]): IndexField[] =>
+  [...fields].sort(
+    (a, b) => (FIELD_TYPE_ORDER[a.type] ?? 3) - (FIELD_TYPE_ORDER[b.type] ?? 3),
+  )


### PR DESCRIPTION
# What

Adds a `generateDynamicFtCreateCommand` utility that constructs `FT.CREATE` commands from dynamic field definitions. 

Supports all field types (TEXT, TAG, NUMERIC, GEO, GEOSHAPE, VECTOR FLAT/HNSW) for both HASH and
JSON key types.

_Note: Fields are reordered by type in the generated schema to avoid RediSearch's greedy keyword parser consuming field names as modifiers (e.g. a NUMERIC field named "weight" placed after a TEXT field would be parsed as the WEIGHT modifier)._

_PS: More info and architecture overview for the feature can be found in #5573_

<img width="532" height="854" alt="image" src="https://github.com/user-attachments/assets/04771176-ef00-460b-b0a4-72ca9345a300" />

# Testing

It's a standalone helper that cannot be tested easily, but it will be used later in the flow for creating an index via existing data. You can refer to the unit tests for more usage details.

Actual usage can be verified in https://github.com/redis/RedisInsight/pull/5562 later.

We rely on this hook to build up the actual command that we use to create the index, based on the set of fields and the customizations applied by the user (change of types, which we initially inferred based on the values themselves).

| Light | Dark |
| - | - |
<img width="1244" height="948" alt="Screenshot 2026-02-25 at 18 17 43" src="https://github.com/user-attachments/assets/ceefb0fb-ed67-4e53-b218-fce9906f933f" />|<img width="1244" height="948" alt="Screenshot 2026-02-25 at 18 17 36" src="https://github.com/user-attachments/assets/3efb590c-6306-4c30-b059-61bb42b6ede6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone command-string generator plus unit tests, with no runtime wiring changes; risk is mainly limited to correctness of emitted `FT.CREATE` syntax for edge-case field names/options.
> 
> **Overview**
> Adds `generateDynamicFtCreateCommand` to build formatted `FT.CREATE` commands from UI-defined index fields for both `HASH` and `JSON` key types.
> 
> The generator supports `TEXT` (with optional `WEIGHT`/`PHONETIC`), `TAG`, `NUMERIC`, `GEO`, `GEOSHAPE`, and `VECTOR` (FLAT/HNSW with defaults and optional HNSW tuning params), and **reorders schema fields by type** to avoid RediSearch’s greedy modifier parsing when field names collide with keywords. A comprehensive unit test suite validates command output across field types, options, JSONPath aliasing, and the reordering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca1d46ebda33915b5a1b935ecbbe29bef33f6522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->