### PR TITLE
RI-8164: Element details components

### DIFF
--- a/redisinsight/ui/src/components/base/forms/buttons/index.ts
+++ b/redisinsight/ui/src/components/base/forms/buttons/index.ts
@@ -9,3 +9,5 @@ export { SecondaryButton } from 'uiSrc/components/base/forms/buttons/SecondaryBu
 export { ToggleButton } from 'uiSrc/components/base/forms/buttons/ToggleButton'
 
 export type { IconType } from 'uiSrc/components/base/forms/buttons/IconButton'
+
+export { TextButton } from '@redis-ui/components'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -27,6 +27,7 @@ const VectorSetDetails = (props: Props) => {
     isDetailsPanelOpen,
     handleViewElement,
     handleClosePanel,
+    handleDrawerDidClose,
   } = useElementDetails()
 
   return (
@@ -47,6 +48,7 @@ const VectorSetDetails = (props: Props) => {
         element={viewedElement}
         isOpen={isDetailsPanelOpen}
         onClose={handleClosePanel}
+        onDrawerDidClose={handleDrawerDidClose}
       />
     </S.Container>
   )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
-
 import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
 import { VectorSetElementList } from './vector-set-element-list'
 import { VectorSetKeySubheader } from './vector-set-key-subheader'
+import { ElementDetails } from './element-details'
+import { useElementDetails } from './hooks'
 import * as S from './VectorSetDetails.styles'
 
 export interface Props extends KeyDetailsHeaderProps {
@@ -21,6 +22,13 @@ const VectorSetDetails = (props: Props) => {
   const { onRemoveKey } = props
   const { loading } = useSelector(selectedKeySelector)
 
+  const {
+    viewedElement,
+    isDetailsPanelOpen,
+    handleViewElement,
+    handleClosePanel,
+  } = useElementDetails()
+
   return (
     <S.Container>
       <KeyDetailsHeader {...props} key="key-details-header" />
@@ -28,10 +36,18 @@ const VectorSetDetails = (props: Props) => {
       <S.DetailsBody>
         {!loading && (
           <S.ListWrapper>
-            <VectorSetElementList onRemoveKey={onRemoveKey} />
+            <VectorSetElementList
+              onRemoveKey={onRemoveKey}
+              onViewElement={handleViewElement}
+            />
           </S.ListWrapper>
         )}
       </S.DetailsBody>
+      <ElementDetails
+        element={viewedElement}
+        isOpen={isDetailsPanelOpen}
+        onClose={handleClosePanel}
+      />
     </S.Container>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
 import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
-import { ElementDetails, ElementDetailsProps } from './ElementDetails'
+import { ElementDetails } from './ElementDetails'
+import { ElementDetailsProps } from './ElementDetails.types'
 
 const mockUseMonacoValidation = jest.fn().mockReturnValue({
   isValid: true,
@@ -38,9 +39,13 @@ const defaultProps: ElementDetailsProps = {
 }
 
 describe('ElementDetails', () => {
+  const renderComponent = (propsOverride?: Partial<ElementDetailsProps>) => {
+    const props = { ...defaultProps, ...propsOverride }
+    return render(<ElementDetails {...props} />)
+  }
+
   beforeEach(() => {
     jest.mocked(setVectorSetElementAttribute).mockClear()
-    ;(defaultProps.onClose as jest.Mock).mockClear()
     mockUseMonacoValidation.mockReturnValue({
       isValid: true,
       isValidating: false,
@@ -48,12 +53,12 @@ describe('ElementDetails', () => {
   })
 
   it('should render when open with element', () => {
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('vector-set-vector-value')).toBeInTheDocument()
   })
 
   it('should display vector values in read-only textarea', () => {
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     const vectorField = screen.getByTestId('vector-set-vector-value')
     const expectedVector = `[${mockElement.vector!.join(', ')}]`
     expect(vectorField).toHaveTextContent(expectedVector)
@@ -61,7 +66,7 @@ describe('ElementDetails', () => {
   })
 
   it('should display formatted attributes in editor', () => {
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     const editor = screen.getByTestId(
       'mock-monaco-editor',
     ) as HTMLTextAreaElement
@@ -74,7 +79,7 @@ describe('ElementDetails', () => {
   })
 
   it('should enter edit mode when edit button is clicked', () => {
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
     expect(
       screen.getByTestId('vector-set-save-attributes-btn'),
@@ -88,7 +93,7 @@ describe('ElementDetails', () => {
     const element = vectorSetElementFactory.build({
       attributes: JSON.stringify({ status: 'original' }),
     })
-    render(<ElementDetails {...defaultProps} element={element} />)
+    renderComponent({ element })
 
     const editor = screen.getByTestId(
       'mock-monaco-editor',
@@ -110,7 +115,7 @@ describe('ElementDetails', () => {
   })
 
   it('should call setVectorSetElementAttribute on save', () => {
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
 
     const editor = screen.getByTestId(
@@ -127,7 +132,7 @@ describe('ElementDetails', () => {
       isValid: false,
       isValidating: false,
     })
-    render(<ElementDetails {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
 
     const saveBtn = screen.getByTestId('vector-set-save-attributes-btn')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
+import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
+import { ElementDetails, ElementDetailsProps } from './ElementDetails'
+
+const mockUseMonacoValidation = jest.fn().mockReturnValue({
+  isValid: true,
+  isValidating: false,
+})
+
+jest.mock('uiSrc/components/monaco-editor', () => ({
+  MonacoEditor: (props: any) => {
+    const mockReact = require('react')
+    return mockReact.createElement('textarea', {
+      'data-testid': 'mock-monaco-editor',
+      value: props.value,
+      readOnly: props.readOnly,
+      onChange: (e: any) => {
+        if (props.onChange) props.onChange(e.target.value)
+      },
+    })
+  },
+  useMonacoValidation: (...args: any[]) => mockUseMonacoValidation(...args),
+}))
+
+jest.mock('uiSrc/slices/browser/vectorSet', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/vectorSet'),
+  setVectorSetElementAttribute: jest.fn(() => jest.fn()),
+}))
+
+const mockElement = vectorSetElementFactory.build()
+
+const defaultProps: ElementDetailsProps = {
+  element: mockElement,
+  isOpen: true,
+  onClose: jest.fn(),
+}
+
+describe('ElementDetails', () => {
+  beforeEach(() => {
+    jest.mocked(setVectorSetElementAttribute).mockClear()
+    ;(defaultProps.onClose as jest.Mock).mockClear()
+    mockUseMonacoValidation.mockReturnValue({
+      isValid: true,
+      isValidating: false,
+    })
+  })
+
+  it('should render when open with element', () => {
+    render(<ElementDetails {...defaultProps} />)
+    expect(screen.getByTestId('vector-set-vector-value')).toBeInTheDocument()
+  })
+
+  it('should display vector values in read-only textarea', () => {
+    render(<ElementDetails {...defaultProps} />)
+    const vectorField = screen.getByTestId('vector-set-vector-value')
+    const expectedVector = `[${mockElement.vector!.join(', ')}]`
+    expect(vectorField).toHaveTextContent(expectedVector)
+    expect(vectorField).toHaveAttribute('readonly')
+  })
+
+  it('should display formatted attributes in editor', () => {
+    render(<ElementDetails {...defaultProps} />)
+    const editor = screen.getByTestId(
+      'mock-monaco-editor',
+    ) as HTMLTextAreaElement
+    if (mockElement.attributes) {
+      const parsed = JSON.parse(mockElement.attributes)
+      Object.keys(parsed).forEach((key) => {
+        expect(editor.value).toContain(key)
+      })
+    }
+  })
+
+  it('should enter edit mode when edit button is clicked', () => {
+    render(<ElementDetails {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
+    expect(
+      screen.getByTestId('vector-set-save-attributes-btn'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('vector-set-cancel-attributes-btn'),
+    ).toBeInTheDocument()
+  })
+
+  it('should revert changes when cancel is clicked', () => {
+    const element = vectorSetElementFactory.build({
+      attributes: JSON.stringify({ status: 'original' }),
+    })
+    render(<ElementDetails {...defaultProps} element={element} />)
+
+    const editor = screen.getByTestId(
+      'mock-monaco-editor',
+    ) as HTMLTextAreaElement
+    const originalValue = editor.value
+
+    fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
+    fireEvent.change(editor, {
+      target: { value: '{"status": "modified"}' },
+    })
+    expect(editor.value).toBe('{"status": "modified"}')
+
+    fireEvent.click(screen.getByTestId('vector-set-cancel-attributes-btn'))
+
+    expect(editor.value).toBe(originalValue)
+    expect(
+      screen.queryByTestId('vector-set-save-attributes-btn'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should call setVectorSetElementAttribute on save', () => {
+    render(<ElementDetails {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
+
+    const editor = screen.getByTestId(
+      'mock-monaco-editor',
+    ) as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '{"changed": true}' } })
+
+    fireEvent.click(screen.getByTestId('vector-set-save-attributes-btn'))
+    expect(setVectorSetElementAttribute).toHaveBeenCalledTimes(1)
+  })
+
+  it('should disable save when validation reports invalid', () => {
+    mockUseMonacoValidation.mockReturnValue({
+      isValid: false,
+      isValidating: false,
+    })
+    render(<ElementDetails {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
+
+    const saveBtn = screen.getByTestId('vector-set-save-attributes-btn')
+    expect(saveBtn).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -10,18 +10,21 @@ const mockUseMonacoValidation = jest.fn().mockReturnValue({
   isValidating: false,
 })
 
-jest.mock('uiSrc/components/monaco-editor', () => ({
-  MonacoEditor: (props: any) => {
+jest.mock('uiSrc/components/base/code-editor', () => ({
+  CodeEditor: (props: any) => {
     const mockReact = require('react')
     return mockReact.createElement('textarea', {
       'data-testid': 'mock-monaco-editor',
       value: props.value,
-      readOnly: props.readOnly,
+      readOnly: props.options?.readOnly,
       onChange: (e: any) => {
         if (props.onChange) props.onChange(e.target.value)
       },
     })
   },
+}))
+
+jest.mock('uiSrc/components/monaco-editor', () => ({
   useMonacoValidation: (...args: any[]) => mockUseMonacoValidation(...args),
 }))
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -36,6 +36,7 @@ const defaultProps: ElementDetailsProps = {
   element: mockElement,
   isOpen: true,
   onClose: jest.fn(),
+  onDrawerDidClose: jest.fn(),
 }
 
 describe('ElementDetails', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -9,7 +9,7 @@ export const Body = styled(Col)`
 `
 
 export const VectorTextArea = styled(TextArea)`
-  font-family: Source Code Pro;
+  font-family: 'Source Code Pro';
   border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
   padding: ${({ theme }) => theme.core?.space?.space020};
   scrollbar-width: thin;

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -17,6 +17,9 @@ export const VectorTextArea = styled(TextArea)`
 
 export const EditorWrapper = styled.div<{ children: React.ReactNode }>`
   position: relative;
+  width: 100%;
+  height: 200px;
+  border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
 `
 
 export const EditButton = styled(IconButton)`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+import { TextArea } from 'uiSrc/components/base/inputs'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
+
+export const Body = styled(Col)`
+  gap: ${({ theme }) => theme.core?.space?.space400};
+  padding-top: ${({ theme }) => theme.core?.space?.space100};
+`
+
+export const VectorTextArea = styled(TextArea)`
+  font-family: Source Code Pro;
+  border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
+  padding: ${({ theme }) => theme.core?.space?.space020};
+  scrollbar-width: thin;
+`
+
+export const EditorWrapper = styled.div<{ children: React.ReactNode }>`
+  position: relative;
+`
+
+export const EditButton = styled(IconButton)`
+  position: absolute;
+  top: ${({ theme }) => theme.core?.space?.space150};
+  right: ${({ theme }) => theme.core?.space?.space200};
+  z-index: 1;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -27,7 +27,12 @@ import { VECTOR_DESCRIPTION, ATTRIBUTES_DESCRIPTION } from './constants'
 import { ElementDetailsProps } from './ElementDetails.types'
 import * as S from './ElementDetails.styles'
 
-const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
+const ElementDetails = ({
+  element,
+  isOpen,
+  onClose,
+  onDrawerDidClose,
+}: ElementDetailsProps) => {
   const dispatch = useDispatch()
   const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
 
@@ -101,75 +106,76 @@ const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
     )
   }, [dispatch, value, element, keyName, isSaveDisabled, savedValue])
 
-  if (!element) return null
-
   return (
     <Drawer
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) onClose()
       }}
+      onDrawerDidClose={onDrawerDidClose}
       data-test-subj="element-details-panel"
     >
       <DrawerHeader title={elementName} />
-      <DrawerBody>
-        <S.Body>
-          <Col gap="l">
-            <Text color="secondary">{VECTOR_DESCRIPTION}</Text>
-            <Col gap="s">
-              <Text color="primary">Vector</Text>
-              <S.VectorTextArea
-                readOnly
-                value={vectorText}
-                data-testid="vector-set-vector-value"
-                height="110px"
-              />
-            </Col>
-          </Col>
-
-          <Col gap="l">
-            <Text color="secondary">{ATTRIBUTES_DESCRIPTION}</Text>
-            <Col gap="s">
-              <Text color="primary">Attributes</Text>
-              <S.EditorWrapper data-testid="vector-set-attributes-json-editor">
-                {!isEditing && (
-                  <S.EditButton
-                    icon={EditIcon}
-                    aria-label="Edit attributes"
-                    onClick={() => setIsEditing(true)}
-                    data-testid="vector-set-edit-attributes-btn"
-                  />
-                )}
-                <Editor
-                  language="json"
-                  value={value}
-                  readOnly={!isEditing}
-                  onChange={setValue}
-                  onEditorDidMount={onEditorDidMount}
-                  data-testid="vector-set-json-editor"
+      {element && (
+        <DrawerBody>
+          <S.Body>
+            <Col gap="l">
+              <Text color="secondary">{VECTOR_DESCRIPTION}</Text>
+              <Col gap="s">
+                <Text color="primary">Vector</Text>
+                <S.VectorTextArea
+                  readOnly
+                  value={vectorText}
+                  data-testid="vector-set-vector-value"
+                  height="110px"
                 />
-              </S.EditorWrapper>
+              </Col>
             </Col>
-            {isEditing && (
-              <Row justify="end" gap="m">
-                <SecondaryButton
-                  onClick={handleCancelEditing}
-                  data-testid="vector-set-cancel-attributes-btn"
-                >
-                  Cancel
-                </SecondaryButton>
-                <PrimaryButton
-                  disabled={isSaveDisabled}
-                  onClick={handleSave}
-                  data-testid="vector-set-save-attributes-btn"
-                >
-                  Save
-                </PrimaryButton>
-              </Row>
-            )}
-          </Col>
-        </S.Body>
-      </DrawerBody>
+
+            <Col gap="l">
+              <Text color="secondary">{ATTRIBUTES_DESCRIPTION}</Text>
+              <Col gap="s">
+                <Text color="primary">Attributes</Text>
+                <S.EditorWrapper data-testid="vector-set-attributes-json-editor">
+                  {!isEditing && (
+                    <S.EditButton
+                      icon={EditIcon}
+                      aria-label="Edit attributes"
+                      onClick={() => setIsEditing(true)}
+                      data-testid="vector-set-edit-attributes-btn"
+                    />
+                  )}
+                  <Editor
+                    language="json"
+                    value={value}
+                    readOnly={!isEditing}
+                    onChange={setValue}
+                    onEditorDidMount={onEditorDidMount}
+                    data-testid="vector-set-json-editor"
+                  />
+                </S.EditorWrapper>
+              </Col>
+              {isEditing && (
+                <Row justify="end" gap="m">
+                  <SecondaryButton
+                    onClick={handleCancelEditing}
+                    data-testid="vector-set-cancel-attributes-btn"
+                  >
+                    Cancel
+                  </SecondaryButton>
+                  <PrimaryButton
+                    disabled={isSaveDisabled}
+                    onClick={handleSave}
+                    data-testid="vector-set-save-attributes-btn"
+                  >
+                    Save
+                  </PrimaryButton>
+                </Row>
+              )}
+            </Col>
+          </S.Body>
+        </DrawerBody>
+      )}
     </Drawer>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -69,8 +69,7 @@ const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
     setIsEditing(false)
   }, [savedValue])
 
-  const isValueEmpty = value.trim() === ''
-  const isValueValid = isValueEmpty || (isValid && !isValidating)
+  const isValueValid = isValid && !isValidating
   const isSaveDisabled = !isValueValid || value === savedValue
 
   const handleSave = useCallback(() => {
@@ -160,7 +159,7 @@ const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
                   Cancel
                 </SecondaryButton>
                 <PrimaryButton
-                  disabled={!isValid || isValidating || value === savedValue}
+                  disabled={isSaveDisabled}
                   onClick={handleSave}
                   data-testid="vector-set-save-attributes-btn"
                 >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { monaco } from 'react-monaco-editor'
+
+import { VectorSetElement, RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import {
+  Drawer,
+  DrawerHeader,
+  DrawerBody,
+} from 'uiSrc/components/base/layout/drawer'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
+import {
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+import { EditIcon } from 'uiSrc/components/base/icons'
+import {
+  MonacoEditor as Editor,
+  useMonacoValidation,
+} from 'uiSrc/components/monaco-editor'
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
+import { bufferToString } from 'uiSrc/utils'
+import * as S from './ElementDetails.styles'
+
+const VECTOR_DESCRIPTION =
+  'The numerical embedding representing this item in vector space, used for similarity search and ranking.'
+const ATTRIBUTES_DESCRIPTION =
+  'Structured metadata associated with this item, used for filtering, display, and hybrid search queries.'
+
+export interface ElementDetailsProps {
+  element: VectorSetElement | null
+  isOpen: boolean
+  onClose: () => void
+}
+
+const formatVector = (vector?: number[]): string => {
+  if (!vector?.length) return '[]'
+  return `[${vector.join(', ')}]`
+}
+
+const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
+  const dispatch = useDispatch()
+  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
+
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
+  const { isValid, isValidating } = useMonacoValidation(editorRef)
+
+  const onEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    editorRef.current = editor
+  }
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [value, setValue] = useState('')
+  const [savedValue, setSavedValue] = useState('')
+
+  useEffect(() => {
+    const formatted = bufferToString(element?.attributes)
+    setValue(formatted)
+    setIsEditing(false)
+  }, [element])
+
+  const elementName = useMemo(
+    () => (element ? bufferToString(element.name) : ''),
+    [element],
+  )
+
+  useEffect(() => {
+    if (isEditing) {
+      setSavedValue(value)
+    }
+  }, [isEditing])
+
+  const vectorText = useMemo(
+    () => formatVector(element?.vector),
+    [element?.vector],
+  )
+
+  const handleCancelEditing = useCallback(() => {
+    setValue(savedValue)
+    setIsEditing(false)
+  }, [savedValue])
+
+  const isValueEmpty = value.trim() === ''
+  const isValueValid = isValueEmpty || (isValid && !isValidating)
+  const isSaveDisabled = !isValueValid || value === savedValue
+
+  const handleSave = useCallback(() => {
+    if (!element || isSaveDisabled) return
+
+    const trimmed = value.trim()
+    const formatted = trimmed
+      ? JSON.stringify(JSON.parse(trimmed), null, 2)
+      : ''
+
+    const applyFormatted = () => {
+      setIsEditing(false)
+      setValue(formatted)
+      setSavedValue(formatted)
+    }
+
+    if (formatted === savedValue) {
+      applyFormatted()
+      return
+    }
+
+    dispatch(
+      setVectorSetElementAttribute(
+        keyName as RedisResponseBuffer,
+        element.name,
+        formatted,
+        applyFormatted,
+      ),
+    )
+  }, [dispatch, value, element, keyName, isSaveDisabled, savedValue])
+
+  if (!element) return null
+
+  return (
+    <Drawer
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      data-test-subj="element-details-panel"
+    >
+      <DrawerHeader title={elementName} />
+      <DrawerBody>
+        <S.Body>
+          <Col gap="l">
+            <Text color="secondary">{VECTOR_DESCRIPTION}</Text>
+            <Col gap="s">
+              <Text color="primary">Vector</Text>
+              <S.VectorTextArea
+                readOnly
+                value={vectorText}
+                data-testid="vector-set-vector-value"
+                height="110px"
+              />
+            </Col>
+          </Col>
+
+          <Col gap="l">
+            <Text color="secondary">{ATTRIBUTES_DESCRIPTION}</Text>
+            <Col gap="s">
+              <Text color="primary">Attributes</Text>
+              <S.EditorWrapper data-testid="vector-set-attributes-json-editor">
+                {!isEditing && (
+                  <S.EditButton
+                    icon={EditIcon}
+                    aria-label="Edit attributes"
+                    onClick={() => setIsEditing(true)}
+                    data-testid="vector-set-edit-attributes-btn"
+                  />
+                )}
+                <Editor
+                  language="json"
+                  value={value}
+                  readOnly={!isEditing}
+                  onChange={setValue}
+                  onEditorDidMount={onEditorDidMount}
+                  data-testid="vector-set-json-editor"
+                />
+              </S.EditorWrapper>
+            </Col>
+            {isEditing && (
+              <Row justify="end" gap="m">
+                <SecondaryButton
+                  onClick={handleCancelEditing}
+                  data-testid="vector-set-cancel-attributes-btn"
+                >
+                  Cancel
+                </SecondaryButton>
+                <PrimaryButton
+                  disabled={!isValid || isValidating || value === savedValue}
+                  onClick={handleSave}
+                  data-testid="vector-set-save-attributes-btn"
+                >
+                  Save
+                </PrimaryButton>
+              </Row>
+            )}
+          </Col>
+        </S.Body>
+      </DrawerBody>
+    </Drawer>
+  )
+}
+
+export { ElementDetails }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -15,15 +15,17 @@ import {
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { EditIcon } from 'uiSrc/components/base/icons'
-import {
-  MonacoEditor as Editor,
-  useMonacoValidation,
-} from 'uiSrc/components/monaco-editor'
+import { CodeEditor } from 'uiSrc/components/base/code-editor'
+import { useMonacoValidation } from 'uiSrc/components/monaco-editor'
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
 import { bufferToString } from 'uiSrc/utils'
 import { formatVector } from './utils'
-import { VECTOR_DESCRIPTION, ATTRIBUTES_DESCRIPTION } from './constants'
+import {
+  VECTOR_DESCRIPTION,
+  ATTRIBUTES_DESCRIPTION,
+  ATTRIBUTES_EDITOR_OPTIONS,
+} from './constants'
 import { ElementDetailsProps } from './ElementDetails.types'
 import * as S from './ElementDetails.styles'
 
@@ -145,13 +147,15 @@ const ElementDetails = ({
                       data-testid="vector-set-edit-attributes-btn"
                     />
                   )}
-                  <Editor
+                  <CodeEditor
                     language="json"
                     value={value}
-                    readOnly={!isEditing}
+                    options={{
+                      ...ATTRIBUTES_EDITOR_OPTIONS,
+                      readOnly: !isEditing,
+                    }}
                     onChange={setValue}
-                    onEditorDidMount={onEditorDidMount}
-                    data-testid="vector-set-json-editor"
+                    editorDidMount={onEditorDidMount}
                   />
                 </S.EditorWrapper>
               </Col>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -83,9 +83,15 @@ const ElementDetails = ({
     if (!element || isSaveDisabled) return
 
     const trimmed = value.trim()
-    const formatted = trimmed
-      ? JSON.stringify(JSON.parse(trimmed), null, 2)
-      : ''
+
+    // Guard against invalid JSON that can slip through due to a race condition
+    // in useMonacoValidation (decorations reset isValidating before markers update isValid)
+    let formatted: string
+    try {
+      formatted = trimmed ? JSON.stringify(JSON.parse(trimmed), null, 2) : ''
+    } catch {
+      return
+    }
 
     const applyFormatted = () => {
       setIsEditing(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { monaco } from 'react-monaco-editor'
 
-import { VectorSetElement, RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
   Drawer,
   DrawerHeader,
@@ -22,23 +22,10 @@ import {
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
 import { bufferToString } from 'uiSrc/utils'
+import { formatVector } from './utils'
+import { VECTOR_DESCRIPTION, ATTRIBUTES_DESCRIPTION } from './constants'
+import { ElementDetailsProps } from './ElementDetails.types'
 import * as S from './ElementDetails.styles'
-
-const VECTOR_DESCRIPTION =
-  'The numerical embedding representing this item in vector space, used for similarity search and ranking.'
-const ATTRIBUTES_DESCRIPTION =
-  'Structured metadata associated with this item, used for filtering, display, and hybrid search queries.'
-
-export interface ElementDetailsProps {
-  element: VectorSetElement | null
-  isOpen: boolean
-  onClose: () => void
-}
-
-const formatVector = (vector?: number[]): string => {
-  if (!vector?.length) return '[]'
-  return `[${vector.join(', ')}]`
-}
 
 const ElementDetails = ({ element, isOpen, onClose }: ElementDetailsProps) => {
   const dispatch = useDispatch()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -60,16 +60,15 @@ const ElementDetails = ({
     [element],
   )
 
-  useEffect(() => {
-    if (isEditing) {
-      setSavedValue(value)
-    }
-  }, [isEditing])
-
   const vectorText = useMemo(
     () => formatVector(element?.vector),
     [element?.vector],
   )
+
+  const startEditing = useCallback(() => {
+    setSavedValue(value)
+    setIsEditing(true)
+  }, [value])
 
   const handleCancelEditing = useCallback(() => {
     setValue(savedValue)
@@ -149,7 +148,7 @@ const ElementDetails = ({
                     <S.EditButton
                       icon={EditIcon}
                       aria-label="Edit attributes"
-                      onClick={() => setIsEditing(true)}
+                      onClick={startEditing}
                       data-testid="vector-set-edit-attributes-btn"
                     />
                   )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.types.ts
@@ -1,0 +1,7 @@
+import { VectorSetElement } from 'uiSrc/slices/interfaces'
+
+export interface ElementDetailsProps {
+  element: VectorSetElement | null
+  isOpen: boolean
+  onClose: () => void
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.types.ts
@@ -4,4 +4,5 @@ export interface ElementDetailsProps {
   element: VectorSetElement | null
   isOpen: boolean
   onClose: () => void
+  onDrawerDidClose: () => void
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
@@ -1,4 +1,26 @@
+import { monaco as monacoEditor } from 'react-monaco-editor'
+
 export const VECTOR_DESCRIPTION =
   'The numerical embedding representing this item in vector space, used for similarity search and ranking.'
 export const ATTRIBUTES_DESCRIPTION =
   'Structured metadata associated with this item, used for filtering, display, and hybrid search queries.'
+
+export const ATTRIBUTES_EDITOR_OPTIONS: Partial<monacoEditor.editor.IStandaloneEditorConstructionOptions> =
+  {
+    domReadOnly: false,
+    contextmenu: false,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    stickyScroll: { enabled: false },
+    overviewRulerLanes: 0,
+    renderLineHighlight: 'none',
+    folding: false,
+    guides: {
+      indentation: false,
+      bracketPairs: false,
+    },
+    scrollbar: {
+      vertical: 'auto' as const,
+      horizontal: 'auto' as const,
+    },
+  }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
@@ -1,0 +1,4 @@
+export const VECTOR_DESCRIPTION =
+  'The numerical embedding representing this item in vector space, used for similarity search and ranking.'
+export const ATTRIBUTES_DESCRIPTION =
+  'Structured metadata associated with this item, used for filtering, display, and hybrid search queries.'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/index.ts
@@ -1,0 +1,1 @@
+export { ElementDetails } from './ElementDetails'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/utils.ts
@@ -1,0 +1,4 @@
+export const formatVector = (vector?: number[]): string => {
+  if (!vector?.length) return '[]'
+  return `[${vector.join(', ')}]`
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useElementDetails } from './useElementDetails'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails.ts
@@ -12,6 +12,7 @@ export const useElementDetails = () => {
   const [viewedElement, setViewedElement] = useState<VectorSetElement | null>(
     null,
   )
+  const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false)
 
   const handleViewElement = useCallback(
     (element: VectorSetElement) => {
@@ -23,6 +24,7 @@ export const useElementDetails = () => {
           element.name,
           (attributes) => {
             setViewedElement({ ...element, attributes })
+            setIsDetailsPanelOpen(true)
           },
         ),
       )
@@ -31,13 +33,18 @@ export const useElementDetails = () => {
   )
 
   const handleClosePanel = useCallback(() => {
+    setIsDetailsPanelOpen(false)
+  }, [])
+
+  const handleDrawerDidClose = useCallback(() => {
     setViewedElement(null)
   }, [])
 
   return {
     viewedElement,
-    isDetailsPanelOpen: !!viewedElement,
+    isDetailsPanelOpen,
     handleViewElement,
     handleClosePanel,
+    handleDrawerDidClose,
   }
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { getVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
+import { VectorSetElement, RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export const useElementDetails = () => {
+  const dispatch = useDispatch()
+  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
+
+  const [viewedElement, setViewedElement] = useState<VectorSetElement | null>(
+    null,
+  )
+
+  const handleViewElement = useCallback(
+    (element: VectorSetElement) => {
+      if (!keyName) return
+
+      dispatch(
+        getVectorSetElementAttribute(
+          keyName as RedisResponseBuffer,
+          element.name,
+          (attributes) => {
+            setViewedElement({ ...element, attributes })
+          },
+        ),
+      )
+    },
+    [dispatch, keyName],
+  )
+
+  const handleClosePanel = useCallback(() => {
+    setViewedElement(null)
+  }, [])
+
+  return {
+    viewedElement,
+    isDetailsPanelOpen: !!viewedElement,
+    handleViewElement,
+    handleClosePanel,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ColumnDef, Row } from 'uiSrc/components/base/layout/table'
+import { ColumnDef } from 'uiSrc/components/base/layout/table'
 import { VectorSetElement } from 'uiSrc/slices/interfaces'
 import {
   bufferToString,
@@ -8,13 +8,15 @@ import {
   createDeleteFieldMessage,
 } from 'uiSrc/utils'
 import HelpTexts from 'uiSrc/constants/help-texts'
-import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
+import { Row } from 'uiSrc/components/base/layout/flex'
 import { ElementNameCell } from './components/ElementNameCell/ElementNameCell'
+import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
 import {
   ElementsListConfig,
   VectorSetColumn,
 } from './VectorSetElementList.types'
 import { VECTOR_SET_COLUMN_HEADERS } from './constants'
+import * as S from './VectorSetElementList.styles'
 
 const createNameColumn = (
   listConfig: ElementsListConfig,
@@ -45,7 +47,11 @@ const createActionsColumn = (
   size: 10,
   cell: ({ row }: { row: Row<VectorSetElement> }) => {
     const { name: nameBuffer } = row.original
-    const { viewFormat, elementDeleteConfig: deleteConfig } = listConfig
+    const {
+      viewFormat,
+      elementDeleteConfig: deleteConfig,
+      onViewElement,
+    } = listConfig
     const {
       deleting,
       suffix,
@@ -60,7 +66,15 @@ const createActionsColumn = (
     const name = bufferToString(nameBuffer, viewFormat)
 
     return (
-      <div className="value-table-actions">
+      <Row gap="s" align="center" justify="center">
+        <S.StyledTextButton
+          onClick={() => onViewElement(row.original)}
+          data-testid={`vector-set-view-btn-${name}`}
+          variant="primary-inline"
+          color="informative400"
+        >
+          View
+        </S.StyledTextButton>
         <PopoverDelete
           header={createDeleteFieldHeader(nameBuffer)}
           text={createDeleteFieldMessage(keyName)}
@@ -76,7 +90,7 @@ const createActionsColumn = (
           testid={`vector-set-remove-btn-${name}`}
           appendInfo={total === 1 ? HelpTexts.REMOVE_LAST_ELEMENT() : null}
         />
-      </div>
+      </Row>
     )
   },
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
@@ -28,42 +28,55 @@ jest.mock('uiSrc/slices/browser/vectorSet', () => {
 })
 
 describe('VectorSetElementList', () => {
+  const defaultProps = {
+    onRemoveKey: jest.fn(),
+    onViewElement: jest.fn(),
+  }
+
   beforeEach(() => {
     jest.mocked(deleteVectorSetElements).mockClear()
+    defaultProps.onViewElement.mockClear()
   })
 
   it('should render', () => {
-    expect(
-      render(<VectorSetElementList onRemoveKey={jest.fn()} />),
-    ).toBeTruthy()
+    expect(render(<VectorSetElementList {...defaultProps} />)).toBeTruthy()
   })
 
   it('should render rows properly', () => {
-    const { container } = render(
-      <VectorSetElementList onRemoveKey={jest.fn()} />,
-    )
+    const { container } = render(<VectorSetElementList {...defaultProps} />)
     const rows = container.querySelectorAll('tbody tr')
     expect(rows).toHaveLength(3)
   })
 
   it('should render vector-set-details test id', () => {
-    render(<VectorSetElementList onRemoveKey={jest.fn()} />)
+    render(<VectorSetElementList {...defaultProps} />)
     expect(screen.getByTestId('vector-set-details')).toBeInTheDocument()
   })
 
   it('should render a remove control for each element row', () => {
-    render(<VectorSetElementList onRemoveKey={jest.fn()} />)
+    render(<VectorSetElementList {...defaultProps} />)
     expect(screen.getAllByLabelText(/remove field/i)).toHaveLength(3)
   })
 
+  it('should render a view button for each element row', () => {
+    render(<VectorSetElementList {...defaultProps} />)
+    expect(screen.getAllByRole('button', { name: 'View' })).toHaveLength(3)
+  })
+
+  it('should call onViewElement when view button is clicked', () => {
+    render(<VectorSetElementList {...defaultProps} />)
+    fireEvent.click(screen.getAllByRole('button', { name: 'View' })[0])
+    expect(defaultProps.onViewElement).toHaveBeenCalledTimes(1)
+  })
+
   it('should open delete confirmation after clicking remove on a row', () => {
-    render(<VectorSetElementList onRemoveKey={jest.fn()} />)
+    render(<VectorSetElementList {...defaultProps} />)
     fireEvent.click(screen.getAllByLabelText(/remove field/i)[0])
     expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
   })
 
   it('should call deleteVectorSetElements when delete is confirmed', () => {
-    render(<VectorSetElementList onRemoveKey={jest.fn()} />)
+    render(<VectorSetElementList {...defaultProps} />)
     fireEvent.click(screen.getAllByLabelText(/remove field/i)[0])
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
     expect(deleteVectorSetElements).toHaveBeenCalledTimes(1)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { Table } from 'uiSrc/components/base/layout/table'
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
+import { TextButton } from 'uiSrc/components/base/forms/buttons'
 
 export const Container = styled(FlexItem)`
   display: flex;
@@ -11,9 +12,23 @@ export const Container = styled(FlexItem)`
 `
 
 export const StyledTable = styled(Table)`
+  scrollbar-width: thin;
   max-height: 100%;
+  box-shadow: 0px 0px 0px 1px
+    ${({ theme }) => theme.semantic.color.border.neutral500};
 
   [data-role='table-scroller'] {
     scrollbar-width: thin;
   }
+
+  [data-role='pagination'] {
+    scrollbar-width: thin;
+    border-top: 1px solid
+      ${({ theme }) => theme.semantic.color.border.neutral500};
+  }
+`
+
+export const StyledTextButton = styled(TextButton)`
+  margin-top: ${({ theme }) => theme.core.space.space025};
+  color: ${({ theme }) => theme.semantic.color.text.informative400};
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
@@ -1,13 +1,15 @@
 import React, { memo } from 'react'
 
+import { VectorSetElement } from 'uiSrc/slices/interfaces'
 import useVectorSetElementListData from './hooks/useVectorSetElementListData'
 import * as S from './VectorSetElementList.styles'
 
 export interface Props {
   onRemoveKey: () => void
+  onViewElement: (element: VectorSetElement) => void
 }
 
-const VectorSetElementList = memo(({ onRemoveKey }: Props) => {
+const VectorSetElementList = memo(({ onRemoveKey, onViewElement }: Props) => {
   const {
     columns,
     currentPageData,
@@ -17,7 +19,7 @@ const VectorSetElementList = memo(({ onRemoveKey }: Props) => {
     emptyMessage,
     isPaginationSupported,
     total,
-  } = useVectorSetElementListData({ onRemoveKey })
+  } = useVectorSetElementListData({ onRemoveKey, onViewElement })
 
   return (
     <S.Container data-testid="vector-set-details">

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.types.ts
@@ -22,6 +22,7 @@ export interface ElementsListConfig {
   compressor: Nullable<KeyValueCompressor>
   viewFormat: KeyValueFormat
   elementDeleteConfig: ElementDeleteConfig
+  onViewElement: (element: VectorSetElement) => void
 }
 
 export interface ElementNameCellProps {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/hooks/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/hooks/useVectorSetElementListData.ts
@@ -13,7 +13,11 @@ import {
   vectorSetDataSelector,
   vectorSetSelector,
 } from 'uiSrc/slices/browser/vectorSet'
-import { RedisResponseBuffer, RedisString } from 'uiSrc/slices/interfaces'
+import {
+  RedisResponseBuffer,
+  RedisString,
+  VectorSetElement,
+} from 'uiSrc/slices/interfaces'
 
 import { getVectorSetColumns } from '../VectorSetElementList.config'
 import {
@@ -27,10 +31,12 @@ const MIN_COLUMN_WIDTH = 100
 
 export interface UseVectorSetElementListDataParams {
   onRemoveKey: () => void
+  onViewElement: (element: VectorSetElement) => void
 }
 
 const useVectorSetElementListData = ({
   onRemoveKey,
+  onViewElement,
 }: UseVectorSetElementListDataParams) => {
   const { loading } = useSelector(vectorSetSelector)
   const { elements, nextCursor, total, isPaginationSupported } = useSelector(
@@ -95,6 +101,7 @@ const useVectorSetElementListData = ({
       compressor: compressor as any,
       viewFormat,
       elementDeleteConfig: deleteConfig,
+      onViewElement,
     }
     return getVectorSetColumns(listConfig)
   }, [compressor, viewFormat, deleting, total, key, closePopover, showPopover])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/hooks/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/hooks/useVectorSetElementListData.ts
@@ -104,7 +104,16 @@ const useVectorSetElementListData = ({
       onViewElement,
     }
     return getVectorSetColumns(listConfig)
-  }, [compressor, viewFormat, deleting, total, key, closePopover, showPopover])
+  }, [
+    compressor,
+    viewFormat,
+    deleting,
+    total,
+    key,
+    closePopover,
+    showPopover,
+    onViewElement,
+  ])
 
   const tableMinWidth = useMemo(
     () => `${Math.max(columns.length * MIN_COLUMN_WIDTH, 550)}px`,


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Add `ElementDetails` drawer component that displays a vector set element's vector (read-only textarea) and attributes (Monaco JSON editor with inline edit/save/cancel flow, validated via `useMonacoValidation`)
- Add `useElementDetails` hook that manages the viewed element state and fetches fresh attributes via `getVectorSetElementAttribute` when the user clicks "View"
- Add "View" `TextButton` to each element row in the vector set table, wired through `onViewElement` prop from `VectorSetElementList` up to `VectorSetDetails`
- Wire `ElementDetails` drawer and `useElementDetails` hook into `VectorSetDetails`, passing `viewedElement`, `isDetailsPanelOpen`, `handleViewElement`, and `handleClosePanel`
- Export `TextButton` from `@redis-ui/components` through the shared buttons barrel
- Add styled components for the element details panel (`Body`, `VectorTextArea`, `EditorWrapper`, `EditButton`) and additional table styles (`StyledTextButton`, table border/pagination styling)
- Add unit tests for `ElementDetails` covering render, read-only vector display, edit mode toggling, cancel reverting changes, save dispatching `setVectorSetElementAttribute`, and save disabled on invalid JSON
- Update `VectorSetElementList` tests to cover the new `onViewElement` prop and "View" button interactions

| Light | Dark |
| --- | --- | 
| <img width="1400" height="875" alt="image" src="https://github.com/user-attachments/assets/6f450982-0aac-4184-8661-80cafe0fc459" /> | <img width="1400" height="875" alt="image" src="https://github.com/user-attachments/assets/600ccca6-6e36-454c-8436-4b815ec734e4" /> | 
| <img width="1400" height="875" alt="image" src="https://github.com/user-attachments/assets/8235b913-acf5-452d-9cfb-f2a3b1c58bf1" /> | <img width="1400" height="875" alt="image" src="https://github.com/user-attachments/assets/ac1ef778-8ee1-4a90-b7cc-925b3fab25a1" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Add vector set key

`VADD vset VALUES 3 1 2 3 v1`

2. Refresh and open the key details
3. Visualize the elements table
4. Click on the View button
5. Visualize the drawer 
6. Edit the attributes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new UI flow that reads and updates vector-set element attributes via Redux thunks; incorrect validation/state handling could lead to lost edits or unintended attribute writes.
> 
> **Overview**
> Adds an **Element Details** drawer for vector-set elements, opened via a new per-row **View** action in the elements table. The drawer shows the element vector (read-only) and enables inline editing of JSON `attributes` with Monaco validation plus Save/Cancel behavior.
> 
> Introduces a `useElementDetails` hook to fetch fresh attributes on view (`getVectorSetElementAttribute`) and to manage drawer state/cleanup, and wires this through `VectorSetDetails`/`VectorSetElementList` via a new `onViewElement` prop. Also exports `TextButton` from the shared buttons barrel, updates table/panel styling, and adds unit tests covering the new drawer and View button interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374573dc8f39912621c605eddaacf914f4e0a421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->