### PR TITLE
RI-8173: Add API support for fp32 vector format 

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Add Elements.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Add Elements.bru
@@ -16,8 +16,13 @@ body:json {
     "elements": [
       {
         "name": "item_3",
-        "vector": [0.7, 0.8, 0.9],
+        "vectorValues": [0.7, 0.8, 0.9],
         "attributes": "{\"color\": \"blue\"}"
+      },
+      {
+        "name": "item_fp32",
+        "vectorFp32": "AACAPwAAAEAAAEBA",
+        "attributes": "{\"format\": \"fp32\"}"
       }
     ]
   }
@@ -28,6 +33,8 @@ docs {
 
   Adds elements to an existing Vector Set key. Uses the Redis `VADD` command internally (one call per element, pipelined).
 
+  Each element must provide exactly one of two equivalent vector representations: `vectorValues` (numeric array, issues `VADD key VALUES <dim> <v1> ...`) or `vectorFp32` (base64-encoded little-endian IEEE-754 FP32 blob, issues `VADD key FP32 <blob> <element>`). The two fields are mutually exclusive. All elements in a single request — and all elements already in the set — must share the same dimension.
+
   ## Request Body
 
   | Field | Type | Description |
@@ -35,8 +42,15 @@ docs {
   | `keyName` | string | The Vector Set key name |
   | `elements` | array | Array of elements to add |
   | `elements[].name` | string | Element name |
-  | `elements[].vector` | number[] | Vector embedding values |
+  | `elements[].vectorValues` | number[] | Vector embedding as numeric values. Mutually exclusive with `vectorFp32`. |
+  | `elements[].vectorFp32` | string (base64) | Vector embedding as a base64-encoded little-endian FP32 blob. Decoded length must be a non-zero multiple of 4 bytes. Mutually exclusive with `vectorValues`. |
   | `elements[].attributes` | string (optional) | Attributes string to associate with the element (passed via SETATTR) |
+
+  ## FP32 Example
+
+  The base64 payload `AACAPwAAAEAAAEBA` decodes to the 12-byte FP32 blob for
+  `[1.0, 2.0, 3.0]` (little-endian IEEE-754):
+  `00 00 80 3f 00 00 00 40 00 00 40 40`.
 
   ## Response
 
@@ -46,7 +60,7 @@ docs {
 
   | Status | Condition |
   |--------|-----------|
-  | `400` | Key exists but is not a Vector Set (WRONGTYPE) |
+  | `400` | Key exists but is not a Vector Set (WRONGTYPE), or an element provided neither `vectorValues` nor `vectorFp32` (or provided both) |
   | `404` | Key does not exist |
   | `403` | User has no permissions |
 }

--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Create Vector Set.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Create Vector Set.bru
@@ -16,12 +16,17 @@ body:json {
     "elements": [
       {
         "name": "item_1",
-        "vector": [0.1, 0.2, 0.3],
+        "vectorValues": [0.1, 0.2, 0.3],
         "attributes": "{\"color\": \"red\"}"
       },
       {
         "name": "item_2",
-        "vector": [0.4, 0.5, 0.6]
+        "vectorValues": [0.4, 0.5, 0.6]
+      },
+      {
+        "name": "item_fp32",
+        "vectorFp32": "AACAPwAAAEAAAEBA",
+        "attributes": "{\"format\": \"fp32\"}"
       }
     ],
     "expire": 3600
@@ -33,6 +38,8 @@ docs {
 
   Creates a new Vector Set key with the provided elements. Uses the Redis `VADD` command internally (one call per element, pipelined).
 
+  Each element must provide exactly one of two equivalent vector representations: `vectorValues` (numeric array, issues `VADD key VALUES <dim> <v1> ...`) or `vectorFp32` (base64-encoded little-endian IEEE-754 FP32 blob, issues `VADD key FP32 <blob> <element>`). The two fields are mutually exclusive. All elements in the request must share the same dimension.
+
   ## Request Body
 
   | Field | Type | Description |
@@ -40,9 +47,16 @@ docs {
   | `keyName` | string | The key name for the new Vector Set |
   | `elements` | array | Array of elements to add |
   | `elements[].name` | string | Element name |
-  | `elements[].vector` | number[] | Vector embedding values |
+  | `elements[].vectorValues` | number[] | Vector embedding as numeric values. Mutually exclusive with `vectorFp32`. |
+  | `elements[].vectorFp32` | string (base64) | Vector embedding as a base64-encoded little-endian FP32 blob. Decoded length must be a non-zero multiple of 4 bytes. Mutually exclusive with `vectorValues`. |
   | `elements[].attributes` | string (optional) | Attributes string to associate with the element (passed via SETATTR) |
   | `expire` | number (optional) | TTL in seconds |
+
+  ## FP32 Example
+
+  The base64 payload `AACAPwAAAEAAAEBA` decodes to the 12-byte FP32 blob for
+  `[1.0, 2.0, 3.0]` (little-endian IEEE-754):
+  `00 00 80 3f 00 00 00 40 00 00 40 40`.
 
   ## Response
 
@@ -52,7 +66,7 @@ docs {
 
   | Status | Condition |
   |--------|-----------|
-  | `400` | Key already exists |
+  | `400` | Key already exists, or an element provided neither `vectorValues` nor `vectorFp32` (or provided both) |
   | `403` | User has no permissions |
 }
 

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -66,11 +66,43 @@ export const downloadVectorSetEmbeddingDtoFactory =
 export const addVectorSetElementDtoFactory =
   Factory.define<AddVectorSetElementDto>(() => ({
     name: Buffer.from(faker.string.alphanumeric(8)),
-    vector: Array.from({ length: 3 }, () =>
+    vectorValues: Array.from({ length: 3 }, () =>
       parseFloat(
         faker.number.float({ min: 0, max: 1, fractionDigits: 2 }).toFixed(2),
       ),
     ),
+  }));
+
+/**
+ * Shared FP32 fixture used across vector-set service/DTO specs. Represents the
+ * vector `[1.0, 2.0, 3.0]` as a 12-byte little-endian IEEE-754 blob along with
+ * its base64 wire form, so tests can assert the `VADD ... FP32 <buf> ...`
+ * pipeline without re-computing the byte layout inline.
+ *
+ * 1.0 -> 00 00 80 3f, 2.0 -> 00 00 00 40, 3.0 -> 00 00 40 40
+ */
+export const FP32_VECTOR_FIXTURE_1_2_3 = (() => {
+  const buffer = Buffer.from([
+    0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40,
+  ]);
+  return {
+    buffer,
+    base64: buffer.toString('base64'),
+    dim: buffer.length / 4,
+  };
+})();
+
+/**
+ * Convenience factory that builds an `AddVectorSetElementDto` carrying a
+ * base64 FP32 payload instead of `vectorValues`. `vectorValues` is explicitly
+ * set to `undefined` so the service's dispatch branch picks FP32 and no
+ * `VALUES` fragment leaks into the pipeline.
+ */
+export const fp32AddVectorSetElementDtoFactory =
+  Factory.define<AddVectorSetElementDto>(() => ({
+    name: Buffer.from(faker.string.alphanumeric(8)),
+    vectorValues: undefined,
+    vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
   }));
 
 export const addElementsToVectorSetDtoFactory =

--- a/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
@@ -2,9 +2,11 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
   IsArray,
+  IsBase64,
   IsDefined,
   IsOptional,
   IsString,
+  ValidateIf,
 } from 'class-validator';
 import { IsRedisString, RedisStringType } from 'src/common/decorators';
 import { RedisString } from 'src/common/constants';
@@ -19,15 +21,31 @@ export class AddVectorSetElementDto {
   @RedisStringType()
   name: RedisString;
 
-  @ApiProperty({
-    description: 'Vector embedding values.',
+  @ApiPropertyOptional({
+    description:
+      'Vector embedding values. Mutually exclusive with `fp32` - exactly one ' +
+      'of the two must be supplied.',
     type: [Number],
     isArray: true,
   })
-  @IsDefined()
+  // Numeric vector and FP32 blob are two equivalent representations of the same
+  // value and must not be supplied together. When `fp32` is present we skip
+  // validation on `vector`; otherwise the legacy rules (non-empty array) apply.
+  @ValidateIf((o) => o.fp32 === undefined)
   @IsArray()
   @ArrayNotEmpty()
-  vector: number[];
+  vector?: number[];
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Base64-encoded little-endian IEEE-754 FP32 blob. Decoded length must ' +
+      'be a non-zero multiple of 4 bytes. Mutually exclusive with `vector`.',
+  })
+  @ValidateIf((o) => o.vector === undefined)
+  @IsString()
+  @IsBase64()
+  fp32?: string;
 
   @ApiPropertyOptional({
     type: String,

--- a/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
@@ -23,29 +23,31 @@ export class AddVectorSetElementDto {
 
   @ApiPropertyOptional({
     description:
-      'Vector embedding values. Mutually exclusive with `fp32` - exactly one ' +
-      'of the two must be supplied.',
+      'Vector embedding as numeric values. Mutually exclusive with ' +
+      '`vectorFp32` - exactly one of the two must be supplied.',
     type: [Number],
     isArray: true,
   })
-  // Numeric vector and FP32 blob are two equivalent representations of the same
-  // value and must not be supplied together. When `fp32` is present we skip
-  // validation on `vector`; otherwise the legacy rules (non-empty array) apply.
-  @ValidateIf((o) => o.fp32 === undefined)
+  // `vectorValues` and `vectorFp32` are two equivalent representations of the
+  // same vector and must not be supplied together. When `vectorFp32` is
+  // present we skip validation on `vectorValues`; otherwise the legacy rules
+  // (non-empty array) apply.
+  @ValidateIf((o) => o.vectorFp32 === undefined)
   @IsArray()
   @ArrayNotEmpty()
-  vector?: number[];
+  vectorValues?: number[];
 
   @ApiPropertyOptional({
     type: String,
     description:
-      'Base64-encoded little-endian IEEE-754 FP32 blob. Decoded length must ' +
-      'be a non-zero multiple of 4 bytes. Mutually exclusive with `vector`.',
+      'Vector embedding as a base64-encoded little-endian IEEE-754 FP32 ' +
+      'blob. Decoded length must be a non-zero multiple of 4 bytes. ' +
+      'Mutually exclusive with `vectorValues`.',
   })
-  @ValidateIf((o) => o.vector === undefined)
+  @ValidateIf((o) => o.vectorValues === undefined)
   @IsString()
   @IsBase64()
-  fp32?: string;
+  vectorFp32?: string;
 
   @ApiPropertyOptional({
     type: String,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -20,6 +20,8 @@ import {
   createVectorSetDtoFactory,
   deleteVectorSetElementsDtoFactory,
   downloadVectorSetEmbeddingDtoFactory,
+  fp32AddVectorSetElementDtoFactory,
+  FP32_VECTOR_FIXTURE_1_2_3,
   getVectorSetElementsDtoFactory,
   getVectorSetElementDetailsDtoFactory,
   setVectorSetElementAttributeDtoFactory,
@@ -76,7 +78,7 @@ describe('VectorSetService', () => {
             BrowserToolVectorSetCommands.VAdd,
             mockCreateDto.keyName,
             'VALUES',
-            el.vector.length,
+            el.vectorValues.length,
           ]),
         ),
       );
@@ -135,6 +137,69 @@ describe('VectorSetService', () => {
         service.createVectorSet(mockBrowserClientMetadata, mockCreateDto),
       ).rejects.toThrow();
     });
+
+    it('should dispatch VADD with FP32 Buffer when element has vectorFp32 payload', async () => {
+      const fp32Element = fp32AddVectorSetElementDtoFactory.build();
+      const dtoWithFp32 = createVectorSetDtoFactory.build({
+        elements: [fp32Element],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dtoWithFp32.keyName])
+        .mockResolvedValue(false);
+
+      client.sendPipeline.mockResolvedValue([[null, 1]]);
+
+      await service.createVectorSet(mockBrowserClientMetadata, dtoWithFp32);
+
+      expect(client.sendPipeline).toHaveBeenCalledWith([
+        [
+          BrowserToolVectorSetCommands.VAdd,
+          dtoWithFp32.keyName,
+          'FP32',
+          FP32_VECTOR_FIXTURE_1_2_3.buffer,
+          fp32Element.name,
+        ],
+      ]);
+    });
+
+    it('should throw BadRequestException when element has neither vectorValues nor vectorFp32', async () => {
+      const invalidElement = addVectorSetElementDtoFactory.build({
+        vectorValues: undefined,
+        vectorFp32: undefined,
+      });
+      const invalidDto = createVectorSetDtoFactory.build({
+        elements: [invalidElement],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, invalidDto.keyName])
+        .mockResolvedValue(false);
+
+      await expect(
+        service.createVectorSet(mockBrowserClientMetadata, invalidDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when element supplies both vectorValues and vectorFp32', async () => {
+      const conflictingElement = addVectorSetElementDtoFactory.build({
+        vectorValues: [0.1, 0.2, 0.3],
+        vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
+      });
+      const conflictingDto = createVectorSetDtoFactory.build({
+        elements: [conflictingElement],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, conflictingDto.keyName])
+        .mockResolvedValue(false);
+
+      await expect(
+        service.createVectorSet(mockBrowserClientMetadata, conflictingDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
+    });
   });
 
   describe('addElements', () => {
@@ -161,7 +226,7 @@ describe('VectorSetService', () => {
           BrowserToolVectorSetCommands.VAdd,
           mockAddDto.keyName,
           'VALUES',
-          mockElement.vector.length,
+          mockElement.vectorValues.length,
           'SETATTR',
           mockElement.attributes,
         ]),
@@ -176,6 +241,73 @@ describe('VectorSetService', () => {
       await expect(
         service.addElements(mockBrowserClientMetadata, mockAddDto),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should dispatch VADD with FP32 Buffer when element has vectorFp32 payload', async () => {
+      const fp32Element = fp32AddVectorSetElementDtoFactory.build({
+        attributes: '{"status":"active"}',
+      });
+      const fp32Dto = addElementsToVectorSetDtoFactory.build({
+        elements: [fp32Element],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, fp32Dto.keyName])
+        .mockResolvedValue(true);
+
+      client.sendPipeline.mockResolvedValue([[null, 1]]);
+
+      await service.addElements(mockBrowserClientMetadata, fp32Dto);
+
+      expect(client.sendPipeline).toHaveBeenCalledWith([
+        [
+          BrowserToolVectorSetCommands.VAdd,
+          fp32Dto.keyName,
+          'FP32',
+          FP32_VECTOR_FIXTURE_1_2_3.buffer,
+          fp32Element.name,
+          'SETATTR',
+          fp32Element.attributes,
+        ],
+      ]);
+    });
+
+    it('should throw BadRequestException when element.vectorValues is an empty array', async () => {
+      const emptyVectorElement = addVectorSetElementDtoFactory.build({
+        vectorValues: [],
+        vectorFp32: undefined,
+      });
+      const emptyDto = addElementsToVectorSetDtoFactory.build({
+        elements: [emptyVectorElement],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, emptyDto.keyName])
+        .mockResolvedValue(true);
+
+      await expect(
+        service.addElements(mockBrowserClientMetadata, emptyDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when element supplies both vectorValues and vectorFp32', async () => {
+      const conflictingElement = addVectorSetElementDtoFactory.build({
+        vectorValues: [0.1, 0.2, 0.3],
+        vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
+      });
+      const conflictingDto = addElementsToVectorSetDtoFactory.build({
+        elements: [conflictingElement],
+      });
+
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, conflictingDto.keyName])
+        .mockResolvedValue(true);
+
+      await expect(
+        service.addElements(mockBrowserClientMetadata, conflictingDto),
+      ).rejects.toThrow(BadRequestException);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
   });
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -394,11 +394,42 @@ export class VectorSetService {
     const args: Array<string | number | Buffer> = [
       BrowserToolVectorSetCommands.VAdd,
       keyName,
-      'VALUES',
-      element.vector.length,
-      ...element.vector.map(String),
-      element.name,
     ];
+
+    // Dispatch explicitly on each payload rather than assuming `vectorValues`
+    // is defined. DTO validation should already guarantee exactly one of the
+    // two is present, but we stay defensive so any future internal caller
+    // that bypasses class-validator still fails loudly instead of crashing on
+    // an `undefined.length` read or silently dropping one of the two inputs.
+    const hasVectorFp32 =
+      typeof element.vectorFp32 === 'string' && element.vectorFp32.length > 0;
+    const hasVectorValues =
+      Array.isArray(element.vectorValues) && element.vectorValues.length > 0;
+
+    if (hasVectorFp32 && hasVectorValues) {
+      throw new BadRequestException(
+        'Vector element must supply either `vectorValues` (number[]) or `vectorFp32` (base64 string), not both.',
+      );
+    }
+
+    if (hasVectorFp32) {
+      args.push(
+        'FP32',
+        Buffer.from(element.vectorFp32, 'base64'),
+        element.name,
+      );
+    } else if (hasVectorValues) {
+      args.push(
+        'VALUES',
+        element.vectorValues.length,
+        ...element.vectorValues.map(String),
+        element.name,
+      );
+    } else {
+      throw new BadRequestException(
+        'Vector element requires either `vectorValues` (number[]) or `vectorFp32` (base64 string).',
+      );
+    }
 
     if (element.attributes !== undefined) {
       args.push('SETATTR', element.attributes);


### PR DESCRIPTION
# What

Extends the `POST /vector-set` (create) and `PUT /vector-set` (add elements) endpoints to accept vector embeddings in a second, equivalent format alongside the existing numeric array:

- `vectorValues: number[]` — existing numeric representation, dispatches `VADD key VALUES <dim> <v1> ...`.
- `vectorFp32: string` — new base64-encoded little-endian IEEE-754 FP32 blob, dispatches `VADD key FP32 <buffer> <element>`.

The two fields are mutually exclusive; exactly one must be supplied per element. `AddVectorSetElementDto` validates this via `@ValidateIf` + `@IsBase64`, and `VectorSetService.buildVaddCommand` adds defensive guards that throw `BadRequestException` if both or neither payload is present (protects against internal callers that bypass class-validator). Numeric field previously named `vector` was renamed to `vectorValues` for symmetry with the new `vectorFp32` — both names now make it explicit that the two are just different serializations of the same vector.

Bruno docs (`Create Vector Set.bru`, `Add Elements.bru`) were updated with mixed-format sample bodies and describe the mutual-exclusion contract and the base64 → FP32 blob decoding.

# Testing

- `vector-set.service.spec.ts` suite passes — 37 tests, including new cases for:
  - Dispatching `VADD ... FP32 <Buffer> ...` for elements carrying `vectorFp32` (both `createVectorSet` and `addElements`).
  - `BadRequestException` when an element supplies neither `vectorValues` nor `vectorFp32`.
  - `BadRequestException` when an element supplies both (mutual-exclusion guard).
  - `BadRequestException` when `vectorValues` is an empty array.
- Manual verification via Bruno collection: both endpoints accept the base64 payload `AACAPwAAAEAAAEBA` (equivalent to `[1.0, 2.0, 3.0]`) and write it to Redis; `VEMB` on the resulting element returns the same floats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public request contract for vector-set write endpoints (renaming `vector` to `vectorValues` and adding `vectorFp32`) and alters how `VADD` commands are constructed, which could break existing clients or introduce validation/encoding edge cases.
> 
> **Overview**
> Adds support for sending vector embeddings to `POST /vector-set` and `PUT /vector-set` as either numeric arrays (`vectorValues`) or a base64-encoded little-endian FP32 blob (`vectorFp32`), and updates docs/examples accordingly.
> 
> Updates DTO validation and service command-building to enforce *exactly one* representation per element and to dispatch `VADD ... VALUES ...` vs `VADD ... FP32 <Buffer> ...`, with new tests/fixtures covering FP32 dispatch and bad-request cases (missing/both payloads, empty arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57110cc79b4dd0d4a14e1ff77ab6f7103b0c41d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->