### PR TITLE
Remove redundant feature flag logic

### DIFF
--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -40,6 +40,5 @@ export enum KnownFeatures {
 export interface IFeatureFlag {
   name: string;
   storage: string;
-  overridable?: boolean;
   factory?: () => Partial<Feature>;
 }

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -61,7 +61,6 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
   [KnownFeatures.VectorSearchV2]: {
     name: KnownFeatures.VectorSearchV2,
     storage: FeatureStorage.Database,
-    overridable: true,
   },
 
   [KnownFeatures.AzureEntraId]: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes an apparently unused `overridable` property from `IFeatureFlag` and the `VectorSearchV2` known feature definition, with no behavioral changes observed elsewhere.
> 
> **Overview**
> Removes the redundant `overridable` field from the `IFeatureFlag` type and drops its only usage on the `VectorSearchV2` entry in `knownFeatures`, simplifying feature flag metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8885980a8263d3f08b1145ee65eefa0a21f442a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->