### PR TITLE
RI-7947 Sync "View index" button state with index panel visibility

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/VectorSearchQueryPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/VectorSearchQueryPage.tsx
@@ -87,6 +87,7 @@ export const VectorSearchQueryPage = () => {
       <PageHeader
         indexName={getIndexDisplayName(decodedIndexName)}
         indexOptions={indexOptions}
+        isIndexPanelOpen={isIndexPanelOpen}
         onIndexChange={handleIndexChange}
         onToggleIndexPanel={toggleIndexPanel}
       />

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.spec.tsx
@@ -12,6 +12,7 @@ describe('PageHeader', () => {
       { value: 'index-1', label: 'index-1' },
       { value: 'index-2', label: 'index-2' },
     ],
+    isIndexPanelOpen: false,
     onIndexChange: jest.fn(),
     onToggleIndexPanel: jest.fn(),
   }

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.tsx
@@ -9,6 +9,7 @@ import * as S from './PageHeader.styles'
 export const PageHeader = ({
   indexName,
   indexOptions,
+  isIndexPanelOpen,
   onIndexChange,
   onToggleIndexPanel,
 }: PageHeaderProps) => (
@@ -18,6 +19,6 @@ export const PageHeader = ({
       indexOptions={indexOptions}
       onIndexChange={onIndexChange}
     />
-    <ViewIndexButton onClick={onToggleIndexPanel} />
+    <ViewIndexButton isActive={isIndexPanelOpen} onClick={onToggleIndexPanel} />
   </S.HeaderRow>
 )

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/page-header/PageHeader.types.ts
@@ -3,6 +3,7 @@ import { RiSelectOption } from 'uiSrc/components/base/forms/select/RiSelect'
 export interface PageHeaderProps {
   indexName: string
   indexOptions: RiSelectOption[]
+  isIndexPanelOpen: boolean
   onIndexChange: (value: string) => void
   onToggleIndexPanel: () => void
 }

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/view-index-button/ViewIndexButton.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchQueryPage/components/view-index-button/ViewIndexButton.tsx
@@ -1,13 +1,21 @@
 import React from 'react'
 
-import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
+import { ToggleButton } from 'uiSrc/components/base/forms/buttons'
 
 export interface ViewIndexButtonProps {
+  isActive: boolean
   onClick: () => void
 }
 
-export const ViewIndexButton = ({ onClick }: ViewIndexButtonProps) => (
-  <EmptyButton size="small" onClick={onClick} data-testid="view-index-btn">
+export const ViewIndexButton = ({
+  isActive,
+  onClick,
+}: ViewIndexButtonProps) => (
+  <ToggleButton
+    pressed={isActive}
+    onPressedChange={onClick}
+    data-testid="view-index-btn"
+  >
     View index
-  </EmptyButton>
+  </ToggleButton>
 )


### PR DESCRIPTION
# What

The "**View index**" button on the **Vector Search Query** page now reflects the open/closed state of the index info side panel. Replaced `EmptyButton` with `ToggleButton` and threaded `isIndexPanelOpen` state from the page down to the button, so closing the panel via its own close button also updates the button's visual state.

https://github.com/user-attachments/assets/8f711531-85f2-4c2a-901a-232aa6ee9671

# Testing

1. Open the **Vector Search Query** page for any index
2. Click "**View index**" — the button should appear pressed/active and the panel opens
3. Click "**View index**" again — the button should appear unpressed and the panel closes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that wires existing `isIndexPanelOpen` state into the header button; main risk is minor behavior/UX regressions in the toggle interaction.
> 
> **Overview**
> The **Vector Search Query** header now keeps the "View index" button visually in sync with the index side panel open/close state.
> 
> This threads `isIndexPanelOpen` into `PageHeader` and updates `ViewIndexButton` to use a `ToggleButton` with `pressed` state (and adjusts the related header test/props).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 913162dd710dd42dd47826ada837aa55df21d65f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->