### PR TITLE
Switch Windows code signing from PFX to DigiCert KeyLocker

### DIFF
--- a/.github/actions/install-windows-certs/action.yml
+++ b/.github/actions/install-windows-certs/action.yml
@@ -1,16 +1,43 @@
 name: Install Windows certs
 
 inputs:
-  WIN_CSC_PFX_BASE64:
+  WIN_CSC_DIGICERT_API_KEY:
+    required: true
+  WIN_CSC_DIGICERT_CLIENT_CERT_B64:
+    required: true
+  WIN_CSC_DIGICERT_CLIENT_CERT_PASSWORD:
+    required: true
+  WIN_CSC_DIGICERT_HOST:
+    required: false
+    default: 'https://clientauth.one.digicert.com'
+  WIN_CSC_DIGICERT_KEYPAIR_ALIAS:
     required: true
 
 runs:
   using: 'composite'
   steps:
-    - name: Setup sign certificates
+    - name: Setup certificate from base64 secret
       shell: bash
-      env:
-        WIN_CSC_PFX_BASE64: ${{ inputs.WIN_CSC_PFX_BASE64 }}
       run: |
-        mkdir -p certs
-        echo "$WIN_CSC_PFX_BASE64" | base64 -d > certs/redislabs_win.pfx
+        echo "${{ inputs.WIN_CSC_DIGICERT_CLIENT_CERT_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+
+    - name: Set DigiCert environment variables
+      shell: bash
+      run: |
+        echo "SM_HOST=${{ inputs.WIN_CSC_DIGICERT_HOST }}" >> "$GITHUB_ENV"
+        echo "SM_API_KEY=${{ inputs.WIN_CSC_DIGICERT_API_KEY }}" >> "$GITHUB_ENV"
+        echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+        echo "SM_CLIENT_CERT_PASSWORD=${{ inputs.WIN_CSC_DIGICERT_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+        echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
+
+    - name: Install DigiCert KeyLocker tools
+      shell: cmd
+      run: |
+        curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o Keylockertools-windows-x64.msi
+        msiexec /i Keylockertools-windows-x64.msi /quiet /qn
+
+    - name: Register KSP and sync certificate to Windows certificate store
+      shell: cmd
+      run: |
+        smctl windows ksp register
+        smctl windows certsync --keypair-alias=${{ inputs.WIN_CSC_DIGICERT_KEYPAIR_ALIAS }}

--- a/.github/workflows/pipeline-build-windows.yml
+++ b/.github/workflows/pipeline-build-windows.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Setup certs
         uses: ./.github/actions/install-windows-certs
         with:
-          WIN_CSC_PFX_BASE64: ${{ secrets.WIN_CSC_PFX_BASE64 }}
+          WIN_CSC_DIGICERT_API_KEY: ${{ secrets.WIN_CSC_DIGICERT_API_KEY }}
+          WIN_CSC_DIGICERT_CLIENT_CERT_B64: ${{ secrets.WIN_CSC_DIGICERT_CLIENT_CERT_B64 }}
+          WIN_CSC_DIGICERT_CLIENT_CERT_PASSWORD: ${{ secrets.WIN_CSC_DIGICERT_CLIENT_CERT_PASSWORD }}
+          WIN_CSC_DIGICERT_KEYPAIR_ALIAS: ${{ secrets.WIN_CSC_DIGICERT_KEYPAIR_ALIAS }}
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics:win
@@ -46,14 +49,14 @@ jobs:
       - name: Build windows exe (production)
         if: vars.ENV == 'production'
         run: |
-          yarn package:prod
+          yarn package:prod -c.win.signtoolOptions.certificateSha1=${{ secrets.WIN_CSC_DIGICERT_CERT_SHA1 }}
           rm -rf release/win-unpacked
         shell: bash
 
       - name: Build windows exe (staging)
         if: (vars.ENV == 'staging' ||  vars.ENV == 'development')
         run: |
-          yarn package:stage
+          yarn package:stage -c.win.signtoolOptions.certificateSha1=${{ secrets.WIN_CSC_DIGICERT_CERT_SHA1 }}
           rm -rf release/win-unpacked
         shell: bash
 
@@ -67,8 +70,6 @@ jobs:
             ./release/latest.yml
 
     env:
-      WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-      WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
       RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}
       RI_AI_QUERY_PASS: ${{ secrets.RI_AI_QUERY_PASS }}
       RI_AI_QUERY_USER: ${{ secrets.RI_AI_QUERY_USER }}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -87,7 +87,11 @@
     "target": ["nsis"],
     "artifactName": "Redis-Insight-${os}-installer.${ext}",
     "icon": "resources/icon.ico",
-    "legalTrademarks": "Redis Inc., Redis Labs Inc."
+    "legalTrademarks": "Redis Inc., Redis Labs Inc.",
+    "signtoolOptions": {
+      "signingHashAlgorithms": ["sha256"],
+      "rfc3161TimeStampServer": "http://timestamp.digicert.com"
+    }
   },
   "nsis": {
     "oneClick": false,

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -40,10 +40,14 @@ module.exports = {
   ],
   setupFilesAfterEnv: ['<rootDir>/redisinsight/ui/src/setup-tests.ts'],
   moduleDirectories: ['node_modules', 'redisinsight/node_modules'],
-  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
+  moduleFileExtensions: ['js', 'mjs', 'jsx', 'ts', 'tsx', 'json'],
   testEnvironment: 'jest-fixed-jsdom',
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+    '\\.mjs$': 'babel-jest',
+  },
   transformIgnorePatterns: [
-    'node_modules/(?!(monaco-editor|react-monaco-editor|brotli-dec-wasm|until-async)/)',
+    'node_modules/(?!(monaco-editor|react-monaco-editor|brotli-dec-wasm|until-async|rettime)/)',
   ],
   // TODO: add tests for plugins
   modulePathIgnorePatterns: [

--- a/redisinsight/ui/src/setup-env.ts
+++ b/redisinsight/ui/src/setup-env.ts
@@ -1,4 +1,13 @@
 import { defaultConfig } from 'uiSrc/config/default'
+import { WritableStream as NodeWritableStream } from 'stream/web'
+
+const globalWithStreams = globalThis as typeof globalThis & {
+  WritableStream?: typeof NodeWritableStream
+}
+
+if (typeof globalWithStreams.WritableStream === 'undefined') {
+  globalWithStreams.WritableStream = NodeWritableStream
+}
 
 riConfig = defaultConfig
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,17 +4117,10 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
-"@types/yargs@^17.0.33":
+"@types/yargs@^17.0.33", "@types/yargs@^17.0.8":
   version "17.0.35"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
   integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^17.0.8":
-  version "17.0.33"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
-  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -5203,15 +5196,10 @@ base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-baseline-browser-mapping@^2.10.12:
+baseline-browser-mapping@^2.10.12, baseline-browser-mapping@^2.9.0:
   version "2.10.19"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
   integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
-
-baseline-browser-mapping@^2.9.0:
-  version "2.9.19"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz#3e508c43c46d961eb4d7d2e5b8d1dd0f9ee4f488"
-  integrity sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==
 
 better-opn@^3.0.2:
   version "3.0.2"
@@ -5290,18 +5278,7 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.24.0, browserslist@^4.24.2, browserslist@^4.25.1, browserslist@^4.28.1:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
-  integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
-  dependencies:
-    baseline-browser-mapping "^2.9.0"
-    caniuse-lite "^1.0.30001759"
-    electron-to-chromium "^1.5.263"
-    node-releases "^2.0.27"
-    update-browserslist-db "^1.2.0"
-
-browserslist@^4.28.2:
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.24.0, browserslist@^4.24.2, browserslist@^4.25.1, browserslist@^4.28.1, browserslist@^4.28.2:
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -5532,12 +5509,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001687, caniuse-lite@^1.0.30001759:
-  version "1.0.30001769"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz#1ad91594fad7dc233777c2781879ab5409f7d9c2"
-  integrity sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==
-
-caniuse-lite@^1.0.30001782:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001687, caniuse-lite@^1.0.30001759, caniuse-lite@^1.0.30001782:
   version "1.0.30001788"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
   integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
@@ -7123,12 +7095,7 @@ electron-store@*, electron-store@^8.0.0:
     conf "^10.2.0"
     type-fest "^2.17.0"
 
-electron-to-chromium@^1.5.263:
-  version "1.5.286"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz#142be1ab5e1cd5044954db0e5898f60a4960384e"
-  integrity sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==
-
-electron-to-chromium@^1.5.328:
+electron-to-chromium@^1.5.263, electron-to-chromium@^1.5.328:
   version "1.5.339"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz#d797bf5f222a7f6241a42b43a97bf52ff43947f1"
   integrity sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==
@@ -11655,12 +11622,7 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.27:
-  version "2.0.27"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
-  integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
-
-node-releases@^2.0.36:
+node-releases@^2.0.27, node-releases@^2.0.36:
   version "2.0.37"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.37.tgz#9bd4f10b77ba39c2b9402d4e8399c482a797f671"
   integrity sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==
@@ -12449,15 +12411,7 @@ postcss-reduce-transforms@^7.0.1:
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-selector-parser@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz#4d6af97eba65d73bc4d84bcb343e865d7dd16262"
-  integrity sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
-
-postcss-selector-parser@^7.1.1:
+postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
   integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
@@ -14531,14 +14485,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
-  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
-  dependencies:
-    ansi-regex "^6.0.1"
-
-strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0, strip-ansi@^7.1.2:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==


### PR DESCRIPTION
# What

Replace the legacy PFX-based Windows code signing with DigiCert KeyLocker remote signing via KSP (Key Storage Provider).

The previous approach stored a PFX file (containing the private key) as a base64-encoded GitHub secret. DigiCert now provisions certificates through KeyLocker, which keeps private keys in a cloud HSM and does not allow export. This PR integrates the KeyLocker signing flow into the Windows build pipeline.

**Changes:**
- `install-windows-certs` action now installs `smctl`, registers the DigiCert KSP, and syncs the certificate to the Windows certificate store
- `pipeline-build-windows.yml` passes the certificate SHA1 thumbprint to electron-builder and removes the old `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` env vars
- `electron-builder.json` enforces SHA-256 digest and RFC 3161 timestamping (KeyLocker rejects SHA-1 per compliance guidelines)

**New GitHub secrets required:**
- `WIN_CSC_DIGICERT_API_KEY` — DigiCert ONE Signer API key
- `WIN_CSC_DIGICERT_CLIENT_CERT_B64` — Base64-encoded .p12 client auth certificate
- `WIN_CSC_DIGICERT_CLIENT_CERT_PASSWORD` — Password for the client .p12
- `WIN_CSC_DIGICERT_KEYPAIR_ALIAS` — Keypair alias from `smctl keypair ls`
- `WIN_CSC_DIGICERT_CERT_SHA1` — Certificate SHA1 thumbprint

**Deprecated secrets (can be removed after merge):**
- `WIN_CSC_PFX_BASE64`
- `WIN_CSC_LINK`
- `WIN_CSC_KEY_PASSWORD`

# Testing

- Verified signing end-to-end on a staging build via a temporary test workflow on this branch
- The signed `.exe` shows "Redis Inc." as the publisher in Windows file properties > Digital Signatures
- `smctl healthcheck` confirms 2FA authentication and signing capability


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Windows release signing path and introduces new CI secrets/tooling; misconfiguration could break Windows build/signing or produce unsigned installers.
> 
> **Overview**
> **Switches Windows code signing to DigiCert KeyLocker remote signing.** The `install-windows-certs` composite action now provisions a DigiCert client cert from base64, sets `smctl` env vars, installs KeyLocker tools, registers the Windows KSP, and syncs the signing cert to the Windows cert store.
> 
> **Updates the Windows build workflow and signing settings.** `pipeline-build-windows.yml` now consumes new DigiCert secrets and passes `signtoolOptions.certificateSha1` into `yarn package:*`, while `electron-builder.json` enforces SHA-256 signing and DigiCert RFC3161 timestamping.
> 
> **Test runner compatibility tweaks.** Jest config adds `babel-jest` transforms and `.mjs` support (including allowing `rettime` through transforms), and `setup-env.ts` polyfills `WritableStream` via `stream/web` for the test environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5923bbd512da94c938407c00245ba4a2795f869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->