### PR TITLE
Add Dependabot config with supply chain defense cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1


### PR DESCRIPTION
# What

Add Dependabot configuration with minimum release age cooldown to defend against supply chain attacks from short-lived malicious npm publishes.

Cooldown policy for both npm and GitHub Actions ecosystems:
- **Major**: 7 days
- **Minor**: 3 days  
- **Patch**: 1 day
- **Default**: 3 days

Security updates bypass the cooldown automatically, so CVE patches are still applied immediately.

Reference: https://daniakash.com/posts/simplest-supply-chain-defense/

# Testing

- Verify Dependabot starts creating PRs on the configured weekly schedule
- Confirm that freshly published versions are held back per the cooldown policy
- Confirm security update PRs are not delayed


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Dependabot configuration only, with no runtime code changes. Main impact is on dependency update PR cadence and potential delay of non-security upgrades.
> 
> **Overview**
> Adds `.github/dependabot.yml` to enable **weekly** Dependabot updates for `npm` and `github-actions`.
> 
> Configures a *minimum release-age cooldown* (default 3 days; major 7, minor 3, patch 1) to delay adopting freshly published versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fda0360129944bba8d7a12564e5c39df17246e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->