### PR TITLE
RI-7944: Handle edge cases when making keys searchable from Browser Page

### DIFF
--- a/redisinsight/api/src/modules/browser/keys/keys.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/keys/keys.service.spec.ts
@@ -471,6 +471,7 @@ describe('KeysService', () => {
 
     beforeEach(() => {
       mockStandaloneRedisClient.sendPipeline.mockReset();
+      mockStandaloneRedisClient.isFeatureSupported.mockResolvedValue(true);
     });
 
     it('should return searchable key when hash key found', async () => {
@@ -562,6 +563,18 @@ describe('KeysService', () => {
       await expect(
         service.getNamespaceSearchable(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return empty results when SCAN TYPE is not supported (Redis < 6)', async () => {
+      mockStandaloneRedisClient.isFeatureSupported.mockResolvedValue(false);
+
+      const result = await service.getNamespaceSearchable(
+        mockBrowserClientMetadata,
+        dto,
+      );
+
+      expect(result).toEqual([{ prefix: 'user:' }, { prefix: 'session:' }]);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
     });
   });
 

--- a/redisinsight/api/src/modules/browser/keys/keys.service.ts
+++ b/redisinsight/api/src/modules/browser/keys/keys.service.ts
@@ -26,7 +26,7 @@ import {
 } from 'src/modules/browser/keys/dto';
 import { RedisDataType } from 'src/modules/browser/keys/dto/key.dto';
 import { BrowserToolKeysCommands } from 'src/modules/browser/constants/browser-tool-commands';
-import { RedisClientCommand } from 'src/modules/redis/client';
+import { RedisClientCommand, RedisFeature } from 'src/modules/redis/client';
 import { ClientMetadata } from 'src/common/models';
 import { Scanner } from 'src/modules/browser/keys/scanner/scanner';
 import { BrowserHistoryMode, RedisString } from 'src/common/constants';
@@ -291,6 +291,20 @@ export class KeysService {
 
       const client =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      const isScanTypeSupported = await client.isFeatureSupported(
+        RedisFeature.ScanTypeFilter,
+      );
+
+      if (!isScanTypeSupported) {
+        this.logger.debug(
+          'SCAN TYPE filter not supported (Redis < 6.0). Skipping namespace searchable check.',
+          clientMetadata,
+        );
+        return dto.prefixes.map((prefix) =>
+          plainToInstance(NamespaceSearchableResponse, { prefix }),
+        );
+      }
 
       const results = await Promise.all(
         dto.prefixes.map((prefix) =>

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -56,6 +56,7 @@ export type RedisClientCommandReply =
 export enum RedisFeature {
   HashFieldsExpiration = 'HashFieldsExpiration',
   UnlinkCommand = 'UnlinkCommand',
+  ScanTypeFilter = 'ScanTypeFilter',
 }
 
 const CLIENT_DATABASE_FIELDS: (keyof Database)[] = ['providerDetails'];
@@ -186,6 +187,13 @@ export abstract class RedisClient extends EventEmitter2 {
           const redisVersion = await this.getRedisVersion();
           // UNLINK command was introduced in Redis 4.0.0
           return redisVersion && semverCompare('4.0.0', redisVersion) < 1;
+        } catch (e) {
+          return false;
+        }
+      case RedisFeature.ScanTypeFilter:
+        try {
+          const redisVersion = await this.getRedisVersion();
+          return redisVersion && semverCompare('6.0', redisVersion) < 1;
         } catch (e) {
           return false;
         }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Handle two edge cases for the "Make keys searchable from Browser" feature:
- **Redis < 6.0**: The `SCAN ... TYPE` filter is not supported. Added a proactive version check (`RedisFeature.ScanTypeFilter`) so the endpoint returns empty results immediately without issuing SCAN commands or producing error logs.

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

Create this docker-compose file and run this redis instance with redisearch version 1.4.20 which is redis 5"

```
version: '3.8'

services:
  redis5-redisearch:
    image: redislabs/redisearch:1.4.20
    container_name: redis5-redisearch
    hostname: redis5-redisearch
    ports:
      - '6378:6379'
    volumes:
      - redis5-data:/data
    command:
      [
        'redis-server',
        '--appendonly',
        'yes',
        '--protected-mode',
        'no',
        '--loadmodule',
        '/usr/lib/redis/modules/redisearch.so',
      ]
    networks:
      redis5-net:
        ipv4_address: 172.22.0.2

networks:
  redis5-net:
    driver: bridge
    ipam:
      config:
        - subnet: 172.22.0.0/16

volumes:
  redis5-data:
```

