### PR TITLE
Fix Windows build

### DIFF
--- a/redisinsight/api/scripts/default-content.ts
+++ b/redisinsight/api/scripts/default-content.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import {
   getFile,
   updateFolderFromArchive,
@@ -10,11 +9,11 @@ const PATH_CONFIG = get('dir_path');
 const CONTENT_CONFIG = get('content');
 
 const archiveUrl = new URL(
-  path.join(CONTENT_CONFIG.updateUrl, CONTENT_CONFIG.zip),
+  `${CONTENT_CONFIG.updateUrl}/${CONTENT_CONFIG.zip}`,
 ).toString();
 
 const buildInfoUrl = new URL(
-  path.join(CONTENT_CONFIG.updateUrl, CONTENT_CONFIG.buildInfo),
+  `${CONTENT_CONFIG.updateUrl}/${CONTENT_CONFIG.buildInfo}`,
 ).toString();
 
 async function init() {

--- a/redisinsight/api/scripts/default-tutorials.ts
+++ b/redisinsight/api/scripts/default-tutorials.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import {
   getFile,
   updateFolderFromArchive,
@@ -10,11 +9,11 @@ const PATH_CONFIG = get('dir_path');
 const TUTORIALS_CONFIG = get('tutorials');
 
 const archiveUrl = new URL(
-  path.join(TUTORIALS_CONFIG.updateUrl, TUTORIALS_CONFIG.zip),
+  `${TUTORIALS_CONFIG.updateUrl}/${TUTORIALS_CONFIG.zip}`,
 ).toString();
 
 const buildInfoUrl = new URL(
-  path.join(TUTORIALS_CONFIG.updateUrl, TUTORIALS_CONFIG.buildInfo),
+  `${TUTORIALS_CONFIG.updateUrl}/${TUTORIALS_CONFIG.buildInfo}`,
 ).toString();
 
 async function init() {


### PR DESCRIPTION
# What

The Windows release build (`pipeline-build-windows.yml`) fails at the `yarn build:statics:win` step with:

```
TypeError: Invalid URL
    at new URL (node:internal/url:827:25)
    at Object.<anonymous> (.../api/scripts/default-content.ts:12:20)
    ...
  input: '.\https:\github.com\RedisInsight\Statics\releases\download\2.54\data.zip'
```

**Root cause:** The Node.js bump from 22.12.0 to 22.22.0 (`edc7a66ca`) included a security fix for [CVE-2025-23084](https://github.com/nodejs/node/issues/56933) that changed `path.win32.join` behavior. Strings containing a colon (like `https:`) now get a `.\` prefix to prevent path traversal attacks. This broke `default-content.ts` and `default-tutorials.ts`, which were using `path.join` to concatenate URL segments — `path.join` is for filesystem paths, not URLs.

| Node.js | `path.win32.join('https://...', 'data.zip')` | `new URL(result)` |
|---------|-----------------------------------------------|-------------------|
| 22.12.0 | `https:\github.com\...\data.zip` | Worked (URL parser treats `\` as `/`) |
| 22.22.0 | `.\https:\github.com\...\data.zip` | **Fails** (`.\` prefix = relative URL) |

**Fix:** Replace `path.join(baseUrl, filename)` with a template literal `` `${baseUrl}/${filename}` ``, keeping the `new URL()` validation wrapper intact.

# Testing

- Windows release pipeline should pass `yarn build:statics:win`
- Linux/macOS builds are unaffected (they use POSIX `path.join` which always used `/`)

---

Fixes https://github.com/redis/RedisInsight/actions/runs/24192000259/job/70619582436

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how two download URLs are concatenated in build-time scripts, primarily affecting Windows builds; runtime logic and data handling remain unchanged.
> 
> **Overview**
> Fixes Windows build failures in `default-content.ts` and `default-tutorials.ts` by **stopping use of `path.join` for URL construction**.
> 
> Both scripts now build `archiveUrl` and `buildInfoUrl` via template-string concatenation (still wrapped in `new URL(...)`), preventing malformed `win32` paths (e.g., `./https:\...`) from breaking URL parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7995c53526a4c7665df4bc931fc7231dc55b6b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->