### PR TITLE
Add feature flags AI skill documentation

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -31,6 +31,11 @@ AGENTS.md                              # 🎯 AI agent entry point
 │   ├── branches.md                    # Branch naming conventions
 │   ├── commits.md                     # Commit message guidelines
 │   └── pull-requests.md               # Pull request process
+├── skills/                            # AI agent skills (step-by-step workflows)
+│   ├── branches/SKILL.md             # Branch naming skill
+│   ├── commits/SKILL.md              # Commit message generation skill
+│   ├── pull-requests/SKILL.md        # PR creation and review skill
+│   └── feature-flags/SKILL.md        # Feature flag lifecycle skill
 └── commands/                          # AI workflow commands
     ├── pr-plan.md                     # JIRA ticket implementation planning
     ├── commit-message.md              # Commit message generation
@@ -39,7 +44,8 @@ AGENTS.md                              # 🎯 AI agent entry point
 # Symlinks (all AI tools read from .ai/)
 .cursor/
   ├── rules/ -> ../.ai/rules/          # Cursor AI (rules)
-  └── commands/ -> ../.ai/commands/  # Cursor AI (commands)
+  ├── commands/ -> ../.ai/commands/    # Cursor AI (commands)
+  └── skills/ -> ../.ai/skills/        # Cursor AI (skills)
 .augment/ -> .ai/                      # Augment AI
 .windsurfrules -> .ai/                 # Windsurf AI
 .github/copilot-instructions.md        # GitHub Copilot
@@ -68,6 +74,7 @@ This directory contains comprehensive development standards that are automatical
 - **Branch Naming**: `.ai/rules/branches.md` - Branch naming conventions
 - **Commit Messages**: `.ai/rules/commits.md` - Commit message guidelines (Conventional Commits)
 - **Pull Request Process**: `.ai/rules/pull-requests.md` - PR creation and review guidelines
+- **Feature Flags**: `.ai/skills/feature-flags/SKILL.md` - Adding, promoting, and removing feature flags
 
 ## MCP (Model Context Protocol) Setup
 

--- a/.ai/skills/feature-flags/SKILL.md
+++ b/.ai/skills/feature-flags/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: feature-flags
+description: >-
+  Create, modify, and remove feature flags in RedisInsight. Use when adding a
+  new feature flag, introducing a dev flag, promoting a dev flag to regular,
+  cleaning up old flags, or the user mentions feature flags, feature toggles,
+  or gating features.
+---
+
+# Feature Flags
+
+RedisInsight has its own feature flag system. Flags are defined in a remote JSON config, fetched by the backend, and served to the frontend via API. This skill covers how to add, promote, and remove flags.
+
+## Flag Types
+
+| Type                         | Naming                            | `flag` value | Strategy                 | Purpose                                                      |
+| ---------------------------- | --------------------------------- | ------------ | ------------------------ | ------------------------------------------------------------ |
+| **Dev flag**                 | `dev-<name>` (e.g. `dev-browser`) | `false`      | `CommonFlagStrategy`     | Hide incomplete features during development                  |
+| **Regular flag**             | `camelCase` (e.g. `azureEntraId`) | `true`       | `CommonFlagStrategy`     | Standard on/off toggle                                       |
+| **Regular with data**        | `camelCase`                       | `true`       | `WithDataFlagStrategy`   | Flag + extra config payload in `data`                        |
+| **Switchable (overridable)** | `camelCase`                       | `true`       | `SwitchableFlagStrategy` | User can override locally via `~/.redis-insight/config.json` |
+
+## Files to Change
+
+Every new flag touches these files (in order):
+
+### Backend (required)
+
+1. **`redisinsight/api/config/features-config.json`**
+   Add the flag entry with `flag`, `perc`, optional `filters` and `data`. Bump the `version` number.
+
+2. **`redisinsight/api/src/modules/feature/constants/index.ts`**
+   Add to the `KnownFeatures` enum.
+
+3. **`redisinsight/api/src/modules/feature/constants/known-features.ts`**
+   Add entry to the `knownFeatures` record with `name` and `storage` (usually `FeatureStorage.Database`).
+
+4. **`redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts`**
+   Register the flag with its strategy (see Strategy Types below).
+
+### Frontend (required if the flag gates UI)
+
+5. **`redisinsight/ui/src/constants/featureFlags.ts`**
+   Add to the `FeatureFlags` enum.
+
+6. **`redisinsight/ui/src/slices/app/features.ts`**
+   Add default state entry in `initialState.featureFlags.features` with `{ flag: false }`.
+
+### Consuming code
+
+7. Use the flag in components/hooks to gate functionality.
+
+## Strategy Selection
+
+Choose the strategy based on what the flag needs:
+
+```
+CommonFlagStrategy        → Most flags (dev and regular on/off)
+WithDataFlagStrategy      → Flag needs to carry extra data payload
+SwitchableFlagStrategy    → Flag should be overridable via local config.json
+```
+
+Register in `feature-flag.provider.ts`:
+
+```typescript
+this.strategies.set(
+  KnownFeatures.YourFeature,
+  new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
+);
+```
+
+## Config JSON Structure
+
+### Minimal (dev flag)
+
+```json
+"dev-myFeature": {
+  "flag": false,
+  "perc": [[0, 100]]
+}
+```
+
+### With filters (Electron-only)
+
+```json
+"myFeature": {
+  "flag": true,
+  "perc": [[0, 100]],
+  "filters": [
+    { "name": "config.server.buildType", "value": "ELECTRON", "cond": "eq" }
+  ]
+}
+```
+
+### Gradual rollout (10% of users)
+
+```json
+"myFeature": {
+  "flag": true,
+  "perc": [[0, 10]]
+}
+```
+
+### With data payload
+
+```json
+"myFeature": {
+  "flag": true,
+  "perc": [[0, 100]],
+  "data": { "strategy": "ioredis" }
+}
+```
+
+## Filter Conditions
+
+Filters compare a value from server state against the filter value.
+
+| Condition    | Meaning                         |
+| ------------ | ------------------------------- |
+| `eq`         | equals                          |
+| `neq`        | not equals                      |
+| `gt` / `gte` | greater than / greater or equal |
+| `lt` / `lte` | less than / less or equal       |
+
+Common `name` paths: `config.server.buildType` (ELECTRON, DOCKER_ON_PREMISE, REDIS_STACK), `config.server.packageVersion` (uses semver), `agreements.analytics`, `env.<VAR_NAME>`.
+
+Filters support `and`/`or` composition for complex conditions.
+
+## Workflows
+
+### Add a dev feature flag
+
+Use for features under active development that should not be visible in production.
+
+1. `features-config.json` → add `"dev-myFeature": { "flag": false, "perc": [[0, 100]] }`
+2. `constants/index.ts` → add `DevMyFeature = 'dev-myFeature'` to `KnownFeatures`
+3. `constants/known-features.ts` → add record entry
+4. `feature-flag.provider.ts` → register with `CommonFlagStrategy`
+5. `ui/src/constants/featureFlags.ts` → add `devMyFeature = 'dev-myFeature'`
+6. `ui/src/slices/app/features.ts` → add default `{ flag: false }`
+
+### Promote dev flag to regular flag
+
+When the feature is complete and ready for rollout.
+
+1. Rename `dev-myFeature` → `myFeature` in all the files above
+2. Set `flag: true` in `features-config.json`
+3. Optionally set `perc` for gradual rollout (e.g. `[[0, 10]]`)
+4. Change strategy if needed (e.g. to `SwitchableFlagStrategy` for overridable)
+5. Bump config `version`
+
+### Clean up a flag
+
+When a feature is fully rolled out and the flag is no longer needed.
+
+1. Remove from `features-config.json`
+2. Remove from `KnownFeatures` enum
+3. Remove from `knownFeatures` record
+4. Remove strategy registration from `feature-flag.provider.ts`
+5. Remove from FE `FeatureFlags` enum
+6. Remove default state from `features.ts`
+7. Remove all gating code (conditionals, `FeatureFlagComponent` wrappers) in consuming components
+
+## FE Usage Patterns
+
+### Check flag in a component
+
+```typescript
+import { FeatureFlags } from 'uiSrc/constants';
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features';
+
+const features = useSelector(appFeatureFlagsFeaturesSelector);
+const isEnabled = features[FeatureFlags.myFeature]?.flag;
+```
+
+### Custom selector for complex logic
+
+```typescript
+export const isMyFeatureEnabledSelector = (state: RootState): boolean => {
+  const features = state.app.features.featureFlags.features;
+  return features[FeatureFlags.myFeature]?.flag ?? false;
+};
+```

--- a/.cursor/skills/feature-flags/SKILL.md
+++ b/.cursor/skills/feature-flags/SKILL.md
@@ -1,0 +1,1 @@
+../../../.ai/skills/feature-flags/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ All detailed development standards are maintained in `.ai/rules/`:
 - **Branches**: `.ai/skills/branches/SKILL.md` - Branch naming conventions
 - **Commits**: `.ai/skills/commits/SKILL.md` - Commit message guidelines
 - **Pull Requests**: `.ai/skills/pull-requests/SKILL.md` - PR process and review guidelines
+- **Feature Flags**: `.ai/skills/feature-flags/SKILL.md` - Adding, promoting, and removing feature flags
 
 **Refer to these files for comprehensive guidelines on each topic.**
 


### PR DESCRIPTION
# What

Add an AI agent skill that documents the feature flag lifecycle in RedisInsight — how to add dev flags, promote them to regular flags, configure filters and overrides, and clean up old flags. 

The skill covers all files that need to change and the different strategy types available.

# Testing

- Ask the AI agent to "add a new dev feature flag called dev-myTestFeature" and confirm it references the correct files and follows the documented workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus a new `.cursor` symlink path; no runtime code paths are modified.
> 
> **Overview**
> Adds a new AI agent skill doc at `.ai/skills/feature-flags/SKILL.md` that standardizes the feature-flag lifecycle (create dev flags, promote to regular, configure filters/data/overrides, and remove flags), including the specific backend/frontend files and strategy selection guidance.
> 
> Updates `.ai/README.md` and `AGENTS.md` to reference the new skill, and adds `.cursor/skills/feature-flags/SKILL.md` plus the `.cursor/skills` symlink entry so Cursor can consume the shared `.ai/skills` content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad0fab238d78a0830d24e90ef644fe2c714c289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->