### PR TITLE
RI-000: Adjust app version position and font color

### DIFF
--- a/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
+++ b/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
@@ -12,9 +12,9 @@ const AppVersion = () => {
   return (
     <Text
       size="s"
-      color="subdued"
+      color="secondary"
       data-testid="settings-app-version"
-      style={{ marginTop: 16, textAlign: 'center' }}
+      style={{ marginTop: 16, textAlign: 'left' }}
     >
       Redis Insight v{server.appVersion}
     </Text>


### PR DESCRIPTION
# What

| Before    | After |
| -------- | ------- |
| <img width="882" height="444" alt="Screenshot 2026-03-24 at 15 18 39" src="https://github.com/user-attachments/assets/82fa6e16-584a-40d2-a24a-7a213e52a0d1" /> | <img width="882" height="444" alt="Screenshot 2026-03-24 at 15 18 16" src="https://github.com/user-attachments/assets/ddae617e-f144-4533-8827-a5b07aad1527" />   |
| <img width="882" height="444" alt="Screenshot 2026-03-24 at 15 18 33" src="https://github.com/user-attachments/assets/d0a30667-2919-47bf-920c-29dee83e35ee" />  | <img width="882" height="444" alt="Screenshot 2026-03-24 at 15 18 22" src="https://github.com/user-attachments/assets/bdea7a4b-989b-48ec-9e1e-66a47883d193" />      |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks text styling on the Settings page without affecting logic or data flow.
> 
> **Overview**
> Updates the Settings page `AppVersion` display to use the `secondary` text color and left-align the version string (previously subdued and centered), adjusting its visual placement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061d04a535adbe07a2ebe54364a2d0829eea7d2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->