### PR TITLE
Enabled editing of the host field for existing Redis connections

### DIFF
--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -199,6 +199,39 @@ describe('InstanceForm', () => {
     )
   })
 
+  it('should change host input properly in edit mode', async () => {
+    const handleSubmit = jest.fn()
+    render(
+      <div id="footerDatabaseForm">
+        <ManualConnectionForm
+          {...instance(mockedProps)}
+          isEditMode
+          formFields={{
+            ...formFields,
+            connectionType: ConnectionType.Standalone,
+          }}
+          onSubmit={handleSubmit}
+        />
+      </div>,
+    )
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('host'), {
+        target: { value: 'redis.example.local' },
+      })
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(BTN_SUBMIT))
+    })
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'redis.example.local',
+      }),
+    )
+  })
+
   it('should change tls checkbox', async () => {
     const handleSubmit = jest.fn()
     const handleTestConnection = jest.fn()
@@ -1334,9 +1367,7 @@ describe('InstanceForm', () => {
         />,
       )
 
-      // Host is not shown in edit mode (shown as info above form)
-      expect(screen.queryByTestId('host')).not.toBeInTheDocument()
-      // Port, username, password should be disabled
+      expect(screen.getByTestId('host')).toBeDisabled()
       expect(screen.getByTestId('port')).toBeDisabled()
       expect(screen.getByTestId('username')).toBeDisabled()
       expect(screen.getByTestId('password')).toBeDisabled()
@@ -1374,9 +1405,7 @@ describe('InstanceForm', () => {
         />,
       )
 
-      // Host is not shown in edit mode (shown as info above form)
-      expect(screen.queryByTestId('host')).not.toBeInTheDocument()
-      // Port, username, password should NOT be disabled for non-Azure databases
+      expect(screen.getByTestId('host')).not.toBeDisabled()
       expect(screen.getByTestId('port')).not.toBeDisabled()
       expect(screen.getByTestId('username')).not.toBeDisabled()
       expect(screen.getByTestId('password')).not.toBeDisabled()

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -60,7 +60,7 @@ const EditConnection = (props: Props) => {
             formik={formik}
             showFields={{
               alias: true,
-              host: (!isEditMode || isCloneMode) && !isFromCloud,
+              host: !isFromCloud,
               port: !isFromCloud,
               timeout: true,
             }}

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
@@ -102,7 +102,7 @@ const EditSentinelConnection = (props: Props) => {
       </Title>
       <DatabaseForm
         formik={formik}
-        showFields={{ host: false, port: true, alias: false, timeout: false }}
+        showFields={{ host: true, port: true, alias: false, timeout: false }}
         onHostNamePaste={onHostNamePaste}
       />
     </Col>


### PR DESCRIPTION
# What
Enabled editing of the host field for existing Redis connections in the manual connection edit flow.

Previously, host was hidden in edit mode for regular connections and Sentinel connections, which forced users to recreate or clone a connection when the endpoint changed. This update exposes the host input during editing while keeping the existing restrictions for cloud-managed connections and Azure connections that are intentionally read-only.

The change also updates the related form tests to cover the new edit behavior and to confirm the Azure/non-Azure restrictions still behave correctly.

# Testing
Automation:

Ran redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
Ran redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx
Results:

ManualConnectionFrom.spec.tsx: 42 tests passed
ManualConnectionWrapper.spec.tsx: 8 tests passed
Manual:

Built a Windows installer from this fork and verified the app packages successfully with the change included.


https://github.com/user-attachments/assets/984362cc-7f51-4187-ae46-b2529317b868


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables modifying the connection `host` during edit flows, which affects how existing instances are updated and could lead to misconfigured endpoints if validation/regressions exist. Changes are limited to UI form field visibility/readonly behavior plus test updates.
> 
> **Overview**
> **Manual connection edit flows now expose the `host` field for editing** (previously hidden), including in Sentinel edit mode; `host` remains hidden/blocked for cloud-managed connections.
> 
> **Azure behavior is preserved but adjusted**: the `host` input is now rendered and *disabled* (along with other connection fields) instead of being absent, and tests were updated/added to cover editing `host` and the Azure vs non-Azure readonly rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e68bc940dccbbfd27fdb0cd404311a075bbaf150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->