### PR TITLE
RI-8164: Add element details actions/thunks 

### DIFF
--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -65,6 +65,8 @@ enum ApiEndpoints {
 
   VECTOR_SET_GET_ELEMENTS = 'vector-set/get-elements',
   VECTOR_SET_ELEMENTS = 'vector-set/elements',
+  VECTOR_SET_GET_ELEMENT_ATTRIBUTES = 'vector-set/get-attributes',
+  VECTOR_SET_ELEMENT_ATTRIBUTES = 'vector-set/attributes',
 
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',

--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -13,7 +13,10 @@ export const mockVectorSetKeyInfo = {
   size: faker.number.int({ min: 1, max: 1000 }),
 }
 
-export const vectorSetElementFactory = Factory.define<VectorSetElement>(() => ({
+export const mockVectorSetElementAttributes = (): string =>
+  JSON.stringify({ [faker.word.noun()]: faker.word.adjective() })
+
+const buildBaseElement = (): Omit<VectorSetElement, 'attributes'> => ({
   name: stringToBuffer(faker.word.words({ count: { min: 1, max: 3 } })),
   vector: faker.helpers.arrayElements(
     Array.from({ length: 128 }, () =>
@@ -21,10 +24,17 @@ export const vectorSetElementFactory = Factory.define<VectorSetElement>(() => ({
     ),
     faker.number.int({ min: 2, max: 8 }),
   ),
-  attributes: faker.datatype.boolean()
-    ? JSON.stringify({ [faker.word.noun()]: faker.word.adjective() })
-    : undefined,
+})
+
+export const vectorSetElementFactory = Factory.define<VectorSetElement>(() => ({
+  ...buildBaseElement(),
 }))
+
+export const vectorSetElementWithAttributesFactory =
+  Factory.define<VectorSetElement>(() => ({
+    ...buildBaseElement(),
+    attributes: mockVectorSetElementAttributes(),
+  }))
 
 /** Redis key name string for vector set tests (stable shape, random value). */
 export const vectorSetTestKeyName = (): string =>

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -119,6 +119,22 @@ const vectorSetSlice = createSlice({
       )
       state.data.total -= elements.length
     },
+    updateElementAttributes: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        element: RedisResponseBuffer
+        attributes: string
+      }>,
+    ) => {
+      const el = state.data.elements.find((e) =>
+        isEqualBuffers(e.name, payload.element),
+      )
+      if (el) {
+        el.attributes = payload.attributes
+      }
+    },
   },
 })
 
@@ -133,6 +149,7 @@ export const {
   removeVectorSetElementsSuccess,
   removeVectorSetElementsFailure,
   removeElementsFromList,
+  updateElementAttributes,
 } = vectorSetSlice.actions
 
 export const vectorSetSelector = (state: RootState) => state.browser.vectorSet
@@ -278,6 +295,84 @@ export function deleteVectorSetElements(
       const errorMessage = getApiErrorMessage(error)
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
       dispatch(removeVectorSetElementsFailure(errorMessage))
+    }
+  }
+}
+
+export function getVectorSetElementAttribute(
+  key: RedisResponseBuffer,
+  element: RedisResponseBuffer,
+  onSuccessAction?: (attributes?: string) => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { data, status } = await apiService.post<{
+        attributes?: string
+      }>(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.VECTOR_SET_GET_ELEMENT_ATTRIBUTES,
+        ),
+        {
+          keyName: key,
+          element,
+        },
+        { params: { encoding } },
+      )
+
+      if (isStatusSuccessful(status)) {
+        dispatch(
+          updateElementAttributes({
+            element,
+            attributes: data.attributes ?? '',
+          }),
+        )
+        onSuccessAction?.(data.attributes)
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+export function setVectorSetElementAttribute(
+  key: RedisResponseBuffer,
+  element: RedisResponseBuffer,
+  attributes: string,
+  onSuccessAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { data, status } = await apiService.put<{ attributes: string }>(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.VECTOR_SET_ELEMENT_ATTRIBUTES,
+        ),
+        {
+          keyName: key,
+          element,
+          attributes,
+        },
+        { params: { encoding } },
+      )
+
+      if (isStatusSuccessful(status)) {
+        dispatch(
+          updateElementAttributes({
+            element,
+            attributes: data.attributes,
+          }),
+        )
+        onSuccessAction?.()
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
     }
   }
 }

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -16,6 +16,7 @@ import successMessages from 'uiSrc/components/notifications/success-messages'
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 import {
   vectorSetElementFactory,
+  vectorSetElementWithAttributesFactory,
   vectorSetTestKeyName,
   vectorSetPaginationCursorAfter,
 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
@@ -37,10 +38,12 @@ import reducer, {
   removeVectorSetElementsSuccess,
   removeVectorSetElementsFailure,
   removeElementsFromList,
+  updateElementAttributes,
   vectorSetSelector,
   fetchVectorSetElements,
   fetchMoreVectorSetElements,
   deleteVectorSetElements,
+  setVectorSetElementAttribute,
 } from '../../browser/vectorSet'
 
 jest.mock('uiSrc/services', () => ({
@@ -625,6 +628,91 @@ describe('vectorSet slice', () => {
 
         expect(mockedStore.getActions()).toEqual(expectedActions)
       })
+    })
+
+    describe('setVectorSetElementAttribute', () => {
+      const mockElement = vectorSetElementWithAttributesFactory.build()
+      const key = vectorSetTestKeyName()
+      const { name: element, attributes } = mockElement
+
+      it('should dispatch updateElementAttributes with response data when set is successful', async () => {
+        const responsePayload = {
+          status: 200,
+          data: { attributes },
+        }
+        apiService.put = jest.fn().mockResolvedValue(responsePayload)
+
+        const onSuccess = jest.fn()
+
+        await store.dispatch<any>(
+          setVectorSetElementAttribute(
+            key as any,
+            element,
+            attributes!,
+            onSuccess,
+          ),
+        )
+
+        const expectedActions = [
+          updateElementAttributes({
+            element,
+            attributes: attributes!,
+          }),
+        ]
+
+        expect(store.getActions()).toEqual(expectedActions)
+        expect(onSuccess).toHaveBeenCalledTimes(1)
+      })
+
+      it('should dispatch error notification when set fails', async () => {
+        const responsePayload = {
+          response: {
+            status: 500,
+            data: { message: 'Something was wrong!' },
+          },
+        }
+        apiService.put = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(
+          setVectorSetElementAttribute(key as any, element, attributes!),
+        )
+
+        const expectedActions = [
+          addErrorNotification(
+            responsePayload as unknown as IAddInstanceErrorPayload,
+          ),
+        ]
+
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+  })
+
+  describe('updateElementAttributes', () => {
+    it('should update attributes of a matching element', () => {
+      const elements = vectorSetElementFactory.buildList(3)
+      const stateWithElements = {
+        ...initialState,
+        data: {
+          ...initialState.data,
+          total: 3,
+          elements,
+        },
+      }
+
+      const newAttributes = '{"updated":true}'
+      const nextState = reducer(
+        stateWithElements,
+        updateElementAttributes({
+          element: elements[1].name,
+          attributes: newAttributes,
+        }),
+      )
+
+      expect(nextState.data.elements[1].attributes).toEqual(newAttributes)
+      expect(nextState.data.elements[0].attributes).toEqual(
+        elements[0].attributes,
+      )
     })
   })
 })

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -43,6 +43,7 @@ import reducer, {
   fetchVectorSetElements,
   fetchMoreVectorSetElements,
   deleteVectorSetElements,
+  getVectorSetElementAttribute,
   setVectorSetElementAttribute,
 } from '../../browser/vectorSet'
 
@@ -627,6 +628,83 @@ describe('vectorSet slice', () => {
         ]
 
         expect(mockedStore.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('getVectorSetElementAttribute', () => {
+      const mockElement = vectorSetElementWithAttributesFactory.build()
+      const key = vectorSetTestKeyName()
+      const { name: element, attributes } = mockElement
+
+      it('should dispatch updateElementAttributes and call onSuccess when get is successful', async () => {
+        const responsePayload = {
+          status: 200,
+          data: { attributes },
+        }
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        const onSuccess = jest.fn()
+
+        await store.dispatch<any>(
+          getVectorSetElementAttribute(key as any, element, onSuccess),
+        )
+
+        const expectedActions = [
+          updateElementAttributes({
+            element,
+            attributes: attributes!,
+          }),
+        ]
+
+        expect(store.getActions()).toEqual(expectedActions)
+        expect(onSuccess).toHaveBeenCalledTimes(1)
+        expect(onSuccess).toHaveBeenCalledWith(attributes)
+      })
+
+      it('should dispatch updateElementAttributes with empty string when attributes is undefined', async () => {
+        const responsePayload = {
+          status: 200,
+          data: { attributes: undefined },
+        }
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        const onSuccess = jest.fn()
+
+        await store.dispatch<any>(
+          getVectorSetElementAttribute(key as any, element, onSuccess),
+        )
+
+        const expectedActions = [
+          updateElementAttributes({
+            element,
+            attributes: '',
+          }),
+        ]
+
+        expect(store.getActions()).toEqual(expectedActions)
+        expect(onSuccess).toHaveBeenCalledWith(undefined)
+      })
+
+      it('should dispatch error notification when get fails', async () => {
+        const responsePayload = {
+          response: {
+            status: 500,
+            data: { message: 'Something was wrong!' },
+          },
+        }
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(
+          getVectorSetElementAttribute(key as any, element),
+        )
+
+        const expectedActions = [
+          addErrorNotification(
+            responsePayload as unknown as IAddInstanceErrorPayload,
+          ),
+        ]
+
+        expect(store.getActions()).toEqual(expectedActions)
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -768,7 +768,7 @@ describe('vectorSet slice', () => {
 
   describe('updateElementAttributes', () => {
     it('should update attributes of a matching element', () => {
-      const elements = vectorSetElementFactory.buildList(3)
+      const elements = vectorSetElementWithAttributesFactory.buildList(3)
       const stateWithElements = {
         ...initialState,
         data: {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Add `updateElementAttributes` reducer to the vector set Redux slice that updates a single element's attributes in-place by matching element buffer, keeping the store in sync after API calls
- Add `getVectorSetElementAttribute` async thunk that calls `POST /vector-set/get-attributes`, dispatches `updateElementAttributes` on success (falling back to empty string when the response has no attributes), and invokes an optional callback with the returned value
- Add `setVectorSetElementAttribute` async thunk that calls `PUT /vector-set/attributes`, dispatches `updateElementAttributes` with the server-confirmed stored value, and invokes an optional success callback
- Add `VECTOR_SET_GET_ELEMENT_ATTRIBUTES` and `VECTOR_SET_ELEMENT_ATTRIBUTES` constants to the `ApiEndpoints` enum
- Add `vectorSetElementWithAttributesFactory` and `mockVectorSetElementAttributes` helper to the mock factories so tests can build elements with guaranteed attributes
- Add unit tests for `setVectorSetElementAttribute` thunk (success + failure paths) and the `updateElementAttributes` reducer (updates correct element, leaves others untouched)

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

- Possible in this PR -> https://github.com/redis/RedisInsight/pull/5759


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new vector set API calls and Redux state updates to mutate element attributes, which could affect element-detail UI consistency if endpoint contracts or buffer matching are incorrect.
> 
> **Overview**
> Adds vector set element *attribute* support in the UI by introducing new API endpoints (`vector-set/get-attributes`, `vector-set/attributes`) and wiring them into the `vectorSet` Redux slice.
> 
> Implements `updateElementAttributes` plus two thunks, `getVectorSetElementAttribute` and `setVectorSetElementAttribute`, to fetch/persist a single element’s `attributes` and keep the store in sync (including an empty-string fallback when attributes are absent). Updates mocks and expands unit coverage for the new factories, reducer, and thunk success/failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26ee8ec9f735fbb6c27b7f07c52397b4500b59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->