### PR TITLE
Generalize Vector Search query onboarding popover title

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/components/query-onboarding-popover/QueryOnboardingPopover.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/components/query-onboarding-popover/QueryOnboardingPopover.spec.tsx
@@ -35,7 +35,7 @@ describe('QueryOnboardingPopover', () => {
     const onboardingContent = screen.getByTestId(
       'query-library-onboarding-content',
     )
-    const title = screen.getByText('Index created successfully.')
+    const title = screen.getByText('Start exploring your data')
 
     expect(onboardingContent).toBeInTheDocument()
     expect(title).toBeInTheDocument()

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/components/query-onboarding-popover/QueryOnboardingPopover.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/components/query-onboarding-popover/QueryOnboardingPopover.tsx
@@ -40,10 +40,11 @@ export const QueryOnboardingPopover = ({
     >
       <S.Content gap="l" data-testid="query-library-onboarding-content">
         <Text size="L" variant="semiBold" color="primary">
-          Index created successfully.
+          Start exploring your data
         </Text>
         <Text size="m" color="secondary">
-          Your data is now searchable. Choose how you&apos;d like to search
+          Build queries in the Query Editor or save them for later in the Query
+          Library.
         </Text>
 
         <S.Section>

--- a/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
@@ -41,7 +41,7 @@ export class QueryEditor {
     this.explainTooltip = page.getByTestId('explain-tooltip');
     this.profileTooltip = page.getByTestId('profile-tooltip');
 
-    this.queryOnboarding = page.getByText('Index created successfully.');
+    this.queryOnboarding = page.getByText('Start exploring your data');
     this.queryOnboardingDismiss = page.getByRole('button', { name: 'Got it' });
   }
 

--- a/tests/e2e-playwright/tests/main/vector-search/query/query-onboarding.spec.ts
+++ b/tests/e2e-playwright/tests/main/vector-search/query/query-onboarding.spec.ts
@@ -13,7 +13,7 @@ test.use({ featureFlags: { vectorSearchV2: true } });
 /**
  * Vector Search > Query Page Onboarding
  *
- * The "Index created successfully" popover appears the first time the
+ * The "Start exploring your data" popover appears the first time the
  * query page is visited. It introduces the Query editor and Query library
  * tabs. Dismissed via the "Got it" button, it does not appear on subsequent visits.
  */


### PR DESCRIPTION
# What

The query onboarding popover on the Vector Search page is shown on the first visit to the query page to introduce the **Query Editor** and **Query Library** tabs. Its visibility is gated by the `vectorSearchQueryOnboarding` key in local storage, *not* by an index-creation event, so it also shows for users who already have indexes and are just landing on the page.

The previous title ("Index created successfully.") read as a post-action confirmation, which was misleading in that scenario. This change replaces the title + subtitle with generic copy that describes what the popover is actually for:

- Title: **Start exploring your data**
- Subtitle: **Build queries in the Query Editor or save them for later in the Query Library.**

| Before | After |
| - | - |
<img width="765" height="387" alt="Screenshot 2026-04-23 at 14 31 44" src="https://github.com/user-attachments/assets/3b0e1509-5962-40a2-9262-47be74e38011" />|<img width="765" height="387" alt="Screenshot 2026-04-23 at 14 34 18" src="https://github.com/user-attachments/assets/1248360e-f9c5-47d5-ba93-f199771e7922" />

# Testing

1. Open the **Search** page in a database that already has at least one index.
2. In DevTools → Application → Local Storage, delete the `vectorSearchQueryOnboarding` key (or run `localStorage.removeItem('vectorSearchQueryOnboarding')` in the console).
3. Navigate to the query page — the popover should appear anchored to the **Query Editor** / **Query Library** toggle.
4. Verify the new copy is shown and that clicking **Got it** dismisses the popover and sets `vectorSearchQueryOnboarding=true` so it does not reappear on subsequent visits.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only UI copy change plus test/locator updates; no functional logic, data handling, or security-sensitive behavior is modified.
> 
> **Overview**
> Updates the Vector Search query-page onboarding popover copy by replacing the title "Index created successfully." with **"Start exploring your data"** and revising the subtitle to describe using the Query Editor vs Query Library.
> 
> Adjusts related automated checks to match the new text, including the React unit test assertion, Playwright page-object locator, and the e2e spec description comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558046a0a341f1c4402f97d4227695b4d9664078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->