### PR TITLE
RI-8157: create add vector thunk and refactor others

### DIFF
--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -63,6 +63,7 @@ enum ApiEndpoints {
   REJSON_SET = 'rejson-rl/set',
   REJSON_ARRAPPEND = 'rejson-rl/arrappend',
 
+  VECTOR_SET = 'vector-set',
   VECTOR_SET_GET_ELEMENTS = 'vector-set/get-elements',
   VECTOR_SET_ELEMENTS = 'vector-set/elements',
   VECTOR_SET_GET_ELEMENT_DETAILS = 'vector-set/get-details',

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -10,20 +10,27 @@ import {
   isEqualBuffers,
   isStatusSuccessful,
   Maybe,
+  stringToBuffer,
 } from 'uiSrc/utils'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 
 import {
   deleteKeyFromList,
   deleteSelectedKeySuccess,
+  fetchKeyInfo,
   refreshKeyInfoAction,
   updateSelectedKeyRefreshTime,
 } from './keys'
 import { AppDispatch, RootState } from '../store'
 import { RedisResponseBuffer } from '../interfaces'
 import {
+  AddVectorSetElementsData,
+  AddVectorSetElementsState,
+  FetchMoreVectorSetElementsParams,
+  FetchVectorSetElementsParams,
+  GetVectorSetElementsResponse,
   InitialStateVectorSet,
-  ModifiedVectorSetResponse,
+  VectorSetData,
   VectorSetElement,
 } from '../interfaces/vectorSet'
 import {
@@ -45,6 +52,10 @@ export const initialState: InitialStateVectorSet = {
     nextCursor: undefined,
     elements: [],
   },
+  adding: {
+    loading: false,
+    error: '',
+  },
 }
 
 const vectorSetSlice = createSlice({
@@ -64,13 +75,12 @@ const vectorSetSlice = createSlice({
     },
     loadVectorSetElementsSuccess: (
       state,
-      { payload }: PayloadAction<ModifiedVectorSetResponse>,
+      { payload }: PayloadAction<VectorSetData>,
     ) => {
       state.data = {
         ...state.data,
         ...payload,
       }
-      state.data.key = payload.keyName as RedisResponseBuffer
       state.loading = false
     },
     loadVectorSetElementsFailure: (state, { payload }) => {
@@ -86,7 +96,7 @@ const vectorSetSlice = createSlice({
       state,
       {
         payload: { elements, nextCursor, ...rest },
-      }: PayloadAction<ModifiedVectorSetResponse>,
+      }: PayloadAction<VectorSetData>,
     ) => {
       state.loading = false
       state.data = {
@@ -138,6 +148,27 @@ const vectorSetSlice = createSlice({
       }
     },
 
+    addElements: (state) => {
+      state.adding = {
+        ...state.adding,
+        loading: true,
+        error: '',
+      }
+    },
+    addElementsSuccess: (state) => {
+      state.adding = {
+        ...state.adding,
+        loading: false,
+      }
+    },
+    addElementsFailure: (state, { payload }) => {
+      state.adding = {
+        ...state.adding,
+        loading: false,
+        error: payload,
+      }
+    },
+
     downloadVectorSetEmbedding: (state) => {
       state.downloading = true
     },
@@ -163,6 +194,9 @@ export const {
   removeVectorSetElementsFailure,
   removeElementsFromList,
   updateElementAttributes,
+  addElements,
+  addElementsSuccess,
+  addElementsFailure,
   downloadVectorSetEmbedding,
   downloadVectorSetEmbeddingSuccess,
   downloadVectorSetEmbeddingFailure,
@@ -171,20 +205,11 @@ export const {
 export const vectorSetSelector = (state: RootState) => state.browser.vectorSet
 export const vectorSetDataSelector = (state: RootState) =>
   state.browser.vectorSet?.data
+export const addVectorSetElementsStateSelector = (
+  state: RootState,
+): AddVectorSetElementsState => state.browser.vectorSet?.adding
 
 export default vectorSetSlice.reducer
-
-interface FetchVectorSetElementsParams {
-  key: RedisResponseBuffer
-  count?: number
-  resetData?: boolean
-}
-
-interface FetchMoreVectorSetElementsParams {
-  key: RedisResponseBuffer
-  nextCursor: string
-  count?: number
-}
 
 export function fetchVectorSetElements({
   key,
@@ -197,20 +222,27 @@ export function fetchVectorSetElements({
     try {
       const state = stateInit()
       const { encoding } = state.app.info
-      const { data, status } = await apiService.post<ModifiedVectorSetResponse>(
-        getUrl(
-          state.connections.instances.connectedInstance?.id,
-          ApiEndpoints.VECTOR_SET_GET_ELEMENTS,
-        ),
-        {
-          keyName: key,
-          count,
-        },
-        { params: { encoding } },
-      )
+      const { data, status } =
+        await apiService.post<GetVectorSetElementsResponse>(
+          getUrl(
+            state.connections.instances.connectedInstance?.id,
+            ApiEndpoints.VECTOR_SET_GET_ELEMENTS,
+          ),
+          {
+            keyName: key,
+            count,
+          },
+          { params: { encoding } },
+        )
 
       if (isStatusSuccessful(status)) {
-        dispatch(loadVectorSetElementsSuccess(data))
+        const { elementNames, ...rest } = data
+        dispatch(
+          loadVectorSetElementsSuccess({
+            ...rest,
+            elements: elementNames.map((name) => ({ name })),
+          }),
+        )
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (_err) {
@@ -233,21 +265,28 @@ export function fetchMoreVectorSetElements({
     try {
       const state = stateInit()
       const { encoding } = state.app.info
-      const { data, status } = await apiService.post<ModifiedVectorSetResponse>(
-        getUrl(
-          state.connections.instances.connectedInstance?.id,
-          ApiEndpoints.VECTOR_SET_GET_ELEMENTS,
-        ),
-        {
-          keyName: key,
-          start: nextCursor,
-          count,
-        },
-        { params: { encoding } },
-      )
+      const { data, status } =
+        await apiService.post<GetVectorSetElementsResponse>(
+          getUrl(
+            state.connections.instances.connectedInstance?.id,
+            ApiEndpoints.VECTOR_SET_GET_ELEMENTS,
+          ),
+          {
+            keyName: key,
+            start: nextCursor,
+            count,
+          },
+          { params: { encoding } },
+        )
 
       if (isStatusSuccessful(status)) {
-        dispatch(loadMoreVectorSetElementsSuccess(data))
+        const { elementNames, ...rest } = data
+        dispatch(
+          loadMoreVectorSetElementsSuccess({
+            ...rest,
+            elements: elementNames.map((name) => ({ name })),
+          }),
+        )
       }
     } catch (_err) {
       const error = _err as AxiosError
@@ -387,6 +426,46 @@ export function setVectorSetElementAttribute(
     } catch (_err) {
       const error = _err as AxiosError
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+export function addVectorSetElements(
+  data: AddVectorSetElementsData,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(addElements())
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { status } = await apiService.put(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.VECTOR_SET,
+        ),
+        {
+          keyName: data.keyName,
+          elements: data.elements.map((el) => ({
+            name: stringToBuffer(el.name),
+            vector: el.vector,
+            ...(el.attributes ? { attributes: el.attributes } : {}),
+          })),
+        },
+        { params: { encoding } },
+      )
+      if (isStatusSuccessful(status)) {
+        onSuccessAction?.()
+        dispatch(addElementsSuccess())
+        dispatch<any>(fetchKeyInfo(data.keyName))
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      onFailAction?.()
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(addElementsFailure(errorMessage))
     }
   }
 }

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -7,9 +7,8 @@ export interface VectorSetElement {
   attributes?: string
 }
 
-export interface ModifiedVectorSetResponse {
+export interface VectorSetData {
   total: number
-  key?: RedisResponseBuffer
   keyName: RedisString
   nextCursor?: string
   /** From API: whether cursor-based pagination is supported for listing elements. */
@@ -17,9 +16,44 @@ export interface ModifiedVectorSetResponse {
   elements: VectorSetElement[]
 }
 
+export interface GetVectorSetElementsResponse {
+  total: number
+  keyName: RedisString
+  nextCursor?: string
+  isPaginationSupported?: boolean
+  elementNames: RedisResponseBuffer[]
+}
+
+export interface AddVectorSetElementsState {
+  loading: boolean
+  error: string
+}
+
+export interface AddVectorSetElementsData {
+  keyName: RedisResponseBuffer
+  elements: {
+    name: string
+    vector: number[]
+    attributes?: string
+  }[]
+}
+
+export interface FetchVectorSetElementsParams {
+  key: RedisResponseBuffer
+  count?: number
+  resetData?: boolean
+}
+
+export interface FetchMoreVectorSetElementsParams {
+  key: RedisResponseBuffer
+  nextCursor: string
+  count?: number
+}
+
 export interface InitialStateVectorSet {
   loading: boolean
   downloading: boolean
   error: string
-  data: ModifiedVectorSetResponse
+  data: VectorSetData
+  adding: AddVectorSetElementsState
 }

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -19,6 +19,7 @@ import {
   vectorSetElementWithAttributesFactory,
   vectorSetTestKeyName,
   vectorSetPaginationCursorAfter,
+  addVectorSetElementsDataFactory,
 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import {
   deletePatternKeyFromList,
@@ -39,6 +40,11 @@ import reducer, {
   removeVectorSetElementsFailure,
   removeElementsFromList,
   updateElementAttributes,
+  addElements,
+  addElementsSuccess,
+  addElementsFailure,
+  addVectorSetElements,
+  addVectorSetElementsStateSelector,
   downloadVectorSetEmbedding,
   downloadVectorSetEmbeddingSuccess,
   downloadVectorSetEmbeddingFailure,
@@ -116,9 +122,9 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: {
           ...data,
-          key: data.keyName,
         },
       }
 
@@ -143,10 +149,10 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: {
           ...initialState.data,
           ...data,
-          key: data.keyName,
         },
       }
 
@@ -177,9 +183,9 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: {
           ...data,
-          key: data.keyName,
         },
       }
 
@@ -212,9 +218,9 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: {
           ...data,
-          key: data.keyName,
         },
       }
 
@@ -239,6 +245,7 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: data,
+        adding: initialState.adding,
         data: initialState.data,
       }
 
@@ -261,6 +268,7 @@ describe('vectorSet slice', () => {
         loading: true,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: initialState.data,
       }
 
@@ -289,6 +297,7 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: '',
+        adding: initialState.adding,
         data: {
           ...initialState.data,
           keyName,
@@ -318,6 +327,7 @@ describe('vectorSet slice', () => {
         loading: false,
         downloading: false,
         error: data,
+        adding: initialState.adding,
         data: initialState.data,
       }
 
@@ -451,27 +461,34 @@ describe('vectorSet slice', () => {
   describe('thunks', () => {
     describe('fetchVectorSetElements', () => {
       const thunkElements = vectorSetElementFactory.buildList(3)
-      const data = {
+      const apiResponse = {
         keyName: vectorSetTestKeyName(),
         total: thunkElements.length,
         nextCursor: vectorSetPaginationCursorAfter(
           thunkElements[thunkElements.length - 1],
         ),
         isPaginationSupported: true,
-        elements: thunkElements,
+        elementNames: thunkElements.map((el) => el.name),
       }
 
       it('call fetchVectorSetElements, loadVectorSetElementsSuccess when fetch is successful', async () => {
-        const responsePayload = { data, status: 200 }
+        const responsePayload = { data: apiResponse, status: 200 }
         apiService.post = jest.fn().mockResolvedValue(responsePayload)
 
         await store.dispatch<any>(
-          fetchVectorSetElements({ key: data.keyName as any, count: 10 }),
+          fetchVectorSetElements({
+            key: apiResponse.keyName as any,
+            count: 10,
+          }),
         )
 
+        const { elementNames, ...rest } = apiResponse
         const expectedActions = [
           loadVectorSetElements(undefined),
-          loadVectorSetElementsSuccess(responsePayload.data),
+          loadVectorSetElementsSuccess({
+            ...rest,
+            elements: elementNames.map((name) => ({ name })),
+          }),
           updateSelectedKeyRefreshTime(Date.now()),
         ]
 
@@ -489,7 +506,10 @@ describe('vectorSet slice', () => {
         apiService.post = jest.fn().mockRejectedValue(responsePayload)
 
         await store.dispatch<any>(
-          fetchVectorSetElements({ key: data.keyName as any, count: 10 }),
+          fetchVectorSetElements({
+            key: apiResponse.keyName as any,
+            count: 10,
+          }),
         )
 
         const expectedActions = [
@@ -504,34 +524,38 @@ describe('vectorSet slice', () => {
 
     describe('fetchMoreVectorSetElements', () => {
       const moreElements = vectorSetElementFactory.buildList(3)
-      const data = {
+      const moreApiResponse = {
         keyName: vectorSetTestKeyName(),
         total: faker.number.int({ min: moreElements.length + 1, max: 100 }),
         nextCursor: vectorSetPaginationCursorAfter(
           moreElements[moreElements.length - 1],
         ),
         isPaginationSupported: true,
-        elements: moreElements,
+        elementNames: moreElements.map((el) => el.name),
       }
       const requestCursor = vectorSetPaginationCursorAfter(
         vectorSetElementFactory.build(),
       )
 
       it('call fetchMoreVectorSetElements, loadMoreVectorSetElementsSuccess when fetch is successful', async () => {
-        const responsePayload = { data, status: 200 }
+        const responsePayload = { data: moreApiResponse, status: 200 }
         apiService.post = jest.fn().mockResolvedValue(responsePayload)
 
         await store.dispatch<any>(
           fetchMoreVectorSetElements({
-            key: data.keyName as any,
+            key: moreApiResponse.keyName as any,
             nextCursor: requestCursor,
             count: 10,
           }),
         )
 
+        const { elementNames: moreElementNames, ...moreRest } = moreApiResponse
         const expectedActions = [
           loadMoreVectorSetElements(),
-          loadMoreVectorSetElementsSuccess(responsePayload.data),
+          loadMoreVectorSetElementsSuccess({
+            ...moreRest,
+            elements: moreElementNames.map((name) => ({ name })),
+          }),
         ]
 
         expect(mockedStore.getActions()).toEqual(expectedActions)
@@ -549,7 +573,7 @@ describe('vectorSet slice', () => {
 
         await store.dispatch<any>(
           fetchMoreVectorSetElements({
-            key: data.keyName as any,
+            key: moreApiResponse.keyName as any,
             nextCursor: requestCursor,
             count: 10,
           }),
@@ -897,6 +921,104 @@ describe('vectorSet slice', () => {
       expect(nextState.data.elements[0].attributes).toEqual(
         elements[0].attributes,
       )
+    })
+  })
+
+  describe('addElements', () => {
+    it('should set adding.loading true and clear error', () => {
+      const nextState = reducer(initialState, addElements())
+
+      expect(nextState.adding.loading).toBe(true)
+      expect(nextState.adding.error).toBe('')
+    })
+  })
+
+  describe('addElementsSuccess', () => {
+    it('should set adding.loading false', () => {
+      const prevState = {
+        ...initialState,
+        adding: { loading: true, error: '' },
+      }
+      const nextState = reducer(prevState, addElementsSuccess())
+
+      expect(nextState.adding.loading).toBe(false)
+    })
+  })
+
+  describe('addElementsFailure', () => {
+    it('should set adding.loading false and store error', () => {
+      const prevState = {
+        ...initialState,
+        adding: { loading: true, error: '' },
+      }
+      const nextState = reducer(prevState, addElementsFailure('add failed'))
+
+      expect(nextState.adding.loading).toBe(false)
+      expect(nextState.adding.error).toBe('add failed')
+    })
+  })
+
+  describe('addVectorSetElementsStateSelector', () => {
+    it('should return the adding state', () => {
+      const addingState = { loading: true, error: 'err' }
+      const rootState = {
+        ...initialStateDefault,
+        browser: {
+          ...initialStateDefault.browser,
+          vectorSet: { ...initialState, adding: addingState },
+        },
+      }
+      expect(addVectorSetElementsStateSelector(rootState)).toEqual(addingState)
+    })
+  })
+
+  describe('addVectorSetElements thunk', () => {
+    const elementsData = addVectorSetElementsDataFactory.build()
+
+    it('should dispatch success actions when add is successful', async () => {
+      const responsePayload = { status: 200 }
+      apiService.put = jest.fn().mockResolvedValue(responsePayload)
+
+      const onSuccess = jest.fn()
+
+      await store.dispatch<any>(
+        addVectorSetElements(elementsData as any, onSuccess),
+      )
+
+      const expectedActions = [addElements(), addElementsSuccess()]
+
+      expect(store.getActions().slice(0, expectedActions.length)).toEqual(
+        expectedActions,
+      )
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('should dispatch failure actions when add fails', async () => {
+      const errorMessage = 'Something was wrong!'
+      const responsePayload = {
+        response: {
+          status: 500,
+          data: { message: errorMessage },
+        },
+      }
+      apiService.put = jest.fn().mockRejectedValue(responsePayload)
+
+      const onFail = jest.fn()
+
+      await store.dispatch<any>(
+        addVectorSetElements(elementsData as any, undefined, onFail),
+      )
+
+      const expectedActions = [
+        addElements(),
+        addErrorNotification(
+          responsePayload as unknown as IAddInstanceErrorPayload,
+        ),
+        addElementsFailure(errorMessage),
+      ]
+
+      expect(store.getActions()).toEqual(expectedActions)
+      expect(onFail).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Adds the `addVectorSetElements` thunk (PUT `/vector-set`) with its own `adding` sub-state (`loading` / `error`), reducers, and `addVectorSetElementsStateSelector`. Refreshes key info after a successful add.
- Introduces a dedicated `GetVectorSetElementsResponse` model that matches the API shape (`elementNames: RedisString[]`) and maps it to the existing frontend `VectorSetData.elements` in `fetchVectorSetElements` / `fetchMoreVectorSetElements`.
- Renames `ModifiedVectorSetResponse` → `VectorSetData`, drops the unused duplicate `key` field on state, and moves `FetchVectorSetElementsParams` / `FetchMoreVectorSetElementsParams` into the interfaces file.
- Adds `AddVectorSetElementsData` and `AddVectorSetElementsState` interfaces and registers the new `VECTOR_SET = 'vector-set'` endpoint in `api.ts`.


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->


Testing in this PR -> <pr_link>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Vector Set browser slice state shape and API response mapping for element listing, which could break UI expectations or pagination if the new `elementNames`→`elements` transform is wrong. It also introduces a new write path (PUT to `vector-set`) that refreshes key info after mutation.
> 
> **Overview**
> Adds support for *adding elements to a Vector Set* via a new `addVectorSetElements` thunk (PUT `ApiEndpoints.VECTOR_SET`) with dedicated `adding` sub-state (`loading`/`error`) and selector, and refreshes key info after a successful add.
> 
> Refactors Vector Set element listing to match the backend response shape by introducing `GetVectorSetElementsResponse` (`elementNames`) and mapping it into the UI’s `VectorSetData.elements` in `fetchVectorSetElements`/`fetchMoreVectorSetElements`, while cleaning up types (renaming `ModifiedVectorSetResponse`→`VectorSetData`, moving fetch param interfaces) and updating tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9188001e41e9ccdc48a6161bf8cf4df7b1a0974f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->