### PR TITLE
Fix FT.SEARCH results table unreadable with wide documents

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -27,6 +27,8 @@ export interface Props {
   cursorId?: null | number
 }
 
+const MIN_COLUMN_WIDTH_PX = 150
+
 const EllipsisText = styled(ColorText)`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -122,6 +124,9 @@ const TableResult = React.memo((props: Props) => {
     setColumns(newColumns)
   }, [result, query])
 
+  const tableMinWidth =
+    columns.length > 0 ? `${columns.length * MIN_COLUMN_WIDTH_PX}px` : undefined
+
   const isDataArr =
     !React.isValidElement(result) && !(isArray(result) && isEmpty(result))
   const isDataEl = React.isValidElement(result)
@@ -138,7 +143,11 @@ const TableResult = React.memo((props: Props) => {
       </div>
       {isDataArr && (
         <div data-testid={`query-table-result-${query}`}>
-          <Table columns={columns} data={result ?? []} />
+          <Table
+            columns={columns}
+            data={result ?? []}
+            minWidth={tableMinWidth}
+          />
         </div>
       )}
       {isDataEl && <div className={cx('resultEl')}>{result}</div>}


### PR DESCRIPTION
# What

When an `FT.SEARCH` query returns documents with many fields (30+), the Workbench results table becomes unreadable — columns collapse to near-zero width, headers are truncated, and values show only 1–2 characters. There is no horizontal scrolling.

The root cause is that the `@redis-ui/table` component uses `table-layout: fixed` with `width: 100%`. Without an explicit `minWidth`, the browser divides the viewport equally among all columns. The component already supports horizontal scrolling internally (`overflow-x: auto` on its scroller wrapper), but it only activates when a `minWidth` is set that exceeds the container width.

This PR passes a dynamic `minWidth` prop to the `Table` component — 150px per column — so wide tables overflow and scroll horizontally. Narrow queries (few columns) are unaffected.

# Testing

### Setup

```
FT.CREATE idx:wide_bug ON HASH PREFIX 1 wide: SCHEMA type TAG profile_id TAG product_reference_id TAG currency TAG country TAG status TAG color TAG brand TAG model TEXT title TEXT description TEXT manufacturer TEXT material TEXT availability TEXT price TEXT stock TEXT created_at TEXT updated_at TEXT retailer TEXT category TEXT f01 TAG f02 TAG f03 TAG f04 TAG f05 TAG f06 TEXT f07 TEXT f08 TEXT f09 TEXT f10 TEXT f11 TAG f12 TAG f13 TAG f14 TAG f15 TAG f16 TEXT f17 TEXT f18 TEXT f19 TEXT f20 TEXT f21 TAG f22 TAG f23 TAG f24 TAG f25 TAG f26 TEXT f27 TEXT f28 TEXT f29 TEXT f30 TEXT

HSET wide:1 type product profile_id e567b099 product_reference_id 20e5db6d currency USD country US status for_sale color blue brand Velorim model "Urban 500" title "Urban Bike 500" description "A wide test document" manufacturer BikeCorp material aluminum availability today price 999 stock 42 created_at 2026-03-18T10:00:00Z updated_at 2026-03-18T10:05:00Z retailer "Redis Bikes" category commuter f01 x01 f02 x02 f03 x03 f04 x04 f05 x05 f06 text06 f07 text07 f08 text08 f09 text09 f10 text10 f11 x11 f12 x12 f13 x13 f14 x14 f15 x15 f16 text16 f17 text17 f18 text18 f19 text19 f20 text20 f21 x21 f22 x22 f23 x23 f24 x24 f25 x25 f26 "longer text twenty six" f27 "longer text twenty seven" f28 "longer text twenty eight" f29 "longer text twenty nine" f30 "longer text thirty"
```

### Verify wide query (should scroll horizontally, columns readable)

```
FT.SEARCH idx:wide_bug "@type:{product}" LIMIT 0 1
```

### Verify narrow query (should render normally, no unnecessary scroll)

```
FT.SEARCH idx:wide_bug "@type:{product}" RETURN 2 product_reference_id title LIMIT 0 1
```

---

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI tweak: only adjusts table sizing by passing a computed `minWidth`, which may affect layout/scroll behavior for very wide result sets.
> 
> **Overview**
> Makes Workbench `FT.SEARCH` result tables readable when many fields are returned by computing a per-column minimum table width and passing it to `@redis-ui/table` via the `minWidth` prop.
> 
> This prevents columns from collapsing in wide documents by forcing horizontal overflow/scrolling, while leaving narrow result tables effectively unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792d9a79687e1c515c1e26febf87363b34a8a757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->