### PR TITLE
RI-7944: Fallback to noop context

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.tsx
+++ b/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.tsx
@@ -27,15 +27,10 @@ const MakeSearchableModalContext = createContext<{
   openMakeSearchableModal: (config: MakeSearchableModalConfig) => void
 } | null>(null)
 
-export const useMakeSearchableModal = () => {
-  const ctx = useContext(MakeSearchableModalContext)
-  if (!ctx) {
-    throw new Error(
-      'useMakeSearchableModal must be used within MakeSearchableModalProvider',
-    )
-  }
-  return ctx
-}
+const noopContext = { openMakeSearchableModal: () => {} } as const
+
+export const useMakeSearchableModal = () =>
+  useContext(MakeSearchableModalContext) ?? noopContext
 
 export const MakeSearchableModalProvider = ({
   children,


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Fix a runtime crash in the `<Node>` component when rendered inside the Vector Search Create Index page.
The `useMakeSearchableModal` hook threw an error when called outside `MakeSearchableModalProvider`, which only wraps `BrowserPage`. The `Node` component is also rendered in the Vector Search page tree (`CreateIndexBrowser` → `KeysBrowser` → `VirtualTree` → `Node`), where no provider exists.
Changed the hook to return a no-op fallback instead of throwing, since the "Index" button functionality (which navigates *to* the Vector Search page) is not relevant when already on that page.


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Navigate to the Vector Search → Create Index page with keys in the database
2. Confirm the key tree renders without errors in the console
3. Navigate to the Browser page and confirm the "Index" button on folder nodes still works correctly
4. Verify clicking "Index" on a folder still opens the Make Searchable modal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a React hook to return a no-op fallback instead of throwing, preventing crashes when components render outside the provider; main behavior change is silent no-op where the modal cannot be opened.
> 
> **Overview**
> Prevents a runtime crash when `useMakeSearchableModal` is called outside `MakeSearchableModalProvider` by replacing the thrown error with a `noopContext` fallback.
> 
> When the provider is missing (e.g., virtual tree `Node` rendered on the Vector Search Create Index page), calls to `openMakeSearchableModal` now safely no-op instead of breaking rendering; behavior within the provider remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95c0375b6e69b7bfa7c332caa2625a4180f0fec1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->