### PR TITLE
Resolve issue with data loading on Browser page

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/browser-left-panel/BrowserLeftPanelLegacy.tsx
+++ b/redisinsight/ui/src/pages/browser/components/browser-left-panel/BrowserLeftPanelLegacy.tsx
@@ -107,7 +107,7 @@ const BrowserLeftPanelLegacy = (props: Props) => {
     ) {
       loadKeys(viewType)
     }
-  }, [searchMode])
+  }, [searchMode, isDataLoaded])
 
   const loadKeys = useCallback(
     (keyViewType: KeyViewType = KeyViewType.Browser) => {

--- a/redisinsight/ui/src/pages/browser/components/keys-browser-panel/contexts/Context.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-browser-panel/contexts/Context.tsx
@@ -165,7 +165,7 @@ export const Context = ({
     ) {
       loadKeys(viewType)
     }
-  }, [searchMode])
+  }, [searchMode, isDataLoaded])
 
   const loadMoreItems = useCallback(
     (


### PR DESCRIPTION
# What

Fix blank **Browser** page key list when navigating from the **Vector Search** page.

## Before 
https://github.com/user-attachments/assets/0eec1105-e941-4a2e-902d-fdf3f29cf949

## After 
https://github.com/user-attachments/assets/ba4aba5b-44fa-4077-8072-d2cb764d26c9

The **Vector Search** keys browser shares Redux state (`browser.keys.data`, `app.context.browser.keyList`) with the **Browser** page. When its component unmounts (on navigation away), the cleanup effect resets `isDataPatternLoaded` to false and clears the keys array. 

However, this cleanup runs after the **Browser** page has already rendered and captured `isDataLoaded = true` in the effect closure. Since the key-loading effect only depended on `[searchMode]`, it never re-ran when `isDataLoaded` changed - leaving the key list blank.

The fix adds `isDataLoaded` to the dependency array so the effect re-evaluates when the flag transitions from true to false. When `isDataLoaded` later becomes true (after a successful fetch), the condition `!isDataLoaded` short-circuits and no extra API call is made.

Both the dev browser (`KeysBrowserPanel/contexts/Context.tsx`) and legacy browser (`BrowserLeftPanelLegacy.tsx`) are patched.

# Testing

1. Connect to a database with existing keys
2. Navigate to the **Vector Search** page from the main nav
3. Start creating an index via existing data
4. Select an item from the keys browser on the right
5. Navigate to the **Browser** page from the main nav
6. Verify the key list loads immediately (previously blank until manual refresh)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small React `useEffect` dependency changes that only affect when key fetching is triggered, with limited blast radius to Browser key list loading behavior.
> 
> **Overview**
> Prevents the **Browser** key list from staying blank after navigating from other pages that reset shared key-list state.
> 
> The key-loading `useEffect` in both the legacy left panel (`BrowserLeftPanelLegacy.tsx`) and the Keys Browser Panel context (`contexts/Context.tsx`) now also depends on `isDataLoaded`, so it re-evaluates and triggers `loadKeys()` when the loaded flag is cleared (instead of only reacting to `searchMode`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71362342764d539104dfc2c43afae4adb91daa4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->