### PR TITLE
Update Vector Search feature flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.2,
+  "version": 3.4,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -118,8 +118,8 @@
       "flag": true,
       "perc": [[0, 100]]
     },
-    "dev-vectorSearch": {
-      "flag": false,
+    "vectorSearchV2": {
+      "flag": true,
       "perc": [[0, 100]]
     },
     "databasesListV2": {

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -31,7 +31,7 @@ export enum KnownFeatures {
   HashFieldExpiration = 'hashFieldExpiration',
   EnhancedCloudUI = 'enhancedCloudUI',
   DatabaseManagement = 'databaseManagement',
-  DevVectorSearch = 'dev-vectorSearch',
+  VectorSearchV2 = 'vectorSearchV2',
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -58,8 +58,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
       flag: SERVER_CONFIG.databaseManagement,
     }),
   },
-  [KnownFeatures.DevVectorSearch]: {
-    name: KnownFeatures.DevVectorSearch,
+  [KnownFeatures.VectorSearchV2]: {
+    name: KnownFeatures.VectorSearchV2,
     storage: FeatureStorage.Database,
   },
 

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -85,7 +85,7 @@ export class FeatureFlagProvider {
       ),
     );
     this.strategies.set(
-      KnownFeatures.DevVectorSearch,
+      KnownFeatures.VectorSearchV2,
       new SwitchableFlagStrategy(
         this.featuresConfigService,
         this.settingsService,

--- a/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
+++ b/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
@@ -76,7 +76,7 @@ const INSTANCE_ROUTES: IRoute[] = [
     path: Pages.vectorSearch(':instanceId'),
     component: LAZY_LOAD ? LazyVectorSearchPageRouter : VectorSearchPageRouter,
     routes: VECTOR_SEARCH_ROUTES,
-    featureFlag: FeatureFlags.devVectorSearch,
+    featureFlag: FeatureFlags.vectorSearchV2,
   },
   {
     pageName: PageNames.workbench,

--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -48,8 +48,9 @@ export function useNavigation() {
     connectedRdiInstanceSelector,
   )
   const highlightedPages = useSelector(appFeaturePagesHighlightingSelector)
-  const { [FeatureFlags.devVectorSearch]: devVectorSearchFeature } =
-    useSelector(appFeatureFlagsFeaturesSelector)
+  const { [FeatureFlags.vectorSearchV2]: vectorSearchV2Feature } = useSelector(
+    appFeatureFlagsFeaturesSelector,
+  )
 
   const isRdiWorkspace = workspace === AppWorkspace.RDI
 
@@ -98,7 +99,7 @@ export function useNavigation() {
       iconType: BrowserIcon,
       onboard: ONBOARDING_FEATURES.BROWSER_PAGE,
     },
-    devVectorSearchFeature?.flag && {
+    vectorSearchV2Feature?.flag && {
       tooltipText: 'Search',
       pageName: PageNames.vectorSearch,
       ariaLabel: 'Search',

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
@@ -602,7 +602,7 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should skip vector search step and navigate to workbench on next when devVectorSearch is off', () => {
+    it('should skip vector search step and navigate to workbench on next when vectorSearchV2 is off', () => {
       const pushMock = jest.fn()
       reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
 
@@ -627,10 +627,10 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should navigate to vector search on next when devVectorSearch is on', () => {
+    it('should navigate to vector search on next when vectorSearchV2 is on', () => {
       ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
         databaseChat: { flag: false },
-        [FeatureFlags.devVectorSearch]: { flag: true },
+        [FeatureFlags.vectorSearchV2]: { flag: true },
       })
 
       const pushMock = jest.fn()
@@ -905,7 +905,7 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should skip vector search step and navigate to browser on back when devVectorSearch is off', () => {
+    it('should skip vector search step and navigate to browser on back when vectorSearchV2 is off', () => {
       const pushMock = jest.fn()
       reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
 
@@ -928,10 +928,10 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should navigate to vector search on back when devVectorSearch is on', () => {
+    it('should navigate to vector search on back when vectorSearchV2 is on', () => {
       ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
         databaseChat: { flag: false },
-        [FeatureFlags.devVectorSearch]: { flag: true },
+        [FeatureFlags.vectorSearchV2]: { flag: true },
       })
 
       const pushMock = jest.fn()

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
@@ -268,8 +268,7 @@ const ONBOARDING_FEATURES = {
       const { id: connectedInstanceId = '' } = useSelector(
         connectedInstanceSelector,
       )
-      // TODO: remove devVectorSearch flag check once the Search page is always available
-      const { [FeatureFlags.devVectorSearch]: devVectorSearchFeature } =
+      const { [FeatureFlags.vectorSearchV2]: vectorSearchV2Feature } =
         useSelector(appFeatureFlagsFeaturesSelector)
 
       const dispatch = useDispatch()
@@ -297,13 +296,12 @@ const ONBOARDING_FEATURES = {
           dispatch(openCliHelper())
           sendBackTelemetryEvent(...telemetryArgs)
         },
-        // TODO: remove flag check once devVectorSearch is removed — always navigate to vector search
         onNext: () => {
           dispatch(resetCliSettings())
           dispatch(resetCliHelperSettings())
           dispatch(setMonitorInitialState())
 
-          if (devVectorSearchFeature?.flag) {
+          if (vectorSearchV2Feature?.flag) {
             history.push(Pages.vectorSearch(connectedInstanceId))
           } else {
             dispatch(setOnboardNextStep())
@@ -361,8 +359,7 @@ const ONBOARDING_FEATURES = {
       const { id: connectedInstanceId = '' } = useSelector(
         connectedInstanceSelector,
       )
-      // TODO: remove devVectorSearch flag check once the Search page is always available
-      const { [FeatureFlags.devVectorSearch]: devVectorSearchFeature } =
+      const { [FeatureFlags.vectorSearchV2]: vectorSearchV2Feature } =
         useSelector(appFeatureFlagsFeaturesSelector)
       const [firstIndex, setFirstIndex] = useState<Nullable<string>>(null)
 
@@ -447,9 +444,8 @@ const ONBOARDING_FEATURES = {
           </>
         ),
         onSkip: () => sendClosedTelemetryEvent(...telemetryArgs),
-        // TODO: remove flag check once devVectorSearch is removed — always navigate to vector search
         onBack: () => {
-          if (devVectorSearchFeature?.flag) {
+          if (vectorSearchV2Feature?.flag) {
             history.push(Pages.vectorSearch(connectedInstanceId))
           } else {
             history.push(Pages.browser(connectedInstanceId))

--- a/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
+++ b/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
@@ -53,16 +53,15 @@ const OnboardingTour = (props: Props) => {
     onSkip = () => {},
   } = Inner ? Inner() : {}
 
-  // TODO: remove devVectorSearch flag check once the Search page is always available
-  const { [FeatureFlags.devVectorSearch]: devVectorSearchFeature } =
-    useSelector(appFeatureFlagsFeaturesSelector)
+  const { [FeatureFlags.vectorSearchV2]: vectorSearchV2Feature } = useSelector(
+    appFeatureFlagsFeaturesSelector,
+  )
 
   const [isOpen, setIsOpen] = useState(step === currentStep && isActive)
   const isLastStep = currentStep === totalSteps
 
-  // TODO: remove once devVectorSearch flag is removed — display step/total directly
   const { displayStep, displayTotalSteps } = useMemo(() => {
-    const skippedSteps = devVectorSearchFeature?.flag ? 0 : 1
+    const skippedSteps = vectorSearchV2Feature?.flag ? 0 : 1
     return {
       displayStep:
         currentStep > OnboardingSteps.VectorSearchPage
@@ -70,7 +69,7 @@ const OnboardingTour = (props: Props) => {
           : currentStep,
       displayTotalSteps: totalSteps - skippedSteps,
     }
-  }, [currentStep, totalSteps, devVectorSearchFeature?.flag])
+  }, [currentStep, totalSteps, vectorSearchV2Feature?.flag])
 
   const dispatch = useDispatch()
 

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -10,7 +10,7 @@ export enum FeatureFlags {
   enhancedCloudUI = 'enhancedCloudUI',
   cloudAds = 'cloudAds',
   databaseManagement = 'databaseManagement',
-  devVectorSearch = 'dev-vectorSearch',
+  vectorSearchV2 = 'vectorSearchV2',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
 }

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -90,6 +90,8 @@ const BrowserPage = () => {
   const overview = useSelector(connectedInstanceOverviewSelector)
   const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
   const isDevBrowser = featureFlags?.[FeatureFlags.devBrowser]?.flag ?? false
+  const isVectorSearchV2 =
+    featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
   const panelMinSize = isDevBrowser ? 20 : 45
   const panelDefaultSize = 50
 
@@ -227,11 +229,12 @@ const BrowserPage = () => {
 
   const handleCreateIndexPanel = useCallback(
     (value: boolean) => {
-      if (value) {
+      if (value && isVectorSearchV2) {
         history.push(Pages.vectorSearch(instanceId))
+        return
       }
     },
-    [instanceId],
+    [isVectorSearchV2, instanceId],
   )
 
   const closeRightPanels = useCallback(() => {

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
@@ -132,7 +132,7 @@ describe('RediSearchIndexesList', () => {
                 ...state.app.features.featureFlags,
                 features: {
                   ...state.app.features.featureFlags?.features,
-                  [FeatureFlags.devVectorSearch]: { flag: true },
+                  [FeatureFlags.vectorSearchV2]: { flag: true },
                 },
               },
             },

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -65,7 +65,7 @@ const RediSearchIndexesList = (props: Props) => {
   const selectedValue = selectedIndex ? bufferToString(selectedIndex) : ''
   const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
   const isDevVectorSearch =
-    featureFlags?.[FeatureFlags.devVectorSearch]?.flag ?? false
+    featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
 
   const dispatch = useDispatch()
   const location = useLocation<{ browseIndex?: string }>()

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -59,7 +59,7 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.cloudAds]: {
         flag: riConfig.features.cloudAds.defaultFlag,
       },
-      [FeatureFlags.devVectorSearch]: {
+      [FeatureFlags.vectorSearchV2]: {
         flag: false,
       },
       [FeatureFlags.azureEntraId]: {


### PR DESCRIPTION
# What
Replace the old `vectorSearch` and `dev-vectorSearch` feature flags with a single `vectorSearchV2` flag. 

- The dead `vectorSearch` flag is removed entirely, and all code previously gated by `dev-vectorSearch` is now gated by `vectorSearchV2`. 
- Stale TODO comments referencing the old flags are cleaned up. 
- Config version bumped to 3.4 with the flag enabled by default.

# Testing

- Verify the Search nav item appears when `vectorSearchV2` is enabled and hidden when disabled
- Confirm the onboarding tour correctly skips/shows the vector search step based on the flag
- Confirm "Create Index" in BrowserPage redirects to vector search only when the flag is on
