### PR TITLE
RI-7941 Improve index name validation UX in create index flow

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/CreateIndexHeader.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/CreateIndexHeader.tsx
@@ -14,7 +14,7 @@ const INFO_TOOLTIP =
   'Select a key from the left panel to auto-detect the indexing schema.'
 
 export const CreateIndexHeader = () => {
-  const { mode, displayName, indexName, setIndexName, fields } =
+  const { mode, displayName, indexName, setIndexName, indexNameError, fields } =
     useCreateIndexPage()
 
   const isSampleData = mode === CreateIndexMode.SampleData
@@ -49,7 +49,11 @@ export const CreateIndexHeader = () => {
       )}
 
       {!isSampleData && hasFields && (
-        <IndexNameEditor indexName={indexName} onNameChange={setIndexName} />
+        <IndexNameEditor
+          indexName={indexName}
+          onNameChange={setIndexName}
+          validationError={indexNameError}
+        />
       )}
     </S.TitleRow>
   )

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.spec.tsx
@@ -43,7 +43,8 @@ describe('IndexNameEditor', () => {
   it('should enter edit mode when clicking the display row', () => {
     renderComponent()
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
 
     const editInput = screen.getByTestId('index-name-edit-input')
     const cancelBtn = screen.getByTestId('index-name-cancel-btn')
@@ -58,8 +59,11 @@ describe('IndexNameEditor', () => {
     const onNameChange = jest.fn()
     renderComponent({ onNameChange })
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
-    fireEvent.click(screen.getByTestId('index-name-confirm-btn'))
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const confirmBtn = screen.getByTestId('index-name-confirm-btn')
+    fireEvent.click(confirmBtn)
 
     const editInput = screen.queryByTestId('index-name-edit-input')
 
@@ -71,8 +75,11 @@ describe('IndexNameEditor', () => {
     const onNameChange = jest.fn()
     renderComponent({ onNameChange })
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
-    fireEvent.click(screen.getByTestId('index-name-cancel-btn'))
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const cancelBtn = screen.getByTestId('index-name-cancel-btn')
+    fireEvent.click(cancelBtn)
 
     const editInput = screen.queryByTestId('index-name-edit-input')
 
@@ -84,30 +91,32 @@ describe('IndexNameEditor', () => {
     const onNameChange = jest.fn()
     renderComponent({ onNameChange })
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
-    fireEvent.keyDown(screen.getByTestId('index-name-edit-input'), {
-      key: 'Enter',
-    })
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
 
-    const editInput = screen.queryByTestId('index-name-edit-input')
+    const editInput = screen.getByTestId('index-name-edit-input')
+    fireEvent.keyDown(editInput, { key: 'Enter' })
+
+    const editInputAfter = screen.queryByTestId('index-name-edit-input')
 
     expect(onNameChange).toHaveBeenCalledWith(defaultProps.indexName)
-    expect(editInput).not.toBeInTheDocument()
+    expect(editInputAfter).not.toBeInTheDocument()
   })
 
   it('should cancel on Escape key', () => {
     const onNameChange = jest.fn()
     renderComponent({ onNameChange })
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
-    fireEvent.keyDown(screen.getByTestId('index-name-edit-input'), {
-      key: 'Escape',
-    })
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
 
-    const editInput = screen.queryByTestId('index-name-edit-input')
+    const editInput = screen.getByTestId('index-name-edit-input')
+    fireEvent.keyDown(editInput, { key: 'Escape' })
+
+    const editInputAfter = screen.queryByTestId('index-name-edit-input')
 
     expect(onNameChange).not.toHaveBeenCalled()
-    expect(editInput).not.toBeInTheDocument()
+    expect(editInputAfter).not.toBeInTheDocument()
   })
 
   it('should submit updated draft value on confirm', () => {
@@ -115,11 +124,14 @@ describe('IndexNameEditor', () => {
     const newName = faker.string.alphanumeric(8)
     renderComponent({ onNameChange })
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
-    fireEvent.change(screen.getByTestId('index-name-edit-input'), {
-      target: { value: newName },
-    })
-    fireEvent.click(screen.getByTestId('index-name-confirm-btn'))
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const editInput = screen.getByTestId('index-name-edit-input')
+    fireEvent.change(editInput, { target: { value: newName } })
+
+    const confirmBtn = screen.getByTestId('index-name-confirm-btn')
+    fireEvent.click(confirmBtn)
 
     expect(onNameChange).toHaveBeenCalledWith(newName)
   })
@@ -129,8 +141,70 @@ describe('IndexNameEditor', () => {
     mockUseIndexNameValidation.mockReturnValue(errorMsg)
     renderComponent()
 
-    fireEvent.click(screen.getByTestId('index-name-display'))
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
 
-    expect(screen.getByText(errorMsg)).toBeInTheDocument()
+    const errorText = screen.getByText(errorMsg)
+    expect(errorText).toBeInTheDocument()
+  })
+
+  it('should not confirm when draft has a validation error', () => {
+    const errorMsg = 'An index with this name already exists.'
+    mockUseIndexNameValidation.mockReturnValue(errorMsg)
+    const onNameChange = jest.fn()
+    renderComponent({ onNameChange })
+
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const confirmBtn = screen.getByTestId('index-name-confirm-btn')
+    fireEvent.click(confirmBtn)
+
+    const editInput = screen.getByTestId('index-name-edit-input')
+
+    expect(onNameChange).not.toHaveBeenCalled()
+    expect(editInput).toBeInTheDocument()
+  })
+
+  it('should not confirm on Enter key when draft has a validation error', () => {
+    const errorMsg = 'Index name is required.'
+    mockUseIndexNameValidation.mockReturnValue(errorMsg)
+    const onNameChange = jest.fn()
+    renderComponent({ onNameChange })
+
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const editInput = screen.getByTestId('index-name-edit-input')
+    fireEvent.keyDown(editInput, { key: 'Enter' })
+
+    expect(onNameChange).not.toHaveBeenCalled()
+    expect(editInput).toBeInTheDocument()
+  })
+
+  it('should disable confirm button when draft has a validation error', () => {
+    mockUseIndexNameValidation.mockReturnValue('Index name is required.')
+    renderComponent()
+
+    const indexNameDisplay = screen.getByTestId('index-name-display')
+    fireEvent.click(indexNameDisplay)
+
+    const confirmBtn = screen.getByTestId('index-name-confirm-btn')
+    expect(confirmBtn).toBeDisabled()
+  })
+
+  it('should show error icon when validationError is provided', () => {
+    const errorMsg = 'An index with this name already exists.'
+    renderComponent({ validationError: errorMsg })
+
+    const errorIcon = screen.getByTestId('index-name-error-icon')
+    expect(errorIcon).toBeInTheDocument()
+  })
+
+  it('should not show error icon when validationError is null', () => {
+    renderComponent({ validationError: null })
+
+    const errorIcon = screen.queryByTestId('index-name-error-icon')
+    expect(errorIcon).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.styles.ts
@@ -17,3 +17,7 @@ export const EditRow = styled(Row).attrs({ grow: false })`
 export const NameInput = styled(TextInput)`
   width: 200px;
 `
+
+export const ErrorIcon = styled(Row).attrs({ align: 'center', grow: false })`
+  color: ${({ theme }) => theme.semantic?.color?.text?.danger500};
+`

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.tsx
@@ -3,10 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Title } from 'uiSrc/components/base/text'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import {
+  RiIcon,
   PencilIcon,
   CancelSlimIcon,
   CheckThinIcon,
 } from 'uiSrc/components/base/icons'
+import { RiTooltip } from 'uiSrc/components/base/tooltip'
 
 import { useIndexNameValidation } from '../../../../hooks'
 import { IndexNameEditorProps } from './IndexNameEditor.types'
@@ -15,11 +17,13 @@ import * as S from './IndexNameEditor.styles'
 export const IndexNameEditor = ({
   indexName,
   onNameChange,
+  validationError,
 }: IndexNameEditorProps) => {
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(indexName)
   const inputRef = useRef<HTMLInputElement>(null)
   const draftError = useIndexNameValidation(draft)
+  const hasError = !!draftError
 
   useEffect(() => {
     if (isEditing) {
@@ -27,6 +31,12 @@ export const IndexNameEditor = ({
       inputRef.current?.select()
     }
   }, [isEditing])
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus()
+    }
+  }, [isEditing, hasError])
 
   const startEditing = useCallback(() => {
     setDraft(indexName)
@@ -39,9 +49,13 @@ export const IndexNameEditor = ({
   }, [indexName])
 
   const confirmEditing = useCallback(() => {
+    if (draftError) {
+      return
+    }
+
     onNameChange(draft)
     setIsEditing(false)
-  }, [draft, onNameChange])
+  }, [draft, draftError, onNameChange])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -81,6 +95,7 @@ export const IndexNameEditor = ({
           color="primary"
           aria-label="Confirm index name"
           onClick={confirmEditing}
+          disabled={hasError}
           data-testid="index-name-confirm-btn"
         />
       </S.EditRow>
@@ -89,6 +104,22 @@ export const IndexNameEditor = ({
 
   return (
     <S.DisplayRow onClick={startEditing} data-testid="index-name-display">
+      {validationError && (
+        <RiTooltip
+          position="bottom"
+          content={validationError}
+          data-testid="index-name-error-tooltip"
+        >
+          <S.ErrorIcon>
+            <RiIcon
+              type="ToastDangerIcon"
+              size="l"
+              data-testid="index-name-error-icon"
+            />
+          </S.ErrorIcon>
+        </RiTooltip>
+      )}
+
       <Title size="M" color="primary">
         {indexName}
       </Title>

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/IndexNameEditor/IndexNameEditor.types.ts
@@ -1,4 +1,5 @@
 export interface IndexNameEditorProps {
   indexName: string
   onNameChange: (name: string) => void
+  validationError?: string | null
 }


### PR DESCRIPTION
# What

Improve the index name validation experience in the "Create index from existing data" flow:

- Block confirming an invalid index name (disable confirm button + ignore Enter key when validation fails)
- Show a danger icon with a tooltip next to the index name when it has a validation error, so users understand why they can't proceed

# Testing

_Note: You ned to manually enable the `dev-vectorSearch` feature flag in order to see the page._

1. Open **Search** page from the main nav 
2. Start creating index from existing data
3. Select a key from the Browser on the left to populate fields

## Index Already exists

If you picked a key, that is already indexed, you see an icon indicator that you can't proceed with the same index name.

<img width="1934" height="1508" alt="image" src="https://github.com/user-attachments/assets/68871ace-8e96-4e03-962a-c79c17e13236" />

## Enter duplicate Index name 

If you try entering a duplicate index name → confirm button should be disabled, the Enter key should do nothing, and an input error message should appear

<img width="2640" height="2058" alt="image" src="https://github.com/user-attachments/assets/14ad5766-a558-4b46-a083-915e46bfb296" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change: tightens client-side validation behavior for index naming and adds visual error affordances, with no backend or data-handling changes.
> 
> **Overview**
> Improves the *create index from existing data* UX by preventing users from confirming an invalid index name: `IndexNameEditor` now disables the confirm action (button + Enter key) when `useIndexNameValidation` returns an error.
> 
> Surfaces index name validation failures earlier by passing `indexNameError` from `CreateIndexHeader` into `IndexNameEditor`, which renders a danger icon with tooltip explaining the error.
> 
> Updates `IndexNameEditor` unit tests to cover the new blocked-confirm behavior and the error icon/tooltip rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc531e2792c6845a93138104d9812882a8b5b9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->