### PR TITLE
center the title when no keys available

### DIFF
--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -13,7 +13,7 @@ import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
-import * as S from './ExploreGuides.styles.ts'
+import * as S from './ExploreGuides.styles'
 
 const ExploreGuides = () => {
   const { data } = useSelector(guideLinksSelector)


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Addition to https://github.com/redis/RedisInsight/pull/5650 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a minor TypeScript/webpack import path adjustment with no behavioral or data-handling changes.
> 
> **Overview**
> Updates `ExploreGuides.tsx` to import `ExploreGuides.styles` without the explicit `.ts` extension, aligning the styles import with standard module resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e594e71e92b52811756b750438666ecd1344ec8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->