### PR TITLE
RI-000 Cherry-pick: Add cancel button for Azure managed Redis OAuth loading state

### DIFF
--- a/redisinsight/ui/src/components/hooks/useAzureAuth.spec.ts
+++ b/redisinsight/ui/src/components/hooks/useAzureAuth.spec.ts
@@ -6,6 +6,7 @@ import {
   azureAuthSelector,
   AzureOAuthPrompt,
   AzureOAuthRedirectType,
+  cancelAzureLoginAction,
   initiateAzureLoginAction,
 } from 'uiSrc/slices/oauth/azure'
 import { AzureAccountFactory } from 'uiSrc/mocks/factories/cloud/AzureAccount.factory'
@@ -30,10 +31,14 @@ jest.mock('uiSrc/slices/oauth/azure', () => ({
     error: '',
   }),
   initiateAzureLoginAction: jest.fn().mockReturnValue({ type: 'mock-action' }),
+  cancelAzureLoginAction: jest
+    .fn()
+    .mockReturnValue({ type: 'mock-cancel-action' }),
 }))
 
 const mockedAzureAuthSelector = azureAuthSelector as jest.Mock
 const mockedInitiateAzureLoginAction = initiateAzureLoginAction as jest.Mock
+const mockedCancelAzureLoginAction = cancelAzureLoginAction as jest.Mock
 
 let store: typeof mockedStore
 
@@ -95,6 +100,28 @@ describe('useAzureAuth', () => {
         prompt: AzureOAuthPrompt.SelectAccount,
         redirectType: AzureOAuthRedirectType.Deeplink,
       })
+    })
+  })
+
+  describe('cancelLogin', () => {
+    it('should dispatch cancelAzureLoginAction', () => {
+      const { result } = renderHook(() => useAzureAuth())
+
+      act(() => {
+        result.current.cancelLogin()
+      })
+
+      expect(mockedCancelAzureLoginAction).toHaveBeenCalled()
+    })
+
+    it('should not throw if no popup is open', () => {
+      const { result } = renderHook(() => useAzureAuth())
+
+      expect(() => {
+        act(() => {
+          result.current.cancelLogin()
+        })
+      }).not.toThrow()
     })
   })
 })

--- a/redisinsight/ui/src/components/hooks/useAzureAuth.ts
+++ b/redisinsight/ui/src/components/hooks/useAzureAuth.ts
@@ -6,6 +6,7 @@ import {
   azureAuthSelector,
   AzureOAuthPrompt,
   AzureOAuthRedirectType,
+  cancelAzureLoginAction,
   initiateAzureLoginAction,
 } from 'uiSrc/slices/oauth/azure'
 import { AzureLoginSource } from 'uiSrc/slices/interfaces'
@@ -80,11 +81,20 @@ export const useAzureAuth = () => {
     [dispatch, openAuthUrl],
   )
 
+  const cancelLogin = useCallback(() => {
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close()
+      popupRef.current = null
+    }
+    dispatch(cancelAzureLoginAction())
+  }, [dispatch])
+
   return {
     loading,
     account,
     error,
     initiateLogin,
+    cancelLogin,
   }
 }
 

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/components/connectivity-options/ConnectivityOptions.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/components/connectivity-options/ConnectivityOptions.spec.tsx
@@ -14,7 +14,14 @@ import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { setSocialDialogState } from 'uiSrc/slices/oauth/cloud'
+import { useConnectivityOptions } from '../../hooks/useConnectivityOptions'
 import ConnectivityOptions, { Props } from './ConnectivityOptions'
+
+jest.mock('../../hooks/useConnectivityOptions', () => ({
+  useConnectivityOptions: jest.fn(),
+}))
+
+const mockedUseConnectivityOptions = useConnectivityOptions as jest.Mock
 
 const mockedProps = mock<Props>()
 
@@ -30,11 +37,43 @@ jest.mock('uiSrc/slices/app/features', () => ({
   }),
 }))
 
+const defaultOptions = [
+  {
+    id: 'sentinel',
+    type: AddDbType.sentinel,
+    title: 'Sentinel',
+    icon: 'SentinelIcon',
+    onClick: jest.fn(),
+    loading: false,
+    onCancel: undefined,
+  },
+  {
+    id: 'software',
+    type: AddDbType.software,
+    title: 'Software',
+    icon: 'SoftwareIcon',
+    onClick: jest.fn(),
+    loading: false,
+    onCancel: undefined,
+  },
+  {
+    id: 'import',
+    type: AddDbType.import,
+    title: 'Import',
+    icon: 'ImportIcon',
+    onClick: jest.fn(),
+    loading: false,
+    onCancel: undefined,
+  },
+]
+
 let store: typeof mockedStore
 beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
   store.clearActions()
+  defaultOptions.forEach((option) => (option.onClick as jest.Mock).mockReset())
+  mockedUseConnectivityOptions.mockReturnValue(defaultOptions)
 })
 
 describe('ConnectivityOptions', () => {
@@ -42,20 +81,20 @@ describe('ConnectivityOptions', () => {
     expect(render(<ConnectivityOptions {...mockedProps} />)).toBeTruthy()
   })
 
-  it('should render all additional options', () => {
+  it('should render all additional options and call their onClick handlers', () => {
     const onClickOption = jest.fn()
     render(
       <ConnectivityOptions {...mockedProps} onClickOption={onClickOption} />,
     )
 
     fireEvent.click(screen.getByTestId('option-btn-sentinel'))
-    expect(onClickOption).toBeCalledWith(AddDbType.sentinel)
+    expect(defaultOptions[0].onClick).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByTestId('option-btn-software'))
-    expect(onClickOption).toBeCalledWith(AddDbType.software)
+    expect(defaultOptions[1].onClick).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByTestId('option-btn-import'))
-    expect(onClickOption).toBeCalledWith(AddDbType.import)
+    expect(defaultOptions[2].onClick).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByTestId('discover-cloud-btn'))
     expect(onClickOption).toBeCalledWith(AddDbType.cloud)
@@ -105,5 +144,76 @@ describe('ConnectivityOptions', () => {
     render(<ConnectivityOptions {...mockedProps} onClose={onClose} />)
 
     expect(screen.queryByTestId('create-free-db-btn')).not.toBeInTheDocument()
+  })
+
+  it('should not render the Cancel button when no option is loading', () => {
+    render(<ConnectivityOptions {...mockedProps} />)
+
+    expect(
+      screen.queryByTestId('cancel-azure-login-btn'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render the Cancel button when an option is loading with onCancel', () => {
+    const mockOnCancel = jest.fn()
+    mockedUseConnectivityOptions.mockReturnValue([
+      ...defaultOptions,
+      {
+        id: 'azure',
+        type: AddDbType.azure,
+        title: 'Azure',
+        icon: 'AzureIcon',
+        onClick: jest.fn(),
+        loading: true,
+        onCancel: mockOnCancel,
+      },
+    ])
+
+    render(<ConnectivityOptions {...mockedProps} />)
+
+    expect(screen.getByTestId('cancel-azure-login-btn')).toBeInTheDocument()
+  })
+
+  it('should not render the Cancel button when an option is loading but has no onCancel', () => {
+    mockedUseConnectivityOptions.mockReturnValue([
+      ...defaultOptions,
+      {
+        id: 'azure',
+        type: AddDbType.azure,
+        title: 'Azure',
+        icon: 'AzureIcon',
+        onClick: jest.fn(),
+        loading: true,
+        onCancel: undefined,
+      },
+    ])
+
+    render(<ConnectivityOptions {...mockedProps} />)
+
+    expect(
+      screen.queryByTestId('cancel-azure-login-btn'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should call onCancel when the Cancel button is clicked', () => {
+    const mockOnCancel = jest.fn()
+    mockedUseConnectivityOptions.mockReturnValue([
+      ...defaultOptions,
+      {
+        id: 'azure',
+        type: AddDbType.azure,
+        title: 'Azure',
+        icon: 'AzureIcon',
+        onClick: jest.fn(),
+        loading: true,
+        onCancel: mockOnCancel,
+      },
+    ])
+
+    render(<ConnectivityOptions {...mockedProps} />)
+
+    fireEvent.click(screen.getByTestId('cancel-azure-login-btn'))
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1)
   })
 })

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/components/connectivity-options/ConnectivityOptions.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/components/connectivity-options/ConnectivityOptions.tsx
@@ -11,6 +11,7 @@ import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { Text } from 'uiSrc/components/base/text/Text'
 import { RiIcon } from 'uiSrc/components/base/icons'
 import { Loader } from 'uiSrc/components/base/display'
+import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
 import { useConnectivityOptions } from '../../hooks/useConnectivityOptions'
 
 import {
@@ -27,6 +28,10 @@ export interface Props {
 const ConnectivityOptions = (props: Props) => {
   const { onClickOption, onClose } = props
   const connectivityOptions = useConnectivityOptions({ onClickOption })
+
+  const loadingOption = connectivityOptions.find(
+    (option) => option.loading && option.onCancel,
+  )
 
   return (
     <>
@@ -99,6 +104,20 @@ const ConnectivityOptions = (props: Props) => {
             </FlexItem>
           ))}
         </Grid>
+        {loadingOption && (
+          <>
+            <Spacer size="m" />
+            <Row justify="center">
+              <SecondaryButton
+                size="s"
+                onClick={loadingOption.onCancel}
+                data-testid="cancel-azure-login-btn"
+              >
+                Cancel
+              </SecondaryButton>
+            </Row>
+          </>
+        )}
       </section>
     </>
   )

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/constants.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/constants.tsx
@@ -15,6 +15,7 @@ export interface ConnectivityOptionConfig {
 export interface ConnectivityOption extends ConnectivityOptionConfig {
   onClick: () => void
   loading?: boolean
+  onCancel?: () => void
 }
 
 export const CONNECTIVITY_OPTIONS_CONFIG: ConnectivityOptionConfig[] = [

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.spec.ts
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.spec.ts
@@ -17,6 +17,7 @@ jest.mock('uiSrc/slices/app/features', () => ({
 jest.mock('uiSrc/components/hooks/useAzureAuth', () => ({
   useAzureAuth: jest.fn().mockReturnValue({
     initiateLogin: jest.fn(),
+    cancelLogin: jest.fn(),
     loading: false,
     account: null,
   }),
@@ -38,10 +39,12 @@ const mockedUseAzureAuth = useAzureAuth as jest.Mock
 describe('useConnectivityOptions', () => {
   const mockOnClickOption = jest.fn()
   const mockInitiateLogin = jest.fn()
+  const mockCancelLogin = jest.fn()
 
   beforeEach(() => {
     mockedUseAzureAuth.mockReturnValue({
       initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
       loading: false,
       account: null,
     })
@@ -83,6 +86,7 @@ describe('useConnectivityOptions', () => {
     mockedIsAzureEntraIdEnabledSelector.mockReturnValue(true)
     mockedUseAzureAuth.mockReturnValue({
       initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
       loading: false,
       account: null,
     })
@@ -112,6 +116,7 @@ describe('useConnectivityOptions', () => {
     mockedIsAzureEntraIdEnabledSelector.mockReturnValue(true)
     mockedUseAzureAuth.mockReturnValue({
       initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
       loading: false,
       account: mockAccount,
     })
@@ -152,6 +157,7 @@ describe('useConnectivityOptions', () => {
     mockedIsAzureEntraIdEnabledSelector.mockReturnValue(true)
     mockedUseAzureAuth.mockReturnValue({
       initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
       loading: true,
     })
 
@@ -202,5 +208,63 @@ describe('useConnectivityOptions', () => {
     expect(sentinelOption).toBeDefined()
     expect(softwareOption).toBeDefined()
     expect(importOption).toBeDefined()
+  })
+
+  it('should return onCancel from cancelLogin for Azure option', () => {
+    mockedIsAzureEntraIdEnabledSelector.mockReturnValue(true)
+    mockedUseAzureAuth.mockReturnValue({
+      initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
+      loading: false,
+      account: null,
+    })
+
+    const { result } = renderHook(() =>
+      useConnectivityOptions({ onClickOption: mockOnClickOption }),
+    )
+
+    const azureOption = result.current.find(
+      (opt) => opt.type === AddDbType.azure,
+    )
+
+    expect(azureOption?.onCancel).toBe(mockCancelLogin)
+  })
+
+  it('should return onCancel = undefined for non-Azure options', () => {
+    mockedIsAzureEntraIdEnabledSelector.mockReturnValue(false)
+
+    const { result } = renderHook(() =>
+      useConnectivityOptions({ onClickOption: mockOnClickOption }),
+    )
+
+    const nonAzureOptions = result.current.filter(
+      (opt) => opt.type !== AddDbType.azure,
+    )
+
+    nonAzureOptions.forEach((option) => {
+      expect(option.onCancel).toBeUndefined()
+    })
+  })
+
+  it('should call cancelLogin when Azure onCancel is invoked', () => {
+    mockedIsAzureEntraIdEnabledSelector.mockReturnValue(true)
+    mockedUseAzureAuth.mockReturnValue({
+      initiateLogin: mockInitiateLogin,
+      cancelLogin: mockCancelLogin,
+      loading: true,
+      account: null,
+    })
+
+    const { result } = renderHook(() =>
+      useConnectivityOptions({ onClickOption: mockOnClickOption }),
+    )
+
+    const azureOption = result.current.find(
+      (opt) => opt.type === AddDbType.azure,
+    )
+
+    azureOption?.onCancel?.()
+
+    expect(mockCancelLogin).toHaveBeenCalled()
   })
 })

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.ts
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.ts
@@ -22,7 +22,12 @@ export const useConnectivityOptions = ({
 }: UseConnectivityOptionsProps): ConnectivityOption[] => {
   const history = useHistory()
   const isAzureEntraIdEnabled = useSelector(isAzureEntraIdEnabledSelector)
-  const { initiateLogin, loading: azureLoading, account } = useAzureAuth()
+  const {
+    initiateLogin,
+    cancelLogin,
+    loading: azureLoading,
+    account,
+  } = useAzureAuth()
 
   const handleAzureClick = useCallback(() => {
     sendEventTelemetry({
@@ -50,6 +55,13 @@ export const useConnectivityOptions = ({
       return false
     }
 
+    const getCancelHandler = (option: ConnectivityOptionConfig) => {
+      if (option.type === AddDbType.azure) {
+        return cancelLogin
+      }
+      return undefined
+    }
+
     const isFeatureEnabled = (option: ConnectivityOptionConfig) => {
       if (option.type === AddDbType.azure) {
         return isAzureEntraIdEnabled
@@ -62,7 +74,14 @@ export const useConnectivityOptions = ({
         ...config,
         onClick: getClickHandler(config),
         loading: getLoadingState(config),
+        onCancel: getCancelHandler(config),
       }),
     )
-  }, [isAzureEntraIdEnabled, handleAzureClick, azureLoading, onClickOption])
+  }, [
+    isAzureEntraIdEnabled,
+    handleAzureClick,
+    azureLoading,
+    cancelLogin,
+    onClickOption,
+  ])
 }

--- a/redisinsight/ui/src/slices/oauth/azure.ts
+++ b/redisinsight/ui/src/slices/oauth/azure.ts
@@ -192,6 +192,13 @@ export function initiateAzureLoginAction(options: InitiateAzureLoginOptions) {
   }
 }
 
+export function cancelAzureLoginAction() {
+  return (dispatch: AppDispatch) => {
+    clearOAuthTimeout()
+    dispatch(setAzureAuthInitialState())
+  }
+}
+
 export function handleAzureOAuthSuccess(account: AzureAccount) {
   return (dispatch: AppDispatch) => {
     clearOAuthTimeout()

--- a/redisinsight/ui/src/slices/tests/oauth/azure.spec.ts
+++ b/redisinsight/ui/src/slices/tests/oauth/azure.spec.ts
@@ -16,6 +16,7 @@ import reducer, {
   azureAuthAccountSelector,
   azureAuthLoadingSelector,
   initiateAzureLoginAction,
+  cancelAzureLoginAction,
   handleAzureOAuthSuccess,
 } from 'uiSrc/slices/oauth/azure'
 import { AzureLoginSource } from 'uiSrc/slices/interfaces'
@@ -361,6 +362,21 @@ describe('azure auth slice', () => {
         const actions = store.getActions()
         expect(actions).toContainEqual(resetDataAzure())
         expect(actions).toContainEqual(azureOAuthCallbackSuccess(mockAccount))
+      })
+    })
+
+    describe('cancelAzureLoginAction', () => {
+      it('should dispatch setAzureAuthInitialState to reset loading state', () => {
+        store.dispatch<any>(cancelAzureLoginAction())
+
+        const actions = store.getActions()
+        expect(actions).toContainEqual(setAzureAuthInitialState())
+      })
+
+      it('should reset loading to false in the reducer when cancelled', () => {
+        const loadingState = { ...initialState, loading: true }
+        const result = reducer(loadingState, setAzureAuthInitialState())
+        expect(result.loading).toBe(false)
       })
     })
   })


### PR DESCRIPTION
# What

Cherry-pick of **9844d7b** from `main` into `release/3.4.0`:

- Add cancel button for Azure managed Redis OAuth loading state (#5715)

# Testing

- Verify the cancel button appears during the Azure managed Redis OAuth loading state
- Confirm cancelling properly interrupts the OAuth flow

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Azure OAuth state management and adds a new cancellation path that resets auth state and closes popups, which could affect login flows if mis-triggered. Changes are localized and covered by new unit tests, but involve user authentication UX.
> 
> **Overview**
> Adds a user-cancelable Azure Managed Redis OAuth flow: a new `cancelAzureLoginAction` clears the OAuth timeout and resets Azure auth state, and `useAzureAuth` now exposes `cancelLogin` (also closing any open web popup).
> 
> The add-database connectivity options now surface a **Cancel** button whenever an option (Azure) is in a loading state and provides an `onCancel` handler; the connectivity options model/hook is extended to include `onCancel`, and tests are updated/added to cover the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09f9df3cc3c8427ee2f845e8fe9579d32ac805fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->