### PR TITLE
Restore full multi-platform release pipeline

### DIFF
--- a/.github/workflows/aws-upload-prod.yml
+++ b/.github/workflows/aws-upload-prod.yml
@@ -85,11 +85,11 @@ jobs:
           if [[ -z "$downloadLatestFolderPath" || -z "$upgradeLatestFolderPath" ]]; then
             exit 1;
           fi
-          # remove only macOS builds from latest (preserve Linux/Windows)
-          aws s3 rm s3://${AWS_BUCKET_NAME}/${downloadLatestFolderPath}/ --recursive --exclude "*" --include "*mac*" --include "*darwin*" --include "latest-mac*"
+          # remove previous build from the latest directory /public/latest
+          aws s3 rm s3://${AWS_BUCKET_NAME}/${downloadLatestFolderPath} --recursive
 
-          # remove only macOS builds from upgrades (preserve Linux/Windows)
-          aws s3 rm s3://${AWS_BUCKET_NAME}/${upgradeLatestFolderPath}/ --recursive --exclude "*" --include "*mac*" --include "*darwin*" --include "latest-mac*"
+          # remove previous build from the upgrade directory /public/upgrades
+          aws s3 rm s3://${AWS_BUCKET_NAME}/${upgradeLatestFolderPath} --recursive
 
           # copy current version apps for download to /public/latest
           aws s3 cp s3://${AWS_BUCKET_NAME}/private/${applicationVersion}/ \
@@ -124,53 +124,53 @@ jobs:
             [objectUpgrade]=${appFileName}'-mac-arm64.zip'
           )
 
-          # declare -A tag02=(
-          #   [arch]='x64'
-          #   [platform]='windows'
-          #   [objectDownload]=${appFileName}'-win-installer.exe'
-          # )
+          declare -A tag02=(
+            [arch]='x64'
+            [platform]='windows'
+            [objectDownload]=${appFileName}'-win-installer.exe'
+          )
 
-          # declare -A tag03=(
-          #   [arch]='x64'
-          #   [platform]='linux_AppImage'
-          #   [objectDownload]=${appFileName}'-linux-x86_64.AppImage'
-          # )
+          declare -A tag03=(
+            [arch]='x64'
+            [platform]='linux_AppImage'
+            [objectDownload]=${appFileName}'-linux-x86_64.AppImage'
+          )
 
-          # declare -A tag04=(
-          #   [arch]='x64'
-          #   [platform]='linux_deb'
-          #   [objectDownload]=${appFileName}'-linux-amd64.deb'
-          # )
+          declare -A tag04=(
+            [arch]='x64'
+            [platform]='linux_deb'
+            [objectDownload]=${appFileName}'-linux-amd64.deb'
+          )
 
-          # declare -A tag05=(
-          #   [arch]='x64'
-          #   [platform]='linux_rpm'
-          #   [objectDownload]=${appFileName}'-linux-x86_64.rpm'
-          # )
+          declare -A tag05=(
+            [arch]='x64'
+            [platform]='linux_rpm'
+            [objectDownload]=${appFileName}'-linux-x86_64.rpm'
+          )
 
-          # declare -A tag06=(
-          #   [arch]='x64'
-          #   [platform]='linux_snap'
-          #   [objectDownload]=${appFileName}'-linux-amd64.snap'
-          # )
+          declare -A tag06=(
+            [arch]='x64'
+            [platform]='linux_snap'
+            [objectDownload]=${appFileName}'-linux-amd64.snap'
+          )
 
-          # declare -A tag07=(
-          #   [arch]='arm64'
-          #   [platform]='linux_AppImage'
-          #   [objectDownload]=${appFileName}'-linux-arm64.AppImage'
-          # )
+          declare -A tag07=(
+            [arch]='arm64'
+            [platform]='linux_AppImage'
+            [objectDownload]=${appFileName}'-linux-arm64.AppImage'
+          )
 
-          # declare -A tag08=(
-          #   [arch]='arm64'
-          #   [platform]='linux_deb'
-          #   [objectDownload]=${appFileName}'-linux-arm64.deb'
-          # )
+          declare -A tag08=(
+            [arch]='arm64'
+            [platform]='linux_deb'
+            [objectDownload]=${appFileName}'-linux-arm64.deb'
+          )
 
-          # declare -A tag09=(
-          #   [arch]='arm64'
-          #   [platform]='linux_rpm'
-          #   [objectDownload]=${appFileName}'-linux-aarch64.rpm'
-          # )
+          declare -A tag09=(
+            [arch]='arm64'
+            [platform]='linux_rpm'
+            [objectDownload]=${appFileName}'-linux-aarch64.rpm'
+          )
 
           # TODO: arm64 snap disabled — no arm64 snap template in electron-builder
           # https://github.com/electron-userland/electron-builder/issues/8167

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,15 @@ on:
         type: boolean
 
 jobs:
-  # build-linux:
-  #   if: contains(inputs.target, 'linux') || inputs.target == 'all'
-  #   uses: ./.github/workflows/pipeline-build-linux.yml
-  #   secrets: inherit
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #     target: ${{ inputs.target }}
-  #     debug: ${{ inputs.debug }}
-  #     enterprise: ${{ inputs.enterprise }}
+  build-linux:
+    if: contains(inputs.target, 'linux') || inputs.target == 'all'
+    uses: ./.github/workflows/pipeline-build-linux.yml
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      target: ${{ inputs.target }}
+      debug: ${{ inputs.debug }}
+      enterprise: ${{ inputs.enterprise }}
 
   build-macos:
     if: contains(inputs.target, 'macos') || inputs.target == 'all'
@@ -43,20 +43,20 @@ jobs:
       debug: ${{ inputs.debug }}
       enterprise: ${{ inputs.enterprise }}
 
-  # build-windows:
-  #   if: contains(inputs.target, 'windows') || inputs.target == 'all'
-  #   uses: ./.github/workflows/pipeline-build-windows.yml
-  #   secrets: inherit
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #     debug: ${{ inputs.debug }}
-  #     enterprise: ${{ inputs.enterprise }}
+  build-windows:
+    if: contains(inputs.target, 'windows') || inputs.target == 'all'
+    uses: ./.github/workflows/pipeline-build-windows.yml
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      debug: ${{ inputs.debug }}
+      enterprise: ${{ inputs.enterprise }}
 
-  # build-docker:
-  #   if: contains(inputs.target, 'docker') || inputs.target == 'all'
-  #   uses: ./.github/workflows/pipeline-build-docker.yml
-  #   secrets: inherit
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #     debug: ${{ inputs.debug }}
-  #     enterprise: ${{ inputs.enterprise }}
+  build-docker:
+    if: contains(inputs.target, 'docker') || inputs.target == 'all'
+    uses: ./.github/workflows/pipeline-build-docker.yml
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      debug: ${{ inputs.debug }}
+      enterprise: ${{ inputs.enterprise }}

--- a/.github/workflows/github-release-upload.yml
+++ b/.github/workflows/github-release-upload.yml
@@ -50,14 +50,14 @@ jobs:
           PATTERNS=(
             "Redis-Insight-mac-x64.dmg"
             "Redis-Insight-mac-arm64.dmg"
-            # "Redis-Insight-win-installer.exe"
-            # "Redis-Insight-linux-x86_64.AppImage"
-            # "Redis-Insight-linux-arm64.AppImage"
-            # "Redis-Insight-linux-amd64.deb"
-            # "Redis-Insight-linux-arm64.deb"
-            # "Redis-Insight-linux-x86_64.rpm"
-            # "Redis-Insight-linux-aarch64.rpm"
-            # "Redis-Insight-linux-amd64.snap"
+            "Redis-Insight-win-installer.exe"
+            "Redis-Insight-linux-x86_64.AppImage"
+            "Redis-Insight-linux-arm64.AppImage"
+            "Redis-Insight-linux-amd64.deb"
+            "Redis-Insight-linux-arm64.deb"
+            "Redis-Insight-linux-x86_64.rpm"
+            "Redis-Insight-linux-aarch64.rpm"
+            "Redis-Insight-linux-amd64.snap"
           )
 
           FILES=()

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -37,11 +37,11 @@ jobs:
     needs: virustotal-prod
     secrets: inherit
 
-  # publish-stores:
-  #   name: Publish to stores
-  #   uses: ./.github/workflows/publish-stores.yml
-  #   needs: aws-upload-prod
-  #   secrets: inherit
+  publish-stores:
+    name: Publish to stores
+    uses: ./.github/workflows/publish-stores.yml
+    needs: aws-upload-prod
+    secrets: inherit
 
   github-release:
     name: Upload to GitHub Release


### PR DESCRIPTION
# What

Reverts the temporary macOS-only release pipeline changes from PR #5773, re-enabling all build targets for a complete release.

**Restored across 4 files:**
- **build.yml**: Uncommented `build-linux`, `build-windows`, `build-docker` jobs
- **release-prod.yml**: Uncommented `publish-stores` (Docker Hub + Snapcraft)
- **aws-upload-prod.yml**: Restored full recursive S3 cleanup and all platform S3 tags (tag02-tag09)
- **github-release-upload.yml**: Restored all platform file patterns

# Testing

- Verify all platform builds trigger on next staging/production release
- Confirm S3 upload, store publishing, and GitHub release upload include all platforms


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it re-enables Linux/Windows/Docker publishing steps and changes S3 cleanup to fully wipe `latest`/`upgrades` directories, which could impact production releases if paths or artifacts are misconfigured.
> 
> **Overview**
> Restores the previously disabled multi-platform release flow by re-enabling `build-linux`, `build-windows`, and `build-docker` jobs and turning `publish-stores` back on for production releases.
> 
> Updates release publishing to handle non-macOS artifacts again: S3 tagging now includes Windows and multiple Linux package formats, GitHub draft release uploads include all installer patterns, and the S3 publish step now fully clears the `latest` and `upgrades` directories before copying new builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddd2cdb30ddfcb8bbf630d10475ba6ce3526c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->