### PR TITLE
Enable gradual rollout for the Vector Search feature

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.4,
+  "version": 3.5,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -120,7 +120,7 @@
     },
     "vectorSearchV2": {
       "flag": true,
-      "perc": [[0, 100]]
+      "perc": [[0, 10]]
     },
     "databasesListV2": {
       "flag": true,


### PR DESCRIPTION
# What

Limit the Vector Search feature to 10% of users initially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that reduces `vectorSearchV2` exposure from 100% to a 10% rollout; no code paths are modified.
> 
> **Overview**
> Updates `features-config.json` to **start a gradual rollout** of `vectorSearchV2` by changing its percentage from `[[0, 100]]` to `[[0, 10]]`.
> 
> Also bumps the feature config `version` from `3.4` to `3.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d204a8dec5f99f0d1e21116885eaf704bef183f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->