### PR TITLE
RI-7944: Add guard for vector search create index page

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/VectorSearchPageRouter.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/VectorSearchPageRouter.spec.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { cleanup, render, screen } from 'uiSrc/utils/test-utils'
+import { IRoute, Pages } from 'uiSrc/constants'
+import { VectorSearchPageRouter } from './VectorSearchPageRouter'
+import { useRedisInstanceCompatibility } from './hooks/useRedisInstanceCompatibility'
+
+jest.mock('./hooks/useRedisInstanceCompatibility', () => ({
+  useRedisInstanceCompatibility: jest.fn(),
+}))
+
+jest.mock('./components/rqe-not-available', () => {
+  const react = require('react')
+  return {
+    RqeNotAvailable: () =>
+      react.createElement('div', { 'data-testid': 'rqe-not-available' }),
+  }
+})
+
+jest.mock('./context/vector-search', () => ({
+  VectorSearchProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const DummyPage = () => <div data-testid="dummy-page">Dummy</div>
+
+const routes: IRoute[] = [
+  {
+    path: Pages.vectorSearch(':instanceId'),
+    component: DummyPage,
+  },
+]
+
+const renderComponent = () =>
+  render(
+    <BrowserRouter>
+      <VectorSearchPageRouter routes={routes} />
+    </BrowserRouter>,
+  )
+
+describe('VectorSearchPageRouter', () => {
+  const mockUseRedisInstanceCompatibility =
+    useRedisInstanceCompatibility as jest.Mock
+
+  beforeEach(() => {
+    cleanup()
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: false,
+      hasRedisearch: true,
+      hasSupportedVersion: true,
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render child routes when RediSearch is available', () => {
+    renderComponent()
+
+    expect(
+      screen.queryByTestId('vector-search-page--rqe-not-available'),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('vector-search-loader')).not.toBeInTheDocument()
+  })
+
+  it('should render loader while compatibility is loading', () => {
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: true,
+      hasRedisearch: undefined,
+      hasSupportedVersion: undefined,
+    })
+
+    renderComponent()
+
+    expect(screen.getByTestId('vector-search-loader')).toBeInTheDocument()
+  })
+
+  it('should render loader when compatibility is uninitialized', () => {
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: undefined,
+      hasRedisearch: undefined,
+      hasSupportedVersion: undefined,
+    })
+
+    renderComponent()
+
+    expect(screen.getByTestId('vector-search-loader')).toBeInTheDocument()
+  })
+
+  it('should render RQE not available when RediSearch module is missing', () => {
+    mockUseRedisInstanceCompatibility.mockReturnValue({
+      loading: false,
+      hasRedisearch: false,
+      hasSupportedVersion: true,
+    })
+
+    renderComponent()
+
+    expect(
+      screen.getByTestId('vector-search-page--rqe-not-available'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('rqe-not-available')).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/VectorSearchPageRouter.tsx
+++ b/redisinsight/ui/src/pages/vector-search/VectorSearchPageRouter.tsx
@@ -1,25 +1,54 @@
 import React from 'react'
 import { Switch } from 'react-router-dom'
 import RouteWithSubRoutes from 'uiSrc/utils/routerWithSubRoutes'
+import { Loader } from 'uiSrc/components/base/display'
 
 import { VectorSearchPageRouterProps } from './VectorSearchPageRouter.types'
 import { VectorSearchProvider } from './context/vector-search'
+import { useRedisInstanceCompatibility } from './hooks'
+import { RqeNotAvailable } from './components/rqe-not-available'
+import * as S from './pages/styles'
 
 /**
  * Router component for Vector Search pages.
  * Handles routing between main page, create index, and query pages.
+ * Guards all sub-routes against missing RediSearch module.
  * Wrapped with VectorSearchProvider to supply global context (modal, shared actions).
  */
 export const VectorSearchPageRouter = ({
   routes,
-}: VectorSearchPageRouterProps) => (
-  <VectorSearchProvider>
-    <Switch>
-      {routes.map((route) => (
-        <RouteWithSubRoutes key={route.path} {...route} />
-      ))}
-    </Switch>
-  </VectorSearchProvider>
-)
+}: VectorSearchPageRouterProps) => {
+  const { hasRedisearch, loading } = useRedisInstanceCompatibility()
+
+  if (loading !== false) {
+    return (
+      <S.PageWrapper
+        data-testid="vector-search-page--loading"
+        align="center"
+        justify="center"
+      >
+        <Loader size="xl" data-testid="vector-search-loader" />
+      </S.PageWrapper>
+    )
+  }
+
+  if (hasRedisearch === false) {
+    return (
+      <S.PageWrapper data-testid="vector-search-page--rqe-not-available">
+        <RqeNotAvailable />
+      </S.PageWrapper>
+    )
+  }
+
+  return (
+    <VectorSearchProvider>
+      <Switch>
+        {routes.map((route) => (
+          <RouteWithSubRoutes key={route.path} {...route} />
+        ))}
+      </Switch>
+    </VectorSearchProvider>
+  )
+}
 
 export default React.memo(VectorSearchPageRouter)

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.spec.tsx
@@ -14,16 +14,11 @@ import {
   INSTANCES_MOCK,
 } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 import { VectorSearchPage } from './VectorSearchPage'
-import { useRedisInstanceCompatibility } from '../../hooks/useRedisInstanceCompatibility'
 import { useRedisearchListData } from '../../hooks/useRedisearchListData'
 
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
   sendPageViewTelemetry: jest.fn(),
-}))
-
-jest.mock('../../hooks/useRedisInstanceCompatibility', () => ({
-  useRedisInstanceCompatibility: jest.fn(),
 }))
 
 jest.mock('../../hooks/useRedisearchListData', () => ({
@@ -56,18 +51,10 @@ const renderComponent = () => {
 }
 
 describe('VectorSearchPage', () => {
-  const mockUseRedisInstanceCompatibility =
-    useRedisInstanceCompatibility as jest.Mock
   const mockUseRedisearchListData = useRedisearchListData as jest.Mock
 
   beforeEach(() => {
     cleanup()
-
-    mockUseRedisInstanceCompatibility.mockReturnValue({
-      loading: false,
-      hasRedisearch: true,
-      hasSupportedVersion: true,
-    })
 
     mockUseRedisearchListData.mockReturnValue({
       loading: false,
@@ -84,19 +71,6 @@ describe('VectorSearchPage', () => {
     const { container } = renderComponent()
 
     expect(container).toBeTruthy()
-  })
-
-  it('should render loader while checking compatibility', () => {
-    mockUseRedisInstanceCompatibility.mockReturnValue({
-      loading: true,
-      hasRedisearch: undefined,
-      hasSupportedVersion: undefined,
-    })
-
-    renderComponent()
-
-    const loader = screen.getByTestId('vector-search-loader')
-    expect(loader).toBeInTheDocument()
   })
 
   it('should render loader while loading indexes', () => {
@@ -126,42 +100,6 @@ describe('VectorSearchPage', () => {
 
     const welcomeScreen = screen.queryByTestId('welcome-screen')
     expect(welcomeScreen).not.toBeInTheDocument()
-  })
-
-  it('should render loader when compatibility is uninitialized (undefined) even if indexes are not loading', () => {
-    mockUseRedisInstanceCompatibility.mockReturnValue({
-      loading: undefined,
-      hasRedisearch: undefined,
-      hasSupportedVersion: undefined,
-    })
-    mockUseRedisearchListData.mockReturnValue({
-      loading: false,
-      data: [],
-      stringData: [],
-    })
-
-    renderComponent()
-
-    const loader = screen.getByTestId('vector-search-loader')
-    expect(loader).toBeInTheDocument()
-
-    const welcomeScreen = screen.queryByTestId('welcome-screen')
-    expect(welcomeScreen).not.toBeInTheDocument()
-  })
-
-  it('should render RQE not available screen when RediSearch is not available', () => {
-    mockUseRedisInstanceCompatibility.mockReturnValue({
-      loading: false,
-      hasRedisearch: false,
-      hasSupportedVersion: true,
-    })
-
-    renderComponent()
-
-    const rqeScreen = screen.getByTestId(
-      'vector-search-page--rqe-not-available',
-    )
-    expect(rqeScreen).toBeInTheDocument()
   })
 
   it('should render welcome screen when no indexes exist', () => {
@@ -225,10 +163,10 @@ describe('VectorSearchPage', () => {
   })
 
   it('should not send page view telemetry while still loading', () => {
-    mockUseRedisInstanceCompatibility.mockReturnValue({
+    mockUseRedisearchListData.mockReturnValue({
       loading: true,
-      hasRedisearch: undefined,
-      hasSupportedVersion: undefined,
+      data: [],
+      stringData: [],
     })
 
     renderComponent()

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
@@ -12,11 +12,7 @@ import {
 } from 'uiSrc/utils'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 
-import {
-  useRedisInstanceCompatibility,
-  useRedisearchListData,
-} from '../../hooks'
-import { RqeNotAvailable } from '../../components/rqe-not-available'
+import { useRedisearchListData } from '../../hooks'
 import { VectorSearchWelcomePage } from '../VectorSearchWelcomePage'
 import { VectorSearchListPage } from '../VectorSearchListPage'
 import * as S from '../styles'
@@ -24,11 +20,10 @@ import * as S from '../styles'
 /**
  * Main Vector Search page component.
  * Acts as the entry point that selects and renders the appropriate screen
- * based on the current state (RQE support, indexes availability).
+ * based on the current state (indexes availability).
+ * RediSearch module availability is guarded at the router level (VectorSearchPageRouter).
  */
 export const VectorSearchPage = () => {
-  const { hasRedisearch, loading: compatibilityLoading } =
-    useRedisInstanceCompatibility()
   const { stringData: indexes, loading: indexesLoading } =
     useRedisearchListData()
 
@@ -39,7 +34,7 @@ export const VectorSearchPage = () => {
     modules,
   } = useSelector(connectedInstanceSelector)
 
-  const isReady = compatibilityLoading === false && indexesLoading === false
+  const isReady = indexesLoading === false
 
   usePageViewTelemetry({
     page: TelemetryPageView.VECTOR_SEARCH_PAGE,
@@ -56,15 +51,7 @@ export const VectorSearchPage = () => {
     `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)} - Vector Search`,
   )
 
-  if (hasRedisearch === false && compatibilityLoading === false) {
-    return (
-      <S.PageWrapper data-testid="vector-search-page--rqe-not-available">
-        <RqeNotAvailable />
-      </S.PageWrapper>
-    )
-  }
-
-  if (compatibilityLoading !== false || indexesLoading !== false) {
+  if (indexesLoading !== false) {
     return (
       <S.PageWrapper
         data-testid="vector-search-page--loading"


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Centralize the RediSearch module guard at the `VectorSearchPageRouter` level so that all vector search sub-pages (main, create index, query) are protected in one place. Previously, only `VectorSearchPage` checked for the RediSearch module — meaning direct navigation to the create index page (e.g. via the "Make searchable" button) would bypass the guard.
Now, when the RediSearch module is missing, any navigation to any vector search page will show the `RqeNotAvailable` screen, including the flow triggered by the "Make searchable" button in the Browser.


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

- Connect to a Redis instance **without** the RediSearch module
- Navigate to the Vector Search page → should show the "RQE not available" screen
- In the Browser, click "Make searchable" on a key → confirm and verify you see the "RQE not available" screen (not the create index page)
- Connect to a Redis instance **with** the RediSearch module
- Verify all vector search pages work as before (main, create index, query)
- Verify the "Make searchable" flow still navigates to the create index page correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI routing change that centralizes the RediSearch availability check; main risk is unintended blocking/rendering states if `useRedisInstanceCompatibility` returns unexpected `loading` values.
> 
> **Overview**
> Centralizes the RediSearch compatibility guard in `VectorSearchPageRouter`, showing a full-page loader until compatibility is initialized and an `RqeNotAvailable` screen when the module is missing, preventing direct navigation to any vector search sub-route (e.g., create index/query) without RediSearch.
> 
> Simplifies `VectorSearchPage` by removing its own compatibility checks so it only gates on index-list loading/telemetry readiness, and updates tests accordingly while adding a dedicated router spec to cover the new guard behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5386179dd60d19d29214ce9d9dbe9b4325ecc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->