### PR TITLE
Skip signing nested Windows binaries to cut DigiCert quota usage

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -89,6 +89,7 @@
     "icon": "resources/icon.ico",
     "legalTrademarks": "Redis Inc., Redis Labs Inc.",
     "signtoolOptions": {
+      "signDlls": false,
       "signingHashAlgorithms": ["sha256"],
       "rfc3161TimeStampServer": "http://timestamp.digicert.com"
     }


### PR DESCRIPTION
# What

Set `win.signtoolOptions.signDlls` to `false` in [electron-builder.json](electron-builder.json). With this flag, `electron-builder` no longer invokes `signtool.exe` on every DLL / `.node` module / helper exe bundled into the NSIS installer payload. Only the final installer (`Redis-Insight-win-installer.exe`) and its embedded NSIS uninstaller are signed.

Motivation: after switching from the old PFX-based signing to DigiCert KeyLocker (cloud HSM), each `signtool` invocation is a metered signature against our DigiCert quota. The default electron-builder behavior burns ~40 signatures per Windows build; this change brings it down to ~2 per build.

Windows Authenticode trust for end users is unchanged — SmartScreen evaluates the installer the user launches and the launcher `.exe` that runs after install, and both remain signed.

# Testing

1. Trigger a staging Windows build (or wait for the next prod release). In the `Build windows exe` step logs, confirm there are roughly 2 `signing file` entries (the installer and the NSIS uninstaller) instead of the ~40 previously emitted for each bundled DLL / native module.
2. After a production release: on Windows, run `Get-AuthenticodeSignature` against the downloaded `Redis-Insight-win-installer.exe` and confirm `Status: Valid` with CN `Redis Inc`. Install and launch to verify no SmartScreen regression.
3. After the first post-merge production release, compare signature usage on the DigiCert KeyLocker dashboard against the previous release — expected delta is ~20x lower.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to Windows packaging; main risk is potential SmartScreen/trust issues if any unsigned bundled binaries are executed directly post-install.
> 
> **Overview**
> Updates `electron-builder.json` to set `win.signtoolOptions.signDlls` to `false`, preventing `electron-builder` from Authenticode-signing bundled DLLs/native modules during NSIS builds.
> 
> This reduces the number of `signtool` invocations (and thus DigiCert KeyLocker signature quota usage) while still signing the top-level Windows installer/uninstaller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9d3288c62a6ffb7007883a078eb12da6339a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->