### PR TITLE
RI-8157: add vector set element components

### DIFF
--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -98,6 +98,7 @@ export class VectorSetService {
         'Adding elements to the VectorSet data type.',
         clientMetadata,
       );
+
       const { keyName, elements } = dto;
       const client: RedisClient =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);

--- a/redisinsight/ui/src/components/base/inputs/TextInput.tsx
+++ b/redisinsight/ui/src/components/base/inputs/TextInput.tsx
@@ -7,16 +7,10 @@ export type RedisInputProps = ComponentProps<typeof RedisInput>
 const TextInput = forwardRef<
   React.ElementRef<typeof RedisInput>,
   RedisInputProps
->((props, ref) => {
-  // eslint-disable-next-line react/destructuring-assignment
-  if (props.error) {
-    return (
-      <TooltipProvider>
-        <RedisInput ref={ref} {...props} />
-      </TooltipProvider>
-    )
-  }
-  return <RedisInput ref={ref} {...props} />
-})
+>((props, ref) => (
+  <TooltipProvider>
+    <RedisInput ref={ref} {...props} />
+  </TooltipProvider>
+))
 
 export default TextInput

--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -6,6 +6,7 @@ import {
   AddVectorSetElementsData,
   VectorSetElement,
 } from 'uiSrc/slices/interfaces'
+import { IVectorSetElementState } from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces'
 
 export const mockKeyBuffer = stringToBuffer(faker.word.noun())
 
@@ -55,6 +56,15 @@ export const addVectorSetElementsDataFactory =
         attributes: mockVectorSetElementAttributes(),
       },
     ],
+  }))
+
+export const vectorSetElementFormStateFactory =
+  Factory.define<IVectorSetElementState>(() => ({
+    id: 1,
+    name: 'item',
+    vector: '1, 2, 3',
+    attributes: '',
+    showAttributes: false,
   }))
 
 /** Redis key name string for vector set tests (stable shape, random value). */

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
@@ -19,7 +19,7 @@ export const AddKeysContainer = styled.div<
   border-top-width: 1px;
   width: 100%;
 
-  z-index: 2;
+  z-index: 3;
 
   max-height: 100%;
   overflow-y: auto;

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.spec.tsx
@@ -1,33 +1,68 @@
 import React from 'react'
-import { instance, mock } from 'ts-mockito'
-import { render, screen } from 'uiSrc/utils/test-utils'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { Props, VectorSetDetails } from './VectorSetDetails'
 
-const mockedProps = mock<Props>()
+const defaultProps = {
+  onRemoveKey: jest.fn(),
+  onOpenAddItemPanel: jest.fn(),
+  onCloseAddItemPanel: jest.fn(),
+} as unknown as Props
 
 jest.mock('uiSrc/slices/browser/vectorSet', () => {
   const defaultState = jest.requireActual(
     'uiSrc/slices/browser/vectorSet',
   ).initialState
   return {
+    ...jest.requireActual('uiSrc/slices/browser/vectorSet'),
     vectorSetSelector: jest.fn().mockReturnValue(defaultState),
     vectorSetDataSelector: jest.fn().mockReturnValue(defaultState.data),
+    addVectorSetElementsStateSelector: jest
+      .fn()
+      .mockReturnValue(defaultState.adding),
     fetchMoreVectorSetElements: () => jest.fn(),
+    fetchVectorSetElements: () => jest.fn(),
+    addVectorSetElements: () => jest.fn(),
   }
 })
 
 describe('VectorSetDetails', () => {
   it('should render', () => {
-    expect(render(<VectorSetDetails {...instance(mockedProps)} />)).toBeTruthy()
+    expect(render(<VectorSetDetails {...defaultProps} />)).toBeTruthy()
   })
 
   it('should render key details header', () => {
-    render(<VectorSetDetails {...instance(mockedProps)} />)
+    render(<VectorSetDetails {...defaultProps} />)
     expect(screen.getByTestId('key-details-header')).toBeInTheDocument()
   })
 
   it('should render subheader with format selector', () => {
-    render(<VectorSetDetails {...instance(mockedProps)} />)
+    render(<VectorSetDetails {...defaultProps} />)
     expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+  })
+
+  it('should render add elements button', () => {
+    render(<VectorSetDetails {...defaultProps} />)
+    expect(screen.getByTestId('add-key-value-items-btn')).toBeInTheDocument()
+  })
+
+  it('should open add element panel when add button is clicked', () => {
+    render(<VectorSetDetails {...defaultProps} />)
+
+    expect(screen.queryByTestId('save-elements-btn')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+
+    expect(screen.getByTestId('save-elements-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('cancel-elements-btn')).toBeInTheDocument()
+  })
+
+  it('should close add element panel when cancel is clicked', () => {
+    render(<VectorSetDetails {...defaultProps} />)
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    expect(screen.getByTestId('save-elements-btn')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('cancel-elements-btn'))
+    expect(screen.queryByTestId('save-elements-btn')).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -6,10 +6,12 @@ import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
+import { VectorSetElementForm, SubmitElement } from './vector-set-element-form'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 import { VectorSetElementList } from './vector-set-element-list'
 import { VectorSetKeySubheader } from './vector-set-key-subheader'
 import { ElementDetails } from './element-details'
-import { useElementDetails } from './hooks'
+import { useAddElementPanel, useAddElements, useElementDetails } from './hooks'
 import * as S from './VectorSetDetails.styles'
 
 export interface Props extends KeyDetailsHeaderProps {
@@ -19,7 +21,8 @@ export interface Props extends KeyDetailsHeaderProps {
 }
 
 const VectorSetDetails = (props: Props) => {
-  const { onRemoveKey } = props
+  const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
+
   const { loading } = useSelector(selectedKeySelector)
 
   const {
@@ -30,10 +33,22 @@ const VectorSetDetails = (props: Props) => {
     handleDrawerDidClose,
   } = useElementDetails()
 
+  const { isAddItemPanelOpen, openAddItemPanel, closeAddItemPanel } =
+    useAddElementPanel({ onOpenAddItemPanel, onCloseAddItemPanel })
+
+  const { loading: addingLoading, vectorDim, submitElements } = useAddElements()
+
+  const handleSubmitElements = useCallback(
+    (elements: SubmitElement[]) => {
+      submitElements(elements, () => closeAddItemPanel())
+    },
+    [submitElements, closeAddItemPanel],
+  )
+
   return (
     <S.Container>
       <KeyDetailsHeader {...props} key="key-details-header" />
-      <VectorSetKeySubheader />
+      <VectorSetKeySubheader openAddItemPanel={openAddItemPanel} />
       <S.DetailsBody>
         {!loading && (
           <S.ListWrapper>
@@ -42,6 +57,16 @@ const VectorSetDetails = (props: Props) => {
               onViewElement={handleViewElement}
             />
           </S.ListWrapper>
+        )}
+        {isAddItemPanelOpen && (
+          <AddKeysContainer>
+            <VectorSetElementForm
+              onSubmit={handleSubmitElements}
+              onCancel={closeAddItemPanel}
+              loading={addingLoading}
+              vectorDim={vectorDim}
+            />
+          </AddKeysContainer>
         )}
       </S.DetailsBody>
       <ElementDetails

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { handleCopy } from 'uiSrc/utils'
-import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
 import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { ElementDetails } from './ElementDetails'
 import { ElementDetailsProps } from './ElementDetails.types'
@@ -9,29 +8,6 @@ import { ElementDetailsProps } from './ElementDetails.types'
 jest.mock('uiSrc/utils', () => ({
   ...jest.requireActual('uiSrc/utils'),
   handleCopy: jest.fn(),
-}))
-
-const mockUseMonacoValidation = jest.fn().mockReturnValue({
-  isValid: true,
-  isValidating: false,
-})
-
-jest.mock('uiSrc/components/base/code-editor', () => ({
-  CodeEditor: (props: any) => {
-    const mockReact = require('react')
-    return mockReact.createElement('textarea', {
-      'data-testid': 'mock-monaco-editor',
-      value: props.value,
-      readOnly: props.options?.readOnly,
-      onChange: (e: any) => {
-        if (props.onChange) props.onChange(e.target.value)
-      },
-    })
-  },
-}))
-
-jest.mock('uiSrc/components/monaco-editor', () => ({
-  useMonacoValidation: (...args: any[]) => mockUseMonacoValidation(...args),
 }))
 
 jest.mock('uiSrc/slices/browser/vectorSet', () => ({
@@ -55,14 +31,6 @@ describe('ElementDetails', () => {
     return render(<ElementDetails {...props} />)
   }
 
-  beforeEach(() => {
-    jest.mocked(setVectorSetElementAttribute).mockClear()
-    mockUseMonacoValidation.mockReturnValue({
-      isValid: true,
-      isValidating: false,
-    })
-  })
-
   it('should render when open with element', () => {
     renderComponent()
     expect(screen.getByTestId('vector-set-vector-value')).toBeInTheDocument()
@@ -76,19 +44,6 @@ describe('ElementDetails', () => {
     expect(vectorField).toHaveAttribute('readonly')
   })
 
-  it('should display formatted attributes in editor', () => {
-    renderComponent()
-    const editor = screen.getByTestId(
-      'mock-monaco-editor',
-    ) as HTMLTextAreaElement
-    if (mockElement.attributes) {
-      const parsed = JSON.parse(mockElement.attributes)
-      Object.keys(parsed).forEach((key) => {
-        expect(editor.value).toContain(key)
-      })
-    }
-  })
-
   it('should enter edit mode when edit button is clicked', () => {
     renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
@@ -100,49 +55,16 @@ describe('ElementDetails', () => {
     ).toBeInTheDocument()
   })
 
-  it('should revert changes when cancel is clicked', () => {
-    const element = vectorSetElementFactory.build({
-      attributes: JSON.stringify({ status: 'original' }),
-    })
-    renderComponent({ element })
-
-    const editor = screen.getByTestId(
-      'mock-monaco-editor',
-    ) as HTMLTextAreaElement
-    const originalValue = editor.value
-
+  it('should exit edit mode when cancel is clicked', () => {
+    renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
-    fireEvent.change(editor, {
-      target: { value: '{"status": "modified"}' },
-    })
-    expect(editor.value).toBe('{"status": "modified"}')
-
     fireEvent.click(screen.getByTestId('vector-set-cancel-attributes-btn'))
-
-    expect(editor.value).toBe(originalValue)
     expect(
       screen.queryByTestId('vector-set-save-attributes-btn'),
     ).not.toBeInTheDocument()
   })
 
-  it('should call setVectorSetElementAttribute on save', () => {
-    renderComponent()
-    fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
-
-    const editor = screen.getByTestId(
-      'mock-monaco-editor',
-    ) as HTMLTextAreaElement
-    fireEvent.change(editor, { target: { value: '{"changed": true}' } })
-
-    fireEvent.click(screen.getByTestId('vector-set-save-attributes-btn'))
-    expect(setVectorSetElementAttribute).toHaveBeenCalledTimes(1)
-  })
-
-  it('should disable save when validation reports invalid', () => {
-    mockUseMonacoValidation.mockReturnValue({
-      isValid: false,
-      isValidating: false,
-    })
+  it('should disable save when value is unchanged', () => {
     renderComponent()
     fireEvent.click(screen.getByTestId('vector-set-edit-attributes-btn'))
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -14,6 +14,8 @@ export const VectorTextArea = styled(TextArea)`
   scrollbar-width: thin;
   padding: ${({ theme }) => theme.core?.space?.space025};
   padding-right: ${({ theme }) => theme.core?.space?.space400};
+  background-color: ${({ theme }) =>
+    theme.semantic?.color?.background?.neutral100};
 `
 
 export const VectorWrapper = styled.div`
@@ -31,8 +33,6 @@ export const VectorActions = styled(Col)`
 export const EditorWrapper = styled.div<{ children: React.ReactNode }>`
   position: relative;
   width: 100%;
-  height: 200px;
-  border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
 `
 
 export const EditButton = styled(IconButton)`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { monaco } from 'react-monaco-editor'
 
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
@@ -19,20 +18,13 @@ import { DownloadIcon, EditIcon } from 'uiSrc/components/base/icons'
 import { CopyButton } from 'uiSrc/components/copy-button'
 import { RiTooltip } from 'uiSrc/components'
 import { downloadFile } from 'uiSrc/utils/dom/downloadFile'
-import { CodeEditor } from 'uiSrc/components/base/code-editor'
-import { useMonacoValidation } from 'uiSrc/components/monaco-editor'
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
-import {
-  fetchDownloadVectorEmbedding,
-  setVectorSetElementAttribute,
-} from 'uiSrc/slices/browser/vectorSet'
+import { fetchDownloadVectorEmbedding } from 'uiSrc/slices/browser/vectorSet'
 import { bufferToString } from 'uiSrc/utils'
+import { AttributeEditor } from '../attribute-editor'
+import { useElementAttributeEditor } from '../hooks'
 import { formatVector } from './utils'
-import {
-  VECTOR_DESCRIPTION,
-  ATTRIBUTES_DESCRIPTION,
-  ATTRIBUTES_EDITOR_OPTIONS,
-} from './constants'
+import { VECTOR_DESCRIPTION, ATTRIBUTES_DESCRIPTION } from './constants'
 import { ElementDetailsProps } from './ElementDetails.types'
 import * as S from './ElementDetails.styles'
 
@@ -45,22 +37,15 @@ const ElementDetails = ({
   const dispatch = useDispatch()
   const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
 
-  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
-  const { isValid, isValidating } = useMonacoValidation(editorRef)
-
-  const onEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
-    editorRef.current = editor
-  }
-
-  const [isEditing, setIsEditing] = useState(false)
-  const [value, setValue] = useState('')
-  const [savedValue, setSavedValue] = useState('')
-
-  useEffect(() => {
-    const formatted = bufferToString(element?.attributes)
-    setValue(formatted)
-    setIsEditing(false)
-  }, [element])
+  const {
+    isEditing,
+    value,
+    isSaveDisabled,
+    onChange,
+    startEditing,
+    cancelEditing,
+    saveAttribute,
+  } = useElementAttributeEditor({ element })
 
   const elementName = useMemo(
     () => (element ? bufferToString(element.name) : ''),
@@ -74,7 +59,7 @@ const ElementDetails = ({
     [element?.vector, isTruncatedVector],
   )
 
-  const handleDownloadVector = useCallback(() => {
+  const handleDownloadVector = () => {
     if (!element || !keyName) return
     dispatch(
       fetchDownloadVectorEmbedding(
@@ -83,55 +68,7 @@ const ElementDetails = ({
         downloadFile,
       ),
     )
-  }, [dispatch, element, keyName])
-
-  const startEditing = useCallback(() => {
-    setSavedValue(value)
-    setIsEditing(true)
-  }, [value])
-
-  const handleCancelEditing = useCallback(() => {
-    setValue(savedValue)
-    setIsEditing(false)
-  }, [savedValue])
-
-  const isValueValid = isValid && !isValidating
-  const isSaveDisabled = !isValueValid || value === savedValue
-
-  const handleSave = useCallback(() => {
-    if (!element || isSaveDisabled) return
-
-    const trimmed = value.trim()
-
-    // Guard against invalid JSON that can slip through due to a race condition
-    // in useMonacoValidation (decorations reset isValidating before markers update isValid)
-    let formatted: string
-    try {
-      formatted = trimmed ? JSON.stringify(JSON.parse(trimmed), null, 2) : ''
-    } catch {
-      return
-    }
-
-    const applyFormatted = () => {
-      setIsEditing(false)
-      setValue(formatted)
-      setSavedValue(formatted)
-    }
-
-    if (formatted === savedValue) {
-      applyFormatted()
-      return
-    }
-
-    dispatch(
-      setVectorSetElementAttribute(
-        keyName as RedisResponseBuffer,
-        element.name,
-        formatted,
-        applyFormatted,
-      ),
-    )
-  }, [dispatch, value, element, keyName, isSaveDisabled, savedValue])
+  }
 
   return (
     <Drawer
@@ -192,29 +129,26 @@ const ElementDetails = ({
                       data-testid="vector-set-edit-attributes-btn"
                     />
                   )}
-                  <CodeEditor
-                    language="json"
+                  <AttributeEditor
+                    key={elementName}
                     value={value}
-                    options={{
-                      ...ATTRIBUTES_EDITOR_OPTIONS,
-                      readOnly: !isEditing,
-                    }}
-                    onChange={setValue}
-                    editorDidMount={onEditorDidMount}
+                    onChange={onChange}
+                    isInEditMode={isEditing}
+                    testId="vector-set-attributes-editor"
                   />
                 </S.EditorWrapper>
               </Col>
               {isEditing && (
                 <Row justify="end" gap="m">
                   <SecondaryButton
-                    onClick={handleCancelEditing}
+                    onClick={cancelEditing}
                     data-testid="vector-set-cancel-attributes-btn"
                   >
                     Cancel
                   </SecondaryButton>
                   <PrimaryButton
                     disabled={isSaveDisabled}
-                    onClick={handleSave}
+                    onClick={saveAttribute}
                     data-testid="vector-set-save-attributes-btn"
                   >
                     Save

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/constants.ts
@@ -1,26 +1,4 @@
-import { monaco as monacoEditor } from 'react-monaco-editor'
-
 export const VECTOR_DESCRIPTION =
   'The numerical embedding representing this item in vector space, used for similarity search and ranking.'
 export const ATTRIBUTES_DESCRIPTION =
   'Structured metadata associated with this item, used for filtering, display, and hybrid search queries.'
-
-export const ATTRIBUTES_EDITOR_OPTIONS: Partial<monacoEditor.editor.IStandaloneEditorConstructionOptions> =
-  {
-    domReadOnly: false,
-    contextmenu: false,
-    minimap: { enabled: false },
-    scrollBeyondLastLine: false,
-    stickyScroll: { enabled: false },
-    overviewRulerLanes: 0,
-    renderLineHighlight: 'none',
-    folding: false,
-    guides: {
-      indentation: false,
-      bracketPairs: false,
-    },
-    scrollbar: {
-      vertical: 'auto' as const,
-      horizontal: 'auto' as const,
-    },
-  }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useAddElementPanel'
 export * from './useAddElements'
+export * from './useElementAttributeEditor'
 export * from './useElementDetails'
 export * from './useVectorSetElementForm'
 export * from './useVectorSetElementListData'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/index.ts
@@ -1,0 +1,5 @@
+export { useElementAttributeEditor } from './useElementAttributeEditor'
+export type {
+  UseElementAttributeEditorParams,
+  UseElementAttributeEditorResult,
+} from './useElementAttributeEditor.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { bufferToString } from 'uiSrc/utils'
+
+import {
+  UseElementAttributeEditorParams,
+  UseElementAttributeEditorResult,
+} from './useElementAttributeEditor.types'
+
+export const useElementAttributeEditor = ({
+  element,
+}: UseElementAttributeEditorParams): UseElementAttributeEditorResult => {
+  const dispatch = useDispatch()
+  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [value, setValue] = useState('')
+  const [savedValue, setSavedValue] = useState('')
+
+  useEffect(() => {
+    const formatted = bufferToString(element?.attributes)
+    setValue(formatted)
+    setSavedValue(formatted)
+    setIsEditing(false)
+  }, [element])
+
+  const startEditing = useCallback(() => setIsEditing(true), [])
+
+  const cancelEditing = useCallback(() => {
+    setValue(savedValue)
+    setIsEditing(false)
+  }, [savedValue])
+
+  const isSaveDisabled = value === savedValue
+
+  const saveAttribute = useCallback(() => {
+    if (!element || !keyName || isSaveDisabled) return
+
+    const trimmed = value.trim()
+
+    dispatch(
+      setVectorSetElementAttribute(
+        keyName as RedisResponseBuffer,
+        element.name,
+        trimmed,
+        () => {
+          setIsEditing(false)
+          setValue(trimmed)
+          setSavedValue(trimmed)
+        },
+      ),
+    )
+  }, [dispatch, element, keyName, value, isSaveDisabled])
+
+  return {
+    isEditing,
+    value,
+    isSaveDisabled,
+    onChange: setValue,
+    startEditing,
+    cancelEditing,
+    saveAttribute,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.types.ts
@@ -1,0 +1,15 @@
+import { VectorSetElement } from 'uiSrc/slices/interfaces'
+
+export interface UseElementAttributeEditorParams {
+  element: VectorSetElement | null
+}
+
+export interface UseElementAttributeEditorResult {
+  isEditing: boolean
+  value: string
+  isSaveDisabled: boolean
+  onChange: (next: string) => void
+  startEditing: () => void
+  cancelEditing: () => void
+  saveAttribute: () => void
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
@@ -5,7 +5,10 @@ import {
   IVectorSetElementState,
   SubmitElement,
 } from '../../vector-set-element-form/interfaces'
-import { parseVector } from '../../vector-set-element-form/utils'
+import {
+  getValidVector,
+  toSubmitElement,
+} from '../../vector-set-element-form/utils'
 
 import {
   EditableStringField,
@@ -25,13 +28,9 @@ export const useVectorSetElementForm = ({
 
   const isFormValid = useMemo(
     () =>
-      elements.every((el) => {
-        if (!el.name.trim()) return false
-        const parsed = parseVector(el.vector)
-        if (!parsed) return false
-        if (vectorDim !== undefined && parsed.length !== vectorDim) return false
-        return true
-      }),
+      elements.every(
+        (el) => el.name.trim() && getValidVector(el.vector, vectorDim) !== null,
+      ),
     [elements, vectorDim],
   )
 
@@ -83,17 +82,10 @@ export const useVectorSetElementForm = ({
   }, [])
 
   const submitData = useCallback(() => {
-    const result: SubmitElement[] = []
-    for (const el of elements) {
-      const parsed = parseVector(el.vector)
-      if (!parsed) return
-      const item: SubmitElement = { name: el.name, vector: parsed }
-      const trimmedAttributes = el.attributes.trim()
-      if (trimmedAttributes) item.attributes = trimmedAttributes
-      result.push(item)
-    }
-    onSubmit(result)
-  }, [elements, onSubmit])
+    const payload = elements.map((el) => toSubmitElement(el, vectorDim))
+    if (payload.some((item) => item === null)) return
+    onSubmit(payload as SubmitElement[])
+  }, [elements, vectorDim, onSubmit])
 
   const isClearDisabled = useCallback(
     (item: IVectorSetElementState): boolean =>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
@@ -1,0 +1,204 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import VectorSetElementForm from './VectorSetElementForm'
+import { Props } from './interfaces'
+
+const ELEMENT_NAME = 'element-name'
+const ELEMENT_VECTOR = 'element-vector'
+
+const defaultProps: Props = {
+  onSubmit: jest.fn(),
+  onCancel: jest.fn(),
+  loading: false,
+}
+
+describe('VectorSetElementForm', () => {
+  it('should render', () => {
+    expect(render(<VectorSetElementForm {...defaultProps} />)).toBeTruthy()
+  })
+
+  it('should render element name and vector inputs', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+
+    expect(screen.getByTestId(ELEMENT_NAME)).toBeInTheDocument()
+    expect(screen.getByTestId(ELEMENT_VECTOR)).toBeInTheDocument()
+  })
+
+  it('should set element name value', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    const nameInput = screen.getByTestId(ELEMENT_NAME)
+    fireEvent.change(nameInput, { target: { value: 'my-element' } })
+    expect(nameInput).toHaveValue('my-element')
+  })
+
+  it('should set vector value', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    const vectorInput = screen.getByTestId(ELEMENT_VECTOR)
+    fireEvent.change(vectorInput, { target: { value: '0.1, 0.2, 0.3' } })
+    expect(vectorInput).toHaveValue('0.1, 0.2, 0.3')
+  })
+
+  it('should have save button disabled when form is empty', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    expect(screen.getByTestId('save-elements-btn')).toBeDisabled()
+  })
+
+  it('should have save button disabled when only name is filled', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+      target: { value: 'test' },
+    })
+    expect(screen.getByTestId('save-elements-btn')).toBeDisabled()
+  })
+
+  it('should have save button disabled when only vector is filled', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, 0.2' },
+    })
+    expect(screen.getByTestId('save-elements-btn')).toBeDisabled()
+  })
+
+  it('should enable save button when name and valid vector are filled', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, 0.2, 0.3' },
+    })
+    expect(screen.getByTestId('save-elements-btn')).not.toBeDisabled()
+  })
+
+  it('should show validation error for invalid vector format', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, abc, 0.3' },
+    })
+    expect(
+      screen.getAllByText('Invalid number format in vector').length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('should show validation error for dimension mismatch', () => {
+    render(<VectorSetElementForm {...defaultProps} vectorDim={3} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, 0.2' },
+    })
+    expect(
+      screen.getAllByText(
+        'Dimension mismatch. Expected 3 values, but received 2',
+      ).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('should not show validation error for correct dimensions', () => {
+    render(<VectorSetElementForm {...defaultProps} vectorDim={3} />)
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, 0.2, 0.3' },
+    })
+    expect(screen.queryByText(/dimension mismatch/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/invalid number format/i)).not.toBeInTheDocument()
+  })
+
+  it('should add another element row when clicking add item', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('add-item'))
+
+    expect(screen.getAllByTestId(ELEMENT_NAME)).toHaveLength(2)
+    expect(screen.getAllByTestId(ELEMENT_VECTOR)).toHaveLength(2)
+  })
+
+  it('should clear element values when clicking remove with single row', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+    const nameInput = screen.getByTestId(ELEMENT_NAME)
+    const vectorInput = screen.getByTestId(ELEMENT_VECTOR)
+
+    fireEvent.change(nameInput, { target: { value: 'test' } })
+    fireEvent.change(vectorInput, { target: { value: '0.1, 0.2' } })
+    fireEvent.click(screen.getByTestId('remove-item'))
+
+    expect(nameInput).toHaveValue('')
+    expect(vectorInput).toHaveValue('')
+  })
+
+  it('should toggle attributes section', () => {
+    render(<VectorSetElementForm {...defaultProps} />)
+
+    expect(screen.queryByTestId('element-attributes')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('toggle-attributes-btn'))
+    expect(screen.getByTestId('element-attributes')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('toggle-attributes-btn'))
+    expect(screen.queryByTestId('element-attributes')).not.toBeInTheDocument()
+  })
+
+  it('should call onCancel when cancel button is clicked', () => {
+    const onCancel = jest.fn()
+    render(<VectorSetElementForm {...defaultProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('cancel-elements-btn'))
+    expect(onCancel).toHaveBeenCalledWith(true)
+  })
+
+  it('should call onSubmit with parsed elements when save is clicked', () => {
+    const onSubmit = jest.fn()
+    render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '0.1, 0.2, 0.3' },
+    })
+    fireEvent.click(screen.getByTestId('save-elements-btn'))
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      { name: 'elem1', vector: [0.1, 0.2, 0.3] },
+    ])
+  })
+
+  it('should include attributes in submit data when provided', () => {
+    const onSubmit = jest.fn()
+    render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+      target: { value: '1, 2, 3' },
+    })
+    fireEvent.click(screen.getByTestId('toggle-attributes-btn'))
+    fireEvent.change(screen.getByTestId('element-attributes'), {
+      target: { value: '{"key":"value"}' },
+    })
+    fireEvent.click(screen.getByTestId('save-elements-btn'))
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      {
+        name: 'elem1',
+        vector: [1, 2, 3],
+        attributes: '{"key":"value"}',
+      },
+    ])
+  })
+
+  it('should use custom submit text', () => {
+    render(<VectorSetElementForm {...defaultProps} submitText="Add Key" />)
+    expect(screen.getByTestId('save-elements-btn')).toHaveTextContent('Add Key')
+  })
+
+  it('should disable inputs when loading', () => {
+    render(<VectorSetElementForm {...defaultProps} loading />)
+    expect(screen.getByTestId(ELEMENT_NAME)).toBeDisabled()
+    expect(screen.getByTestId(ELEMENT_VECTOR)).toBeDisabled()
+  })
+
+  it('should show vector dimension hint in placeholder when vectorDim is provided', () => {
+    render(<VectorSetElementForm {...defaultProps} vectorDim={5} />)
+    expect(screen.getByTestId(ELEMENT_VECTOR)).toHaveAttribute(
+      'placeholder',
+      'Enter Vector (5 dimensions)',
+    )
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+
+import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import {
+  IconButton,
+  PrimaryButton,
+  SecondaryButton,
+  ToggleButton,
+} from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Text } from 'uiSrc/components/base/text'
+import { ChevronDownIcon, ChevronRightIcon } from 'uiSrc/components/base/icons'
+
+import { EntryContent } from 'uiSrc/pages/browser/modules/key-details/components/common/AddKeysContainer.styled'
+import { AttributeEditor } from '../attribute-editor'
+import { useVectorSetElementForm } from '../hooks'
+
+import { Props } from './interfaces'
+import { getVectorFieldInfo } from './utils'
+
+const VectorSetElementForm = (props: Props) => {
+  const { onSubmit, onCancel, loading, vectorDim, submitText = 'Save' } = props
+
+  const {
+    elements,
+    isFormValid,
+    lastAddedNameRef,
+    addElement,
+    onClickRemove,
+    handleFieldChange,
+    toggleAttributes,
+    submitData,
+    isClearDisabled,
+  } = useVectorSetElementForm({ vectorDim, onSubmit })
+
+  return (
+    <Col gap="m">
+      <EntryContent>
+        <AddMultipleFields
+          items={elements}
+          isClearDisabled={isClearDisabled}
+          onClickRemove={onClickRemove}
+          onClickAdd={addElement}
+        >
+          {(item, index) => {
+            const vectorInfo = getVectorFieldInfo(item.vector, vectorDim)
+
+            return (
+              <Col gap="s">
+                <Row align="start" gap="m">
+                  <FlexItem grow>
+                    <FormField additionalText="Unique identifier for this vector.">
+                      <TextInput
+                        required
+                        aria-required="true"
+                        name={`element-name-${item.id}`}
+                        id={`element-name-${item.id}`}
+                        placeholder="Enter Element Name"
+                        value={item.name}
+                        onChange={(value) =>
+                          handleFieldChange('name', item.id, value)
+                        }
+                        ref={
+                          index === elements.length - 1
+                            ? lastAddedNameRef
+                            : null
+                        }
+                        disabled={loading}
+                        data-testid="element-name"
+                      />
+                    </FormField>
+                  </FlexItem>
+                  <FlexItem grow>
+                    <FormField additionalText={vectorInfo.text}>
+                      <TextInput
+                        required
+                        aria-required="true"
+                        name={`element-vector-${item.id}`}
+                        id={`element-vector-${item.id}`}
+                        placeholder={
+                          vectorDim !== undefined
+                            ? `Enter Vector (${vectorDim} dimensions)`
+                            : 'Enter Vector'
+                        }
+                        value={item.vector}
+                        onChange={(value) =>
+                          handleFieldChange('vector', item.id, value)
+                        }
+                        disabled={loading}
+                        error={vectorInfo.isError ? vectorInfo.text : undefined}
+                        data-testid="element-vector"
+                      />
+                    </FormField>
+                  </FlexItem>
+                </Row>
+
+                <Row align="center" gap="s">
+                  <ToggleButton
+                    onPressedChange={() => toggleAttributes(item.id)}
+                    pressed={item.showAttributes}
+                    data-testid="toggle-attributes-btn"
+                  >
+                    <Text>Add attributes </Text>
+                    <IconButton
+                      icon={
+                        item.showAttributes ? ChevronDownIcon : ChevronRightIcon
+                      }
+                    />
+                  </ToggleButton>{' '}
+                  <Text color="secondary">(Optional)</Text>
+                </Row>
+                {item.showAttributes && (
+                  <AttributeEditor
+                    value={item.attributes}
+                    onChange={(val: string) =>
+                      handleFieldChange('attributes', item.id, val)
+                    }
+                    isInEditMode={!loading}
+                    height="120px"
+                    testId="element-attributes"
+                  />
+                )}
+              </Col>
+            )
+          }}
+        </AddMultipleFields>
+      </EntryContent>
+      <Row justify="end" gap="m">
+        <FlexItem>
+          <SecondaryButton
+            onClick={() => onCancel(true)}
+            data-testid="cancel-elements-btn"
+          >
+            Cancel
+          </SecondaryButton>
+        </FlexItem>
+        <FlexItem>
+          <PrimaryButton
+            disabled={loading || !isFormValid}
+            loading={loading}
+            onClick={submitData}
+            data-testid="save-elements-btn"
+          >
+            {submitText}
+          </PrimaryButton>
+        </FlexItem>
+      </Row>
+    </Col>
+  )
+}
+
+export default VectorSetElementForm

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/constants.ts
@@ -1,0 +1,14 @@
+import { IVectorSetElementState } from './interfaces'
+
+export const INITIAL_VECTOR_SET_ELEMENT_STATE: IVectorSetElementState = {
+  id: 0,
+  name: '',
+  vector: '',
+  attributes: '',
+  showAttributes: false,
+}
+
+export const VECTOR_SEPARATOR = /[\s,]+/
+
+export const DEFAULT_VECTOR_HELP_TEXT =
+  'Format is detected automatically. The first vector defines the required dimension for this set.'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/index.ts
@@ -1,0 +1,7 @@
+export { default as VectorSetElementForm } from './VectorSetElementForm'
+export type {
+  IVectorSetElementState,
+  SubmitElement,
+  Props as VectorSetElementFormProps,
+} from './interfaces'
+export { INITIAL_VECTOR_SET_ELEMENT_STATE } from './constants'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
@@ -24,3 +24,8 @@ export interface VectorFieldInfo {
   text: string
   isError: boolean
 }
+
+export interface VectorValidationResult {
+  parsed: number[] | null
+  error?: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
@@ -1,0 +1,26 @@
+export interface IVectorSetElementState {
+  id: number
+  name: string
+  vector: string
+  attributes: string
+  showAttributes: boolean
+}
+
+export interface SubmitElement {
+  name: string
+  vector: number[]
+  attributes?: string
+}
+
+export interface Props {
+  onSubmit: (elements: SubmitElement[]) => void
+  onCancel: (isCancelled?: boolean) => void
+  loading: boolean
+  vectorDim?: number
+  submitText?: string
+}
+
+export interface VectorFieldInfo {
+  text: string
+  isError: boolean
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
@@ -1,5 +1,12 @@
+import { vectorSetElementFormStateFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { DEFAULT_VECTOR_HELP_TEXT } from './constants'
-import { getVectorError, getVectorFieldInfo, parseVector } from './utils'
+import {
+  getValidVector,
+  getVectorError,
+  getVectorFieldInfo,
+  parseVector,
+  toSubmitElement,
+} from './utils'
 
 describe('parseVector', () => {
   it('should return null for an empty string', () => {
@@ -92,5 +99,76 @@ describe('getVectorFieldInfo', () => {
       text: 'Detected numeric vector (4 dimensions).',
       isError: false,
     })
+  })
+})
+
+describe('getValidVector', () => {
+  it('should return null for an empty string', () => {
+    expect(getValidVector('')).toBeNull()
+    expect(getValidVector('   ')).toBeNull()
+  })
+
+  it('should return null for an unparsable vector', () => {
+    expect(getValidVector('1, abc, 3')).toBeNull()
+  })
+
+  it('should return the parsed vector without dimension check', () => {
+    expect(getValidVector('1, 2, 3')).toEqual([1, 2, 3])
+  })
+
+  it('should return the parsed vector when dimension matches', () => {
+    expect(getValidVector('1, 2, 3', 3)).toEqual([1, 2, 3])
+  })
+
+  it('should return null when dimension does not match', () => {
+    expect(getValidVector('1, 2', 3)).toBeNull()
+  })
+})
+
+describe('toSubmitElement', () => {
+  it('should return null when the vector is invalid', () => {
+    expect(
+      toSubmitElement(
+        vectorSetElementFormStateFactory.build({ vector: '1, abc' }),
+      ),
+    ).toBeNull()
+  })
+
+  it('should return null when the vector dimension does not match', () => {
+    expect(
+      toSubmitElement(
+        vectorSetElementFormStateFactory.build({ vector: '1, 2' }),
+        3,
+      ),
+    ).toBeNull()
+  })
+
+  it('should map a valid element without attributes', () => {
+    expect(toSubmitElement(vectorSetElementFormStateFactory.build())).toEqual({
+      name: 'item',
+      vector: [1, 2, 3],
+    })
+  })
+
+  it('should include trimmed attributes when provided', () => {
+    expect(
+      toSubmitElement(
+        vectorSetElementFormStateFactory.build({
+          attributes: '  {"a":1}  ',
+        }),
+      ),
+    ).toEqual({
+      name: 'item',
+      vector: [1, 2, 3],
+      attributes: '{"a":1}',
+    })
+  })
+
+  it('should omit attributes when they are whitespace only', () => {
+    const result = toSubmitElement(
+      vectorSetElementFormStateFactory.build({ attributes: '   ' }),
+    )
+    expect(result).toEqual({ name: 'item', vector: [1, 2, 3] })
+    expect(result).not.toHaveProperty('attributes')
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
@@ -1,0 +1,96 @@
+import { DEFAULT_VECTOR_HELP_TEXT } from './constants'
+import { getVectorError, getVectorFieldInfo, parseVector } from './utils'
+
+describe('parseVector', () => {
+  it('should return null for an empty string', () => {
+    expect(parseVector('')).toBeNull()
+  })
+
+  it('should return null for a whitespace-only string', () => {
+    expect(parseVector('   \t  ')).toBeNull()
+  })
+
+  it('should parse a comma-separated list of numbers', () => {
+    expect(parseVector('1, 2.5, -3')).toEqual([1, 2.5, -3])
+  })
+
+  it('should parse a whitespace-separated list of numbers', () => {
+    expect(parseVector('1 2 3')).toEqual([1, 2, 3])
+  })
+
+  it('should ignore leading/trailing separators and empty segments', () => {
+    expect(parseVector(' , 1 ,, 2 , 3 , ')).toEqual([1, 2, 3])
+  })
+
+  it('should return null when any token is not a finite number', () => {
+    expect(parseVector('1, abc, 3')).toBeNull()
+    expect(parseVector('1, Infinity, 3')).toBeNull()
+    expect(parseVector('1, NaN, 3')).toBeNull()
+  })
+
+  it('should return null when no numeric tokens are present', () => {
+    expect(parseVector(', ,')).toBeNull()
+  })
+})
+
+describe('getVectorError', () => {
+  it('should return undefined for an empty string', () => {
+    expect(getVectorError('')).toBeUndefined()
+    expect(getVectorError('   ')).toBeUndefined()
+  })
+
+  it('should return an error for an unparsable vector', () => {
+    expect(getVectorError('1, abc, 3')).toBe('Invalid number format in vector')
+  })
+
+  it('should return undefined for a valid vector without dimension check', () => {
+    expect(getVectorError('1, 2, 3')).toBeUndefined()
+  })
+
+  it('should return undefined when dimension matches', () => {
+    expect(getVectorError('1, 2, 3', 3)).toBeUndefined()
+  })
+
+  it('should return a dimension-mismatch error when dimension does not match', () => {
+    expect(getVectorError('1, 2', 3)).toBe(
+      'Dimension mismatch. Expected 3 values, but received 2',
+    )
+  })
+})
+
+describe('getVectorFieldInfo', () => {
+  it('should return the default help text for an empty input', () => {
+    expect(getVectorFieldInfo('')).toEqual({
+      text: DEFAULT_VECTOR_HELP_TEXT,
+      isError: false,
+    })
+  })
+
+  it('should return an error message when parsing fails', () => {
+    expect(getVectorFieldInfo('1, abc, 3')).toEqual({
+      text: 'Invalid number format in vector',
+      isError: true,
+    })
+  })
+
+  it('should return a dimension-mismatch error when dimension does not match', () => {
+    expect(getVectorFieldInfo('1, 2', 3)).toEqual({
+      text: 'Dimension mismatch. Expected 3 values, but received 2',
+      isError: true,
+    })
+  })
+
+  it('should return detected dimensions for a valid vector', () => {
+    expect(getVectorFieldInfo('1, 2, 3')).toEqual({
+      text: 'Detected numeric vector (3 dimensions).',
+      isError: false,
+    })
+  })
+
+  it('should return detected dimensions when dimension matches', () => {
+    expect(getVectorFieldInfo('1 2 3 4', 4)).toEqual({
+      text: 'Detected numeric vector (4 dimensions).',
+      isError: false,
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
@@ -1,5 +1,5 @@
 import { VECTOR_SEPARATOR, DEFAULT_VECTOR_HELP_TEXT } from './constants'
-import { VectorFieldInfo } from './interfaces'
+import { VectorFieldInfo, VectorValidationResult } from './interfaces'
 
 export function parseVector(raw: string): number[] | null {
   const trimmed = raw.trim()
@@ -17,44 +17,47 @@ export function parseVector(raw: string): number[] | null {
   return nums.length > 0 ? nums : null
 }
 
+function validateVector(
+  raw: string,
+  vectorDim?: number,
+): VectorValidationResult {
+  if (!raw.trim()) return { parsed: null }
+
+  const parsed = parseVector(raw)
+  if (!parsed) return { parsed: null, error: 'Invalid number format in vector' }
+
+  if (vectorDim !== undefined && parsed.length !== vectorDim) {
+    return {
+      parsed,
+      error: `Dimension mismatch. Expected ${vectorDim} values, but received ${parsed.length}`,
+    }
+  }
+
+  return { parsed }
+}
+
 export function getVectorError(
   raw: string,
   vectorDim?: number,
 ): string | undefined {
-  if (!raw.trim()) return undefined
-
-  const parsed = parseVector(raw)
-  if (!parsed) return 'Invalid number format in vector'
-
-  if (vectorDim !== undefined && parsed.length !== vectorDim) {
-    return `Dimension mismatch. Expected ${vectorDim} values, but received ${parsed.length}`
-  }
-
-  return undefined
+  return validateVector(raw, vectorDim).error
 }
 
 export function getVectorFieldInfo(
   raw: string,
   vectorDim?: number,
 ): VectorFieldInfo {
-  const trimmed = raw.trim()
-
-  if (!trimmed) {
+  if (!raw.trim()) {
     return { text: DEFAULT_VECTOR_HELP_TEXT, isError: false }
   }
 
-  const error = getVectorError(raw, vectorDim)
+  const { parsed, error } = validateVector(raw, vectorDim)
   if (error) {
     return { text: error, isError: true }
   }
 
-  const parsed = parseVector(raw)
-  if (parsed) {
-    return {
-      text: `Detected numeric vector (${parsed.length} dimensions).`,
-      isError: false,
-    }
+  return {
+    text: `Detected numeric vector (${parsed!.length} dimensions).`,
+    isError: false,
   }
-
-  return { text: '', isError: false }
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
@@ -1,5 +1,10 @@
 import { VECTOR_SEPARATOR, DEFAULT_VECTOR_HELP_TEXT } from './constants'
-import { VectorFieldInfo, VectorValidationResult } from './interfaces'
+import {
+  IVectorSetElementState,
+  SubmitElement,
+  VectorFieldInfo,
+  VectorValidationResult,
+} from './interfaces'
 
 export function parseVector(raw: string): number[] | null {
   const trimmed = raw.trim()
@@ -41,6 +46,28 @@ export function getVectorError(
   vectorDim?: number,
 ): string | undefined {
   return validateVector(raw, vectorDim).error
+}
+
+export function getValidVector(
+  raw: string,
+  vectorDim?: number,
+): number[] | null {
+  const { parsed, error } = validateVector(raw, vectorDim)
+  return !error && parsed ? parsed : null
+}
+
+export function toSubmitElement(
+  el: IVectorSetElementState,
+  vectorDim?: number,
+): SubmitElement | null {
+  const vector = getValidVector(el.vector, vectorDim)
+  if (!vector) return null
+
+  const item: SubmitElement = { name: el.name, vector }
+  const trimmedAttributes = el.attributes.trim()
+  if (trimmedAttributes) item.attributes = trimmedAttributes
+
+  return item
 }
 
 export function getVectorFieldInfo(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
@@ -1,0 +1,60 @@
+import { VECTOR_SEPARATOR, DEFAULT_VECTOR_HELP_TEXT } from './constants'
+import { VectorFieldInfo } from './interfaces'
+
+export function parseVector(raw: string): number[] | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  const parts = trimmed.split(VECTOR_SEPARATOR).filter(Boolean)
+  const nums: number[] = []
+
+  for (const part of parts) {
+    const n = Number(part)
+    if (!Number.isFinite(n)) return null
+    nums.push(n)
+  }
+
+  return nums.length > 0 ? nums : null
+}
+
+export function getVectorError(
+  raw: string,
+  vectorDim?: number,
+): string | undefined {
+  if (!raw.trim()) return undefined
+
+  const parsed = parseVector(raw)
+  if (!parsed) return 'Invalid number format in vector'
+
+  if (vectorDim !== undefined && parsed.length !== vectorDim) {
+    return `Dimension mismatch. Expected ${vectorDim} values, but received ${parsed.length}`
+  }
+
+  return undefined
+}
+
+export function getVectorFieldInfo(
+  raw: string,
+  vectorDim?: number,
+): VectorFieldInfo {
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return { text: DEFAULT_VECTOR_HELP_TEXT, isError: false }
+  }
+
+  const error = getVectorError(raw, vectorDim)
+  if (error) {
+    return { text: error, isError: true }
+  }
+
+  const parsed = parseVector(raw)
+  if (parsed) {
+    return {
+      text: `Detected numeric vector (${parsed.length} dimensions).`,
+      isError: false,
+    }
+  }
+
+  return { text: '', isError: false }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ColumnDef } from 'uiSrc/components/base/layout/table'
+import { ColumnDef, Row as TableRow } from 'uiSrc/components/base/layout/table'
 import { VectorSetElement } from 'uiSrc/slices/interfaces'
 import {
   bufferToString,
@@ -28,7 +28,7 @@ const createNameColumn = (
     header: VECTOR_SET_COLUMN_HEADERS[VectorSetColumn.Name],
     enableSorting: false,
     size: 150,
-    cell: ({ row }: { row: Row<VectorSetElement> }) => (
+    cell: ({ row }: { row: TableRow<VectorSetElement> }) => (
       <ElementNameCell
         element={row.original}
         compressor={compressor}
@@ -45,7 +45,7 @@ const createActionsColumn = (
   header: VECTOR_SET_COLUMN_HEADERS[VectorSetColumn.Actions],
   enableSorting: false,
   size: 10,
-  cell: ({ row }: { row: Row<VectorSetElement> }) => {
+  cell: ({ row }: { row: TableRow<VectorSetElement> }) => {
     const { name: nameBuffer } = row.original
     const {
       viewFormat,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react'
 
 import { VectorSetElement } from 'uiSrc/slices/interfaces'
-import useVectorSetElementListData from './hooks/useVectorSetElementListData'
+import { useVectorSetElementListData } from '../hooks'
 import * as S from './VectorSetElementList.styles'
 
 export interface Props {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker'
 import React from 'react'
-import { render, screen } from 'uiSrc/utils/test-utils'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
 import { VectorSetKeySubheader } from './VectorSetKeySubheader'
+import { Props } from './VectorSetKeySubheader.types'
 
 jest.mock('uiSrc/slices/browser/vectorSet', () => ({
   vectorSetDataSelector: jest.fn(),
@@ -22,8 +23,17 @@ jest.mock(
   },
 )
 
+const defaultProps: Props = {
+  openAddItemPanel: jest.fn(),
+}
+
 describe('VectorSetKeySubheader', () => {
   const getMockedSelector = () => vectorSetDataSelector as jest.Mock
+
+  const renderComponent = (propsOverride?: Partial<Props>) => {
+    const props = { ...defaultProps, ...propsOverride }
+    return render(<VectorSetKeySubheader {...props} />)
+  }
 
   beforeEach(() => {
     getMockedSelector().mockReset()
@@ -39,7 +49,7 @@ describe('VectorSetKeySubheader', () => {
       isPaginationSupported: true,
     })
 
-    render(<VectorSetKeySubheader />)
+    renderComponent()
 
     expect(
       screen.queryByTestId('vector-set-preview-summary'),
@@ -53,7 +63,7 @@ describe('VectorSetKeySubheader', () => {
       elements,
     })
 
-    render(<VectorSetKeySubheader />)
+    renderComponent()
 
     expect(
       screen.queryByTestId('vector-set-preview-summary'),
@@ -71,10 +81,36 @@ describe('VectorSetKeySubheader', () => {
       isPaginationSupported: false,
     })
 
-    render(<VectorSetKeySubheader />)
+    renderComponent()
 
     expect(screen.getByTestId('vector-set-preview-summary')).toHaveTextContent(
       `${elements.length} out of ${total}`,
     )
+  })
+
+  it('renders the Add Elements button', () => {
+    getMockedSelector().mockReturnValue({
+      total: 5,
+      elements: vectorSetElementFactory.buildList(3),
+      isPaginationSupported: true,
+    })
+
+    renderComponent()
+
+    expect(screen.getByTestId('add-key-value-items-btn')).toBeInTheDocument()
+  })
+
+  it('calls openAddItemPanel when Add Elements button is clicked', () => {
+    const openAddItemPanel = jest.fn()
+    getMockedSelector().mockReturnValue({
+      total: 5,
+      elements: vectorSetElementFactory.buildList(3),
+      isPaginationSupported: true,
+    })
+
+    renderComponent({ openAddItemPanel })
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    expect(openAddItemPanel).toHaveBeenCalledTimes(1)
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
@@ -6,11 +6,14 @@ import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
 import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
+import Divider from 'uiSrc/components/divider/Divider'
 import { KeyDetailsHeaderFormatter } from 'uiSrc/pages/browser/modules/key-details-header/components/key-details-header-formatter'
+import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
 
 import * as S from './VectorSetKeySubheader.styles'
+import { Props } from './VectorSetKeySubheader.types'
 
-const VectorSetKeySubheader = () => {
+const VectorSetKeySubheader = ({ openAddItemPanel }: Props) => {
   const { total, elements, isPaginationSupported } = useSelector(
     vectorSetDataSelector,
   )
@@ -38,6 +41,12 @@ const VectorSetKeySubheader = () => {
               <FlexItem>
                 <KeyDetailsHeaderFormatter width={width} />
               </FlexItem>
+              <Divider orientation="vertical" />
+              <AddItemsAction
+                title="Add Elements"
+                width={width}
+                openAddItemPanel={openAddItemPanel}
+              />
             </Row>
           </div>
         )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
@@ -1,0 +1,3 @@
+export interface Props {
+  openAddItemPanel: () => void
+}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- **Add-element flow** — new `VectorSetElementForm` (inputs for element name, vector, attributes) wired into `VectorSetDetails` via an add-elements drawer, opened from `VectorSetKeySubheader`.
- **Attribute editing** — new `AttributeEditor` (Monaco, JSON, non-blocking warning banner) used in both the add form and the element details drawer; `ElementDetails` now supports edit / cancel / save of attributes.
- **Small fixes** — `TextInput` always wraps children in `TooltipProvider` (required by new validation path); add-elements drawer `z-index` raised above details drawer.

| Light | Dark |
| --- | --- |
| <img width="872" height="908" alt="image" src="https://github.com/user-attachments/assets/9aac8ef1-d940-4721-9592-6caadcfe12d0" /> | <img width="847" height="703" alt="image" src="https://github.com/user-attachments/assets/570b882f-3752-45c4-82e4-745cf80437fa" /> |
| <img width="872" height="908" alt="image" src="https://github.com/user-attachments/assets/eb8c94e3-aca5-459b-be8e-622d6e1a398a" /> | <img width="867" height="703" alt="image" src="https://github.com/user-attachments/assets/46130104-5cf9-4360-9c6b-8d1a3482cc3f" /> |
| <img width="872" height="908" alt="image" src="https://github.com/user-attachments/assets/1c9dcf4a-c00a-4a44-aac1-abe98d4cf491" /> | <img width="872" height="908" alt="image" src="https://github.com/user-attachments/assets/89e90204-ae8b-48c8-8ab5-fb572c6c6105" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Add vector set using CLI:

`VADD test VALUES 3 1 2 3 firstElement`

2. Refresh and open the added vector set
3. Click + Add Elements button
4. Enter data in the form
5. Click Save

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches key Vector Set CRUD UX and changes attribute-edit save behavior (now saves trimmed text without prior JSON formatting/validation), which could affect stored metadata and user workflows.
> 
> **Overview**
> Adds an **Add Elements** flow to Vector Set key details: `VectorSetKeySubheader` now exposes an Add action that opens an in-page drawer with the new `VectorSetElementForm`, supporting multiple rows, vector dimension/format validation, and optional attributes.
> 
> Refactors element attribute editing in `ElementDetails` to use a shared `AttributeEditor` plus a new `useElementAttributeEditor` hook (centralizing edit/cancel/save state and dispatch), and updates tests/mocks accordingly. Minor UI/infra tweaks include always wrapping `TextInput` with `TooltipProvider`, raising the add-drawer `z-index`, and small typing/import adjustments in the elements table config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c69bdde2584b63a39baa62caae2e21d020f11bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->