### PR TITLE
RI-7941 Vector Search - Remove GEOSHAPE as indexing type

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndexWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndexWrapper.spec.tsx
@@ -135,14 +135,4 @@ describe('CreateRedisearchIndexWrapper', () => {
 
     expect(screen.getByTestId('identifier-info-icon')).toBeInTheDocument()
   })
-
-  it('should show GEOSHAPE in field type dropdown', async () => {
-    const { findByText } = render(
-      <CreateRedisearchIndexWrapper onClosePanel={onClose} />,
-    )
-
-    await userEvent.click(screen.getByTestId('field-type-0'))
-
-    expect(await findByText('GEOSHAPE')).toBeInTheDocument()
-  })
 })

--- a/redisinsight/ui/src/pages/browser/components/create-redisearch-index/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/create-redisearch-index/constants.ts
@@ -45,10 +45,6 @@ export const FIELD_TYPE_OPTIONS = [
     value: FieldTypes.GEO,
   },
   {
-    text: 'GEOSHAPE',
-    value: FieldTypes.GEOSHAPE,
-  },
-  {
     text: 'VECTOR',
     value: FieldTypes.VECTOR,
   },

--- a/redisinsight/ui/src/pages/vector-search/components/index-details/components/FieldTypeCell/FieldTypeTooltip.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-details/components/FieldTypeCell/FieldTypeTooltip.tsx
@@ -17,10 +17,6 @@ const FIELD_TYPE_DESCRIPTIONS: { type: FieldTypes; description: string }[] = [
     type: FieldTypes.GEO,
     description: 'Geographic distance and radius queries',
   },
-  {
-    type: FieldTypes.GEOSHAPE,
-    description: 'WKT shapes: points, polygons, linestrings and collections',
-  },
   { type: FieldTypes.VECTOR, description: 'Similarity and semantic search' },
 ]
 

--- a/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.spec.ts
@@ -65,7 +65,6 @@ describe('generateDynamicFtCreateCommand', () => {
     it.each([
       { type: FieldTypes.NUMERIC, expected: 'NUMERIC' },
       { type: FieldTypes.GEO, expected: 'GEO' },
-      { type: FieldTypes.GEOSHAPE, expected: 'GEOSHAPE' },
     ])('should generate $expected field for HASH key', ({ type, expected }) => {
       const fields: IndexField[] = [
         { id: 'f1', name: 'myfield', value: 'val', type },
@@ -87,7 +86,6 @@ describe('generateDynamicFtCreateCommand', () => {
     it.each([
       { type: FieldTypes.NUMERIC, expected: 'NUMERIC' },
       { type: FieldTypes.GEO, expected: 'GEO' },
-      { type: FieldTypes.GEOSHAPE, expected: 'GEOSHAPE' },
     ])(
       'should generate $expected field with JSONPath alias for JSON key',
       ({ type, expected }) => {

--- a/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.ts
+++ b/redisinsight/ui/src/pages/vector-search/utils/generateDynamicFtCreateCommand.ts
@@ -136,10 +136,9 @@ const getVectorParams = (options?: VectorFieldOptions): [string, string][] => {
 const FIELD_TYPE_ORDER: Record<string, number> = {
   [FieldTypes.NUMERIC]: 0,
   [FieldTypes.GEO]: 1,
-  [FieldTypes.GEOSHAPE]: 2,
-  [FieldTypes.TAG]: 3,
-  [FieldTypes.TEXT]: 4,
-  [FieldTypes.VECTOR]: 5,
+  [FieldTypes.TAG]: 2,
+  [FieldTypes.TEXT]: 3,
+  [FieldTypes.VECTOR]: 4,
 }
 
 const sortFieldsByType = (fields: IndexField[]): IndexField[] =>

--- a/redisinsight/ui/src/pages/vector-search/utils/inferFieldType.ts
+++ b/redisinsight/ui/src/pages/vector-search/utils/inferFieldType.ts
@@ -7,16 +7,6 @@ import { IndexField } from '../components/index-details/IndexDetails.types'
 const TAG_MAX_LENGTH = 50
 const MIN_VECTOR_LENGTH = 2
 
-const WKT_PREFIXES = [
-  'point(',
-  'polygon(',
-  'linestring(',
-  'multipoint(',
-  'multipolygon(',
-  'multilinestring(',
-  'geometrycollection(',
-]
-
 const LON_MIN = -180
 const LON_MAX = 180
 const LAT_MIN = -90
@@ -52,19 +42,6 @@ export const isGeoCoordinates = (value: unknown): boolean => {
     return isLonLatInRange(lon, lat)
   }
   return false
-}
-
-/**
- * Returns true if value looks like valid WKT (starts with a known type, has content, and a closing paren).
- * Rejects malformed inputs like "POINT(" or "POINT(1 2" to avoid inferring invalid GEOSHAPE index schemas.
- */
-export const isGeoShape = (value: string): boolean => {
-  const lower = value.trimStart().toLowerCase()
-  const prefix = WKT_PREFIXES.find((p) => lower.startsWith(p))
-  if (!prefix) return false
-  const afterOpen = lower.slice(prefix.length)
-  const closeIdx = afterOpen.indexOf(')')
-  return closeIdx > 0
 }
 
 const GEO_REGEX = /^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/
@@ -142,9 +119,6 @@ export const inferFieldType = (
   }
 
   const str = String(value)
-  if (isGeoShape(str)) {
-    return FieldTypes.GEOSHAPE
-  }
   if (isGeoString(str)) {
     return FieldTypes.GEO
   }


### PR DESCRIPTION
# What

Remove GEOSHAPE as an indexing type from the "create index from existing data" flow. For now, we'll use only GEO

- Removed GEOSHAPE from the field type dropdown options
- Removed GEOSHAPE inference logic (WKT strings now fall through to TAG/TEXT)
- Removed GEOSHAPE from command generation field ordering
- Removed GEOSHAPE from the field type tooltip
- Kept the enum value for backward compatibility when displaying existing indexes
- 
<img width="1574" height="1390" alt="2026-02-27_14-49" src="https://github.com/user-attachments/assets/1e49eeb6-3113-401e-9a87-06aabaa267b9" />

# Testing

- Open the create index from existing data flow and verify GEOSHAPE does not appear in the field type dropdown
- Add a key with a WKT value (e.g. `POINT(1 2)`) and verify it is inferred as TAG, not GEOSHAPE
- Verify existing indexes with GEOSHAPE fields still display correctly in the index details view



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes field-type inference and schema generation for new index creation, which can alter the resulting `FT.CREATE` schema for WKT-like values. Existing index display should remain unaffected, but creation behavior and tests are updated.
> 
> **Overview**
> Removes `GEOSHAPE` from the **create index from existing data** UX: it no longer appears in the field-type dropdown or the field-type tooltip.
> 
> Updates vector-search utilities so WKT-like strings are **no longer inferred as `GEOSHAPE`** (they now fall through to `TAG`/`TEXT`), and removes `GEOSHAPE` from `FT.CREATE` field reordering logic.
> 
> Cleans up/adjusts related tests to stop asserting `GEOSHAPE` options and command generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f974083e6921968022153760329cfb82aee423ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->