### PR TITLE
RI-8141 Еnhance vector field handling and visualisation

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/helpers.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/helpers.spec.ts
@@ -1,3 +1,9 @@
+import { FieldTypes } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+import {
+  VectorAlgorithm,
+  VectorDataType,
+  VectorFlatFieldOptions,
+} from '../../components/index-details/IndexDetails.types'
 import {
   isIndexableJsonValue,
   filterJsonData,
@@ -87,6 +93,55 @@ describe('parseHashFields', () => {
 
     expect(result.fields).toEqual([])
     expect(result.skippedFields).toEqual([])
+  })
+
+  it('should detect binary float32 vector and return VECTOR type with options', () => {
+    // Two float32 values: 1.0 and 2.0 in little-endian
+    const float1 = [0x00, 0x00, 0x80, 0x3f] // 1.0
+    const float2 = [0x00, 0x00, 0x00, 0x40] // 2.0
+    const apiFields = [
+      {
+        field: { data: [101, 109, 98], type: 'Buffer' as const }, // "emb"
+        value: { data: [...float1, ...float2], type: 'Buffer' as const },
+      },
+    ]
+
+    const result = parseHashFields(apiFields)
+
+    expect(result.fields).toHaveLength(1)
+    const vectorField = result.fields[0]
+    expect(vectorField.type).toBe(FieldTypes.VECTOR)
+    expect(vectorField.name).toBe('emb')
+    expect(vectorField.value).toContain('(2 dims)')
+    const options = vectorField.options as VectorFlatFieldOptions
+    expect(options.algorithm).toBe(VectorAlgorithm.FLAT)
+    expect(options.dimensions).toBe(2)
+    expect(options.dataType).toBe(VectorDataType.FLOAT32)
+  })
+
+  it('should mix binary vector fields with regular text fields', () => {
+    const float1 = [0x00, 0x00, 0x80, 0x3f]
+    const float2 = [0x00, 0x00, 0x00, 0x40]
+    const apiFields = [
+      {
+        field: { data: [110, 97, 109, 101], type: 'Buffer' as const }, // "name"
+        value: { data: [65, 108, 105, 99, 101], type: 'Buffer' as const }, // "Alice"
+      },
+      {
+        field: { data: [118, 101, 99], type: 'Buffer' as const }, // "vec"
+        value: { data: [...float1, ...float2], type: 'Buffer' as const },
+      },
+    ]
+
+    const result = parseHashFields(apiFields)
+
+    expect(result.fields).toHaveLength(2)
+
+    const nameField = result.fields.find((f) => f.name === 'name')
+    expect(nameField?.type).not.toBe(FieldTypes.VECTOR)
+
+    const vecField = result.fields.find((f) => f.name === 'vec')
+    expect(vecField?.type).toBe(FieldTypes.VECTOR)
   })
 })
 

--- a/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/helpers.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/helpers.ts
@@ -1,6 +1,13 @@
-import { bufferToString } from 'uiSrc/utils'
+import {
+  bufferToString,
+  isBinaryVector,
+  bufferToFloat32Array,
+} from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { RedisearchIndexKeyType } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+import {
+  FieldTypes,
+  RedisearchIndexKeyType,
+} from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
 
 import {
   inferKeyFields,
@@ -9,6 +16,12 @@ import {
   HashKeyData,
   JsonKeyData,
 } from '../../utils/inferFieldType'
+import {
+  IndexField,
+  VectorAlgorithm,
+  VectorDataType,
+  VectorFlatFieldOptions,
+} from '../../components/index-details/IndexDetails.types'
 import { InferredFieldsResult } from './useLoadKeyData.types'
 
 const EMPTY_RESULT: InferredFieldsResult = { fields: [], skippedFields: [] }
@@ -73,21 +86,63 @@ export const filterJsonData = (data: JsonKeyData): FilterJsonDataResult => {
 // Response → IndexField[] converters
 // ---------------------------------------------------------------------------
 
+const MAX_VECTOR_PREVIEW_ELEMENTS = 4
+
+const formatVectorPreview = (floats: Float32Array): string => {
+  const items = Array.from(floats.slice(0, MAX_VECTOR_PREVIEW_ELEMENTS), (v) =>
+    v.toPrecision(6),
+  )
+  const suffix = floats.length > MAX_VECTOR_PREVIEW_ELEMENTS ? ', ...' : ''
+  return `[${items.join(', ')}${suffix}] (${floats.length} dims)`
+}
+
+/**
+ * Builds an IndexField for a binary float32 vector buffer.
+ * Pre-populates the VECTOR field options with inferred dimensions and data type.
+ */
+const buildBinaryVectorField = (
+  fieldName: string,
+  valueBuf: RedisResponseBuffer,
+): IndexField => {
+  const floats = bufferToFloat32Array(new Uint8Array(valueBuf.data))
+  const options: VectorFlatFieldOptions = {
+    algorithm: VectorAlgorithm.FLAT,
+    dimensions: floats.length,
+    dataType: VectorDataType.FLOAT32,
+  }
+  return {
+    id: fieldName,
+    name: fieldName,
+    value: formatVectorPreview(floats),
+    type: FieldTypes.VECTOR,
+    options,
+  }
+}
+
 /**
  * Converts raw hash field API response into inferred IndexField[].
+ * Detects binary float32 vectors before falling back to string-based inference.
  */
 export const parseHashFields = (
   apiFields: Array<{ field: RedisResponseBuffer; value: RedisResponseBuffer }>,
 ): InferredFieldsResult => {
-  const hashData: HashKeyData = Object.fromEntries(
-    apiFields.map(({ field, value }) => [
-      bufferToString(field),
-      bufferToString(value),
-    ]),
-  )
+  const binaryVectorFields: IndexField[] = []
+  const textEntries: Array<[string, string]> = []
+
+  apiFields.forEach(({ field, value }) => {
+    const fieldName = bufferToString(field)
+    if (isBinaryVector(value)) {
+      binaryVectorFields.push(buildBinaryVectorField(fieldName, value))
+    } else {
+      textEntries.push([fieldName, bufferToString(value)])
+    }
+  })
+
+  const hashData: HashKeyData = Object.fromEntries(textEntries)
+  const inferred = inferKeyFields(hashData, RedisearchIndexKeyType.HASH)
 
   return {
-    fields: inferKeyFields(hashData, RedisearchIndexKeyType.HASH),
+    fields: [...inferred, ...binaryVectorFields],
     skippedFields: [],
   }
 }

--- a/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
+++ b/redisinsight/ui/src/utils/formatters/bufferFormatters.ts
@@ -123,6 +123,41 @@ const ASCIIToBuffer = (strInit: string) => {
   return anyToBuffer(Array.from(Buffer.from(result, 'hex')))
 }
 
+const MIN_VECTOR_BYTES = 8 // at least 2 float32 values
+
+/**
+ * Returns true when the buffer holds non-text (binary) data.
+ * Uses a UTF-8 round-trip: encode → decode; if the bytes differ the
+ * original payload is not valid UTF-8 text.
+ */
+const isBinaryData = (buf: RedisResponseBuffer): boolean => {
+  const utf8 = decoder.decode(new Uint8Array(buf.data))
+  const roundTrip = encoder.encode(utf8)
+  if (roundTrip.length !== buf.data.length) return true
+  for (let i = 0; i < roundTrip.length; i++) {
+    if (roundTrip[i] !== buf.data[i]) return true
+  }
+  return false
+}
+
+/**
+ * Heuristic: returns true when the buffer is likely a binary-encoded
+ * float32 vector (e.g. embeddings stored via Redis HSET as raw bytes).
+ */
+const isBinaryVector = (buf: RedisResponseBuffer): boolean => {
+  const len = buf.data.length
+  if (len < MIN_VECTOR_BYTES || len % 4 !== 0) return false
+  if (!isBinaryData(buf)) return false
+
+  const bytes = new Uint8Array(buf.data)
+  const view = new DataView(bytes.buffer)
+  for (let i = 0; i < view.byteLength; i += 4) {
+    const f = view.getFloat32(i, true)
+    if (!Number.isFinite(f)) return false
+  }
+  return true
+}
+
 const bufferToFloat32Array = (data: Uint8Array) => {
   const { buffer } = new Uint8Array(data)
   const dataView = new DataView(buffer)
@@ -244,6 +279,8 @@ export {
   bufferToJava,
   bufferToFloat32Array,
   bufferToFloat64Array,
+  isBinaryData,
+  isBinaryVector,
 }
 
 window.ri = {

--- a/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
@@ -14,6 +14,8 @@ import {
   binaryToBuffer,
   bufferToJava,
   bufferToUint8Array,
+  isBinaryData,
+  isBinaryVector,
 } from 'uiSrc/utils'
 
 try {
@@ -291,5 +293,61 @@ describe('bufferToUint8Array', () => {
     expect(bufferToUint8Array(anyToBuffer(uint8Array))).toEqual(
       new Uint8Array(uint8Array),
     )
+  })
+})
+
+describe('isBinaryData', () => {
+  it('should return false for plain ASCII text', () => {
+    expect(isBinaryData(anyToBuffer([116, 101, 115, 116]))).toBe(false)
+  })
+
+  it('should return false for valid UTF-8 multibyte text', () => {
+    // "привет" in UTF-8
+    expect(
+      isBinaryData(
+        anyToBuffer([
+          208, 191, 209, 128, 208, 184, 208, 178, 208, 181, 209, 130,
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('should return true for binary data that is not valid UTF-8 round-trip', () => {
+    // float32 representation of 1.0 (little-endian: 0x00 0x00 0x80 0x3F)
+    expect(isBinaryData(anyToBuffer([0x00, 0x00, 0x80, 0x3f]))).toBe(true)
+  })
+})
+
+describe('isBinaryVector', () => {
+  it('should return true for a valid float32 binary vector', () => {
+    // Two float32 values: 1.0 and 2.0 in little-endian
+    const float1 = [0x00, 0x00, 0x80, 0x3f] // 1.0
+    const float2 = [0x00, 0x00, 0x00, 0x40] // 2.0
+    expect(isBinaryVector(anyToBuffer([...float1, ...float2]))).toBe(true)
+  })
+
+  it('should return false for plain text', () => {
+    // "test" is 4 bytes, divisible by 4, but valid UTF-8
+    expect(isBinaryVector(anyToBuffer([116, 101, 115, 116]))).toBe(false)
+  })
+
+  it('should return false for buffer with length not divisible by 4', () => {
+    expect(isBinaryVector(anyToBuffer([0x00, 0x00, 0x80]))).toBe(false)
+  })
+
+  it('should return false for buffer shorter than MIN_VECTOR_BYTES', () => {
+    // 4 bytes = only 1 float32 (need at least 2)
+    expect(isBinaryVector(anyToBuffer([0x00, 0x00, 0x80, 0x3f]))).toBe(false)
+  })
+
+  it('should return false when float32 values contain NaN', () => {
+    // NaN in float32: 0x7FC00000 little-endian = [0x00, 0x00, 0xC0, 0x7F]
+    const nan = [0x00, 0x00, 0xc0, 0x7f]
+    const valid = [0x00, 0x00, 0x80, 0x3f]
+    expect(isBinaryVector(anyToBuffer([...nan, ...valid]))).toBe(false)
+  })
+
+  it('should return false for empty buffer', () => {
+    expect(isBinaryVector(anyToBuffer([]))).toBe(false)
   })
 })


### PR DESCRIPTION
# What

Binary float32 vector embeddings (e.g. `description_embeddings` in the `bikes` sample data collection) are stored as raw bytes in Redis Hash fields. When the "Make Searchable" / "Create Index" flow loads these fields, all values were converted to UTF-8 strings via `bufferToString()`. This produced garbled text for binary data, and the type inference logic - which only recognized vectors from JSON array strings like `"[1,2,3]"` - fell back to `TEXT` instead of `VECTOR`.

This PR fixes both the inference and the display:
- Binary detection (`bufferFormatters.ts`): Two new utilities `isBinaryData` and `isBinaryVector`. 
   - `isBinaryData` uses a UTF-8 round-trip technique - encode the raw bytes to UTF-8, re-encode the result back, and compare. If the bytes differ, the payload is binary (not valid text). 
   - `isBinaryVector` builds on that by additionally checking the byte length is divisible by 4, is at least 8 bytes (2 floats minimum), and every 4-byte chunk decodes to a finite float32 value (no NaN or Infinity).

- Hash field parsing (`helpers.ts`): `parseHashFields` now inspects each field's raw `RedisResponseBuffer` before converting to string. Fields detected as binary vectors are routed to `buildBinaryVectorField`, which decodes the bytes into a Float32Array, produces a human-readable preview (e.g. [0.0352, -0.0127, ...] (768 dims)), sets the type to `VECTOR`, and pre-populates field options with the inferred dimensions and FLOAT32 data type. Non-binary fields continue through the existing string-based inferFieldType path unchanged.

# Testing

1. Connect to a Redis database
2. Navigate to **Search** page from the main nav
3. Click **Create index** > **Use existing data** > select the Bikes sample dataset and load it
4. Once loaded, pick a bike key (e.g. bikes:10001) --the index creation table should appear

## See Index definition table

Verify `description_embeddings` shows:
- Field sample value: a readable float preview like [0.0352..., -0.0127..., ...] (768 dims) instead of garbled diamond characters
- Suggested indexing type: VECTOR (not TEXT)

| Before | After |
| - | - |
<img width="2746" height="1996" alt="2026-03-17_16-52" src="https://github.com/user-attachments/assets/214994fb-c9b6-4a78-806d-7c36bfdcedd6" />|<img width="2640" height="1872" alt="image" src="https://github.com/user-attachments/assets/7bac11a8-6da4-4a0f-80aa-9ea63d1aa0b6" />

## Edit field type modal

5. Click the edit (pencil) icon on the `description_embeddings` row 
 
The "Edit field" modal should display the same readable preview under "Field sample value" and have VECTOR pre-selected as the field type with dimensions (768) and data type (FLOAT32) already filled in

| Before | After |
| - | - |
<img width="1270" height="1566" alt="2026-03-17_16-52_1" src="https://github.com/user-attachments/assets/36188b73-980e-47b8-966d-5c843a61f153" />|<img width="1266" height="1188" alt="image" src="https://github.com/user-attachments/assets/03b2787c-c252-4fe3-bfa6-743fb3943e70" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds heuristic detection and decoding of binary hash values as float32 vectors, which can affect field type inference and displayed sample values during index creation; misclassification edge cases could change suggested indexing types/options.
> 
> **Overview**
> Improves the vector-search “Create Index/Make Searchable” flow to **detect Redis Hash fields that store embeddings as raw float32 bytes** and treat them as `VECTOR` fields instead of converting them to garbled UTF-8 text.
> 
> Adds `isBinaryData`/`isBinaryVector` utilities and uses them in `parseHashFields` to decode binary vectors into a readable preview and to prefill vector options (algorithm `FLAT`, inferred dimensions, `FLOAT32`). Updates unit tests to cover the new binary detection and mixed-field parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f30c4f3f4c19be991a9740ad311f1544664dd805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->