### PR TITLE
RI-7940 Add source to SEARCH_INDEX_DETAILS_VIEWED telemetry event

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
@@ -10,6 +10,7 @@ import {
 } from 'uiSrc/slices/browser/redisearch'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { SearchIndexDetailsSource } from 'uiSrc/pages/vector-search/telemetry.constants'
 
 import { useListContent } from './useListContent'
 import { useIndexListData } from '../useIndexListData'
@@ -163,7 +164,10 @@ describe('useListContent', () => {
 
       expect(sendEventTelemetry).toHaveBeenCalledWith({
         event: TelemetryEvent.SEARCH_INDEX_DETAILS_VIEWED,
-        eventData: { databaseId: mockInstanceId },
+        eventData: {
+          databaseId: mockInstanceId,
+          source: SearchIndexDetailsSource.IndexList,
+        },
       })
     })
 

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -21,6 +21,7 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { QueryLibraryService } from 'uiSrc/services/query-library/QueryLibraryService'
 import { queryLibraryNotifications } from 'uiSrc/pages/vector-search/constants'
+import { SearchIndexDetailsSource } from 'uiSrc/pages/vector-search/telemetry.constants'
 import { localStorageService } from 'uiSrc/services'
 
 import { IndexListAction } from '../../components/index-list/IndexList.types'
@@ -63,7 +64,10 @@ export const useListContent = () => {
       setViewingIndexName(indexName)
       sendEventTelemetry({
         event: TelemetryEvent.SEARCH_INDEX_DETAILS_VIEWED,
-        eventData: { databaseId: instanceId },
+        eventData: {
+          databaseId: instanceId,
+          source: SearchIndexDetailsSource.IndexList,
+        },
       })
     },
     [instanceId],

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/VectorSearchQueryPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/VectorSearchQueryPage.tsx
@@ -4,6 +4,7 @@ import { useHistory, useParams } from 'react-router-dom'
 import { RiSelectOption } from 'uiSrc/components/base/forms/select/RiSelect'
 import { Pages } from 'uiSrc/constants'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { SearchIndexDetailsSource } from 'uiSrc/pages/vector-search/telemetry.constants'
 
 import {
   getIndexDisplayName,
@@ -68,7 +69,10 @@ export const VectorSearchQueryPage = () => {
     if (!isIndexPanelOpen) {
       sendEventTelemetry({
         event: TelemetryEvent.SEARCH_INDEX_DETAILS_VIEWED,
-        eventData: { databaseId: instanceId },
+        eventData: {
+          databaseId: instanceId,
+          source: SearchIndexDetailsSource.Query,
+        },
       })
     }
     setIsIndexPanelOpen((prev) => !prev)

--- a/redisinsight/ui/src/pages/vector-search/telemetry.constants.ts
+++ b/redisinsight/ui/src/pages/vector-search/telemetry.constants.ts
@@ -30,6 +30,11 @@ export enum SearchOnboardingAction {
   Skip = 'skip',
 }
 
+export enum SearchIndexDetailsSource {
+  IndexList = 'index_list',
+  Query = 'query',
+}
+
 export enum SearchCommandType {
   Search = 'search',
   Aggregate = 'aggregate',


### PR DESCRIPTION
# What

Added a `source` field to the `SEARCH_INDEX_DETAILS_VIEWED` telemetry event to distinguish whether it was triggered from the index list page (`index_list`) or the query page (`query`).

# Testing

- Open the vector search index list and click "View index" on any index — verify the telemetry event includes `source: 'index_list'`
- Open the query page and toggle the index details panel — verify the telemetry event includes `source: 'query'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: telemetry-only change that adds an extra `source` field to an existing event with minimal impact on app behavior; main risk is downstream analytics expecting the old schema.
> 
> **Overview**
> Adds a new `SearchIndexDetailsSource` enum and includes a `source` attribute in the `SEARCH_INDEX_DETAILS_VIEWED` telemetry payload to distinguish whether index details were opened from the index list vs the query page.
> 
> Updates the index list hook (`useListContent`) and the query page panel toggle to send the appropriate `source`, and adjusts the related unit test to assert the enriched payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6179f0e1c1b2deed2fa007ee3bff51690826eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->