### PR TITLE
RI-8094: Show App Version 

### DIFF
--- a/redisinsight/ui/src/pages/settings/SettingsPage.tsx
+++ b/redisinsight/ui/src/pages/settings/SettingsPage.tsx
@@ -17,7 +17,6 @@ import {
   fetchUserSettingsSpec,
   userSettingsSelector,
 } from 'uiSrc/slices/user/user-settings'
-
 import Divider from 'uiSrc/components/divider/Divider'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
@@ -33,6 +32,7 @@ import { Loader, RICollapsibleNavGroup } from 'uiSrc/components/base/display'
 import { Col } from 'uiSrc/components/base/layout/flex'
 import {
   AdvancedSettings,
+  AppVersion,
   CloudSettings,
   ThemeSettings,
   WorkbenchSettings,
@@ -184,6 +184,7 @@ const SettingsPage = () => {
               {AdvancedSettingsGroup()}
             </RICollapsibleNavGroup>
           </Col>
+          <AppVersion />
         </PageContentBody>
       </PageBody>
     </Page>

--- a/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { faker } from '@faker-js/faker'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { appServerInfoSelector } from 'uiSrc/slices/app/info'
+import AppVersion from './AppVersion'
+
+jest.mock('uiSrc/slices/app/info', () => ({
+  ...jest.requireActual('uiSrc/slices/app/info'),
+  appServerInfoSelector: jest.fn().mockReturnValue(null),
+}))
+
+describe('AppVersion', () => {
+  it('should render app version when available', () => {
+    const mockVersion = faker.system.semver()
+    ;(appServerInfoSelector as jest.Mock).mockReturnValue({
+      appVersion: mockVersion,
+    })
+
+    render(<AppVersion />)
+
+    expect(screen.getByTestId('settings-app-version')).toHaveTextContent(
+      `Redis Insight v${mockVersion}`,
+    )
+  })
+
+  it('should not render when server info is null', () => {
+    ;(appServerInfoSelector as jest.Mock).mockReturnValue(null)
+
+    render(<AppVersion />)
+
+    expect(screen.queryByTestId('settings-app-version')).not.toBeInTheDocument()
+  })
+
+  it('should not render when appVersion is missing', () => {
+    ;(appServerInfoSelector as jest.Mock).mockReturnValue({})
+
+    render(<AppVersion />)
+
+    expect(screen.queryByTestId('settings-app-version')).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
+++ b/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+
+import { appServerInfoSelector } from 'uiSrc/slices/app/info'
+import { Text } from 'uiSrc/components/base/text'
+
+const AppVersion = () => {
+  const server = useSelector(appServerInfoSelector)
+
+  if (!server?.appVersion) return null
+
+  return (
+    <Text
+      size="s"
+      color="subdued"
+      data-testid="settings-app-version"
+      style={{ marginTop: 16, textAlign: 'center' }}
+    >
+      Redis Insight v{server.appVersion}
+    </Text>
+  )
+}
+
+export default AppVersion

--- a/redisinsight/ui/src/pages/settings/components/app-version/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/app-version/index.ts
@@ -1,0 +1,3 @@
+import AppVersion from './AppVersion'
+
+export default AppVersion

--- a/redisinsight/ui/src/pages/settings/components/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/index.ts
@@ -1,4 +1,5 @@
 import AdvancedSettings from './advanced-settings'
+import AppVersion from './app-version'
 import WorkbenchSettings from './workbench-settings'
 import CloudSettings from './cloud-settings'
 import GeneralSettings from './general-settings'
@@ -6,6 +7,7 @@ import ThemeSettings from './theme-settings'
 
 export {
   AdvancedSettings,
+  AppVersion,
   WorkbenchSettings,
   CloudSettings,
   GeneralSettings,


### PR DESCRIPTION
# What

Display the application version in the Web UI Settings page for users running RedisInsight via Docker or the web interface, where the native Electron About panel is not available.

Added a new `AppVersion` component that reads the version from the existing `GET /api/info` endpoint (already stored in Redux) and renders it as subdued text below the Settings accordion sections. No backend changes needed.

| Before | After |
|--------|-------|
| No version info visible in the Web UI |  <img width="920" height="776" alt="image" src="https://github.com/user-attachments/assets/ff832327-dda1-4373-8fd3-c1f61514f843" /> |

# Testing

1. Run RedisInsight (web or Docker mode)
2. Navigate to **Settings** page
3. Scroll to the bottom, below the last accordion section
4. Verify "Redis Insight v{version}" is displayed in subdued text, centered
5. Confirm the version matches the value from `GET /api/info` → `appVersion`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reads an already-fetched Redux `server.appVersion` value and conditionally renders it, with no backend or data-mutation impact.
> 
> **Overview**
> Shows the running RedisInsight version on the Settings page by adding a new `AppVersion` component and rendering it beneath the accordion sections.
> 
> `AppVersion` reads `appVersion` via `appServerInfoSelector` and renders subdued centered text only when the version is available, with accompanying unit tests covering the render/hidden cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef85082a05b755327fc9ba59f1db516dbf1c0d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->