### PR TITLE
Center the title when no keys available

### DIFF
--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.styles.ts
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { FlexGroup } from 'uiSrc/components/base/layout/flex'
+import { Title } from 'uiSrc/components/base/text/Title'
+
+export const Guides = styled(FlexGroup)`
+  max-width: 414px;
+`
+
+export const CenteredTitle = styled(Title)`
+  text-align: center;
+`

--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -10,12 +10,10 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { openTutorialByPath } from 'uiSrc/slices/panels/sidePanels'
 import { findTutorialPath } from 'uiSrc/utils'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
-import { Title } from 'uiSrc/components/base/text/Title'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
-import { FlexGroup } from 'uiSrc/components/base/layout/flex'
-import styles from './styles.module.scss'
+import * as S from './ExploreGuides.styles.ts'
 
 const ExploreGuides = () => {
   const { data } = useSelector(guideLinksSelector)
@@ -43,16 +41,16 @@ const ExploreGuides = () => {
 
   return (
     <div data-testid="explore-guides">
-      <Title color="primary" size="S" textAlign="center">
-        <span>Here&apos;s a good starting point</span>
-      </Title>
+      <S.CenteredTitle color="primary" size="S">
+        Here&apos;s a good starting point
+      </S.CenteredTitle>
       <Spacer size="s" />
       <Text color="primary" textAlign="center">
         Explore the amazing world of Redis with our interactive guides
       </Text>
       <Spacer size="xl" />
       {!!data.length && (
-        <FlexGroup gap="l" wrap justify="center" className={styles.guides}>
+        <S.Guides gap="l" wrap justify="center">
           {data.map(({ title, tutorialId, icon }) => (
             <SecondaryButton
               key={tutorialId}
@@ -71,7 +69,7 @@ const ExploreGuides = () => {
               {title}
             </SecondaryButton>
           ))}
-        </FlexGroup>
+        </S.Guides>
       )}
     </div>
   )

--- a/redisinsight/ui/src/components/explore-guides/styles.module.scss
+++ b/redisinsight/ui/src/components/explore-guides/styles.module.scss
@@ -1,3 +1,0 @@
-.guides {
-  max-width: 414px;
-}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

| Before | After |
| --- | --- |
| <img width="1374" height="969" alt="image" src="https://github.com/user-attachments/assets/53599bbc-1653-4018-9298-5bf02d6308f6" /> | <img width="1374" height="969" alt="image" src="https://github.com/user-attachments/assets/ad8a3504-e82f-4b29-8d36-aeec90a43d33" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: swaps SCSS for styled-components in `ExploreGuides` and centers the title text; no data flow or behavior changes beyond styling.
> 
> **Overview**
> **Explore Guides empty-state header is now centered.** This replaces the previous `Title` usage with a styled `CenteredTitle` to ensure consistent `text-align: center`.
> 
> The guide button container styling (`max-width: 414px`) is migrated from `styles.module.scss` to a new styled-component wrapper (`Guides`), and the unused SCSS module is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c52e2c8f4a1f285ae46ae261f3893f638cbb79f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->