### PR TITLE
Split Linux VirusTotal scan by architecture

### DIFF
--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -50,8 +50,19 @@ jobs:
           # Get list of artifacts
           ARTIFACTS=$(ls ./release)
 
-          # Conver list to json
-          ARTIFACTS_JSON=$(echo "$ARTIFACTS" | jq -R -s -c 'split("\n")[:-1]')
+          # Convert list to json.
+          # linux-builds is split into two virtual scans (x86_64 and arm64) because
+          # the combined zip exceeds VirusTotal's ~650MB upload limit once arm64
+          # binaries are included. Both virtual scans still download the same
+          # linux-builds artifact; the split happens at zip time via file filters.
+          ARTIFACTS_JSON=$(echo "$ARTIFACTS" | jq -R -s -c '
+            split("\n")[:-1]
+            | reduce .[] as $a ([];
+                if $a == "linux-builds"
+                then . + ["linux-x86_64-builds", "linux-arm64-builds"]
+                else . + [$a]
+                end)
+          ')
 
           echo "artifact_exists=true" >> $GITHUB_OUTPUT
           echo "artifact_names=$ARTIFACTS_JSON" >> $GITHUB_OUTPUT
@@ -71,7 +82,9 @@ jobs:
         if: needs.download_artifacts.outputs.artifact_exists == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
+          # linux-x86_64-builds and linux-arm64-builds are virtual scan entries;
+          # both resolve to the single linux-builds artifact uploaded by the build.
+          name: ${{ (matrix.artifact == 'linux-x86_64-builds' || matrix.artifact == 'linux-arm64-builds') && 'linux-builds' || matrix.artifact }}
           path: ./release
 
       - name: Send File to scan
@@ -79,19 +92,31 @@ jobs:
         run: |
           uploadZipFile="./${{ matrix.artifact }}.zip"
 
-          # Compress artifactes
-          zip -r "${uploadZipFile}" "./release" ${{ startsWith(matrix.artifact, 'macos-') && '-x "*/redisstack/*" "*.tar.gz" "*.zip"' || '' }}
+          # Compress artifacts. Per-scan exclusions keep each zip under
+          # VirusTotal's ~650MB /files/upload_url limit:
+          #   - macos-*            : exclude bundled redisstack and archives
+          #   - linux-x86_64-builds: exclude arm64/aarch64 binaries
+          #   - linux-arm64-builds : exclude x86_64/amd64 binaries
+          zip -r "${uploadZipFile}" "./release" \
+            ${{ startsWith(matrix.artifact, 'macos-')      && '-x "*/redisstack/*" "*.tar.gz" "*.zip"' || '' }} \
+            ${{ matrix.artifact == 'linux-x86_64-builds'    && '-x "*arm64*" "*aarch64*"'              || '' }} \
+            ${{ matrix.artifact == 'linux-arm64-builds'     && '-x "*x86_64*" "*amd64*"'               || '' }}
+
+          echo "File to upload: ${uploadZipFile} ($(du -h "${uploadZipFile}" | cut -f1))"
 
           # Generate url to download zip file
           uploadUrl=$(curl -sq -XGET https://www.virustotal.com/api/v3/files/upload_url -H "x-apikey: $VIRUSTOTAL_API_KEY" | jq -r '.data')
 
-          echo "File to upload: ${uploadZipFile}"
+          # Upload zip file to VirusTotal. Capture the raw response so a non-JSON
+          # error (e.g. payload too large) produces a readable log instead of a
+          # cryptic "jq: parse error".
+          uploadResponse=$(curl -sq -XPOST "${uploadUrl}" -H "x-apikey: $VIRUSTOTAL_API_KEY" --form file=@"${uploadZipFile}")
+          analysedId=$(echo "$uploadResponse" | jq -r '.data.id' 2>/dev/null || true)
 
-          # Upload zip file to VirusTotal
-          analysedId=$(curl -sq -XPOST "${uploadUrl}" -H "x-apikey: $VIRUSTOTAL_API_KEY" --form file=@"${uploadZipFile}" | jq -r '.data.id')
-
-          if [ $analysedId == "null" ]; then
-            echo 'Status is null, something went wrong';
+          if [ -z "$analysedId" ] || [ "$analysedId" == "null" ]; then
+            echo 'VirusTotal upload failed. Raw response (first 2KB):'
+            echo "$uploadResponse" | head -c 2048
+            echo
             exit 1;
           fi
 


### PR DESCRIPTION
# What

Splits the Linux VirusTotal scan into two virtual matrix entries — `linux-x86_64-builds` and `linux-arm64-builds` — each zipping only the binaries for its architecture.

Since Linux ARM64 support was added (#5641), the `linux-builds` artifact contains 7 binaries (`amd64.snap`, `x86_64.rpm`, `x86_64.AppImage`, `amd64.deb`, `arm64.AppImage`, `aarch64.rpm`, `arm64.deb`) totalling ~700 MB. Because these formats are already compressed (`deflated 0%`), the upload zip is roughly the same size and exceeds VirusTotal's ~650 MB `/files/upload_url` cap. Uploads were failing with a cryptic `jq: parse error` because VT returns a non-JSON error body and the script piped it straight into `jq`.

After the split, each scan zip is well under the limit (~400 MB x86_64, ~300 MB arm64) and both architectures remain covered by the scan.

Only `.github/workflows/virustotal.yml` is touched — the build, AWS upload, and e2e workflows still produce/consume a single `linux-builds` artifact.

Also logs the zip size on upload and the raw VT response on failure so future size/rate-limit issues surface clearly instead of as a `jq` parse error.

# Testing

CI: on push, the `Virustotal` workflow should now show two Linux jobs:
- `Analyze file (linux-x86_64-builds)`
- `Analyze file (linux-arm64-builds)`

Both should complete successfully, with the new `File to upload: ./*.zip (<size>)` line visible in the logs showing each zip well under 650 MB.

---

Related to the failed release run: https://github.com/redis/RedisInsight/actions/runs/24562509322

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: adjusts VirusTotal workflow matrix/zipping and improves upload error handling/logging; main risk is mis-filtering binaries or breaking artifact name resolution in the scan job.
> 
> **Overview**
> Updates the `Virustotal` GitHub Actions workflow to **split the `linux-builds` VirusTotal scan into two virtual matrix entries** (`linux-x86_64-builds` and `linux-arm64-builds`) while still downloading the single `linux-builds` artifact.
> 
> Adds per-architecture `zip` exclusion filters to keep uploads under VirusTotal’s size cap, logs the generated zip size, and improves upload robustness by capturing and printing the raw VirusTotal response when the upload fails (instead of failing with a `jq` parse error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8d7cce7f67c28e1d8695a2ff5216a37ed94abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->