### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @redis/redis-insight
+* @redis/redis-insight-codeowners


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates GitHub review ownership routing; no runtime or production code is affected.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to replace a list of individual email addresses with the `@redis/redis-insight-codeowners` team as the default code owner for the repository.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d6573ba500b7a3387bbf241a8a42977176c8cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->