### PR TITLE
Reconnect Redis clients on network interface change

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -178,10 +178,26 @@ export default {
     maxRedirections: parseInt(process.env.RI_CLIENTS_MAX_REDIRECTIONS, 10) || 3,
     slotsRefreshTimeout:
       parseInt(process.env.RI_CLIENTS_SLOTS_REQUEST_TIMEOUT, 10) || 5000,
+    // TCP keepalive initial idle delay in ms. Enables SO_KEEPALIVE so that
+    // half-open sockets (e.g. after a network interface switch) are eventually
+    // detected and closed by the OS instead of hanging indefinitely.
+    // Set to 0 to disable.
+    keepAlive:
+      process.env.RI_CLIENTS_KEEP_ALIVE !== undefined
+        ? parseInt(process.env.RI_CLIENTS_KEEP_ALIVE, 10)
+        : 5_000,
     maxStringSize: parseInt(process.env.RI_CLIENTS_MAX_STRING_SIZE, 10),
     truncatedStringPrefix:
       process.env.RI_CLIENTS_TRUNCATED_STRING_PREFIX ||
       '[Truncated due to length]',
+    // When enabled, the backend watches the host's network interfaces and
+    // disconnects every cached Redis client whenever the interface set
+    // changes (e.g. Ethernet -> Wi-Fi). The next command then opens a fresh
+    // socket on the currently-active interface instead of reusing a
+    // half-open one and hanging until the HTTP requestTimeout fires.
+    networkWatcher: process.env.RI_CLIENTS_NETWORK_WATCHER !== 'false',
+    networkWatcherInterval:
+      parseInt(process.env.RI_CLIENTS_NETWORK_WATCHER_INTERVAL, 10) || 2_000,
   },
   redis_scan: {
     countDefault: parseInt(process.env.RI_SCAN_COUNT_DEFAULT, 10) || 200,

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
@@ -230,6 +230,20 @@ describe('IoredisRedisConnectionStrategy', () => {
 
       process.nextTick(() => mockIoredisNativeClient.emit('ready'));
     });
+    it('should pass keepAlive to detect half-open sockets after network switch', (done) => {
+      service
+        .createStandaloneClient(mockClientMetadata, mockDatabase, {})
+        .then(() => {
+          expect(spyRedis).toHaveBeenCalledWith(
+            expect.objectContaining({
+              keepAlive: REDIS_CLIENTS_CONFIG.keepAlive,
+            }),
+          );
+          done();
+        });
+
+      process.nextTick(() => mockIoredisNativeClient.emit('ready'));
+    });
   });
 
   describe('createClusterClient', () => {

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
@@ -54,6 +54,11 @@ export class IoredisRedisConnectionStrategy extends RedisConnectionStrategy {
       password,
       family: 0, // Enable dual-stack IPv4/IPv6 (auto-detect)
       connectTimeout: timeout,
+      // TCP keepalive. Required to detect half-open sockets after the OS
+      // silently drops a network interface (e.g. Ethernet -> Wi-Fi hand-off).
+      // Without this, ioredis would never surface an error on the pending
+      // command and requests would hang forever.
+      keepAlive: REDIS_CLIENTS_CONFIG.keepAlive,
       db: isNumber(clientMetadata.db) ? clientMetadata.db : db,
       connectionName:
         options?.connectionName ||

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
@@ -5,9 +5,14 @@ import {
   mockDatabase,
   mockSshTunnelProvider,
 } from 'src/__mocks__';
+import apiConfig, { Config } from 'src/utils/config';
 import { SshTunnelProvider } from 'src/modules/ssh/ssh-tunnel.provider';
 import { NodeRedisConnectionStrategy } from 'src/modules/redis/connection/node.redis.connection.strategy';
 import { StandaloneNodeRedisClient } from 'src/modules/redis/client/node-redis/standalone.node-redis.client';
+
+const REDIS_CLIENTS_CONFIG = apiConfig.get(
+  'redis_clients',
+) as Config['redis_clients'];
 
 jest.mock('redis', () => ({
   ...jest.requireActual('redis'),
@@ -57,6 +62,27 @@ describe('NodeRedisConnectionStrategy', () => {
         expect.objectContaining({
           socket: expect.objectContaining({
             family: 0,
+          }),
+        }),
+      );
+    });
+    it('should pass keepAlive on socket to detect half-open sockets after network switch', async () => {
+      const mockClient = {
+        on: jest.fn().mockReturnThis(),
+        connect: jest.fn().mockResolvedValue(undefined),
+      };
+      createClientSpy.mockReturnValue(mockClient);
+
+      await service.createStandaloneClient(
+        mockClientMetadata,
+        mockDatabase,
+        {},
+      );
+
+      expect(createClientSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          socket: expect.objectContaining({
+            keepAlive: REDIS_CLIENTS_CONFIG.keepAlive || false,
           }),
         }),
       );

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
@@ -59,6 +59,10 @@ export class NodeRedisConnectionStrategy extends RedisConnectionStrategy {
         port,
         family: 0, // Enable dual-stack IPv4/IPv6 (auto-detect)
         connectTimeout: timeout,
+        // TCP keepalive. Required to detect half-open sockets after the OS
+        // silently drops a network interface (e.g. Ethernet -> Wi-Fi hand-off).
+        // Without this, commands issued on a stale socket would hang forever.
+        keepAlive: REDIS_CLIENTS_CONFIG.keepAlive || false,
         ...tlsOptions,
         reconnectStrategy: options?.useRetry
           ? this.retryStrategy.bind(this)

--- a/redisinsight/api/src/modules/redis/network-change.monitor.spec.ts
+++ b/redisinsight/api/src/modules/redis/network-change.monitor.spec.ts
@@ -1,0 +1,154 @@
+import * as os from 'os';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NetworkChangeMonitor } from 'src/modules/redis/network-change.monitor';
+import { RedisClientStorage } from 'src/modules/redis/redis.client.storage';
+
+describe('NetworkChangeMonitor', () => {
+  let monitor: NetworkChangeMonitor;
+  let storage: { removeAll: jest.Mock };
+  let interfacesSpy: jest.SpyInstance;
+
+  const ifacesA: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+    lo0: [
+      {
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: true,
+        cidr: '127.0.0.1/8',
+      },
+    ],
+    en0: [
+      {
+        address: '192.168.1.10',
+        netmask: '255.255.255.0',
+        family: 'IPv4',
+        mac: 'aa:bb:cc:dd:ee:ff',
+        internal: false,
+        cidr: '192.168.1.10/24',
+      },
+    ],
+  };
+
+  const ifacesB: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+    lo0: ifacesA.lo0,
+    en1: [
+      {
+        address: '10.0.0.5',
+        netmask: '255.255.255.0',
+        family: 'IPv4',
+        mac: '11:22:33:44:55:66',
+        internal: false,
+        cidr: '10.0.0.5/24',
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    storage = { removeAll: jest.fn().mockResolvedValue(0) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NetworkChangeMonitor,
+        { provide: RedisClientStorage, useValue: storage },
+      ],
+    }).compile();
+
+    monitor = module.get(NetworkChangeMonitor);
+    interfacesSpy = jest.spyOn(os, 'networkInterfaces');
+  });
+
+  afterEach(() => {
+    monitor.onModuleDestroy();
+    interfacesSpy.mockRestore();
+  });
+
+  it('does not drop clients when interfaces have not changed', async () => {
+    interfacesSpy.mockReturnValue(ifacesA);
+    monitor.onModuleInit();
+    await monitor['check']();
+    expect(storage.removeAll).not.toHaveBeenCalled();
+  });
+
+  it('drops all clients when the interface set changes', async () => {
+    interfacesSpy.mockReturnValue(ifacesA);
+    monitor.onModuleInit();
+
+    interfacesSpy.mockReturnValue(ifacesB);
+    await monitor['check']();
+
+    expect(storage.removeAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores IPv6 link-local address churn', async () => {
+    const withLinkLocalA: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+      en0: [
+        ...ifacesA.en0!,
+        {
+          address: 'fe80::aaaa',
+          netmask: 'ffff:ffff:ffff:ffff::',
+          family: 'IPv6',
+          mac: 'aa:bb:cc:dd:ee:ff',
+          scopeid: 4,
+          internal: false,
+          cidr: 'fe80::aaaa/64',
+        },
+      ],
+    };
+    const withLinkLocalB: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+      en0: [
+        ...ifacesA.en0!,
+        {
+          address: 'fe80::bbbb',
+          netmask: 'ffff:ffff:ffff:ffff::',
+          family: 'IPv6',
+          mac: 'aa:bb:cc:dd:ee:ff',
+          scopeid: 4,
+          internal: false,
+          cidr: 'fe80::bbbb/64',
+        },
+      ],
+    };
+
+    interfacesSpy.mockReturnValue(withLinkLocalA);
+    monitor.onModuleInit();
+
+    interfacesSpy.mockReturnValue(withLinkLocalB);
+    await monitor['check']();
+
+    expect(storage.removeAll).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by removeAll', async () => {
+    interfacesSpy.mockReturnValue(ifacesA);
+    monitor.onModuleInit();
+
+    storage.removeAll.mockRejectedValueOnce(new Error('boom'));
+    interfacesSpy.mockReturnValue(ifacesB);
+
+    await expect(monitor['check']()).resolves.toBeUndefined();
+  });
+
+  it('retries on the next tick when removeAll fails', async () => {
+    interfacesSpy.mockReturnValue(ifacesA);
+    monitor.onModuleInit();
+
+    storage.removeAll.mockRejectedValueOnce(new Error('boom'));
+    interfacesSpy.mockReturnValue(ifacesB);
+    await monitor['check']();
+    expect(storage.removeAll).toHaveBeenCalledTimes(1);
+
+    // interfaces are still in the "new" state; signature wasn't committed,
+    // so the next tick should attempt the disconnect again.
+    storage.removeAll.mockResolvedValueOnce(0);
+    await monitor['check']();
+    expect(storage.removeAll).toHaveBeenCalledTimes(2);
+
+    // once it succeeds, the signature is committed and no further attempts.
+    await monitor['check']();
+    expect(storage.removeAll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/redisinsight/api/src/modules/redis/network-change.monitor.ts
+++ b/redisinsight/api/src/modules/redis/network-change.monitor.ts
@@ -1,0 +1,139 @@
+import * as os from 'os';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { RedisClientStorage } from 'src/modules/redis/redis.client.storage';
+import apiConfig from 'src/utils/config';
+
+const REDIS_CLIENTS_CONFIG = apiConfig.get('redis_clients');
+
+/**
+ * Watches the host's network interfaces and, when they change, disconnects
+ * every cached Redis client so the next command opens a fresh TCP socket
+ * bound to the currently-active interface.
+ *
+ * Why this exists:
+ * When the user hands off between Ethernet and Wi-Fi, the kernel tears down
+ * the old interface but any existing TCP sockets routed through it end up
+ * half-open. Writing to them appears to succeed (packets are queued on the
+ * now-dead interface) and the command hangs until TCP retransmit / keepalive
+ * eventually times out — which, at OS defaults, can take minutes. Dropping
+ * the cached clients as soon as the interface set changes makes the very
+ * next request reconnect cleanly.
+ *
+ * Implementation notes:
+ * - We compute a stable signature from `os.networkInterfaces()` (excluding
+ *   internal interfaces and link-local addresses which flap under macOS).
+ * - We poll rather than subscribe to platform-specific APIs — this keeps the
+ *   logic cross-platform (macOS / Linux / Windows) without native deps.
+ * - Can be disabled via RI_CLIENTS_NETWORK_WATCHER=false, or tuned via
+ *   RI_CLIENTS_NETWORK_WATCHER_INTERVAL (ms).
+ */
+@Injectable()
+export class NetworkChangeMonitor implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger('NetworkChangeMonitor');
+
+  private readonly enabled: boolean;
+
+  private readonly intervalMs: number;
+
+  private lastSignature: string = '';
+
+  private timer?: NodeJS.Timeout;
+
+  constructor(private readonly redisClientStorage: RedisClientStorage) {
+    this.enabled = REDIS_CLIENTS_CONFIG.networkWatcher !== false;
+    this.intervalMs = REDIS_CLIENTS_CONFIG.networkWatcherInterval;
+  }
+
+  onModuleInit(): void {
+    if (!this.enabled) {
+      this.logger.debug('Network change monitor disabled via config');
+      return;
+    }
+
+    this.lastSignature = NetworkChangeMonitor.computeSignature();
+    this.timer = setInterval(() => this.check(), this.intervalMs);
+    // allow the process to exit even if this is the only timer running
+    this.timer.unref?.();
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private async check(): Promise<void> {
+    const nextSignature = NetworkChangeMonitor.computeSignature();
+
+    if (nextSignature === this.lastSignature) {
+      return;
+    }
+
+    const previous = this.lastSignature;
+
+    this.logger.log(
+      `Network interfaces changed; disconnecting cached Redis clients. ` +
+        `before=${previous || '(none)'} after=${nextSignature || '(none)'}`,
+    );
+
+    try {
+      await this.redisClientStorage.removeAll();
+      // Only commit the new signature once the cache was successfully
+      // dropped — if removeAll fails, leave lastSignature untouched so the
+      // next tick retries instead of silently leaving stale clients in place.
+      this.lastSignature = nextSignature;
+    } catch (e) {
+      this.logger.warn(
+        'Failed to drop cached clients on network change, will retry',
+        e,
+      );
+    }
+  }
+
+  /**
+   * Produce a stable string describing the current "routable" interface set.
+   * Excludes internal / loopback interfaces and IPv6 link-local addresses,
+   * both of which can flap in normal operation and would trigger false
+   * positives.
+   *
+   * Example output for a laptop on Wi-Fi with an active Ethernet dongle:
+   *   "en0|IPv4|192.168.1.10,en0|IPv6|2001:db8::42,en7|IPv4|10.0.0.5"
+   *
+   * Same laptop after unplugging Ethernet:
+   *   "en0|IPv4|192.168.1.10,en0|IPv6|2001:db8::42"
+   *
+   * The two strings are not equal, so `check()` calls `removeAll()` and
+   * every cached Redis client is dropped.
+   */
+  private static computeSignature(): string {
+    const interfaces = os.networkInterfaces();
+    const lines: string[] = [];
+
+    for (const name of Object.keys(interfaces).sort()) {
+      const addresses = interfaces[name] || [];
+      for (const addr of addresses) {
+        if (addr.internal) {
+          continue;
+        }
+        // IPv6 link-local (fe80::/10) changes regularly on macOS and is
+        // not relevant for routing to Redis.
+        if (
+          addr.family === 'IPv6' &&
+          addr.address?.toLowerCase()?.startsWith('fe80')
+        ) {
+          continue;
+        }
+
+        lines.push(`${name}|${addr.family}|${addr.address}`);
+      }
+    }
+
+    return lines.join(',');
+  }
+}

--- a/redisinsight/api/src/modules/redis/redis.client.storage.spec.ts
+++ b/redisinsight/api/src/modules/redis/redis.client.storage.spec.ts
@@ -669,6 +669,41 @@ describe('RedisClientStorage', () => {
     });
   });
 
+  describe('removeAll', () => {
+    it('should disconnect and remove every cached client', async () => {
+      expect(service['clients'].size).toEqual(6);
+
+      const removed = await service.removeAll();
+
+      expect(removed).toEqual(6);
+      expect(service['clients'].size).toEqual(0);
+      expect(mockRedisClient1.disconnect).toHaveBeenCalled();
+      expect(mockRedisClient2.disconnect).toHaveBeenCalled();
+      expect(mockRedisClient3.disconnect).toHaveBeenCalled();
+      expect(mockRedisClient4.disconnect).toHaveBeenCalled();
+      expect(mockRedisClient5.disconnect).toHaveBeenCalled();
+      expect(mockRedisClient6.disconnect).toHaveBeenCalled();
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        RedisClientEvents.ClientRemoved,
+        expect.objectContaining({
+          clientId: mockRedisClient1.id,
+          databaseId: mockRedisClient1.clientMetadata.databaseId,
+        }),
+      );
+    });
+
+    it('should be a no-op when there are no cached clients', async () => {
+      // @ts-ignore
+      service['clients'] = new Map();
+
+      const removed = await service.removeAll();
+
+      expect(removed).toEqual(0);
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('advanced', () => {
     beforeEach(() => {
       // @ts-ignore

--- a/redisinsight/api/src/modules/redis/redis.client.storage.ts
+++ b/redisinsight/api/src/modules/redis/redis.client.storage.ts
@@ -227,4 +227,25 @@ export class RedisClientStorage {
       (client) => get(client.database, fieldPath) === value,
     );
   }
+
+  /**
+   * Disconnects and removes every cached client.
+   *
+   * Intended for events that invalidate all existing sockets at once — e.g.
+   * the host's network interface changed (Ethernet -> Wi-Fi) and any socket
+   * bound to the old interface is now half-open. Forcing a fresh connection
+   * on next use avoids the "first refresh hangs until the OS keepalive probe
+   * finally fires" problem.
+   */
+  public async removeAll(): Promise<number> {
+    const ids = [...this.clients.keys()];
+
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    this.logger.debug(`Disconnecting ${ids.length} cached client(s)`);
+
+    return sum(await Promise.all(ids.map(this.remove.bind(this))));
+  }
 }

--- a/redisinsight/api/src/modules/redis/redis.module.ts
+++ b/redisinsight/api/src/modules/redis/redis.module.ts
@@ -4,6 +4,7 @@ import { IoredisRedisConnectionStrategy } from 'src/modules/redis/connection/ior
 import { NodeRedisConnectionStrategy } from 'src/modules/redis/connection/node.redis.connection.strategy';
 import { RedisClientStorage } from 'src/modules/redis/redis.client.storage';
 import { LocalRedisClientFactory } from 'src/modules/redis/local.redis.client.factory';
+import { NetworkChangeMonitor } from 'src/modules/redis/network-change.monitor';
 
 @Module({})
 export class RedisModule {
@@ -14,6 +15,7 @@ export class RedisModule {
       module: RedisModule,
       providers: [
         RedisClientStorage,
+        NetworkChangeMonitor,
         {
           provide: RedisClientFactory,
           useClass: redisClientFactory,

--- a/redisinsight/api/src/utils/catch-redis-errors.spec.ts
+++ b/redisinsight/api/src/utils/catch-redis-errors.spec.ts
@@ -9,8 +9,11 @@ import {
   RedisConnectionUnavailableException,
 } from 'src/modules/redis/exceptions/connection';
 import {
+  catchAclError,
   catchRedisSearchError,
   getRedisConnectionException,
+  isRedisRuntimeConnectionError,
+  wrapRedisRuntimeConnectionError,
 } from 'src/utils/catch-redis-errors';
 import { ReplyError } from 'src/models';
 import { CertificatesErrorCodes, RedisErrorCodes } from 'src/constants';
@@ -160,6 +163,91 @@ describe('catch-redis-errors', () => {
       expect(
         getRedisConnectionException(error as ReplyError, database),
       ).toEqual(output);
+    });
+  });
+
+  describe('runtime connection errors', () => {
+    const makeError = (
+      fields: Partial<{ message: string; code: string }>,
+    ): ReplyError =>
+      Object.assign(new Error(fields.message || ''), {
+        code: fields.code,
+      }) as ReplyError;
+
+    it.each([
+      'Command timed out',
+      'Connection is closed.',
+      'Connection is already closed.',
+      'The client is closed',
+      'Socket closed unexpectedly',
+      "Stream isn't writeable and enableOfflineQueue options is false",
+      'Failed to refresh slots cache.',
+      'CLUSTERDOWN The cluster is down',
+    ])(
+      'should recognize message "%s" as a runtime connection error',
+      (message) => {
+        expect(isRedisRuntimeConnectionError(makeError({ message }))).toBe(
+          true,
+        );
+      },
+    );
+
+    it.each([
+      'ECONNRESET',
+      'EPIPE',
+      'EADDRNOTAVAIL',
+      'ENETUNREACH',
+      'ENETDOWN',
+      'EHOSTUNREACH',
+      'ETIMEDOUT',
+    ])(
+      'should recognize socket code "%s" as a runtime connection error',
+      (code) => {
+        expect(
+          isRedisRuntimeConnectionError(
+            makeError({ message: `read ${code}`, code }),
+          ),
+        ).toBe(true);
+      },
+    );
+
+    it('should not flag unrelated errors', () => {
+      expect(
+        isRedisRuntimeConnectionError(
+          new Error('WRONGTYPE operation') as ReplyError,
+        ),
+      ).toBe(false);
+      expect(
+        isRedisRuntimeConnectionError(undefined as unknown as ReplyError),
+      ).toBe(false);
+    });
+
+    it('wrapRedisRuntimeConnectionError should map Command timed out to RedisConnectionTimeoutException', () => {
+      expect(
+        wrapRedisRuntimeConnectionError(
+          makeError({ message: 'Command timed out' }),
+        ),
+      ).toBeInstanceOf(RedisConnectionTimeoutException);
+    });
+
+    it('wrapRedisRuntimeConnectionError should map socket failures to RedisConnectionFailedException', () => {
+      expect(
+        wrapRedisRuntimeConnectionError(
+          makeError({ message: 'read ECONNRESET', code: 'ECONNRESET' }),
+        ),
+      ).toBeInstanceOf(RedisConnectionFailedException);
+    });
+
+    it('catchAclError should re-throw runtime connection errors as RedisConnection* (424)', () => {
+      const error = makeError({ message: 'Command timed out' });
+      expect(() => catchAclError(error)).toThrow(
+        RedisConnectionTimeoutException,
+      );
+    });
+
+    it('catchAclError should still throw 500 for non-connection runtime errors', () => {
+      const error = makeError({ message: 'WRONGTYPE operation' });
+      expect(() => catchAclError(error)).toThrow(InternalServerErrorException);
     });
   });
 

--- a/redisinsight/api/src/utils/catch-redis-errors.ts
+++ b/redisinsight/api/src/utils/catch-redis-errors.ts
@@ -40,6 +40,78 @@ export const isCertError = (error: ReplyError): boolean => {
   }
 };
 
+/**
+ * Detects runtime errors produced by the redis client driver (ioredis /
+ * node-redis) when the underlying connection is broken / unavailable mid-way
+ * through a command. These are NOT "initial connect" failures but rather
+ * errors thrown by a command on an already-established client whose socket
+ * just died (e.g. network interface switched and the host became unroutable,
+ * half-open TCP socket, reconnect backoff gave up, etc.).
+ *
+ * We convert these to `RedisConnection*` exceptions (HTTP 424) so the UI's
+ * connectivityErrorsInterceptor picks them up and shows the "Connection Lost"
+ * banner instead of a generic 500 / request-timed-out toast.
+ */
+export const isRedisRuntimeConnectionError = (error: ReplyError): boolean => {
+  if (!error || error instanceof HttpException) {
+    return false;
+  }
+
+  const message = error?.message || '';
+  const code = error?.code || '';
+
+  return (
+    // ioredis / node-redis: command aborted because the underlying stream
+    // errored / was closed before a reply arrived
+    message === 'Command timed out' ||
+    // ioredis / node-redis: client disconnected before reply arrived
+    message === 'Connection is closed.' ||
+    message === 'Connection is already closed.' ||
+    message === 'The client is closed' ||
+    message === 'Socket closed unexpectedly' ||
+    // ioredis: commands issued while disconnected and offline queue disabled
+    message.startsWith("Stream isn't writeable") ||
+    // ioredis cluster: reconnect backoff exhausted / all nodes failed mid-flight
+    message.includes('Failed to refresh slots cache') ||
+    message.includes('CLUSTERDOWN') ||
+    // Low-level socket errors surfaced through the driver
+    code === 'ECONNRESET' ||
+    code === 'EPIPE' ||
+    code === 'EADDRNOTAVAIL' ||
+    code === 'ENETUNREACH' ||
+    code === 'ENETDOWN' ||
+    code === 'EHOSTUNREACH' ||
+    code === 'ETIMEDOUT' ||
+    message.includes('EADDRNOTAVAIL') ||
+    message.includes('ENETUNREACH') ||
+    message.includes('ENETDOWN') ||
+    message.includes('EHOSTUNREACH') ||
+    message.includes('ECONNRESET')
+  );
+};
+
+/**
+ * If the error represents a runtime connection failure, wrap it in the
+ * appropriate `RedisConnection*` HttpException (status 424). Otherwise
+ * returns `undefined` so callers can continue their normal error handling.
+ */
+export const wrapRedisRuntimeConnectionError = (
+  error: ReplyError,
+): HttpException | undefined => {
+  if (!isRedisRuntimeConnectionError(error)) {
+    return undefined;
+  }
+
+  const message = error?.message || '';
+  if (message.includes('timed out') || error?.code === 'ETIMEDOUT') {
+    return new RedisConnectionTimeoutException(undefined, { cause: error });
+  }
+
+  return new RedisConnectionFailedException(message || undefined, {
+    cause: error,
+  });
+};
+
 export const getRedisConnectionException = (
   error: ReplyError,
   connectionOptions: { host: string; port: number },
@@ -140,6 +212,16 @@ export const catchAclError = (error: ReplyError): HttpException => {
       throw new ForbiddenException(noPermError.message);
     }
   }
+
+  // If the underlying driver surfaced a runtime connection error (socket
+  // dropped, host unroutable, reconnect backoff exhausted, etc.) re-throw
+  // it as a RedisConnection* exception so the UI renders the "Connection
+  // Lost" banner instead of a generic 500.
+  const connectionException = wrapRedisRuntimeConnectionError(error);
+  if (connectionException) {
+    throw connectionException;
+  }
+
   throw new InternalServerErrorException(error.message);
 };
 


### PR DESCRIPTION
# What

Fixes a bug where the UI spun on a loading indicator after the host switched network interfaces (e.g. Ethernet → Wi-Fi). Clicking Refresh immediately after unplugging the cable would hang for the full HTTP request timeout before any error surfaced; subsequent clicks worked.

### Before

https://github.com/user-attachments/assets/a4c15914-a998-4a3c-a7ef-65bf051383d2

### After

https://github.com/user-attachments/assets/50869ed4-805c-478f-95fe-8c2a55a2cb14

## Root cause

Cached Redis clients kept TCP sockets that became half-open the moment the OS tore down the old interface. Writes on those sockets are silently queued by the kernel — ioredis/node-redis never see an error, so queued commands sit until something else times out.

## Fix

Three layers, backend-only:

1. **TCP keep-alive** — `redis_clients.keepAlive: 5000` is now passed to both ioredis and node-redis connection strategies. Gives the OS a chance to surface a dead socket on its own.
2. **NetworkChangeMonitor** (`redisinsight/api/src/modules/redis/network-change.monitor.ts`) — polls `os.networkInterfaces()` every 2 s, computes a stable signature (excluding loopback + IPv6 link-local), and when the interface set changes, calls `RedisClientStorage.removeAll()`. The next request opens a fresh socket on the currently-active interface. Cross-platform, no native deps, tunable via `RI_CLIENTS_NETWORK_WATCHER*` env vars.
3. **424 error mapping** — `catchAclError` now converts runtime driver errors (`EADDRNOTAVAIL`, `ECONNRESET`, `Socket closed unexpectedly`, reconnect backoff exhausted, …) into `RedisConnection*` exceptions (HTTP 424), which the existing UI `connectivityErrorsInterceptor` already handles to show the "Connection Lost" banner instead of a generic 500.

Existing HTTP `requestTimeout` (25 s) remains the single per-request cap.

## Testing

1. Connect to a Redis DB via wired connection, browse keys → data loads.
2. Unplug the cable, switch to Wi-Fi (with the Redis host reachable on the new network).
3. Immediately click Refresh → should return data without a hang (previously spun for ~25 s).
4. Same with keep-alive disabled (`RI_CLIENTS_KEEP_ALIVE=0`) → still works because the monitor handles it.
5. Disable the monitor (`RI_CLIENTS_NETWORK_WATCHER=false`) → reverts to old behavior.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redis connection setup and runtime error handling, which can affect connectivity and user-facing error behavior if misclassified; also introduces a background polling monitor that clears all cached clients on interface churn.
> 
> **Overview**
> Prevents hangs after host network switches by **enabling TCP keepalive** for both ioredis and node-redis clients (new `redis_clients.keepAlive`, default `5000`, configurable via `RI_CLIENTS_KEEP_ALIVE`).
> 
> Adds a **`NetworkChangeMonitor`** (configurable via `RI_CLIENTS_NETWORK_WATCHER*`) that polls `os.networkInterfaces()` and calls `RedisClientStorage.removeAll()` when the routable interface set changes, forcing fresh sockets on next use.
> 
> Updates error handling so **runtime driver/socket disconnects** are recognized and re-thrown as `RedisConnection*` (HTTP 424) via `wrapRedisRuntimeConnectionError`, improving UI handling; includes new/expanded unit tests for keepalive passthrough, `removeAll`, interface-change monitoring, and runtime error mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555da668f3e447e8e1bb54e652b3b7fde8b9cdcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->