### PR TITLE
Temporary macOS-only release pipeline

### DIFF
--- a/.github/workflows/aws-upload-prod.yml
+++ b/.github/workflows/aws-upload-prod.yml
@@ -85,11 +85,11 @@ jobs:
           if [[ -z "$downloadLatestFolderPath" || -z "$upgradeLatestFolderPath" ]]; then
             exit 1;
           fi
-          # remove previous build from the latest directory /public/latest
-          aws s3 rm s3://${AWS_BUCKET_NAME}/${downloadLatestFolderPath} --recursive
+          # remove only macOS builds from latest (preserve Linux/Windows)
+          aws s3 rm s3://${AWS_BUCKET_NAME}/${downloadLatestFolderPath}/ --recursive --exclude "*" --include "*mac*" --include "*darwin*" --include "latest-mac*"
 
-          # remove previous build from the upgrade directory /public/upgrades
-          aws s3 rm s3://${AWS_BUCKET_NAME}/${upgradeLatestFolderPath} --recursive
+          # remove only macOS builds from upgrades (preserve Linux/Windows)
+          aws s3 rm s3://${AWS_BUCKET_NAME}/${upgradeLatestFolderPath}/ --recursive --exclude "*" --include "*mac*" --include "*darwin*" --include "latest-mac*"
 
           # copy current version apps for download to /public/latest
           aws s3 cp s3://${AWS_BUCKET_NAME}/private/${applicationVersion}/ \
@@ -124,53 +124,53 @@ jobs:
             [objectUpgrade]=${appFileName}'-mac-arm64.zip'
           )
 
-          declare -A tag02=(
-            [arch]='x64'
-            [platform]='windows'
-            [objectDownload]=${appFileName}'-win-installer.exe'
-          )
+          # declare -A tag02=(
+          #   [arch]='x64'
+          #   [platform]='windows'
+          #   [objectDownload]=${appFileName}'-win-installer.exe'
+          # )
 
-          declare -A tag03=(
-            [arch]='x64'
-            [platform]='linux_AppImage'
-            [objectDownload]=${appFileName}'-linux-x86_64.AppImage'
-          )
+          # declare -A tag03=(
+          #   [arch]='x64'
+          #   [platform]='linux_AppImage'
+          #   [objectDownload]=${appFileName}'-linux-x86_64.AppImage'
+          # )
 
-          declare -A tag04=(
-            [arch]='x64'
-            [platform]='linux_deb'
-            [objectDownload]=${appFileName}'-linux-amd64.deb'
-          )
+          # declare -A tag04=(
+          #   [arch]='x64'
+          #   [platform]='linux_deb'
+          #   [objectDownload]=${appFileName}'-linux-amd64.deb'
+          # )
 
-          declare -A tag05=(
-            [arch]='x64'
-            [platform]='linux_rpm'
-            [objectDownload]=${appFileName}'-linux-x86_64.rpm'
-          )
+          # declare -A tag05=(
+          #   [arch]='x64'
+          #   [platform]='linux_rpm'
+          #   [objectDownload]=${appFileName}'-linux-x86_64.rpm'
+          # )
 
-          declare -A tag06=(
-            [arch]='x64'
-            [platform]='linux_snap'
-            [objectDownload]=${appFileName}'-linux-amd64.snap'
-          )
+          # declare -A tag06=(
+          #   [arch]='x64'
+          #   [platform]='linux_snap'
+          #   [objectDownload]=${appFileName}'-linux-amd64.snap'
+          # )
 
-          declare -A tag07=(
-            [arch]='arm64'
-            [platform]='linux_AppImage'
-            [objectDownload]=${appFileName}'-linux-arm64.AppImage'
-          )
+          # declare -A tag07=(
+          #   [arch]='arm64'
+          #   [platform]='linux_AppImage'
+          #   [objectDownload]=${appFileName}'-linux-arm64.AppImage'
+          # )
 
-          declare -A tag08=(
-            [arch]='arm64'
-            [platform]='linux_deb'
-            [objectDownload]=${appFileName}'-linux-arm64.deb'
-          )
+          # declare -A tag08=(
+          #   [arch]='arm64'
+          #   [platform]='linux_deb'
+          #   [objectDownload]=${appFileName}'-linux-arm64.deb'
+          # )
 
-          declare -A tag09=(
-            [arch]='arm64'
-            [platform]='linux_rpm'
-            [objectDownload]=${appFileName}'-linux-aarch64.rpm'
-          )
+          # declare -A tag09=(
+          #   [arch]='arm64'
+          #   [platform]='linux_rpm'
+          #   [objectDownload]=${appFileName}'-linux-aarch64.rpm'
+          # )
 
           # TODO: arm64 snap disabled — no arm64 snap template in electron-builder
           # https://github.com/electron-userland/electron-builder/issues/8167

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,15 @@ on:
         type: boolean
 
 jobs:
-  build-linux:
-    if: contains(inputs.target, 'linux') || inputs.target == 'all'
-    uses: ./.github/workflows/pipeline-build-linux.yml
-    secrets: inherit
-    with:
-      environment: ${{ inputs.environment }}
-      target: ${{ inputs.target }}
-      debug: ${{ inputs.debug }}
-      enterprise: ${{ inputs.enterprise }}
+  # build-linux:
+  #   if: contains(inputs.target, 'linux') || inputs.target == 'all'
+  #   uses: ./.github/workflows/pipeline-build-linux.yml
+  #   secrets: inherit
+  #   with:
+  #     environment: ${{ inputs.environment }}
+  #     target: ${{ inputs.target }}
+  #     debug: ${{ inputs.debug }}
+  #     enterprise: ${{ inputs.enterprise }}
 
   build-macos:
     if: contains(inputs.target, 'macos') || inputs.target == 'all'
@@ -43,20 +43,20 @@ jobs:
       debug: ${{ inputs.debug }}
       enterprise: ${{ inputs.enterprise }}
 
-  build-windows:
-    if: contains(inputs.target, 'windows') || inputs.target == 'all'
-    uses: ./.github/workflows/pipeline-build-windows.yml
-    secrets: inherit
-    with:
-      environment: ${{ inputs.environment }}
-      debug: ${{ inputs.debug }}
-      enterprise: ${{ inputs.enterprise }}
+  # build-windows:
+  #   if: contains(inputs.target, 'windows') || inputs.target == 'all'
+  #   uses: ./.github/workflows/pipeline-build-windows.yml
+  #   secrets: inherit
+  #   with:
+  #     environment: ${{ inputs.environment }}
+  #     debug: ${{ inputs.debug }}
+  #     enterprise: ${{ inputs.enterprise }}
 
-  build-docker:
-    if: contains(inputs.target, 'docker') || inputs.target == 'all'
-    uses: ./.github/workflows/pipeline-build-docker.yml
-    secrets: inherit
-    with:
-      environment: ${{ inputs.environment }}
-      debug: ${{ inputs.debug }}
-      enterprise: ${{ inputs.enterprise }}
+  # build-docker:
+  #   if: contains(inputs.target, 'docker') || inputs.target == 'all'
+  #   uses: ./.github/workflows/pipeline-build-docker.yml
+  #   secrets: inherit
+  #   with:
+  #     environment: ${{ inputs.environment }}
+  #     debug: ${{ inputs.debug }}
+  #     enterprise: ${{ inputs.enterprise }}

--- a/.github/workflows/github-release-upload.yml
+++ b/.github/workflows/github-release-upload.yml
@@ -50,14 +50,14 @@ jobs:
           PATTERNS=(
             "Redis-Insight-mac-x64.dmg"
             "Redis-Insight-mac-arm64.dmg"
-            "Redis-Insight-win-installer.exe"
-            "Redis-Insight-linux-x86_64.AppImage"
-            "Redis-Insight-linux-arm64.AppImage"
-            "Redis-Insight-linux-amd64.deb"
-            "Redis-Insight-linux-arm64.deb"
-            "Redis-Insight-linux-x86_64.rpm"
-            "Redis-Insight-linux-aarch64.rpm"
-            "Redis-Insight-linux-amd64.snap"
+            # "Redis-Insight-win-installer.exe"
+            # "Redis-Insight-linux-x86_64.AppImage"
+            # "Redis-Insight-linux-arm64.AppImage"
+            # "Redis-Insight-linux-amd64.deb"
+            # "Redis-Insight-linux-arm64.deb"
+            # "Redis-Insight-linux-x86_64.rpm"
+            # "Redis-Insight-linux-aarch64.rpm"
+            # "Redis-Insight-linux-amd64.snap"
           )
 
           FILES=()

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
     with:
       environment: "production"
-      target: "all"
+      target: "macos"
 
   virustotal-prod:
     name: Virustotal
@@ -37,11 +37,11 @@ jobs:
     needs: virustotal-prod
     secrets: inherit
 
-  publish-stores:
-    name: Publish to stores
-    uses: ./.github/workflows/publish-stores.yml
-    needs: aws-upload-prod
-    secrets: inherit
+  # publish-stores:
+  #   name: Publish to stores
+  #   uses: ./.github/workflows/publish-stores.yml
+  #   needs: aws-upload-prod
+  #   secrets: inherit
 
   github-release:
     name: Upload to GitHub Release

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
     with:
       environment: "production"
-      target: "macos"
+      target: "all"
 
   virustotal-prod:
     name: Virustotal

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
     with:
       environment: "staging"
-      target: "all"
+      target: "macos"
 
   aws:
     uses: ./.github/workflows/aws-upload-dev.yml

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
     with:
       environment: "staging"
-      target: "macos"
+      target: "all"
 
   aws:
     uses: ./.github/workflows/aws-upload-dev.yml


### PR DESCRIPTION
# What

Temporarily disables all non-macOS parts of the staging and production release pipelines to support a macOS-only release.

**Changes across 5 workflow files:**
- **build.yml**: Commented out `build-linux`, `build-windows`, `build-docker` jobs
- **release-stage.yml**: Changed build target from `all` to `macos`
- **release-prod.yml**: Changed build target to `macos`, commented out `publish-stores` (Docker Hub + Snapcraft)
- **aws-upload-prod.yml**: Replaced blanket `aws s3 rm --recursive` with selective macOS-only deletes (preserves existing Linux/Windows artifacts in S3), commented out non-macOS S3 tags
- **github-release-upload.yml**: Commented out non-macOS file patterns

**Important**: All changes must be reverted immediately after the macOS release is confirmed working.

# Testing

- Verify staging release pipeline runs successfully with only macOS builds
- Confirm existing Linux/Windows S3 artifacts are preserved after production deploy
- Validate macOS DMGs are uploaded correctly to S3 and GitHub Release


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production release workflows (build matrix, S3 cleanup, and GitHub release asset uploads), and misconfiguration could skip non-macOS artifacts or accidentally delete the wrong S3 objects.
> 
> **Overview**
> This PR temporarily scopes the release pipeline to **macOS-only artifacts** by commenting out Linux/Windows/Docker build jobs and excluding non-macOS installers from GitHub release uploads.
> 
> On the production S3 publish step, it replaces blanket `aws s3 rm --recursive` cleanup with **macOS-only deletions** (via `--exclude "*"` + `--include` patterns) and comments out non-macOS tagging/metrics definitions, preserving existing Linux/Windows artifacts while publishing new macOS builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95dd760120ff701ce18ab7312814ba877e43e457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->