### PR TITLE
RI-8161: add vector set key

### DIFF
--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -189,6 +189,7 @@ export const ENDPOINT_BASED_ON_KEY_TYPE = Object.freeze({
   [KeyTypes.List]: ApiEndpoints.LIST,
   [KeyTypes.ReJSON]: ApiEndpoints.REJSON,
   [KeyTypes.Stream]: ApiEndpoints.STREAMS,
+  [KeyTypes.VectorSet]: ApiEndpoints.VECTOR_SET,
 })
 
 export type EndpointBasedOnKeyType = keyof typeof ENDPOINT_BASED_ON_KEY_TYPE

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -35,6 +35,7 @@ import AddKeySet from './AddKeySet'
 import AddKeyList from './AddKeyList'
 import AddKeyReJSON from './AddKeyReJSON'
 import AddKeyStream from './AddKeyStream'
+import AddKeyVectorSet from './AddKeyVectorSet'
 import { ContentFields } from './AddKey.styles'
 
 import styles from './styles.module.scss'
@@ -200,6 +201,12 @@ const AddKey = (props: Props) => {
               )}
               {typeSelected === KeyTypes.Stream && (
                 <AddKeyStream onCancel={closeAddKeyPanel} {...defaultFields} />
+              )}
+              {typeSelected === KeyTypes.VectorSet && (
+                <AddKeyVectorSet
+                  onCancel={closeAddKeyPanel}
+                  {...defaultFields}
+                />
               )}
             </ContentFields>
           </div>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { cloneDeep } from 'lodash'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import { stringToBuffer } from 'uiSrc/utils'
 import AddKeyVectorSet from './AddKeyVectorSet'
 import { Props } from './AddKeyVectorSet.types'
 
@@ -78,7 +79,7 @@ describe('AddKeyVectorSet', () => {
 
     expect(addVectorSetKey).toHaveBeenCalledWith(
       expect.objectContaining({
-        elements: [{ name: 'elem1', vector: [1, 2, 3] }],
+        elements: [{ name: stringToBuffer('elem1'), vector: [1, 2, 3] }],
       }),
       expect.any(Function),
     )

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { cloneDeep } from 'lodash'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import AddKeyVectorSet from './AddKeyVectorSet'
+import { Props } from './AddKeyVectorSet.types'
+
+jest.mock('uiSrc/slices/browser/keys', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/keys'),
+  addVectorSetKey: jest.fn(() => ({ type: 'keys/addVectorSetKey' })),
+}))
+
+const defaultProps: Props = {
+  keyName: 'myVectorSet',
+  keyTTL: undefined,
+  onCancel: jest.fn(),
+}
+
+describe('AddKeyVectorSet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // ActionFooter renders via a portal to #formFooterBar
+    const footer = document.createElement('div')
+    footer.setAttribute('id', 'formFooterBar')
+    document.body.appendChild(footer)
+  })
+
+  afterEach(() => {
+    const footer = document.getElementById('formFooterBar')
+    footer?.remove()
+  })
+
+  it('should render', () => {
+    expect(render(<AddKeyVectorSet {...defaultProps} />)).toBeTruthy()
+  })
+
+  it('should render the populate mode radio group with manual pre-selected', () => {
+    render(<AddKeyVectorSet {...defaultProps} />)
+    expect(
+      screen.getByTestId('add-key-vector-set-populate'),
+    ).toBeInTheDocument()
+  })
+
+  it('should render element name and vector inputs', () => {
+    render(<AddKeyVectorSet {...defaultProps} />)
+    expect(screen.getByTestId('element-name')).toBeInTheDocument()
+    expect(screen.getByTestId('element-vector')).toBeInTheDocument()
+  })
+
+  it('should disable the submit button when the form is invalid', () => {
+    render(<AddKeyVectorSet {...defaultProps} />)
+    expect(screen.getByTestId('add-key-vector-set-btn')).toBeDisabled()
+  })
+
+  it('should enable the submit button once name and a valid vector are entered', () => {
+    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} />)
+
+    fireEvent.change(screen.getByTestId('element-name'), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId('element-vector'), {
+      target: { value: '0.1, 0.2, 0.3' },
+    })
+
+    expect(screen.getByTestId('add-key-vector-set-btn')).not.toBeDisabled()
+  })
+
+  it('should dispatch addVectorSetKey with parsed elements on submit', () => {
+    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} />)
+
+    fireEvent.change(screen.getByTestId('element-name'), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId('element-vector'), {
+      target: { value: '1, 2, 3' },
+    })
+    fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+
+    expect(addVectorSetKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elements: [{ name: 'elem1', vector: [1, 2, 3] }],
+      }),
+      expect.any(Function),
+    )
+  })
+
+  it('should include expire in payload when keyTTL is provided', () => {
+    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} keyTTL={60} />)
+
+    fireEvent.change(screen.getByTestId('element-name'), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId('element-vector'), {
+      target: { value: '1, 2, 3' },
+    })
+    fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+
+    expect(addVectorSetKey).toHaveBeenCalledWith(
+      expect.objectContaining({ expire: 60 }),
+      expect.any(Function),
+    )
+  })
+
+  it('should call onCancel when the cancel button is clicked', () => {
+    const onCancel = jest.fn()
+    render(<AddKeyVectorSet {...defaultProps} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledWith(true)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { cloneDeep } from 'lodash'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
@@ -18,6 +17,11 @@ const defaultProps: Props = {
 }
 
 describe('AddKeyVectorSet', () => {
+  const renderComponent = (propsOverride?: Partial<Props>) => {
+    const props = { ...defaultProps, ...propsOverride }
+    return render(<AddKeyVectorSet {...props} />)
+  }
+
   beforeEach(() => {
     jest.clearAllMocks()
     // ActionFooter renders via a portal to #formFooterBar
@@ -32,29 +36,29 @@ describe('AddKeyVectorSet', () => {
   })
 
   it('should render', () => {
-    expect(render(<AddKeyVectorSet {...defaultProps} />)).toBeTruthy()
+    expect(renderComponent()).toBeTruthy()
   })
 
   it('should render the populate mode radio group with manual pre-selected', () => {
-    render(<AddKeyVectorSet {...defaultProps} />)
+    renderComponent()
     expect(
       screen.getByTestId('add-key-vector-set-populate'),
     ).toBeInTheDocument()
   })
 
   it('should render element name and vector inputs', () => {
-    render(<AddKeyVectorSet {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('element-name')).toBeInTheDocument()
     expect(screen.getByTestId('element-vector')).toBeInTheDocument()
   })
 
   it('should disable the submit button when the form is invalid', () => {
-    render(<AddKeyVectorSet {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('add-key-vector-set-btn')).toBeDisabled()
   })
 
   it('should enable the submit button once name and a valid vector are entered', () => {
-    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId('element-name'), {
       target: { value: 'elem1' },
@@ -67,7 +71,7 @@ describe('AddKeyVectorSet', () => {
   })
 
   it('should dispatch addVectorSetKey with parsed elements on submit', () => {
-    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId('element-name'), {
       target: { value: 'elem1' },
@@ -86,7 +90,7 @@ describe('AddKeyVectorSet', () => {
   })
 
   it('should include expire in payload when keyTTL is provided', () => {
-    render(<AddKeyVectorSet {...cloneDeep(defaultProps)} keyTTL={60} />)
+    renderComponent({ keyTTL: 60 })
 
     fireEvent.change(screen.getByTestId('element-name'), {
       target: { value: 'elem1' },
@@ -104,7 +108,7 @@ describe('AddKeyVectorSet', () => {
 
   it('should call onCancel when the cancel button is clicked', () => {
     const onCancel = jest.fn()
-    render(<AddKeyVectorSet {...defaultProps} onCancel={onCancel} />)
+    renderComponent({ onCancel })
 
     fireEvent.click(screen.getByText('Cancel'))
     expect(onCancel).toHaveBeenCalledWith(true)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Row } from 'uiSrc/components/base/layout/flex'
+
+export const RadioCardList = styled(Row)`
+  width: 100%;
+`
+
+export const RadioCard = styled(Row)<
+  React.LabelHTMLAttributes<HTMLLabelElement> & { $disabled?: boolean }
+>`
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.secondary500};
+  border-radius: ${({ theme }) =>
+    theme.components.boxSelectionGroup.item.borderRadius};
+  padding: ${({ theme }) => theme.core.space.space150};
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.6 : 1)};
+`

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
@@ -7,9 +7,12 @@ export const RadioCardList = styled(Row)`
   width: 100%;
 `
 
-export const RadioCard = styled(Row)<
+export const RadioCard = styled.label<
   React.LabelHTMLAttributes<HTMLLabelElement> & { $disabled?: boolean }
 >`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.core.space.space050};
   border: 1px solid ${({ theme }) => theme.semantic.color.border.secondary500};
   border-radius: ${({ theme }) =>
     theme.components.boxSelectionGroup.item.borderRadius};

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -1,0 +1,114 @@
+import React, { FormEvent, useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { toNumber } from 'lodash'
+
+import { stringToBuffer } from 'uiSrc/utils'
+import { addKeyStateSelector, addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
+import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
+import {
+  RiRadioGroupItemIndicator,
+  RiRadioGroupItemRoot,
+  RiRadioGroupRoot,
+} from 'uiSrc/components/base/forms/radio-group/RadioGroup'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { Col } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
+
+import {
+  SubmitElement,
+  VectorSetElementFormFields,
+} from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form'
+import { useVectorSetElementForm } from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/hooks'
+
+import { POPULATE_LABEL, POPULATE_OPTIONS, PopulateMode } from './constants'
+import { Props } from './AddKeyVectorSet.types'
+import * as S from './AddKeyVectorSet.styles'
+
+const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
+  const dispatch = useDispatch()
+  const { loading } = useSelector(addKeyStateSelector)
+
+  const [populateMode, setPopulateMode] = useState<string>(PopulateMode.Manual)
+
+  const handleSubmit = (elements: SubmitElement[]) => {
+    const data: CreateVectorSetWithExpireDto = {
+      keyName: stringToBuffer(keyName),
+      elements,
+      ...(keyTTL !== undefined ? { expire: toNumber(keyTTL) } : {}),
+    }
+    dispatch(addVectorSetKey(data, () => onCancel()))
+  }
+
+  const formApi = useVectorSetElementForm({ onSubmit: handleSubmit })
+
+  const [isKeyNameValid, setIsKeyNameValid] = useState<boolean>(false)
+  useEffect(() => {
+    setIsKeyNameValid(`${keyName}`.length > 0)
+  }, [keyName])
+
+  const isFormValid = isKeyNameValid && formApi.isFormValid
+
+  const onFormSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault()
+    if (isFormValid) {
+      formApi.submitData()
+    }
+  }
+
+  return (
+    <form onSubmit={onFormSubmit}>
+      <Col gap="m">
+        <FormField label={POPULATE_LABEL}>
+          <RiRadioGroupRoot
+            value={populateMode}
+            onChange={(value) => setPopulateMode(value)}
+            data-testid="add-key-vector-set-populate"
+          >
+            <S.RadioCardList gap="m">
+              {POPULATE_OPTIONS.map((option) => (
+                <S.RadioCard
+                  key={option.value}
+                  $disabled={option.disabled}
+                  data-testid={`add-key-vector-set-populate-${option.value}`}
+                  align="center"
+                  gap="s"
+                >
+                  <RiRadioGroupItemRoot
+                    value={option.value}
+                    disabled={option.disabled}
+                  >
+                    <RiRadioGroupItemIndicator />
+                  </RiRadioGroupItemRoot>
+                  <Col gap="xs">
+                    <Text size="M" color="primary">
+                      {option.label}
+                    </Text>
+                    {option.description && (
+                      <Text size="XS" color="secondary">
+                        {option.description}
+                      </Text>
+                    )}
+                  </Col>
+                </S.RadioCard>
+              ))}
+            </S.RadioCardList>
+          </RiRadioGroupRoot>
+        </FormField>
+
+        <VectorSetElementFormFields {...formApi} loading={loading} />
+      </Col>
+
+      <ActionFooter
+        onCancel={() => onCancel(true)}
+        onAction={formApi.submitData}
+        actionText="Add Key"
+        loading={loading}
+        disabled={!isFormValid}
+        actionTestId="add-key-vector-set-btn"
+      />
+    </form>
+  )
+}
+
+export default AddKeyVectorSet

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -34,7 +34,10 @@ const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
   const handleSubmit = (elements: SubmitElement[]) => {
     const data: CreateVectorSetWithExpireDto = {
       keyName: stringToBuffer(keyName),
-      elements,
+      elements: elements.map((el) => ({
+        ...el,
+        name: stringToBuffer(el.name),
+      })),
       ...(keyTTL !== undefined ? { expire: toNumber(keyTTL) } : {}),
     }
     dispatch(addVectorSetKey(data, () => onCancel()))

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -74,8 +74,6 @@ const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
                   key={option.value}
                   $disabled={option.disabled}
                   data-testid={`add-key-vector-set-populate-${option.value}`}
-                  align="center"
-                  gap="s"
                 >
                   <RiRadioGroupItemRoot
                     value={option.value}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
@@ -1,7 +1,16 @@
 import { Maybe } from 'uiSrc/utils'
+import { PopulateMode } from './constants'
 
 export interface Props {
   keyName: string
   keyTTL: Maybe<number>
   onCancel: (isCancelled?: boolean) => void
+}
+
+export interface PopulateOption {
+  value: PopulateMode
+  label: string
+  description?: string
+  disabled?: boolean
+  id: string
 }

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
@@ -1,0 +1,7 @@
+import { Maybe } from 'uiSrc/utils'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
@@ -1,14 +1,8 @@
+import { PopulateOption } from './AddKeyVectorSet.types'
+
 export enum PopulateMode {
   Sample = 'sample',
   Manual = 'manual',
-}
-
-export interface PopulateOption {
-  value: PopulateMode
-  label: string
-  description?: string
-  disabled?: boolean
-  id: string
 }
 
 export const POPULATE_OPTIONS: PopulateOption[] = [

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
@@ -1,0 +1,30 @@
+export enum PopulateMode {
+  Sample = 'sample',
+  Manual = 'manual',
+}
+
+export interface PopulateOption {
+  value: PopulateMode
+  label: string
+  description?: string
+  disabled?: boolean
+  id: string
+}
+
+export const POPULATE_OPTIONS: PopulateOption[] = [
+  {
+    value: PopulateMode.Sample,
+    label: 'Load sample dataset',
+    description: 'Explore vector sets with pre-loaded word embeddings',
+    disabled: true,
+    id: 'populate-sample',
+  },
+  {
+    value: PopulateMode.Manual,
+    label: 'Create manually',
+    description: 'Define your own key, elements, and vectors from scratch.',
+    id: 'populate-manual',
+  },
+]
+
+export const POPULATE_LABEL = 'How would you like to populate this vector set?'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/index.ts
@@ -1,0 +1,4 @@
+import AddKeyVectorSet from './AddKeyVectorSet'
+
+export default AddKeyVectorSet
+export type { Props } from './AddKeyVectorSet.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -36,4 +36,9 @@ export const ADD_KEY_TYPE_OPTIONS = [
     value: KeyTypes.Stream,
     color: GROUP_TYPES_COLORS[KeyTypes.Stream],
   },
+  {
+    text: 'Vector Set',
+    value: KeyTypes.VectorSet,
+    color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
+  },
 ]

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
@@ -7,6 +7,7 @@ import {
 } from '../../vector-set-element-form/interfaces'
 import {
   isValidElement,
+  parseVector,
   toSubmitElement,
 } from '../../vector-set-element-form/utils'
 
@@ -26,9 +27,29 @@ export const useVectorSetElementForm = ({
   const lastAddedNameRef = useRef<HTMLInputElement>(null)
   const prevElementsLengthRef = useRef(elements.length)
 
+  // When creating a new vector set, `vectorDim` is not known up-front.
+  // The first row with a valid vector defines the expected dimension for the rest.
+  const inferredVectorDim = useMemo<number | undefined>(() => {
+    if (vectorDim !== undefined) return vectorDim
+    const firstVector = parseVector(elements[0]?.vector ?? '')
+    return firstVector?.length
+  }, [vectorDim, elements])
+
+  const getDimForElement = useCallback(
+    (index: number): number | undefined => {
+      if (vectorDim !== undefined) return vectorDim
+      // First element defines the dim; validate it only as a plain vector.
+      return index === 0 ? undefined : inferredVectorDim
+    },
+    [vectorDim, inferredVectorDim],
+  )
+
   const isFormValid = useMemo(
-    () => elements.every((el) => isValidElement(el, vectorDim)),
-    [elements, vectorDim],
+    () =>
+      elements.every((el, index) =>
+        isValidElement(el, getDimForElement(index)),
+      ),
+    [elements, getDimForElement],
   )
 
   useEffect(() => {
@@ -79,10 +100,12 @@ export const useVectorSetElementForm = ({
   }, [])
 
   const submitData = useCallback(() => {
-    const payload = elements.map((el) => toSubmitElement(el, vectorDim))
+    const payload = elements.map((el, index) =>
+      toSubmitElement(el, getDimForElement(index)),
+    )
     if (payload.some((item) => item === null)) return
     onSubmit(payload as SubmitElement[])
-  }, [elements, vectorDim, onSubmit])
+  }, [elements, getDimForElement, onSubmit])
 
   const isClearDisabled = useCallback(
     (item: IVectorSetElementState): boolean =>
@@ -100,5 +123,6 @@ export const useVectorSetElementForm = ({
     toggleAttributes,
     submitData,
     isClearDisabled,
+    getDimForElement,
   }
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.types.ts
@@ -24,4 +24,10 @@ export interface UseVectorSetElementFormResult {
   toggleAttributes: (id: number) => void
   submitData: () => void
   isClearDisabled: (item: IVectorSetElementState) => boolean
+  /**
+   * Returns the expected vector dimension for the element at the given index.
+   * When `vectorDim` is not supplied (new vector set creation), the first
+   * element's vector defines the required dimension for subsequent rows.
+   */
+  getDimForElement: (index: number) => number | undefined
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
@@ -201,4 +201,85 @@ describe('VectorSetElementForm', () => {
       'Enter Vector (5 dimensions)',
     )
   })
+
+  describe('when vectorDim is not provided (new vector set)', () => {
+    it('should infer required dimension from the first element vector', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: '0.1, 0.2, 0.3' },
+      })
+
+      fireEvent.click(screen.getByTestId('add-item'))
+
+      const vectorInputs = screen.getAllByTestId(ELEMENT_VECTOR)
+      expect(vectorInputs[1]).toHaveAttribute(
+        'placeholder',
+        'Enter Vector (3 dimensions)',
+      )
+    })
+
+    it('should show dimension mismatch error on subsequent element that does not match the first', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: '0.1, 0.2, 0.3' },
+      })
+
+      fireEvent.click(screen.getByTestId('add-item'))
+
+      const nameInputs = screen.getAllByTestId(ELEMENT_NAME)
+      const vectorInputs = screen.getAllByTestId(ELEMENT_VECTOR)
+
+      fireEvent.change(nameInputs[1], { target: { value: 'elem2' } })
+      fireEvent.change(vectorInputs[1], { target: { value: '0.4, 0.5' } })
+
+      expect(
+        screen.getAllByText(
+          'Dimension mismatch. Expected 3 values, but received 2',
+        ).length,
+      ).toBeGreaterThan(0)
+      expect(screen.getByTestId('save-elements-btn')).toBeDisabled()
+    })
+
+    it('should not validate the first element against an inferred dimension from itself', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: '0.1, 0.2, 0.3' },
+      })
+
+      expect(screen.queryByText(/dimension mismatch/i)).not.toBeInTheDocument()
+      expect(screen.getByTestId('save-elements-btn')).not.toBeDisabled()
+    })
+
+    it('should enable save when all subsequent elements match the first element dimension', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: '1, 2, 3' },
+      })
+
+      fireEvent.click(screen.getByTestId('add-item'))
+
+      const nameInputs = screen.getAllByTestId(ELEMENT_NAME)
+      const vectorInputs = screen.getAllByTestId(ELEMENT_VECTOR)
+
+      fireEvent.change(nameInputs[1], { target: { value: 'elem2' } })
+      fireEvent.change(vectorInputs[1], { target: { value: '4, 5, 6' } })
+
+      expect(screen.queryByText(/dimension mismatch/i)).not.toBeInTheDocument()
+      expect(screen.getByTestId('save-elements-btn')).not.toBeDisabled()
+    })
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.tsx
@@ -1,132 +1,24 @@
 import React from 'react'
 
-import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
-  IconButton,
   PrimaryButton,
   SecondaryButton,
-  ToggleButton,
 } from 'uiSrc/components/base/forms/buttons'
-import { FormField } from 'uiSrc/components/base/forms/FormField'
-import { TextInput } from 'uiSrc/components/base/inputs'
-import { Text } from 'uiSrc/components/base/text'
-import { ChevronDownIcon, ChevronRightIcon } from 'uiSrc/components/base/icons'
 
-import { EntryContent } from 'uiSrc/pages/browser/modules/key-details/components/common/AddKeysContainer.styled'
-import { AttributeEditor } from '../attribute-editor'
 import { useVectorSetElementForm } from '../hooks'
 
+import VectorSetElementFormFields from './VectorSetElementFormFields'
 import { Props } from './interfaces'
-import { getVectorFieldInfo } from './utils'
 
 const VectorSetElementForm = (props: Props) => {
   const { onSubmit, onCancel, loading, vectorDim, submitText = 'Save' } = props
 
-  const {
-    elements,
-    isFormValid,
-    lastAddedNameRef,
-    addElement,
-    onClickRemove,
-    handleFieldChange,
-    toggleAttributes,
-    submitData,
-    isClearDisabled,
-  } = useVectorSetElementForm({ vectorDim, onSubmit })
+  const formApi = useVectorSetElementForm({ vectorDim, onSubmit })
 
   return (
     <Col gap="m">
-      <EntryContent>
-        <AddMultipleFields
-          items={elements}
-          isClearDisabled={isClearDisabled}
-          onClickRemove={onClickRemove}
-          onClickAdd={addElement}
-        >
-          {(item, index) => {
-            const vectorInfo = getVectorFieldInfo(item.vector, vectorDim)
-
-            return (
-              <Col gap="s">
-                <Row align="start" gap="m">
-                  <FlexItem grow>
-                    <FormField additionalText="Unique identifier for this vector.">
-                      <TextInput
-                        required
-                        aria-required="true"
-                        name={`element-name-${item.id}`}
-                        id={`element-name-${item.id}`}
-                        placeholder="Enter Element Name"
-                        value={item.name}
-                        onChange={(value) =>
-                          handleFieldChange('name', item.id, value)
-                        }
-                        ref={
-                          index === elements.length - 1
-                            ? lastAddedNameRef
-                            : null
-                        }
-                        disabled={loading}
-                        data-testid="element-name"
-                      />
-                    </FormField>
-                  </FlexItem>
-                  <FlexItem grow>
-                    <FormField additionalText={vectorInfo.text}>
-                      <TextInput
-                        required
-                        aria-required="true"
-                        name={`element-vector-${item.id}`}
-                        id={`element-vector-${item.id}`}
-                        placeholder={
-                          vectorDim !== undefined
-                            ? `Enter Vector (${vectorDim} dimensions)`
-                            : 'Enter Vector'
-                        }
-                        value={item.vector}
-                        onChange={(value) =>
-                          handleFieldChange('vector', item.id, value)
-                        }
-                        disabled={loading}
-                        error={vectorInfo.isError ? vectorInfo.text : undefined}
-                        data-testid="element-vector"
-                      />
-                    </FormField>
-                  </FlexItem>
-                </Row>
-
-                <Row align="center" gap="s">
-                  <ToggleButton
-                    onPressedChange={() => toggleAttributes(item.id)}
-                    pressed={item.showAttributes}
-                    data-testid="toggle-attributes-btn"
-                  >
-                    <Text>Add attributes </Text>
-                    <IconButton
-                      icon={
-                        item.showAttributes ? ChevronDownIcon : ChevronRightIcon
-                      }
-                    />
-                  </ToggleButton>{' '}
-                  <Text color="secondary">(Optional)</Text>
-                </Row>
-                {item.showAttributes && (
-                  <AttributeEditor
-                    value={item.attributes}
-                    onChange={(val: string) =>
-                      handleFieldChange('attributes', item.id, val)
-                    }
-                    isInEditMode={!loading}
-                    height="120px"
-                    testId="element-attributes"
-                  />
-                )}
-              </Col>
-            )
-          }}
-        </AddMultipleFields>
-      </EntryContent>
+      <VectorSetElementFormFields {...formApi} loading={loading} />
       <Row justify="end" gap="m">
         <FlexItem>
           <SecondaryButton
@@ -138,9 +30,9 @@ const VectorSetElementForm = (props: Props) => {
         </FlexItem>
         <FlexItem>
           <PrimaryButton
-            disabled={loading || !isFormValid}
+            disabled={loading || !formApi.isFormValid}
             loading={loading}
-            onClick={submitData}
+            onClick={formApi.submitData}
             data-testid="save-elements-btn"
           >
             {submitText}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementFormFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementFormFields.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+
+import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { IconButton, ToggleButton } from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Text } from 'uiSrc/components/base/text'
+import { ChevronDownIcon, ChevronRightIcon } from 'uiSrc/components/base/icons'
+
+import { EntryContent } from 'uiSrc/pages/browser/modules/key-details/components/common/AddKeysContainer.styled'
+import { AttributeEditor } from '../attribute-editor'
+import { UseVectorSetElementFormResult } from '../hooks/useVectorSetElementForm/useVectorSetElementForm.types'
+import { getVectorFieldInfo } from './utils'
+
+export interface VectorSetElementFormFieldsProps
+  extends UseVectorSetElementFormResult {
+  loading: boolean
+}
+
+const VectorSetElementFormFields = ({
+  elements,
+  lastAddedNameRef,
+  addElement,
+  onClickRemove,
+  handleFieldChange,
+  toggleAttributes,
+  isClearDisabled,
+  getDimForElement,
+  loading,
+}: VectorSetElementFormFieldsProps) => (
+  <EntryContent>
+    <AddMultipleFields
+      items={elements}
+      isClearDisabled={isClearDisabled}
+      onClickRemove={onClickRemove}
+      onClickAdd={addElement}
+    >
+      {(item, index) => {
+        const rowVectorDim = getDimForElement(index)
+        const vectorInfo = getVectorFieldInfo(item.vector, rowVectorDim)
+
+        return (
+          <Col gap="s">
+            <Row align="start" gap="m">
+              <FlexItem grow>
+                <FormField additionalText="Unique identifier for this vector.">
+                  <TextInput
+                    required
+                    aria-required="true"
+                    name={`element-name-${item.id}`}
+                    id={`element-name-${item.id}`}
+                    placeholder="Enter Element Name"
+                    value={item.name}
+                    onChange={(value) =>
+                      handleFieldChange('name', item.id, value)
+                    }
+                    ref={
+                      index === elements.length - 1 ? lastAddedNameRef : null
+                    }
+                    disabled={loading}
+                    data-testid="element-name"
+                  />
+                </FormField>
+              </FlexItem>
+              <FlexItem grow>
+                <FormField additionalText={vectorInfo.text}>
+                  <TextInput
+                    required
+                    aria-required="true"
+                    name={`element-vector-${item.id}`}
+                    id={`element-vector-${item.id}`}
+                    placeholder={
+                      rowVectorDim !== undefined
+                        ? `Enter Vector (${rowVectorDim} dimensions)`
+                        : 'Enter Vector'
+                    }
+                    value={item.vector}
+                    onChange={(value) =>
+                      handleFieldChange('vector', item.id, value)
+                    }
+                    disabled={loading}
+                    error={vectorInfo.isError ? vectorInfo.text : undefined}
+                    data-testid="element-vector"
+                  />
+                </FormField>
+              </FlexItem>
+            </Row>
+
+            <Row align="center" gap="s">
+              <ToggleButton
+                onPressedChange={() => toggleAttributes(item.id)}
+                pressed={item.showAttributes}
+                data-testid="toggle-attributes-btn"
+              >
+                <Text>Add attributes </Text>
+                <IconButton
+                  icon={
+                    item.showAttributes ? ChevronDownIcon : ChevronRightIcon
+                  }
+                />
+              </ToggleButton>{' '}
+              <Text color="secondary">(Optional)</Text>
+            </Row>
+            {item.showAttributes && (
+              <AttributeEditor
+                value={item.attributes}
+                onChange={(val: string) =>
+                  handleFieldChange('attributes', item.id, val)
+                }
+                isInEditMode={!loading}
+                height="120px"
+                testId="element-attributes"
+              />
+            )}
+          </Col>
+        )
+      }}
+    </AddMultipleFields>
+  </EntryContent>
+)
+
+export default VectorSetElementFormFields

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/index.ts
@@ -1,4 +1,6 @@
 export { default as VectorSetElementForm } from './VectorSetElementForm'
+export { default as VectorSetElementFormFields } from './VectorSetElementFormFields'
+export type { VectorSetElementFormFieldsProps } from './VectorSetElementFormFields'
 export type {
   IVectorSetElementState,
   SubmitElement,

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -27,6 +27,7 @@ import {
   bufferToString,
   isEqualBuffers,
   isRedisearchAvailable,
+  stringToBuffer,
 } from 'uiSrc/utils'
 import { DEFAULT_SEARCH_MATCH, SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import {
@@ -55,6 +56,7 @@ import {
   GetKeysWithDetailsResponse,
 } from 'apiSrc/modules/browser/keys/dto'
 import { CreateStreamDto } from 'apiSrc/modules/browser/stream/dto'
+import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
 
 import { fetchString } from './string'
 import {
@@ -1057,6 +1059,67 @@ export function addStreamKey(
   onFailAction?: () => void,
 ) {
   return addTypedKey(data, KeyTypes.Stream, onSuccessAction, onFailAction)
+}
+
+// Asynchronous thunk action
+// Vector set create uses POST /vector-set (create-only; VADD against a new key).
+// The element PUT endpoint reuses the same path for adding to an existing key.
+export function addVectorSetKey(
+  data: CreateVectorSetWithExpireDto,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(addKey())
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const payload = {
+        keyName: data.keyName,
+        elements: data.elements.map((el) => ({
+          name: stringToBuffer(el.name),
+          vector: el.vector,
+          ...(el.attributes ? { attributes: el.attributes } : {}),
+        })),
+        ...(data.expire !== undefined ? { expire: data.expire } : {}),
+      }
+      const { status } = await apiService.post(
+        getUrl(
+          state.connections.instances?.connectedInstance?.id ?? '',
+          ApiEndpoints.VECTOR_SET,
+        ),
+        payload,
+        { params: { encoding } },
+      )
+      if (isStatusSuccessful(status)) {
+        onSuccessAction?.()
+        dispatch(addKeySuccess())
+        dispatch<any>(
+          addKeyIntoList({ key: data.keyName, keyType: KeyTypes.VectorSet }),
+        )
+        dispatch(
+          addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
+        )
+        sendEventTelemetry({
+          event: getBasedOnViewTypeEvent(
+            state.browser.keys?.viewType,
+            TelemetryEvent.BROWSER_KEY_ADDED,
+            TelemetryEvent.TREE_VIEW_KEY_ADDED,
+          ),
+          eventData: {
+            databaseId: state.connections.instances?.connectedInstance?.id,
+            ...getAdditionalAddedEventData(ApiEndpoints.VECTOR_SET, data),
+          },
+        })
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      onFailAction?.()
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error))
+      dispatch(addKeyFailure(errorMessage))
+    }
+  }
 }
 
 // Asynchronous thunk action

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -27,7 +27,6 @@ import {
   bufferToString,
   isEqualBuffers,
   isRedisearchAvailable,
-  stringToBuffer,
 } from 'uiSrc/utils'
 import { DEFAULT_SEARCH_MATCH, SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import {
@@ -1069,57 +1068,7 @@ export function addVectorSetKey(
   onSuccessAction?: () => void,
   onFailAction?: () => void,
 ) {
-  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    dispatch(addKey())
-    try {
-      const state = stateInit()
-      const { encoding } = state.app.info
-      const payload = {
-        keyName: data.keyName,
-        elements: data.elements.map((el) => ({
-          name: stringToBuffer(el.name),
-          vector: el.vector,
-          ...(el.attributes ? { attributes: el.attributes } : {}),
-        })),
-        ...(data.expire !== undefined ? { expire: data.expire } : {}),
-      }
-      const { status } = await apiService.post(
-        getUrl(
-          state.connections.instances?.connectedInstance?.id ?? '',
-          ApiEndpoints.VECTOR_SET,
-        ),
-        payload,
-        { params: { encoding } },
-      )
-      if (isStatusSuccessful(status)) {
-        onSuccessAction?.()
-        dispatch(addKeySuccess())
-        dispatch<any>(
-          addKeyIntoList({ key: data.keyName, keyType: KeyTypes.VectorSet }),
-        )
-        dispatch(
-          addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
-        )
-        sendEventTelemetry({
-          event: getBasedOnViewTypeEvent(
-            state.browser.keys?.viewType,
-            TelemetryEvent.BROWSER_KEY_ADDED,
-            TelemetryEvent.TREE_VIEW_KEY_ADDED,
-          ),
-          eventData: {
-            databaseId: state.connections.instances?.connectedInstance?.id,
-            ...getAdditionalAddedEventData(ApiEndpoints.VECTOR_SET, data),
-          },
-        })
-      }
-    } catch (_err) {
-      const error = _err as AxiosError
-      onFailAction?.()
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
-      dispatch(addKeyFailure(errorMessage))
-    }
-  }
+  return addTypedKey(data, KeyTypes.VectorSet, onSuccessAction, onFailAction)
 }
 
 // Asynchronous thunk action

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -38,6 +38,16 @@ export interface AddVectorSetElementsData {
   }[]
 }
 
+export interface CreateVectorSetWithExpireDto {
+  keyName: RedisResponseBuffer
+  elements: {
+    name: string
+    vector: number[]
+    attributes?: string
+  }[]
+  expire?: number
+}
+
 export interface FetchVectorSetElementsParams {
   key: RedisResponseBuffer
   count?: number

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -41,7 +41,7 @@ export interface AddVectorSetElementsData {
 export interface CreateVectorSetWithExpireDto {
   keyName: RedisResponseBuffer
   elements: {
-    name: string
+    name: RedisResponseBuffer
     vector: number[]
     attributes?: string
   }[]

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -55,6 +55,7 @@ import reducer, {
   addReJSONKey,
   addSetKey,
   addStringKey,
+  addVectorSetKey,
   addZsetKey,
   defaultSelectedKeyAction,
   defaultSelectedKeyActionFailure,
@@ -1781,6 +1782,54 @@ describe('keys slice', () => {
           addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
         ]
         expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('addVectorSetKey', () => {
+      it('success to add vector set key', async () => {
+        const data = {
+          keyName: stringToBuffer('myVectorSet'),
+          elements: [{ name: 'el-1', vector: [0.1, 0.2, 0.3] }],
+        }
+        const responsePayload = { status: 200 }
+
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        await store.dispatch<any>(addVectorSetKey(data, jest.fn()))
+
+        const expectedActions = [
+          addKey(),
+          addKeySuccess(),
+          updateKeyList({
+            keyName: data.keyName,
+            keyType: KeyTypes.VectorSet,
+          }),
+          addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+
+      it('calls onFailAction and dispatches failure on error', async () => {
+        const data = {
+          keyName: stringToBuffer('myVectorSet'),
+          elements: [{ name: 'el-1', vector: [0.1, 0.2, 0.3] }],
+        }
+        const errorMessage = 'Something went wrong'
+        const responsePayload = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(addVectorSetKey(data, jest.fn(), onFail))
+
+        expect(onFail).toHaveBeenCalled()
+        expect(
+          store
+            .getActions()
+            .some((action) => action.type === 'keys/addKeyFailure'),
+        ).toBe(true)
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1916,6 +1916,10 @@ describe('keys slice', () => {
         const responsePayload = { status: 200 }
 
         apiService.patch = jest.fn().mockResolvedValue(responsePayload)
+        apiService.post = jest.fn().mockResolvedValue({
+          data: { data: '{}', keyName: 'keyName' },
+          status: 200,
+        })
 
         // Act
         await store.dispatch<any>(editKeyTTL(key, ttl))

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1789,7 +1789,7 @@ describe('keys slice', () => {
       it('success to add vector set key', async () => {
         const data = {
           keyName: stringToBuffer('myVectorSet'),
-          elements: [{ name: 'el-1', vector: [0.1, 0.2, 0.3] }],
+          elements: [{ name: stringToBuffer('el-1'), vector: [0.1, 0.2, 0.3] }],
         }
         const responsePayload = { status: 200 }
 
@@ -1812,7 +1812,7 @@ describe('keys slice', () => {
       it('calls onFailAction and dispatches failure on error', async () => {
         const data = {
           keyName: stringToBuffer('myVectorSet'),
-          elements: [{ name: 'el-1', vector: [0.1, 0.2, 0.3] }],
+          elements: [{ name: stringToBuffer('el-1'), vector: [0.1, 0.2, 0.3] }],
         }
         const errorMessage = 'Something went wrong'
         const responsePayload = {

--- a/redisinsight/ui/src/telemetry/telemetryUtils.ts
+++ b/redisinsight/ui/src/telemetry/telemetryUtils.ts
@@ -192,6 +192,12 @@ const getAdditionalAddedEventData = (endpoint: ApiEndpoints, data: any) => {
         length: 1,
         TTL: data.expire || -1,
       }
+    case ApiEndpoints.VECTOR_SET:
+      return {
+        keyType: KeyTypes.VectorSet,
+        length: data.elements?.length,
+        TTL: data.expire || -1,
+      }
     default:
       return {}
   }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Adds support for creating a new **Vector Set** key from the "Add Key" panel

High-level changes:
- New `AddKeyVectorSet` form: key name, TTL, populate-mode selector (manual vs. sample dataset — sample is a placeholder), and inline element rows (reused from the element form).
- Registered `KeyTypes.VectorSet` as an option in the Add Key type dropdown and in browser-filter / telemetry helpers.
- Added `addVectorSetKey` Redux thunk and `CreateVectorSetWithExpireDto` UI type hitting `POST /vector-set`.
- Refactored `VectorSetElementForm` to extract `VectorSetElementFormFields`, allowing the new Add-Key form to reuse the element input UI without its own action footer.
- Extended `useVectorSetElementForm` to infer the vector dimension from the first element when `vectorDim` is not provided, and validate subsequent elements against it (prevents mixed-dimension payloads on create).


| Light | Dark | 
| --- | --- | 
| <img width="1374" height="884" alt="image" src="https://github.com/user-attachments/assets/a778222b-4a92-44d3-8254-0a38959c725b" /> | <img width="1374" height="884" alt="image" src="https://github.com/user-attachments/assets/4cf9c46c-017d-4db6-9d81-779355ae2f0f" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new key type creation path (UI + Redux thunk) and changes vector-set element validation logic to infer dimensions, which could affect vector set editing/creation behavior and telemetry payloads.
> 
> **Overview**
> Enables creating **Vector Set** keys from the *Add Key* panel, including a new `AddKeyVectorSet` form that reuses the vector element row UI, supports optional TTL, and introduces a (currently disabled) populate-mode selector.
> 
> Registers `KeyTypes.VectorSet` across the UI (type dropdown, endpoint mapping, telemetry additional event data) and adds a new `addVectorSetKey` thunk + `CreateVectorSetWithExpireDto` for `POST /vector-set`.
> 
> Refactors vector set element UI/logic by extracting `VectorSetElementFormFields` for reuse and updating `useVectorSetElementForm` to infer vector dimension from the first element when `vectorDim` isn’t provided, validating subsequent rows accordingly; associated unit tests were added/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9f7d08a3a7de4fd9860abcfb842f0cb8ec3853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->