### PR TITLE
RI-8140: adjust the spacings for the query library items when expanded

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/command-view/CommandView.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/command-view/CommandView.styles.ts
@@ -6,7 +6,6 @@ export const EditorWrapper = styled(FlexGroup)`
   width: 100%;
   height: 100%;
   border: none;
-  padding-top: ${({ theme }) => theme.core?.space.space300};
 
   /*
    * Override Monaco CSS variables so the editor blends with the parent card.
@@ -27,7 +26,7 @@ export const EditorWrapper = styled(FlexGroup)`
 
 export const CopyButtonWrapper = styled(FlexGroup)`
   position: absolute;
-  top: ${({ theme }) => theme.core.space.space300};
-  right: ${({ theme }) => theme.core.space.space300};
+  top: ${({ theme }) => theme.core.space.space100};
+  right: ${({ theme }) => theme.core.space.space250};
   z-index: 10;
 `


### PR DESCRIPTION
# What

Removed the container-level `padding-top` from `EditorWrapper` in `CommandView.styles.ts` that caused a white strip to appear when scrolling inside an expanded query library item. The Monaco editor already provides its own text-level padding via `defaultMonacoOptions` (`padding: { top: 10 }`), which scrolls correctly with the content.
Also adjusted the `CopyButtonWrapper` positioning (`top`/`right` from `space300` to `space100`) to align with the updated layout.

# Testing

1. Open the Vector Search page with an index selected
2. Switch to the "Query Library" tab
3. Expand a query item with enough content to scroll
4. Scroll up and down inside the expanded item
5. Verify no white strip appears at the top
6. Verify the copy button is correctly positioned
7. Repeat in both light and dark themes


Before:

https://github.com/user-attachments/assets/d5c6fa14-1de8-468a-b69a-57ca95e0a821

After:

https://github.com/user-attachments/assets/bcf362d1-45fe-4ca5-b79b-bb937dc3afc7


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling change that tweaks padding/positioning; potential impact is limited to layout regressions in the vector search command view.
> 
> **Overview**
> Removes the container-level top padding from `EditorWrapper` in `CommandView.styles.ts` to avoid a visible strip when scrolling inside expanded query library items.
> 
> Adjusts `CopyButtonWrapper` absolute positioning (smaller `top` offset and updated `right` offset) to match the updated layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcf3de9d6760a0ce9a4aa3cf3a2c0b9007837abf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->