### PR TITLE
#5776 Fix Docker build failure due to sass-embedded dart binary on Alpine

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Docker Build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    name: Docker Build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t redisinsight-local .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,9 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
+  docker-build:
+    uses: ./.github/workflows/docker-build.yml
+
   frontend-tests:
     needs: [changes, lint, should-run-all-tests]
     if: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # the best way to minimize the number of node_module restores and build steps
 # while still keeping the final image small.
 
-FROM node:22.22.0-alpine as build
+FROM node:22.22.0-alpine AS build
 
 # update apk repository and install build dependencies
 RUN apk update && apk add --no-cache --virtual .gyp \
@@ -14,7 +14,8 @@ RUN apk update && apk add --no-cache --virtual .gyp \
         py3-setuptools \
         make \
         git \
-        g++
+        g++ \
+        gcompat
 
 # set workdir
 WORKDIR /usr/src/app


### PR DESCRIPTION
# What

Added `gcompat` to the Alpine build stage to provide glibc compatibility for the `sass-embedded` Dart VM binary. The `sass` dependency is aliased to `sass-embedded`, which bundles a Dart runtime compiled for glibc. Since Alpine uses musl libc, the build fails at `yarn build:statics` when the `sass` CLI is invoked.

Also fixed the `FROM ... as` -> `FROM ... AS` casing warning.

# Testing

```
docker build -t redis-insight-local .
```

Built the Docker image locally and confirmed:
- `yarn build:statics` completes successfully (sass compiles plugin SCSS files)
- The full image builds end-to-end without errors

---

Fixes #5776

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Docker build dependencies and CI workflows, but could affect build reproducibility/size and fail if `gcompat` availability changes on Alpine.
> 
> **Overview**
> Fixes Alpine Docker image build failures by adding `gcompat` to the build-stage `apk add` list so the `sass-embedded` (glibc-linked) binary can run during `yarn build:statics`, and adjusts `FROM ... AS` casing to avoid warnings.
> 
> Adds a reusable GitHub Actions `docker-build` workflow and wires it into the main `tests` workflow to build the Docker image in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b351af79fede0b4878372d7646bac4da646a086a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->