### PR TITLE
Update monaco editor background color on the Workbench

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/query/Query/Query.styles.ts
+++ b/redisinsight/ui/src/pages/workbench/components/query/Query/Query.styles.ts
@@ -40,7 +40,10 @@ export const InputContainer = styled.div<ComponentPropsWithRef<'div'>>`
   width: 100%;
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   background-color: ${({ theme }) =>
-    theme.semantic.color.background.neutral100};
+    theme.semantic.color.background.neutral300};
+
+  --monaco-color-bg: ${({ theme }) =>
+    theme.semantic.color.background.neutral300};
 `
 
 export const QueryFooter = styled(Row).attrs({


### PR DESCRIPTION
# What

Restore the grey background on the Workbench code editor. 

After migrating from the global `_monaco.scss` (which used `--monacoBgColor`) to styled-components, the editor background defaulted to `neutral100` which is nearly white. Updated the `InputContainer` to use `neutral300` and override `--monaco-color-bg` so the Monaco editor matches.

| Before | After |
| - | - |
<img width="1173" height="962" alt="image" src="https://github.com/user-attachments/assets/28a0b453-0dad-4721-af85-09dbae651965" />|<img width="1173" height="965" alt="image" src="https://github.com/user-attachments/assets/7d7055b5-6da6-4d95-a635-4d1b04eb7923" />
<img width="1173" height="961" alt="image" src="https://github.com/user-attachments/assets/4e68f20c-63fc-4062-aea4-66c4a4cfc720" />|<img width="1171" height="961" alt="image" src="https://github.com/user-attachments/assets/98a91a39-44cc-46c1-821e-6249961f1a89" />

# Testing

1. Open the **Workbench** page
2. Verify the code editor has a visible grey background (not white)
3. Switch between light and dark themes — both should look correct
4. Confirm the Vector Search editor is unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling change limited to the Workbench query editor background and a local `--monaco-color-bg` override.
> 
> **Overview**
> Restores the grey background in the Workbench query Monaco editor by switching `InputContainer` from `neutral100` to `neutral300`.
> 
> Also sets a local `--monaco-color-bg` CSS variable on the container so Monaco’s background styling matches the surrounding Workbench theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 085adf1eddd94c85c92fb21b42c29ab501393e6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->