### PR TITLE
Fix Swagger example for PATCH /api/settings agreements

### DIFF
--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -188,10 +188,14 @@ export class UpdateSettingsDto {
   batchSize?: number;
 
   @ApiPropertyOptional({
-    description: 'Agreements',
+    description:
+      'Agreements. On first setup all keys from the agreements spec must be provided: eula, analytics, notifications, encryption.',
     type: Map,
     example: {
       eula: true,
+      analytics: false,
+      notifications: false,
+      encryption: false,
     },
   })
   @IsOptional()


### PR DESCRIPTION
# What

The Swagger example for the `agreements` field in `PATCH /api/settings` only showed `{ eula: true }`, but the API requires all four agreement keys (`eula`, `analytics`, `notifications`, `encryption`) on first setup. This caused API consumers to get a `400 Bad Request` with messages like `agreements.analytics should not be null or undefined`.

Updated the example and description to list all required keys.

# Testing

1. Start RedisInsight and navigate to Swagger at `http://localhost:5540/api/docs`
2. Open `PATCH /api/settings` endpoint
3. Verify the `agreements` example now shows all four keys

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Swagger/OpenAPI metadata (description and example) for the `agreements` field, without changing validation or runtime behavior.
> 
> **Overview**
> Updates the Swagger documentation for `PATCH /api/settings` so the `agreements` field explicitly documents that first-time setup requires all four keys (`eula`, `analytics`, `notifications`, `encryption`) and shows an example containing all of them, instead of only `eula`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc52bd8f944265ad50383e2bdf5580ac5c2e9e83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->