### PR TITLE
Use URL search params for browse dataset navigation

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -68,7 +68,7 @@ const RediSearchIndexesList = (props: Props) => {
     featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
 
   const dispatch = useDispatch()
-  const location = useLocation<{ browseIndex?: string }>()
+  const location = useLocation()
   const history = useHistory()
 
   const selectIndex = useCallback(
@@ -114,11 +114,13 @@ const RediSearchIndexesList = (props: Props) => {
   }, [instanceHost, modules])
 
   useEffect(() => {
-    const browseIndex = location.state?.browseIndex
+    const params = new URLSearchParams(location.search)
+    const browseIndex = params.get('browseIndex')
     if (!browseIndex || list.length === 0) return
 
     if (selectIndex(browseIndex)) {
-      history.replace({ ...location, state: undefined })
+      params.delete('browseIndex')
+      history.replace({ ...location, search: params.toString() })
     }
   }, [list])
 

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
@@ -178,8 +178,9 @@ describe('useListContent', () => {
       })
 
       expect(mockDispatch).toHaveBeenCalled()
-      expect(mockPush).toHaveBeenCalledWith(Pages.browser(mockInstanceId), {
-        browseIndex: indexName,
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: Pages.browser(mockInstanceId),
+        search: `browseIndex=${indexName}`,
       })
     })
   })

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -76,7 +76,12 @@ export const useListContent = () => {
         SearchMode.Redisearch,
       )
       dispatch(changeSearchMode(SearchMode.Redisearch))
-      history.push(Pages.browser(instanceId), { browseIndex: indexName })
+      const search = new URLSearchParams()
+      search.set('browseIndex', indexName)
+      history.push({
+        pathname: Pages.browser(instanceId),
+        search: search.toString(),
+      })
     },
     [dispatch, history, instanceId],
   )


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Fixed "Browse dataset" navigation from the Vector Search index list not working in Electron. The navigation passed browseIndex via React Router's location state, which does not persist reliably in Electron's routing context. Switched to URL search params, matching the pattern already used by MakeSearchableModalProvider.

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Run the app in Electron (yarn dev:desktop)
2. Connect to a Redis instance with RediSearch and at least one index
3. Navigate to Vector Search > Index list
4. Click the "Browse dataset" action on any index
5. Verify it navigates to the Browser page with the correct index selected
6. Verify the same flow works in the web version (yarn dev:ui)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk routing change that only affects how the selected RediSearch index is passed during navigation; main risk is minor URL/query-string edge cases or regressions in deep-link handling.
> 
> **Overview**
> Fixes the Vector Search "Browse dataset" flow by switching `browseIndex` from React Router `location.state` to a `?browseIndex=` query param when navigating to the Browser page.
> 
> Updates the Browser’s `RediSearchIndexesList` to read `browseIndex` from `location.search`, auto-select the index on load, and then remove the param via `history.replace`; corresponding hook test expectations were updated to match the new navigation shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ded40efd77b6500b1315ab0f65e04f6c33dc67b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->