### PR TITLE
RI-7947 Fix Explain/Profile buttons disabled when sample query has comments

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.utils.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.utils.spec.ts
@@ -40,6 +40,31 @@ describe('parseExplainableCommand', () => {
     expect(parseExplainableCommand('FT.SEARCH   ')).toBeNull()
     expect(parseExplainableCommand('FT.AGGREGATE  ')).toBeNull()
   })
+
+  it('ignores leading comment lines from sample queries', () => {
+    const query = '// Some description\nFT.SEARCH idx "*"'
+    const result = parseExplainableCommand(query)
+    expect(result).toEqual({ command: 'FT.SEARCH', afterCommand: ' idx "*"' })
+  })
+
+  it('ignores multiple leading comment lines', () => {
+    const query = '// Line 1\n// Line 2\nFT.AGGREGATE idx "*"'
+    const result = parseExplainableCommand(query)
+    expect(result).toEqual({
+      command: 'FT.AGGREGATE',
+      afterCommand: ' idx "*"',
+    })
+  })
+
+  it('ignores indented comment lines', () => {
+    const query = '  // indented comment\nFT.SEARCH idx "*"'
+    const result = parseExplainableCommand(query)
+    expect(result).toEqual({ command: 'FT.SEARCH', afterCommand: ' idx "*"' })
+  })
+
+  it('returns null when only comments remain', () => {
+    expect(parseExplainableCommand('// just a comment')).toBeNull()
+  })
 })
 
 describe('buildExplainQuery', () => {

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.utils.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditor.utils.ts
@@ -7,10 +7,16 @@ import { ExplainableCommand } from './QueryEditor.types'
  * Returns the matched command and its position so that Explain / Profile
  * can transform the query without a second regex pass.
  */
+export const stripCommentLines = (text: string): string =>
+  text
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n')
+
 export const parseExplainableCommand = (
   query: string,
 ): { command: ExplainableCommand; afterCommand: string } | null => {
-  const trimmed = query.trim()
+  const trimmed = stripCommentLines(query).trim()
   if (!trimmed) return null
 
   const upper = trimmed.toUpperCase()


### PR DESCRIPTION
# What

When loading a sample query from the **Query Library**, the **Explain** and **Profile** buttons become disabled. This happens because `buildLoadQuery` prepends a `// description` comment line to sample queries, and `parseExplainableCommand` checks if the raw trimmed text starts with `FT.SEARCH`/`FT.AGGREGATE` — which it doesn't when it starts with `//`.

| Before | After |
| - | - | 
<img width="2242" height="862" alt="image" src="https://github.com/user-attachments/assets/18bbe16f-fe35-4719-89ff-4a8d8519fe60" />|<img width="2352" height="1084" alt="image" src="https://github.com/user-attachments/assets/e4e405ca-98c4-4439-8740-b33541e69308" />

Added a `stripCommentLines` utility that removes comment lines (lines starting with optional whitespace + `//`) before parsing the command, so **Explain** and **Profile** correctly detect the underlying command.

# Testing

1. Open **Vector Search** query page
2. Switch to **Query Library** tab
3. Load a sample query that has a description (e.g. the movies genre filter sample, if you don't have such create an index with Sample data)
4. Verify the editor shows the comment line + command
5. Verify **Explain** and **Profile** buttons are **enabled**
6. Click **Explain** — should send `FT.EXPLAIN ...`
7. Click **Profile** — should send `FT.PROFILE ...`
8. Also verify - loading a query without comments still works as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to query parsing for Explain/Profile and only strips full-line `//` comments before detection; could affect edge cases where users intentionally include `//` lines in executable input.
> 
> **Overview**
> Fixes Explain/Profile command detection for Vector Search queries that include leading `//` comment lines (e.g., from the Query Library).
> 
> Adds `stripCommentLines()` and uses it in `parseExplainableCommand` so `FT.SEARCH`/`FT.AGGREGATE` are recognized after removing comment-only lines, and extends unit tests to cover single/multiple/indented comments and comment-only input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f664bcc8b114ee243c1ae7f65c823290f0ca8e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->