### PR TITLE
RI-8132 Fix view-type dropdown crash with external plugins

### DIFF
--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.spec.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.spec.tsx
@@ -11,7 +11,7 @@ import {
   waitForRiTooltipVisible,
 } from 'uiSrc/utils/test-utils'
 import { INSTANCE_ID_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
-import QueryCardHeader, { Props, VIEW_TYPE_SEPARATOR } from './QueryCardHeader'
+import QueryCardHeader, { Props } from './QueryCardHeader'
 import {
   QueryResultsProvider,
   QueryResultsTelemetry,
@@ -33,39 +33,6 @@ jest.mock('uiSrc/services', () => ({
     get: jest.fn(),
   },
 }))
-
-jest.mock('uiSrc/components/base/forms/select/RiSelect', () => {
-  const React = require('react')
-  const actual = jest.requireActual(
-    'uiSrc/components/base/forms/select/RiSelect',
-  )
-  return {
-    ...actual,
-    RiSelect: ({
-      options,
-      value,
-      onChange,
-      'data-testid': testId,
-      className,
-    }: any) =>
-      React.createElement(
-        'select',
-        {
-          'data-testid': testId,
-          className,
-          value: value ?? '',
-          onChange: (e: any) => onChange?.(e.target.value),
-        },
-        options?.map((o: any) =>
-          React.createElement(
-            'option',
-            { key: o.value, value: o.value, disabled: o.disabled },
-            o.label || o.value,
-          ),
-        ),
-      ),
-  }
-})
 
 jest.mock('uiSrc/slices/app/plugins', () => ({
   ...jest.requireActual('uiSrc/slices/app/plugins'),
@@ -274,7 +241,7 @@ describe('QueryCardHeader', () => {
     // Should not throw when telemetry callbacks are undefined
   })
 
-  it('should render view-type dropdown without crash when external plugins add a separator', () => {
+  it('should render view-type when external plugins are present', () => {
     expect(() =>
       renderQueryCardHeaderComponent({
         ...instance(mockedProps),
@@ -285,22 +252,5 @@ describe('QueryCardHeader', () => {
     ).not.toThrow()
 
     expect(screen.getByTestId('select-view-type')).toBeInTheDocument()
-  })
-
-  it('should not change view when separator value is selected', () => {
-    const mockSetSelectedValue = jest.fn()
-
-    renderQueryCardHeaderComponent({
-      ...instance(mockedProps),
-      query: 'FT.SEARCH idx *',
-      isOpen: true,
-      selectedValue: 'default__Text',
-      setSelectedValue: mockSetSelectedValue,
-    })
-
-    const select = screen.getByTestId('select-view-type')
-    fireEvent.change(select, { target: { value: VIEW_TYPE_SEPARATOR } })
-
-    expect(mockSetSelectedValue).not.toHaveBeenCalled()
   })
 })

--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -53,8 +53,6 @@ import styles from './styles.module.scss'
 import { useQueryResultsContext } from '../../context/query-results.context'
 import { ProfileSelect } from './QueryCardHeader.styles'
 
-export const VIEW_TYPE_SEPARATOR = '__separator__'
-
 export interface Props {
   query: string
   isOpen: boolean
@@ -150,7 +148,10 @@ const QueryCardHeader = (props: Props) => {
   }
 
   const onChangeView = (initValue: string) => {
-    if (selectedValue === initValue || initValue === VIEW_TYPE_SEPARATOR) return
+    if (selectedValue === initValue) {
+      return
+    }
+
     const currentView = options.find(({ id }) => id === initValue)
     const previousView = options.find(({ id }) => id === selectedValue)
     const type = currentView.value
@@ -226,8 +227,19 @@ const QueryCardHeader = (props: Props) => {
 
   const options: any[] = getViewTypeOptions()
   options.push(...pluginsOptions)
-  const modifiedOptions = options.map((item) => {
+
+  const firstExternalIndex = findIndex(
+    pluginsOptions,
+    (option) => !option.internal,
+  )
+  const firstExternalOptionIndex =
+    firstExternalIndex > -1
+      ? getViewTypeOptions().length + firstExternalIndex
+      : -1
+
+  const modifiedOptions = options.map((item, index) => {
     const { value, id, text, iconDark, iconLight } = item
+    const hasSeparator = index === firstExternalOptionIndex
     return {
       value: id ?? value,
       label: id ?? value,
@@ -245,7 +257,11 @@ const QueryCardHeader = (props: Props) => {
         </RiTooltip>
       ),
       dropdownDisplay: (
-        <div className={cx(styles.dropdownOption)}>
+        <div
+          className={cx(styles.dropdownOption, {
+            [styles.dropdownOptionSeparator]: hasSeparator,
+          })}
+        >
           <RiIcon type={theme === Theme.Dark ? iconDark : iconLight} />
           <span>{truncateText(text, 20)}</span>
         </div>
@@ -283,21 +299,6 @@ const QueryCardHeader = (props: Props) => {
   })
 
   const canCommandProfile = isCommandAllowedForProfile(query)
-
-  const indexForSeparator = findIndex(
-    pluginsOptions,
-    (option) => !option.internal,
-  )
-  if (indexForSeparator > -1) {
-    modifiedOptions.splice(indexForSeparator + 1, 0, {
-      value: VIEW_TYPE_SEPARATOR,
-      disabled: true,
-      inputDisplay: <span className={styles.separator} />,
-      label: VIEW_TYPE_SEPARATOR,
-      dropdownDisplay: <span />,
-      'data-test-subj': 'view-type-separator',
-    })
-  }
 
   return (
     <Row

--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/styles.module.scss
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/styles.module.scss
@@ -152,15 +152,14 @@ $marginIcon: 12px;
   flex-shrink: 0;
 }
 
-.dropdownOptionSeparator:after {
-  content: "";
-  display: block;
-  height: 0;
-  width: 100%;
-  border-bottom: 1px solid var(--separatorDropdownColor);
-  opacity: 0.5;
-  position: absolute;
-  bottom: -8.5px;
+.dropdownOptionSeparator {
+  content-visibility: auto;
+}
+
+:global {
+  [role="option"]:has([class*="dropdownOptionSeparator"]) {
+    border-top: 1px solid var(--separatorDropdownColor);
+  }
 }
 
 .changeView:global(.euiSuperSelectControl) {


### PR DESCRIPTION
## Summary

Fixes the Workbench view-type dropdown crash that occurred when external plugins were loaded. The original separator implementation inserted a disabled option with an empty string value (`''`) into the `RiSelect` dropdown, which caused rendering issues.

<img width="309" height="165" alt="image" src="https://github.com/user-attachments/assets/42e3d90b-2d87-40e6-a07a-c46b43833330" />


### Changes

- **Replaced fake separator option with CSS border**: Instead of splicing a disabled `__separator__` option into the dropdown list, the first external plugin option now receives a `dropdownOptionSeparator` CSS class. A `:global` `:has()` selector applies a `border-top` on the enclosing `[role="option"]` element, creating a clean visual divider without adding phantom options to the select.

## Testing

To trigger the bug, you need an external plugin installed. External plugins cause a separator to appear in the view-type dropdown, which is what crashed the UI.

1. Create a minimal external plugin
Create the following directory and file inside the repository:

`redisinsight/api/plugins/hello-world/package.json`

With this content:

```
{
  "name": "hello-world",
  "version": "0.0.1",
  "main": "./index.js",
  "visualizations": [
    {
      "id": "hello-viewer",
      "name": "Hello",
      "activationMethod": "renderHello",
      "matchCommands": ["INFO"]
    }
  ]
}
```

Then create `redisinsight/api/plugins/hello-world/index.js`:

```
var renderHello = function (props) {
  document.getElementById('app').innerHTML = '<p>Hello from plugin</p>';
};
export default { renderHello };
```

2. Start the dev build
```
yarn dev:api
yarn dev:ui
```

3. Reproduce the crash (on main branch, before fix)
- Open RedisInsight and connect to any Redis database
- Open the Workbench
- Run the `INFO` command
- Click the view-type dropdown in the query result card
- The UI crashes (or the dropdown fails to render correctly)

4. Verify the fix (on this branch)
- Same setup as above
- Open Workbench and run `INFO`
- Click the view-type dropdown — it renders without crash
- A separator line appears between the built-in options and the external plugin option ("Hello")
- Selecting any option (built-in or external) works correctly

---

Closes #RI-8132
References #5608


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Workbench view-type selection logic and dropdown rendering; regressions could affect changing result views or option styling, especially given the new separator/index calculation and CSS `:has` selector usage.
> 
> **Overview**
> Fixes a crash in the Workbench view-type dropdown when external visualization plugins are present by **removing the injected separator option** (which previously used an invalid empty `value`) and instead **styling the first external option as the separator boundary**.
> 
> Updates `onChangeView` to early-return when the selected value doesn’t change, and adjusts SCSS to draw the separator via a global `[role="option"]:has(...)` rule. Adds a unit test to ensure the view-type select renders when external plugins exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 772de8646a08501598c2df268979a4c607805f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->