### PR TITLE
RI-8139: constraint the description space to 40 percent

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/query-library-item/QueryLibraryItem.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/query-library-item/QueryLibraryItem.styles.ts
@@ -68,6 +68,7 @@ export const Name = styled(Text)`
 
 export const Description = styled(Text)`
   min-width: 0;
+  max-width: 40%;
   flex-shrink: 1;
   ${truncatedText}
 `


### PR DESCRIPTION
# What
Limit the query description width in the Query Library item header to prevent it from taking too much horizontal space. Added `max-width: 40%` to the `Description` styled component so the name and badge remain clearly visible.

| before | after |
| --- | --- |
| <img width="1510" height="581" alt="image" src="https://github.com/user-attachments/assets/b23e9bc7-0bb9-456c-870e-661e658d3942" /> | <img width="1510" height="581" alt="image" src="https://github.com/user-attachments/assets/5928e90a-142f-491a-bd49-f5be33eb80ff" /> |

# Testing
1. Open the Vector Search Query Library
2. Verify that long query descriptions are truncated with ellipsis and do not push the name/badge out of view
3. Hover over a truncated description to see the full text in the tooltip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling change that adjusts layout constraints for the description text and should not affect data or application logic.
> 
> **Overview**
> Limits the `QueryLibraryItem` header description to `max-width: 40%` so long descriptions truncate earlier and don’t consume excessive horizontal space, keeping the query name and type badge visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0e8bf749e8c2772f19a6fa4ccf9f7931fa0b25d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->