### PR TITLE
RI-7902: reset form when field is added

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/field-type-modal/FieldTypeModal.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/field-type-modal/FieldTypeModal.tsx
@@ -43,8 +43,9 @@ export const FieldTypeModal = ({
     validate,
     enableReinitialize: true,
     validateOnMount: true,
-    onSubmit: (values) => {
+    onSubmit: (values, { resetForm }) => {
       onSubmit(buildFieldFromValues(values, mode, field))
+      resetForm()
     },
   })
 


### PR DESCRIPTION
# What

Reset the field type modal form state after a field is submitted, so that reopening the "Add field" modal starts with a clean form instead of retaining stale values from the previous submission.

# Testing

1. Open the Create Index page
2. Click "Add field" and fill in a field name, select a type, configure options
3. Click "Add" to submit
4. Click "Add field" again
5. Verify the form is reset to defaults (empty field name, default field type and options)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change limited to Formik submit behavior; main risk is unintentionally clearing state when users expect the modal to remain populated after adding a field.
> 
> **Overview**
> After submitting the Vector Search `FieldTypeModal`, the Formik form is now explicitly reset via `resetForm()` so reopening the **Add field** modal starts from default values instead of retaining the previous submission’s inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6528e663395a6c9cece6a70fc6e995b41563146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->