### PR TITLE
RI-8168: Copy Download Vector

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -1,9 +1,21 @@
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { bufferToString, handleCopy } from 'uiSrc/utils'
+import { handleDownloadButton } from 'uiSrc/utils/events'
 import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
 import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { ElementDetails } from './ElementDetails'
 import { ElementDetailsProps } from './ElementDetails.types'
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  handleCopy: jest.fn(),
+}))
+
+jest.mock('uiSrc/utils/events', () => ({
+  ...jest.requireActual('uiSrc/utils/events'),
+  handleDownloadButton: jest.fn(),
+}))
 
 const mockUseMonacoValidation = jest.fn().mockReturnValue({
   isValid: true,
@@ -141,5 +153,25 @@ describe('ElementDetails', () => {
 
     const saveBtn = screen.getByTestId('vector-set-save-attributes-btn')
     expect(saveBtn).toBeDisabled()
+  })
+
+  it('should copy vector text when copy button is clicked', () => {
+    renderComponent()
+    fireEvent.click(screen.getByTestId('vector-set-copy-vector-btn-btn'))
+
+    const expectedVector = `[${mockElement.vector!.join(', ')}]`
+    expect(handleCopy).toHaveBeenCalledWith(expectedVector)
+  })
+
+  it('should download vector when download button is clicked', () => {
+    renderComponent()
+    fireEvent.click(screen.getByTestId('vector-set-download-vector-btn'))
+
+    const expectedVector = `[${mockElement.vector!.join(', ')}]`
+    const expectedFilename = `${bufferToString(mockElement.name)}_vector.txt`
+    expect(handleDownloadButton).toHaveBeenCalledWith(
+      expectedVector,
+      expectedFilename,
+    )
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -11,8 +11,21 @@ export const Body = styled(Col)`
 export const VectorTextArea = styled(TextArea)`
   font-family: 'Source Code Pro';
   border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
-  padding: ${({ theme }) => theme.core?.space?.space020};
   scrollbar-width: thin;
+  padding: ${({ theme }) => theme.core?.space?.space025};
+  padding-right: ${({ theme }) => theme.core?.space?.space400};
+`
+
+export const VectorWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`
+
+export const VectorActions = styled(Col)`
+  position: absolute;
+  top: ${({ theme }) => theme.core?.space?.space150};
+  right: ${({ theme }) => theme.core?.space?.space150};
+  z-index: 1;
 `
 
 export const EditorWrapper = styled.div<{ children: React.ReactNode }>`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -11,10 +11,14 @@ import {
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 import {
+  IconButton,
   PrimaryButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
-import { EditIcon } from 'uiSrc/components/base/icons'
+import { DownloadIcon, EditIcon } from 'uiSrc/components/base/icons'
+import { CopyButton } from 'uiSrc/components/copy-button'
+import { RiTooltip } from 'uiSrc/components'
+import { handleDownloadButton } from 'uiSrc/utils/events'
 import { CodeEditor } from 'uiSrc/components/base/code-editor'
 import { useMonacoValidation } from 'uiSrc/components/monaco-editor'
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
@@ -64,6 +68,10 @@ const ElementDetails = ({
     () => formatVector(element?.vector),
     [element?.vector],
   )
+
+  const handleDownloadVector = useCallback(() => {
+    handleDownloadButton(vectorText, `${elementName}_vector.txt`)
+  }, [vectorText])
 
   const startEditing = useCallback(() => {
     setSavedValue(value)
@@ -130,12 +138,29 @@ const ElementDetails = ({
               <Text color="secondary">{VECTOR_DESCRIPTION}</Text>
               <Col gap="s">
                 <Text color="primary">Vector</Text>
-                <S.VectorTextArea
-                  readOnly
-                  value={vectorText}
-                  data-testid="vector-set-vector-value"
-                  height="110px"
-                />
+                <S.VectorWrapper>
+                  <S.VectorActions gap="m" align="end">
+                    <CopyButton
+                      copy={vectorText}
+                      aria-label="Copy vector"
+                      data-testid="vector-set-copy-vector-btn"
+                    />
+                    <RiTooltip content="Download" position="left">
+                      <IconButton
+                        icon={DownloadIcon}
+                        aria-label="Download vector"
+                        onClick={handleDownloadVector}
+                        data-testid="vector-set-download-vector-btn"
+                      />
+                    </RiTooltip>
+                  </S.VectorActions>
+                  <S.VectorTextArea
+                    readOnly
+                    value={vectorText}
+                    data-testid="vector-set-vector-value"
+                    height="110px"
+                  />
+                </S.VectorWrapper>
               </Col>
             </Col>
 


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Added copy and download action buttons to the vector embedding text area in the Element Details Panel.
Both buttons are positioned in the top-right corner of the vector area (copy on top, download below),
using the existing `CopyButton` component and `handleDownloadButton` utility. The download button
includes a tooltip.

| Light | Dark |
| --- | --- | 
| <img width="948" height="809" alt="image" src="https://github.com/user-attachments/assets/1e62a53a-9784-4cea-8423-8c45916adcee" /> | <img width="948" height="809" alt="image" src="https://github.com/user-attachments/assets/a3aa22ae-dab0-4ef2-a48b-8aaffd474f1c" /> |
| <img width="948" height="809" alt="image" src="https://github.com/user-attachments/assets/e1c43a3e-5783-4f35-b8ea-89234828a8e9" /> | <img width="948" height="809" alt="image" src="https://github.com/user-attachments/assets/52eb68d6-5134-498e-9d7d-42827fc0430a" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Open a vector set key in the Browser
2. Click "View" on any element to open the Element Details Panel
3. Verify the copy and download buttons appear in the top-right of the vector text area
4. Click copy — confirm the vector text is copied to clipboard
5. Click download — confirm a `.txt` file is downloaded with the vector content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change adding copy/download controls and related styling/tests; no changes to data fetching or persistence logic beyond invoking existing utilities.
> 
> **Overview**
> Adds **Copy** and **Download** actions to the vector embedding textarea in the Vector Set Element Details drawer, using the existing `CopyButton` and `handleDownloadButton` (with a tooltip) and generating a `${elementName}_vector.txt` filename.
> 
> Updates styling to overlay the action buttons in the top-right of the vector area and adjusts textarea padding, and extends unit tests to mock the utilities and assert copy/download behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09ba2eda0467de985724450ea0400b54e8f2d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->