### PR TITLE
RI-8157: add vector set element attribute editor

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, screen, waitFor } from 'uiSrc/utils/test-utils'
+
+import { AttributeEditor } from './AttributeEditor'
+import {
+  ATTRIBUTES_WARNING_MESSAGE,
+  JSON_VALIDATION_DEBOUNCE_MS,
+} from './constants'
+
+const queryWarning = () => screen.queryByText(ATTRIBUTES_WARNING_MESSAGE)
+
+describe('AttributeEditor', () => {
+  it('should not show warning for empty value', () => {
+    render(<AttributeEditor value="" onChange={jest.fn()} />)
+    expect(queryWarning()).not.toBeInTheDocument()
+  })
+
+  it('should not show warning for valid JSON value', () => {
+    render(<AttributeEditor value='{"status":"ok"}' onChange={jest.fn()} />)
+    expect(queryWarning()).not.toBeInTheDocument()
+  })
+
+  it('should show warning immediately for non-JSON initial value', () => {
+    render(<AttributeEditor value="not-json" onChange={jest.fn()} />)
+    expect(queryWarning()).toBeInTheDocument()
+  })
+
+  it('should toggle warning after debounce when value becomes invalid', async () => {
+    const { rerender } = render(
+      <AttributeEditor value='{"ok":true}' onChange={jest.fn()} />,
+    )
+    expect(queryWarning()).not.toBeInTheDocument()
+
+    rerender(<AttributeEditor value="invalid-json" onChange={jest.fn()} />)
+
+    await waitFor(
+      () => {
+        expect(queryWarning()).toBeInTheDocument()
+      },
+      { timeout: JSON_VALIDATION_DEBOUNCE_MS + 500 },
+    )
+  })
+
+  it('should use provided testId as prefix for the warning', () => {
+    render(
+      <AttributeEditor value="not-json" onChange={jest.fn()} testId="custom" />,
+    )
+    expect(screen.getByTestId('custom-warning')).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.styles.ts
@@ -1,10 +1,8 @@
 import styled from 'styled-components'
 import { Banner } from 'uiSrc/components/base/display/banner'
+import { Col } from 'uiSrc/components/base/layout/flex'
 
-export const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.core?.space?.space050};
+export const Wrapper = styled(Col)`
   width: 100%;
   min-width: 0;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.styles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import { Banner } from 'uiSrc/components/base/display/banner'
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.core?.space?.space050};
+  width: 100%;
+  min-width: 0;
+`
+
+export const EditorContainer = styled.div<{
+  $height: string
+  children: React.ReactNode
+}>`
+  height: ${({ $height }) => $height};
+  border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
+  overflow: hidden;
+`
+
+export const StyledBanner = styled(Banner)`
+  width: 100%;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react'
+
+import { CodeEditor } from 'uiSrc/components/base/code-editor'
+import { Text } from 'uiSrc/components/base/text'
+import { useDebouncedEffect } from 'uiSrc/services'
+
+import {
+  ATTRIBUTES_EDITOR_OPTIONS,
+  ATTRIBUTES_WARNING_MESSAGE,
+  DEFAULT_ATTRIBUTE_EDITOR_HEIGHT,
+  JSON_VALIDATION_DEBOUNCE_MS,
+} from './constants'
+import {
+  isJsonValid,
+  restoreJsonValidation,
+  suppressJsonValidation,
+} from './utils'
+import { AttributeEditorProps } from './AttributeEditor.types'
+import * as S from './AttributeEditor.styles'
+
+const AttributeEditor = ({
+  value,
+  onChange,
+  isInEditMode = false,
+  height = DEFAULT_ATTRIBUTE_EDITOR_HEIGHT,
+  testId = 'attribute-editor',
+}: AttributeEditorProps) => {
+  const [showNonJsonWarning, setShowNonJsonWarning] = useState(
+    () => !isJsonValid(value),
+  )
+
+  useEffect(() => {
+    suppressJsonValidation()
+    return restoreJsonValidation
+  }, [])
+
+  useDebouncedEffect(
+    () => {
+      setShowNonJsonWarning(!isJsonValid(value))
+    },
+    JSON_VALIDATION_DEBOUNCE_MS,
+    [value],
+  )
+
+  return (
+    <S.Wrapper>
+      <S.EditorContainer $height={height}>
+        <CodeEditor
+          language="json"
+          value={value}
+          options={{
+            ...ATTRIBUTES_EDITOR_OPTIONS,
+            readOnly: !isInEditMode,
+          }}
+          onChange={onChange}
+          data-testid={testId}
+        />
+      </S.EditorContainer>
+      <S.StyledBanner
+        show={showNonJsonWarning}
+        variant="attention"
+        size="S"
+        message={
+          <Text size="s" component="span">
+            {ATTRIBUTES_WARNING_MESSAGE}
+          </Text>
+        }
+        data-testid={`${testId}-warning`}
+      />
+    </S.Wrapper>
+  )
+}
+
+export { AttributeEditor }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
@@ -21,7 +21,9 @@ const AttributeEditor = ({
   height = DEFAULT_ATTRIBUTE_EDITOR_HEIGHT,
   testId = 'attribute-editor',
 }: AttributeEditorProps) => {
-  const [showNonJsonWarning, setShowNonJsonWarning] = useState(false)
+  const [showNonJsonWarning, setShowNonJsonWarning] = useState(
+    () => !isJsonValid(value),
+  )
 
   useDebouncedEffect(
     () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { CodeEditor } from 'uiSrc/components/base/code-editor'
 import { Text } from 'uiSrc/components/base/text'
@@ -10,11 +10,7 @@ import {
   DEFAULT_ATTRIBUTE_EDITOR_HEIGHT,
   JSON_VALIDATION_DEBOUNCE_MS,
 } from './constants'
-import {
-  isJsonValid,
-  restoreJsonValidation,
-  suppressJsonValidation,
-} from './utils'
+import { isJsonValid } from './utils'
 import { AttributeEditorProps } from './AttributeEditor.types'
 import * as S from './AttributeEditor.styles'
 
@@ -25,14 +21,7 @@ const AttributeEditor = ({
   height = DEFAULT_ATTRIBUTE_EDITOR_HEIGHT,
   testId = 'attribute-editor',
 }: AttributeEditorProps) => {
-  const [showNonJsonWarning, setShowNonJsonWarning] = useState(
-    () => !isJsonValid(value),
-  )
-
-  useEffect(() => {
-    suppressJsonValidation()
-    return restoreJsonValidation
-  }, [])
+  const [showNonJsonWarning, setShowNonJsonWarning] = useState(false)
 
   useDebouncedEffect(
     () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.tsx
@@ -34,7 +34,7 @@ const AttributeEditor = ({
   )
 
   return (
-    <S.Wrapper>
+    <S.Wrapper gap="s">
       <S.EditorContainer $height={height}>
         <CodeEditor
           language="json"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.types.ts
@@ -1,0 +1,7 @@
+export interface AttributeEditorProps {
+  value: string
+  onChange: (value: string) => void
+  isInEditMode?: boolean
+  height?: string
+  testId?: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/constants.ts
@@ -1,0 +1,30 @@
+import { monaco as monacoEditor } from 'react-monaco-editor'
+
+export const ATTRIBUTES_EDITOR_OPTIONS: Partial<monacoEditor.editor.IStandaloneEditorConstructionOptions> =
+  {
+    automaticLayout: true,
+    contextmenu: false,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    stickyScroll: { enabled: false },
+    overviewRulerLanes: 0,
+    overviewRulerBorder: false,
+    hideCursorInOverviewRuler: true,
+    renderLineHighlight: 'none',
+    folding: false,
+    guides: {
+      indentation: false,
+      bracketPairs: false,
+    },
+    scrollbar: {
+      vertical: 'auto' as const,
+      horizontal: 'auto' as const,
+    },
+  }
+
+export const ATTRIBUTES_WARNING_MESSAGE =
+  'Non-JSON attributes are not supported as filter expressions in similarity search queries.'
+
+export const JSON_VALIDATION_DEBOUNCE_MS = 500
+
+export const DEFAULT_ATTRIBUTE_EDITOR_HEIGHT = '200px'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/index.ts
@@ -1,0 +1,2 @@
+export { AttributeEditor } from './AttributeEditor'
+export type { AttributeEditorProps } from './AttributeEditor.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.spec.ts
@@ -1,0 +1,43 @@
+import { isJsonValid } from './utils'
+
+describe('isJsonValid', () => {
+  describe('empty values', () => {
+    it.each([
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['tabs and newlines', '\t\n  \n'],
+    ])('should return true for %s', (_label, input) => {
+      expect(isJsonValid(input)).toBe(true)
+    })
+  })
+
+  describe('valid JSON', () => {
+    it.each([
+      ['object', '{"status":"ok"}'],
+      ['nested object', '{"a":{"b":{"c":1}}}'],
+      ['array', '[1, 2, 3]'],
+      ['array of objects', '[{"id":1},{"id":2}]'],
+      ['string literal', '"hello"'],
+      ['number literal', '42'],
+      ['boolean literal', 'true'],
+      ['null literal', 'null'],
+      ['JSON with surrounding whitespace', '  {"a":1}  \n'],
+    ])('should return true for %s', (_label, input) => {
+      expect(isJsonValid(input)).toBe(true)
+    })
+  })
+
+  describe('invalid JSON', () => {
+    it.each([
+      ['plain text', 'not json'],
+      ['single-quoted keys', "{'a':1}"],
+      ['trailing comma', '{"a":1,}'],
+      ['unquoted keys', '{a:1}'],
+      ['unclosed object', '{"a":1'],
+      ['unclosed array', '[1, 2'],
+      ['bare identifier', 'undefined'],
+    ])('should return false for %s', (_label, input) => {
+      expect(isJsonValid(input)).toBe(false)
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.ts
@@ -1,27 +1,3 @@
-import { monaco } from 'react-monaco-editor'
-
-let jsonValidationSuppressors = 0
-
-const setJsonValidation = (validate: boolean) => {
-  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({ validate })
-}
-
-export const suppressJsonValidation = () => {
-  if (jsonValidationSuppressors === 0) {
-    setJsonValidation(false)
-  }
-  jsonValidationSuppressors += 1
-}
-
-export const restoreJsonValidation = () => {
-  if (jsonValidationSuppressors === 0) return
-
-  jsonValidationSuppressors -= 1
-  if (jsonValidationSuppressors === 0) {
-    setJsonValidation(true)
-  }
-}
-
 export const isJsonValid = (text: string): boolean => {
   const trimmed = text.trim()
   if (!trimmed) return true

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/utils.ts
@@ -1,0 +1,34 @@
+import { monaco } from 'react-monaco-editor'
+
+let jsonValidationSuppressors = 0
+
+const setJsonValidation = (validate: boolean) => {
+  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({ validate })
+}
+
+export const suppressJsonValidation = () => {
+  if (jsonValidationSuppressors === 0) {
+    setJsonValidation(false)
+  }
+  jsonValidationSuppressors += 1
+}
+
+export const restoreJsonValidation = () => {
+  if (jsonValidationSuppressors === 0) return
+
+  jsonValidationSuppressors -= 1
+  if (jsonValidationSuppressors === 0) {
+    setJsonValidation(true)
+  }
+}
+
+export const isJsonValid = (text: string): boolean => {
+  const trimmed = text.trim()
+  if (!trimmed) return true
+  try {
+    JSON.parse(trimmed)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->


Introduces a reusable `AttributeEditor` component under `vector-set-details/attribute-editor/` for editing Vector Set element attributes. Consumed in follow-up PRs by both the element details drawer and the add-elements form.
- Monaco-based JSON editor (via `CodeEditor`) configured for a compact, chrome-less look in `constants.ts` (no minimap, sticky scroll, overview ruler, line highlight, folding, or context menu; `automaticLayout` on).
- Controlled component API in `AttributeEditor.types.ts`: `value`, `onChange`, `isInEditMode` (drives `readOnly`), optional `height` (default `200px`), and optional `testId` used as a prefix for `data-testid` attributes on the editor and warning banner.
- Accepts arbitrary text as a valid value — validity is checked via a lightweight `isJsonValid` helper in `utils.ts` (empty / whitespace-only values treated as valid). Revalidated on `value` changes through `useDebouncedEffect` with `JSON_VALIDATION_DEBOUNCE_MS = 500` to avoid flicker while typing.
- Renders an attention banner (`Banner` via `StyledBanner`) below the editor when the current value isn't valid JSON, informing the user that non-JSON attributes can't be used as filter expressions in similarity-search queries.
- Styles extracted into `AttributeEditor.styles.ts` (`Wrapper`, `EditorContainer`, `StyledBanner`); barrel export in `index.ts`.


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

Follow up PR - https://github.com/redis/RedisInsight/pull/5815 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only addition with lightweight JSON parsing and debounced state updates; risk is mainly around warning visibility/UX rather than data or security behavior.
> 
> **Overview**
> Adds a reusable `AttributeEditor` component for vector-set element attributes, using the Monaco-based `CodeEditor` with a compact JSON-focused configuration and optional `readOnly`/height/testId controls.
> 
> Introduces debounced JSON validation (`isJsonValid` + `useDebouncedEffect`) that shows an attention `Banner` when the current value isn’t valid JSON, and adds unit tests covering validation and warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae172e31df672edd786f300eba3470d0170ffff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->