### PR TITLE
Fix workbench plugin table layout when many columns are present

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import parse from 'html-react-parser'
 import cx from 'classnames'
 import { flatten, isArray, isEmpty, map, uniq } from 'lodash'
@@ -30,6 +30,12 @@ export interface Props {
 const EllipsisText = styled(ColorText)`
   overflow: hidden;
   text-overflow: ellipsis;
+`
+
+const TableWrapper = styled.div<React.HTMLAttributes<HTMLDivElement>>`
+  min-width: 0;
+  overflow: auto;
+  padding: 2px;
 `
 
 const noResultsMessage = 'No results found.'
@@ -126,6 +132,12 @@ const TableResult = React.memo((props: Props) => {
     !React.isValidElement(result) && !(isArray(result) && isEmpty(result))
   const isDataEl = React.isValidElement(result)
 
+  const MIN_COLUMN_WIDTH = 180
+  const tableMinWidth = useMemo(
+    () => `${Math.max(columns.length * MIN_COLUMN_WIDTH, 920)}px`,
+    [columns.length],
+  )
+
   return (
     <div className={cx('queryResultsContainer', 'container')}>
       <div className="queryHeader">
@@ -137,9 +149,9 @@ const TableResult = React.memo((props: Props) => {
         )}
       </div>
       {isDataArr && (
-        <div data-testid={`query-table-result-${query}`}>
-          <Table columns={columns} data={result ?? []} />
-        </div>
+        <TableWrapper data-testid={`query-table-result-${query}`}>
+          <Table columns={columns} data={result ?? []} minWidth={tableMinWidth} />
+        </TableWrapper>
       )}
       {isDataEl && <div className={cx('resultEl')}>{result}</div>}
       {!isDataArr && !isDataEl && (


### PR DESCRIPTION
# What

Fixed the Workbench search plugin table (TableResult) becoming cramped and unreadable when query results contain many columns.
- Wrapped the table in a styled `TableWrapper` with `min-width: 0`, `overflow: auto`, and minimal padding to enable horizontal scrolling
- Added a dynamic `minWidth` on the `Table` component calculated from column count (180px per column, floor of 920px) to prevent columns from collapsing

https://github.com/user-attachments/assets/3070a0d7-f894-42af-8b17-d6ec585372b1

# Testing

### Commands to reproduce

1. Create wide index:
```
FT.CREATE idx:wide_bug ON HASH PREFIX 1 wide: SCHEMA type TAG profile_id TAG product_reference_id TAG currency TAG country TAG status TAG color TAG brand TAG model TEXT title TEXT description TEXT manufacturer TEXT material TEXT availability TEXT price TEXT stock TEXT created_at TEXT updated_at TEXT retailer TEXT category TEXT f01 TAG f02 TAG f03 TAG f04 TAG f05 TAG f06 TEXT f07 TEXT f08 TEXT f09 TEXT f10 TEXT f11 TAG f12 TAG f13 TAG f14 TAG f15 TAG f16 TEXT f17 TEXT f18 TEXT f19 TEXT f20 TEXT f21 TAG f22 TAG f23 TAG f24 TAG f25 TAG f26 TEXT f27 TEXT f28 TEXT f29 TEXT f30 TEXT
```

2. Insert wide entry:
```
HSET wide:1 type product profile_id e567b099-b6fb-11ed-8685-8372584b67ec product_reference_id 20e5db6df5ab3967ebecb250c2d5ebee currency USD country US status for_sale color blue brand Velorim model "Urban 500" title "Urban Bike 500" description "A deliberately wide test document for Workbench rendering" manufacturer BikeCorp material aluminum availability today price 999 stock 42 created_at 2026-03-18T10:00:00Z updated_at 2026-03-18T10:05:00Z retailer "Redis Bikes" category commuter f01 x01 f02 x02 f03 x03 f04 x04 f05 x05 f06 text06 f07 text07 f08 text08 f09 text09 f10 text10 f11 x11 f12 x12 f13 x13 f14 x14 f15 x15 f16 text16 f17 text17 f18 text18 f19 text19 f20 text20 f21 x21 f22 x22 f23 x23 f24 x24 f25 x25 f26 "longer text twenty six" f27 "longer text twenty seven" f28 "longer text twenty eight" f29 "longer text twenty nine" f30 "longer text thirty"
```
3. Run search in Workbench:

```FT.SEARCH idx:wide_bug "@type:{product}" LIMIT 0 1```

### Verify
- [ ] Columns are readable and not cramped
- [ ] Horizontal scroll appears when the table exceeds the container width
- [ ] Tables with few columns (1-3) still display normally without unnecessary scroll

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts table layout/styling for wide result sets; main risk is minor visual/regression in table sizing or scroll behavior.
> 
> **Overview**
> Improves Workbench search results table readability for queries returning many columns by enabling horizontal scrolling and preventing columns from collapsing.
> 
> `TableResult` now wraps the `Table` in a styled `TableWrapper` (`overflow: auto`) and passes a computed `minWidth` based on column count (180px/col, minimum 920px).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd676b1933e48fbe5c705cbfe972ab7fa26d5658. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->