### PR TITLE
RI-8164: Add/Update element details endpoints 

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Get Element Attribute.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Get Element Attribute.bru
@@ -1,0 +1,55 @@
+meta {
+  name: Get Element Attribute
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/vector-set/get-attributes
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "vset:small_3d",
+    "element": "item_1"
+  }
+}
+
+docs {
+  # Get Element Attribute
+
+  Retrieves the attributes of a single element in the Vector Set stored at `keyName`. Uses the Redis `VGETATTR` command.
+
+  ## Request Body
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The Vector Set key name |
+  | `element` | string | The element name within the vector set |
+
+  ## Response
+
+  Returns `200 OK` with the element's attributes.
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `attributes` | string \| undefined | The attributes string stored on the element, or `undefined` if the element has no attributes |
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Key exists but is not a Vector Set (WRONGTYPE) |
+  | `404` | Key does not exist |
+
+  ## Notes
+
+  - Returns `undefined` for `attributes` when the element has no attributes set (i.e. `VGETATTR` returns `null`).
+  - The `attributes` value is a plain string. While it is typically JSON, Redis does not enforce any format.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Set Element Attribute.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Set Element Attribute.bru
@@ -35,7 +35,11 @@ docs {
 
   ## Response
 
-  Returns `200 OK` with no body on success.
+  Returns `200 OK` with the stored attributes after the update.
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `attributes` | string | The attributes string as stored on the element after the update (read back via `VGETATTR`) |
 
   ## Error Responses
 
@@ -47,7 +51,8 @@ docs {
   ## Notes
 
   - The `attributes` field is a plain string. While it is typically used to store JSON, Redis does not enforce any format.
-  - Use **Get Elements** to retrieve the current attributes for an element.
+  - After setting, the endpoint reads back the stored value using `VGETATTR` to confirm what was persisted.
+  - Use **Get Element Attribute** to retrieve the current attributes for a single element.
 }
 
 settings {

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -6,6 +6,7 @@ import {
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
   SetVectorSetElementAttributeDto,
+  GetVectorSetElementAttributeDto,
 } from 'src/modules/browser/vector-set/dto';
 
 export const vectorSetElementFactory = Factory.define<VectorSetElementDto>(
@@ -37,6 +38,12 @@ export const deleteVectorSetElementsDtoFactory =
       Buffer.from(faker.string.alphanumeric(8)),
       Buffer.from(faker.string.alphanumeric(8)),
     ],
+  }));
+
+export const getVectorSetElementAttributeDtoFactory =
+  Factory.define<GetVectorSetElementAttributeDto>(() => ({
+    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
+    element: Buffer.from(faker.string.alphanumeric(8)),
   }));
 
 export const setVectorSetElementAttributeDtoFactory =

--- a/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-element-attribute.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-element-attribute.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined } from 'class-validator';
+import { IsRedisString, RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+
+export class GetVectorSetElementAttributeDto extends KeyDto {
+  @ApiProperty({
+    type: String,
+    description: 'Element name in the vector set.',
+  })
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  element: RedisString;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-element-attribute.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-element-attribute.response.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GetVectorSetElementAttributeResponse {
+  @ApiPropertyOptional({
+    type: String,
+    description: 'The attributes string stored on the element, if any.',
+  })
+  attributes?: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
@@ -3,4 +3,6 @@ export * from './get.vector-set-elements.dto';
 export * from './get.vector-set-elements.response';
 export * from './delete.vector-set-elements.dto';
 export * from './delete.vector-set-elements.response';
+export * from './get.vector-set-element-attribute.dto';
+export * from './get.vector-set-element-attribute.response';
 export * from './set.vector-set-element-attribute.dto';

--- a/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
@@ -6,3 +6,4 @@ export * from './delete.vector-set-elements.response';
 export * from './get.vector-set-element-attribute.dto';
 export * from './get.vector-set-element-attribute.response';
 export * from './set.vector-set-element-attribute.dto';
+export * from './set.vector-set-element-attribute.response';

--- a/redisinsight/api/src/modules/browser/vector-set/dto/set.vector-set-element-attribute.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/set.vector-set-element-attribute.response.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SetVectorSetElementAttributeResponse {
+  @ApiProperty({
+    type: String,
+    description:
+      'The attributes string as stored on the element after the update.',
+  })
+  attributes: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
@@ -16,9 +16,12 @@ import { ClientMetadata } from 'src/common/models';
 import {
   DeleteVectorSetElementsDto,
   DeleteVectorSetElementsResponse,
+  GetVectorSetElementAttributeDto,
+  GetVectorSetElementAttributeResponse,
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
   SetVectorSetElementAttributeDto,
+  SetVectorSetElementAttributeResponse,
 } from 'src/modules/browser/vector-set/dto';
 import { VectorSetService } from 'src/modules/browser/vector-set/vector-set.service';
 import { BrowserSerializeInterceptor } from 'src/common/interceptors';
@@ -54,17 +57,43 @@ export class VectorSetController extends BrowserBaseController {
     return await this.vectorSetService.getElements(clientMetadata, dto);
   }
 
+  @Post('/get-attributes')
+  @ApiRedisInstanceOperation({
+    description: 'Get attributes of an element in the VectorSet stored at key',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: GetVectorSetElementAttributeResponse,
+      },
+    ],
+  })
+  @ApiQueryRedisStringEncoding()
+  async getElementAttribute(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: GetVectorSetElementAttributeDto,
+  ): Promise<GetVectorSetElementAttributeResponse> {
+    return await this.vectorSetService.getElementAttribute(clientMetadata, dto);
+  }
+
   @Put('/attributes')
   @ApiRedisInstanceOperation({
     description: 'Set attributes on an element of the VectorSet stored at key',
     statusCode: 200,
-    responses: [{ status: 200, description: 'Ok' }],
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: SetVectorSetElementAttributeResponse,
+      },
+    ],
   })
   @ApiQueryRedisStringEncoding()
   async setElementAttribute(
     @BrowserClientMetadata() clientMetadata: ClientMetadata,
     @Body() dto: SetVectorSetElementAttributeDto,
-  ): Promise<void> {
+  ): Promise<SetVectorSetElementAttributeResponse> {
     return await this.vectorSetService.setElementAttribute(clientMetadata, dto);
   }
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -17,6 +17,7 @@ import { BrowserToolVectorSetCommands } from 'src/modules/browser/constants/brow
 import {
   deleteVectorSetElementsDtoFactory,
   getVectorSetElementsDtoFactory,
+  getVectorSetElementAttributeDtoFactory,
   setVectorSetElementAttributeDtoFactory,
   vectorSetElementFactory,
 } from 'src/modules/browser/vector-set/__tests__/vector-set.factory';
@@ -258,6 +259,91 @@ describe('VectorSetService', () => {
     });
   });
 
+  describe('getElementAttribute', () => {
+    const mockGetAttrDto = getVectorSetElementAttributeDtoFactory.build();
+
+    beforeEach(() => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockGetAttrDto.keyName])
+        .mockResolvedValue(true);
+    });
+
+    it('should get element attribute successfully', async () => {
+      const mockAttributes = '{"color":"red"}';
+
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VGetAttr,
+          mockGetAttrDto.keyName,
+          mockGetAttrDto.element,
+        ])
+        .mockResolvedValue(mockAttributes);
+
+      const result = await service.getElementAttribute(
+        mockBrowserClientMetadata,
+        mockGetAttrDto,
+      );
+
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolVectorSetCommands.VGetAttr,
+        mockGetAttrDto.keyName,
+        mockGetAttrDto.element,
+      ]);
+      expect(result.attributes).toEqual(mockAttributes);
+    });
+
+    it('should return undefined attributes when element has no attributes', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VGetAttr,
+          mockGetAttrDto.keyName,
+          mockGetAttrDto.element,
+        ])
+        .mockResolvedValue(null);
+
+      const result = await service.getElementAttribute(
+        mockBrowserClientMetadata,
+        mockGetAttrDto,
+      );
+
+      expect(result.attributes).toBeUndefined();
+    });
+
+    it('should throw NotFoundException when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockGetAttrDto.keyName])
+        .mockResolvedValue(false);
+
+      await expect(
+        service.getElementAttribute(mockBrowserClientMetadata, mockGetAttrDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException for wrong type error', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'VGETATTR',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+
+      await expect(
+        service.getElementAttribute(mockBrowserClientMetadata, mockGetAttrDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException when user has no permissions', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'VGETATTR',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+
+      await expect(
+        service.getElementAttribute(mockBrowserClientMetadata, mockGetAttrDto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
   describe('setElementAttribute', () => {
     const mockSetAttrDto = setVectorSetElementAttributeDtoFactory.build();
 
@@ -267,10 +353,25 @@ describe('VectorSetService', () => {
         .mockResolvedValue(true);
     });
 
-    it('should set element attribute successfully', async () => {
-      client.sendCommand.mockResolvedValue(1);
+    it('should set element attribute and return the stored value', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VSetAttr,
+          mockSetAttrDto.keyName,
+          mockSetAttrDto.element,
+          mockSetAttrDto.attributes,
+        ])
+        .mockResolvedValue(1);
 
-      await service.setElementAttribute(
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VGetAttr,
+          mockSetAttrDto.keyName,
+          mockSetAttrDto.element,
+        ])
+        .mockResolvedValue(mockSetAttrDto.attributes);
+
+      const result = await service.setElementAttribute(
         mockBrowserClientMetadata,
         mockSetAttrDto,
       );
@@ -281,6 +382,12 @@ describe('VectorSetService', () => {
         mockSetAttrDto.element,
         mockSetAttrDto.attributes,
       ]);
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolVectorSetCommands.VGetAttr,
+        mockSetAttrDto.keyName,
+        mockSetAttrDto.element,
+      ]);
+      expect(result.attributes).toEqual(mockSetAttrDto.attributes);
     });
 
     it('should throw NotFoundException when key does not exist', async () => {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -14,9 +14,12 @@ import { ClientMetadata } from 'src/common/models';
 import {
   DeleteVectorSetElementsDto,
   DeleteVectorSetElementsResponse,
+  GetVectorSetElementAttributeDto,
+  GetVectorSetElementAttributeResponse,
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
   SetVectorSetElementAttributeDto,
+  SetVectorSetElementAttributeResponse,
   VectorSetElementDto,
 } from 'src/modules/browser/vector-set/dto';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
@@ -174,10 +177,52 @@ export class VectorSetService {
     }
   }
 
+  public async getElementAttribute(
+    clientMetadata: ClientMetadata,
+    dto: GetVectorSetElementAttributeDto,
+  ): Promise<GetVectorSetElementAttributeResponse> {
+    try {
+      this.logger.debug(
+        'Getting element attribute in the VectorSet data type.',
+        clientMetadata,
+      );
+      const { keyName, element } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyNotExists(keyName, client);
+
+      const attributes = (await client.sendCommand([
+        BrowserToolVectorSetCommands.VGetAttr,
+        keyName,
+        element,
+      ])) as string;
+
+      this.logger.debug(
+        'Succeed to get element attribute in the VectorSet data type.',
+        clientMetadata,
+      );
+
+      return plainToInstance(GetVectorSetElementAttributeResponse, {
+        attributes: attributes || undefined,
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to get element attribute in the VectorSet data type.',
+        error,
+        clientMetadata,
+      );
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
   public async setElementAttribute(
     clientMetadata: ClientMetadata,
     dto: SetVectorSetElementAttributeDto,
-  ): Promise<void> {
+  ): Promise<SetVectorSetElementAttributeResponse> {
     try {
       this.logger.debug(
         'Setting element attribute in the VectorSet data type.',
@@ -196,10 +241,20 @@ export class VectorSetService {
         attributes,
       ]);
 
+      const storedAttributes = (await client.sendCommand([
+        BrowserToolVectorSetCommands.VGetAttr,
+        keyName,
+        element,
+      ])) as string | undefined;
+
       this.logger.debug(
         'Succeed to set element attribute in the VectorSet data type.',
         clientMetadata,
       );
+
+      return plainToInstance(SetVectorSetElementAttributeResponse, {
+        attributes: storedAttributes,
+      });
     } catch (error) {
       this.logger.error(
         'Failed to set element attribute in the VectorSet data type.',


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Add POST /vector-set/get-attributes endpoint to fetch element attributes via VGETATTR
- Update PUT /vector-set/attributes to return the stored attributes in the response (reads back via VGETATTR after VSETATTR)
- Add request/response DTOs for both endpoints
- Add Bruno API docs for the new endpoint, update existing one

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Vector Set API endpoint and changes the `PUT /vector-set/attributes` response contract to include a body, which may impact API clients and introduces an extra Redis round-trip (`VGETATTR`) per update.
> 
> **Overview**
> Adds `POST /vector-set/get-attributes` to fetch a single Vector Set element’s `attributes` via Redis `VGETATTR`, including new request/response DTOs and service/controller wiring.
> 
> Updates `PUT /vector-set/attributes` to return the persisted `attributes` by reading back the value with `VGETATTR` after `VSETATTR`, and adjusts tests and Bruno API docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc825ecbfb8f040ed333bd8dd2eca2309c66a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->