### PR TITLE
RI-000: Fix top bar spacing

### DIFF
--- a/redisinsight/ui/src/components/page-header/PageHeader.tsx
+++ b/redisinsight/ui/src/components/page-header/PageHeader.tsx
@@ -75,7 +75,7 @@ const PageHeader = (props: Props) => {
                 <CopilotTrigger />
               </FlexItem>
             )}
-            <FlexItem grow>
+            <FlexItem>
               <InsightsTrigger source="home page" />
             </FlexItem>
             <FeatureFlagComponent


### PR DESCRIPTION
# What

Remove `grow` from a static button; it's consuming the space reserved for the SSO profile button. That causes horizontal scrollbars to appear on some pages. 

## Before

<img width="548" height="154" alt="Screenshot 2026-03-24 at 14 44 09" src="https://github.com/user-attachments/assets/4967a021-2ba5-449d-99fc-1d3f7eda6672" />

## After

<img width="548" height="154" alt="Screenshot 2026-03-24 at 14 44 02" src="https://github.com/user-attachments/assets/0883ab3c-7858-4030-82b5-8525ada0f788" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak in `PageHeader` that changes flex behavior; potential impact is limited to header spacing/alignment across pages.
> 
> **Overview**
> Fixes top-bar spacing in `PageHeader` by removing `grow` from the `InsightsTrigger` container so it no longer expands to consume space needed by the SSO profile area, preventing horizontal overflow/scrollbars on some pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb8fb580716ff39138598ae06a317c92ca9420a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->