### PR TITLE
RI-8173: Add UI support for fp32 vector format 

### DIFF
--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -67,6 +67,32 @@ export const vectorSetElementFormStateFactory =
     showAttributes: false,
   }))
 
+/**
+ * Shared FP32 fixture used across vector-set unit tests. Represents the vector
+ * `[1.0, 2.0, 3.0]` as a 12-byte little-endian IEEE-754 blob, together with
+ * its two wire representations: the C/Python-style escaped string that the
+ * form accepts as input, and the base64 string that the BE DTO receives.
+ *
+ * 1.0 -> 00 00 80 3f, 2.0 -> 00 00 00 40, 3.0 -> 00 00 40 40
+ */
+export const FP32_VECTOR_FIXTURE_1_2_3 = (() => {
+  const bytes = [
+    0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x40, 0x40,
+  ]
+  const escaped = bytes
+    .map((b) => `\\x${b.toString(16).padStart(2, '0')}`)
+    .join('')
+  const base64 = btoa(String.fromCharCode(...bytes))
+  return { bytes, escaped, base64, dim: bytes.length / 4 }
+})()
+
+/**
+ * 3-byte FP32 input used by negative tests. Starts with `\x` (so detection
+ * commits to the FP32 branch) but fails the "byte length must be a multiple
+ * of 4" check, exercising the format-specific error path.
+ */
+export const FP32_INVALID_BYTE_LENGTH_INPUT = '\\x00\\x00\\x00'
+
 /** Redis key name string for vector set tests (stable shape, random value). */
 export const vectorSetTestKeyName = (): string =>
   `vset:${faker.string.alphanumeric(10)}`

--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -49,10 +49,10 @@ export const addVectorSetElementsDataFactory =
   Factory.define<AddVectorSetElementsData>(() => ({
     keyName: stringToBuffer(`vset:${faker.string.alphanumeric(10)}`),
     elements: [
-      { name: faker.word.noun(), vector: buildMockVector() },
+      { name: faker.word.noun(), vectorValues: buildMockVector() },
       {
         name: faker.word.noun(),
-        vector: buildMockVector(),
+        vectorValues: buildMockVector(),
         attributes: mockVectorSetElementAttributes(),
       },
     ],

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
+import { FP32_VECTOR_FIXTURE_1_2_3 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import AddKeyVectorSet from './AddKeyVectorSet'
 import { Props } from './AddKeyVectorSet.types'
 
@@ -83,7 +84,31 @@ describe('AddKeyVectorSet', () => {
 
     expect(addVectorSetKey).toHaveBeenCalledWith(
       expect.objectContaining({
-        elements: [{ name: stringToBuffer('elem1'), vector: [1, 2, 3] }],
+        elements: [{ name: stringToBuffer('elem1'), vectorValues: [1, 2, 3] }],
+      }),
+      expect.any(Function),
+    )
+  })
+
+  it('should dispatch addVectorSetKey with vectorFp32 base64 when an FP32 input is entered', () => {
+    renderComponent()
+
+    const { escaped: fp32Escaped, base64: expectedBase64 } =
+      FP32_VECTOR_FIXTURE_1_2_3
+
+    fireEvent.change(screen.getByTestId('element-name'), {
+      target: { value: 'elem1' },
+    })
+    fireEvent.change(screen.getByTestId('element-vector'), {
+      target: { value: fp32Escaped },
+    })
+    fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+
+    expect(addVectorSetKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elements: [
+          { name: stringToBuffer('elem1'), vectorFp32: expectedBase64 },
+        ],
       }),
       expect.any(Function),
     )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementForm/useVectorSetElementForm.ts
@@ -6,8 +6,8 @@ import {
   SubmitElement,
 } from '../../vector-set-element-form/interfaces'
 import {
+  getRowDim,
   isValidElement,
-  parseVector,
   toSubmitElement,
 } from '../../vector-set-element-form/utils'
 
@@ -28,11 +28,12 @@ export const useVectorSetElementForm = ({
   const prevElementsLengthRef = useRef(elements.length)
 
   // When creating a new vector set, `vectorDim` is not known up-front.
-  // The first row with a valid vector defines the expected dimension for the rest.
+  // The first row with a valid vector defines the expected dimension for the
+  // rest. `getRowDim` handles both numeric (`number[]`) and FP32 (`\xHH...`)
+  // inputs, so mixed-format sets share a single dimension source of truth.
   const inferredVectorDim = useMemo<number | undefined>(() => {
     if (vectorDim !== undefined) return vectorDim
-    const firstVector = parseVector(elements[0]?.vector ?? '')
-    return firstVector?.length
+    return getRowDim(elements[0]?.vector ?? '')
   }, [vectorDim, elements])
 
   const getDimForElement = useCallback(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import {
+  FP32_INVALID_BYTE_LENGTH_INPUT,
+  FP32_VECTOR_FIXTURE_1_2_3,
+} from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import VectorSetElementForm from './VectorSetElementForm'
 import { Props } from './interfaces'
 
@@ -154,7 +158,7 @@ describe('VectorSetElementForm', () => {
     fireEvent.click(screen.getByTestId('save-elements-btn'))
 
     expect(onSubmit).toHaveBeenCalledWith([
-      { name: 'elem1', vector: [0.1, 0.2, 0.3] },
+      { name: 'elem1', vectorValues: [0.1, 0.2, 0.3] },
     ])
   })
 
@@ -177,7 +181,7 @@ describe('VectorSetElementForm', () => {
     expect(onSubmit).toHaveBeenCalledWith([
       {
         name: 'elem1',
-        vector: [1, 2, 3],
+        vectorValues: [1, 2, 3],
         attributes: '{"key":"value"}',
       },
     ])
@@ -200,6 +204,65 @@ describe('VectorSetElementForm', () => {
       'placeholder',
       'Enter Vector (5 dimensions)',
     )
+  })
+
+  describe('FP32 input', () => {
+    const { escaped: FP32_ESCAPED, base64: FP32_BASE64 } =
+      FP32_VECTOR_FIXTURE_1_2_3
+
+    it('should show the FP32 detected hint for a valid escaped-byte input', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: FP32_ESCAPED },
+      })
+      expect(
+        screen.getByText('Detected FP32 vector (3 dimensions).'),
+      ).toBeInTheDocument()
+    })
+
+    it('should submit a vectorFp32 payload instead of vectorValues', () => {
+      const onSubmit = jest.fn()
+      render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: FP32_ESCAPED },
+      })
+      fireEvent.click(screen.getByTestId('save-elements-btn'))
+
+      expect(onSubmit).toHaveBeenCalledWith([
+        { name: 'elem1', vectorFp32: FP32_BASE64 },
+      ])
+    })
+
+    it('should flag an FP32 input whose byte length is not a multiple of 4', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: FP32_INVALID_BYTE_LENGTH_INPUT },
+      })
+      expect(
+        screen.getAllByText('FP32 byte length must be a multiple of 4').length,
+      ).toBeGreaterThan(0)
+    })
+
+    it('should infer required dim from a FP32 first element for a numeric second row', () => {
+      render(<VectorSetElementForm {...defaultProps} />)
+      fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
+        target: { value: 'elem1' },
+      })
+      fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
+        target: { value: FP32_ESCAPED },
+      })
+
+      fireEvent.click(screen.getByTestId('add-item'))
+
+      const vectorInputs = screen.getAllByTestId(ELEMENT_VECTOR)
+      expect(vectorInputs[1]).toHaveAttribute(
+        'placeholder',
+        'Enter Vector (3 dimensions)',
+      )
+    })
   })
 
   describe('when vectorDim is not provided (new vector set)', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/constants.ts
@@ -10,5 +10,21 @@ export const INITIAL_VECTOR_SET_ELEMENT_STATE: IVectorSetElementState = {
 
 export const VECTOR_SEPARATOR = /[\s,]+/
 
+// Matches an FP32 escaped-byte string: one or more `\xHH` tokens (optionally
+// separated by whitespace). Validates the full input end-to-end, used only for
+// format detection and parsing of the binary FP32 VADD payload.
+export const FP32_ESCAPE_REGEX = /^(?:\s*\\x[0-9a-fA-F]{2})+\s*$/
+
+// Partial match used for cheap `isFp32Input` detection - any `\x` occurrence
+// at the start of the trimmed input commits the caller to the FP32 branch, so
+// that malformed FP32 tokens (e.g. `\xZZ`) surface a format-specific error
+// instead of leaking through to the numeric parser as "not a number".
+export const FP32_ESCAPE_PREFIX_REGEX = /^\\x/
+
 export const DEFAULT_VECTOR_HELP_TEXT =
   'Format is detected automatically. The first vector defines the required dimension for this set.'
+
+export const INVALID_FP32_FORMAT_ERROR = 'Invalid FP32 byte string'
+export const INVALID_FP32_BYTE_LENGTH_ERROR =
+  'FP32 byte length must be a multiple of 4'
+export const INVALID_NUMERIC_FORMAT_ERROR = 'Invalid number format in vector'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces.ts
@@ -6,9 +6,17 @@ export interface IVectorSetElementState {
   showAttributes: boolean
 }
 
+export type VectorKind = 'numeric' | 'fp32'
+
 export interface SubmitElement {
   name: string
-  vector: number[]
+  /** Vector embedding as numeric values. Set when the form detected a
+   *  `number[]` input. */
+  vectorValues?: number[]
+  /** Vector embedding as a base64-encoded FP32 little-endian blob. Set when
+   *  the form detected a C/Python-style escaped byte string
+   *  (e.g. `\x00\x00\x80\x3f...`). */
+  vectorFp32?: string
   attributes?: string
 }
 
@@ -26,6 +34,9 @@ export interface VectorFieldInfo {
 }
 
 export interface VectorValidationResult {
-  parsed: number[] | null
+  kind?: VectorKind
+  numeric?: number[]
+  fp32Bytes?: Uint8Array
+  dim?: number
   error?: string
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
@@ -10,7 +10,6 @@ import {
 } from './constants'
 import {
   getRowDim,
-  getValidVector,
   getVectorError,
   getVectorFieldInfo,
   isFp32Input,
@@ -117,29 +116,6 @@ describe('getVectorFieldInfo', () => {
       text: 'Detected numeric vector (4 dimensions).',
       isError: false,
     })
-  })
-})
-
-describe('getValidVector', () => {
-  it('should return null for an empty string', () => {
-    expect(getValidVector('')).toBeNull()
-    expect(getValidVector('   ')).toBeNull()
-  })
-
-  it('should return null for an unparsable vector', () => {
-    expect(getValidVector('1, abc, 3')).toBeNull()
-  })
-
-  it('should return the parsed vector without dimension check', () => {
-    expect(getValidVector('1, 2, 3')).toEqual([1, 2, 3])
-  })
-
-  it('should return the parsed vector when dimension matches', () => {
-    expect(getValidVector('1, 2, 3', 3)).toEqual([1, 2, 3])
-  })
-
-  it('should return null when dimension does not match', () => {
-    expect(getValidVector('1, 2', 3)).toBeNull()
   })
 })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.spec.ts
@@ -1,13 +1,30 @@
-import { vectorSetElementFormStateFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
-import { DEFAULT_VECTOR_HELP_TEXT } from './constants'
 import {
+  FP32_INVALID_BYTE_LENGTH_INPUT,
+  FP32_VECTOR_FIXTURE_1_2_3,
+  vectorSetElementFormStateFactory,
+} from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
+import {
+  DEFAULT_VECTOR_HELP_TEXT,
+  INVALID_FP32_BYTE_LENGTH_ERROR,
+  INVALID_FP32_FORMAT_ERROR,
+} from './constants'
+import {
+  getRowDim,
   getValidVector,
   getVectorError,
   getVectorFieldInfo,
+  isFp32Input,
   isValidElement,
+  parseFp32EscapedString,
   parseVector,
   toSubmitElement,
 } from './utils'
+
+const {
+  bytes: FP32_BYTES_1_2_3,
+  escaped: FP32_ESCAPED_1_2_3,
+  base64: FP32_BASE64_1_2_3,
+} = FP32_VECTOR_FIXTURE_1_2_3
 
 describe('parseVector', () => {
   it('should return null for an empty string', () => {
@@ -165,14 +182,14 @@ describe('toSubmitElement', () => {
       ),
     ).toEqual({
       name: 'padded',
-      vector: [1, 2, 3],
+      vectorValues: [1, 2, 3],
     })
   })
 
   it('should map a valid element without attributes', () => {
     expect(toSubmitElement(vectorSetElementFormStateFactory.build())).toEqual({
       name: 'item',
-      vector: [1, 2, 3],
+      vectorValues: [1, 2, 3],
     })
   })
 
@@ -185,7 +202,7 @@ describe('toSubmitElement', () => {
       ),
     ).toEqual({
       name: 'item',
-      vector: [1, 2, 3],
+      vectorValues: [1, 2, 3],
       attributes: '{"a":1}',
     })
   })
@@ -194,7 +211,7 @@ describe('toSubmitElement', () => {
     const result = toSubmitElement(
       vectorSetElementFormStateFactory.build({ attributes: '   ' }),
     )
-    expect(result).toEqual({ name: 'item', vector: [1, 2, 3] })
+    expect(result).toEqual({ name: 'item', vectorValues: [1, 2, 3] })
     expect(result).not.toHaveProperty('attributes')
   })
 })
@@ -233,5 +250,159 @@ describe('isValidElement', () => {
 
   it('should return true for a valid element', () => {
     expect(isValidElement(vectorSetElementFormStateFactory.build())).toBe(true)
+  })
+
+  it('should return true for a valid FP32 element with matching dim', () => {
+    expect(
+      isValidElement(
+        vectorSetElementFormStateFactory.build({ vector: FP32_ESCAPED_1_2_3 }),
+        3,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('isFp32Input', () => {
+  it('should return false for plain numeric input', () => {
+    expect(isFp32Input('1, 2, 3')).toBe(false)
+    expect(isFp32Input('')).toBe(false)
+  })
+
+  it('should return true when input starts with an `\\xHH` escape', () => {
+    expect(isFp32Input(FP32_ESCAPED_1_2_3)).toBe(true)
+    expect(isFp32Input('  \\x00\\x01')).toBe(true)
+  })
+
+  it('should treat any `\\x` prefix as an FP32 attempt (even when malformed)', () => {
+    // So that malformed FP32 inputs surface a format-specific error instead
+    // of falling through to the numeric parser as "not a number".
+    expect(isFp32Input('\\xG0')).toBe(true)
+    expect(isFp32Input('\\x')).toBe(true)
+  })
+
+  it('should return false for inputs that do not start with `\\x`', () => {
+    expect(isFp32Input('x00')).toBe(false)
+    expect(isFp32Input('0x00')).toBe(false)
+  })
+})
+
+describe('parseFp32EscapedString', () => {
+  it('should return null for an empty/whitespace string', () => {
+    expect(parseFp32EscapedString('')).toBeNull()
+    expect(parseFp32EscapedString('   ')).toBeNull()
+  })
+
+  it('should return null when the string does not match the full escape regex', () => {
+    expect(parseFp32EscapedString('\\x00 hello')).toBeNull()
+    expect(parseFp32EscapedString('\\xZZ')).toBeNull()
+  })
+
+  it('should decode a valid escaped-byte string', () => {
+    const bytes = parseFp32EscapedString(FP32_ESCAPED_1_2_3)
+    expect(bytes).not.toBeNull()
+    expect(Array.from(bytes as Uint8Array)).toEqual(FP32_BYTES_1_2_3)
+  })
+
+  it('should tolerate whitespace between escape tokens', () => {
+    const spaced = FP32_ESCAPED_1_2_3.replace(/\\x/g, ' \\x')
+    const bytes = parseFp32EscapedString(spaced)
+    expect(bytes).not.toBeNull()
+    expect(Array.from(bytes as Uint8Array)).toEqual(FP32_BYTES_1_2_3)
+  })
+})
+
+describe('getRowDim', () => {
+  it('should return undefined for an empty/invalid input', () => {
+    expect(getRowDim('')).toBeUndefined()
+    expect(getRowDim('1, abc')).toBeUndefined()
+  })
+
+  it('should return the numeric length for a numeric input', () => {
+    expect(getRowDim('1, 2, 3, 4')).toBe(4)
+  })
+
+  it('should return bytes/4 for a valid FP32 input', () => {
+    expect(getRowDim(FP32_ESCAPED_1_2_3)).toBe(3)
+  })
+
+  it('should return undefined for an FP32 input with invalid byte length', () => {
+    expect(getRowDim(FP32_INVALID_BYTE_LENGTH_INPUT)).toBeUndefined()
+  })
+})
+
+describe('FP32 detection in getVectorError', () => {
+  it('should return undefined for a valid FP32 input', () => {
+    expect(getVectorError(FP32_ESCAPED_1_2_3)).toBeUndefined()
+  })
+
+  it('should return the FP32 byte-length error when bytes are not a multiple of 4', () => {
+    expect(getVectorError(FP32_INVALID_BYTE_LENGTH_INPUT)).toBe(
+      INVALID_FP32_BYTE_LENGTH_ERROR,
+    )
+  })
+
+  it('should return the FP32 format error for stray hex characters', () => {
+    expect(getVectorError('\\xZZ')).toBe(INVALID_FP32_FORMAT_ERROR)
+  })
+
+  it('should return a dimension-mismatch error when FP32 dim disagrees', () => {
+    expect(getVectorError(FP32_ESCAPED_1_2_3, 5)).toBe(
+      'Dimension mismatch. Expected 5 values, but received 3',
+    )
+  })
+})
+
+describe('FP32 detection in getVectorFieldInfo', () => {
+  it('should return the FP32 detected message for a valid FP32 input', () => {
+    expect(getVectorFieldInfo(FP32_ESCAPED_1_2_3)).toEqual({
+      text: 'Detected FP32 vector (3 dimensions).',
+      isError: false,
+    })
+  })
+
+  it('should return the FP32 byte-length error in the hint', () => {
+    expect(getVectorFieldInfo(FP32_INVALID_BYTE_LENGTH_INPUT)).toEqual({
+      text: INVALID_FP32_BYTE_LENGTH_ERROR,
+      isError: true,
+    })
+  })
+})
+
+describe('FP32 detection in toSubmitElement', () => {
+  it('should produce a `vectorFp32` base64 payload for a valid FP32 input', () => {
+    const result = toSubmitElement(
+      vectorSetElementFormStateFactory.build({
+        vector: FP32_ESCAPED_1_2_3,
+      }),
+    )
+    expect(result).toEqual({
+      name: 'item',
+      vectorFp32: FP32_BASE64_1_2_3,
+    })
+    expect(result).not.toHaveProperty('vectorValues')
+  })
+
+  it('should include attributes alongside the vectorFp32 payload', () => {
+    const result = toSubmitElement(
+      vectorSetElementFormStateFactory.build({
+        vector: FP32_ESCAPED_1_2_3,
+        attributes: '{"a":1}',
+      }),
+    )
+    expect(result).toEqual({
+      name: 'item',
+      vectorFp32: FP32_BASE64_1_2_3,
+      attributes: '{"a":1}',
+    })
+  })
+
+  it('should return null when the FP32 byte length is invalid', () => {
+    expect(
+      toSubmitElement(
+        vectorSetElementFormStateFactory.build({
+          vector: FP32_INVALID_BYTE_LENGTH_INPUT,
+        }),
+      ),
+    ).toBeNull()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
@@ -103,15 +103,6 @@ export function getVectorError(
   return validateVector(raw, vectorDim).error
 }
 
-export function getValidVector(
-  raw: string,
-  vectorDim?: number,
-): number[] | null {
-  const result = validateVector(raw, vectorDim)
-  if (result.error || result.kind !== 'numeric' || !result.numeric) return null
-  return result.numeric
-}
-
 /**
  * Returns the detected dimension of the row's vector input regardless of format
  * (numeric `number[]` or FP32 byte blob). Used to infer the required dimension

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/utils.ts
@@ -1,4 +1,12 @@
-import { VECTOR_SEPARATOR, DEFAULT_VECTOR_HELP_TEXT } from './constants'
+import {
+  DEFAULT_VECTOR_HELP_TEXT,
+  FP32_ESCAPE_PREFIX_REGEX,
+  FP32_ESCAPE_REGEX,
+  INVALID_FP32_BYTE_LENGTH_ERROR,
+  INVALID_FP32_FORMAT_ERROR,
+  INVALID_NUMERIC_FORMAT_ERROR,
+  VECTOR_SEPARATOR,
+} from './constants'
 import {
   IVectorSetElementState,
   SubmitElement,
@@ -22,23 +30,70 @@ export function parseVector(raw: string): number[] | null {
   return nums.length > 0 ? nums : null
 }
 
+export function isFp32Input(raw: string): boolean {
+  return FP32_ESCAPE_PREFIX_REGEX.test(raw.trim())
+}
+
+export function parseFp32EscapedString(raw: string): Uint8Array | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  if (!FP32_ESCAPE_REGEX.test(trimmed)) return null
+
+  const matches = trimmed.match(/\\x([0-9a-fA-F]{2})/g)
+  if (!matches || matches.length === 0) return null
+
+  const bytes = new Uint8Array(matches.length)
+  for (let i = 0; i < matches.length; i += 1) {
+    bytes[i] = parseInt(matches[i].slice(2), 16)
+  }
+  return bytes
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
 function validateVector(
   raw: string,
   vectorDim?: number,
 ): VectorValidationResult {
-  if (!raw.trim()) return { parsed: null }
+  if (!raw.trim()) return {}
+
+  if (isFp32Input(raw)) {
+    const bytes = parseFp32EscapedString(raw)
+    if (!bytes) return { error: INVALID_FP32_FORMAT_ERROR }
+    if (bytes.length === 0 || bytes.length % 4 !== 0) {
+      return { error: INVALID_FP32_BYTE_LENGTH_ERROR }
+    }
+    const dim = bytes.length / 4
+    if (vectorDim !== undefined && dim !== vectorDim) {
+      return {
+        kind: 'fp32',
+        fp32Bytes: bytes,
+        dim,
+        error: `Dimension mismatch. Expected ${vectorDim} values, but received ${dim}`,
+      }
+    }
+    return { kind: 'fp32', fp32Bytes: bytes, dim }
+  }
 
   const parsed = parseVector(raw)
-  if (!parsed) return { parsed: null, error: 'Invalid number format in vector' }
+  if (!parsed) return { error: INVALID_NUMERIC_FORMAT_ERROR }
 
   if (vectorDim !== undefined && parsed.length !== vectorDim) {
     return {
-      parsed,
+      kind: 'numeric',
+      numeric: parsed,
+      dim: parsed.length,
       error: `Dimension mismatch. Expected ${vectorDim} values, but received ${parsed.length}`,
     }
   }
 
-  return { parsed }
+  return { kind: 'numeric', numeric: parsed, dim: parsed.length }
 }
 
 export function getVectorError(
@@ -52,15 +107,28 @@ export function getValidVector(
   raw: string,
   vectorDim?: number,
 ): number[] | null {
-  const { parsed, error } = validateVector(raw, vectorDim)
-  return !error && parsed ? parsed : null
+  const result = validateVector(raw, vectorDim)
+  if (result.error || result.kind !== 'numeric' || !result.numeric) return null
+  return result.numeric
+}
+
+/**
+ * Returns the detected dimension of the row's vector input regardless of format
+ * (numeric `number[]` or FP32 byte blob). Used to infer the required dimension
+ * for subsequent rows when creating a new vector set.
+ */
+export function getRowDim(raw: string): number | undefined {
+  const result = validateVector(raw)
+  return result.dim
 }
 
 export function isValidElement(
   el: IVectorSetElementState,
   vectorDim?: number,
 ): boolean {
-  return !!el.name.trim() && getValidVector(el.vector, vectorDim) !== null
+  if (!el.name.trim()) return false
+  const result = validateVector(el.vector, vectorDim)
+  return !result.error && result.kind !== undefined
 }
 
 export function toSubmitElement(
@@ -70,10 +138,18 @@ export function toSubmitElement(
   const name = el.name.trim()
   if (!name) return null
 
-  const vector = getValidVector(el.vector, vectorDim)
-  if (!vector) return null
+  const result = validateVector(el.vector, vectorDim)
+  if (result.error || !result.kind) return null
 
-  const item: SubmitElement = { name, vector }
+  const item: SubmitElement = { name }
+  if (result.kind === 'fp32' && result.fp32Bytes) {
+    item.vectorFp32 = bytesToBase64(result.fp32Bytes)
+  } else if (result.kind === 'numeric' && result.numeric) {
+    item.vectorValues = result.numeric
+  } else {
+    return null
+  }
+
   const trimmedAttributes = el.attributes.trim()
   if (trimmedAttributes) item.attributes = trimmedAttributes
 
@@ -88,13 +164,20 @@ export function getVectorFieldInfo(
     return { text: DEFAULT_VECTOR_HELP_TEXT, isError: false }
   }
 
-  const { parsed, error } = validateVector(raw, vectorDim)
-  if (error) {
-    return { text: error, isError: true }
+  const result = validateVector(raw, vectorDim)
+  if (result.error) {
+    return { text: result.error, isError: true }
+  }
+
+  if (result.kind === 'fp32') {
+    return {
+      text: `Detected FP32 vector (${result.dim} dimensions).`,
+      isError: false,
+    }
   }
 
   return {
-    text: `Detected numeric vector (${parsed!.length} dimensions).`,
+    text: `Detected numeric vector (${result.dim} dimensions).`,
     isError: false,
   }
 }

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -449,7 +449,9 @@ export function addVectorSetElements(
           keyName: data.keyName,
           elements: data.elements.map((el) => ({
             name: stringToBuffer(el.name),
-            vector: el.vector,
+            ...(el.vectorFp32 !== undefined
+              ? { vectorFp32: el.vectorFp32 }
+              : { vectorValues: el.vectorValues }),
             ...(el.attributes ? { attributes: el.attributes } : {}),
           })),
         },

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -29,11 +29,18 @@ export interface AddVectorSetElementsState {
   error: string
 }
 
+/**
+ * Element payload for add/create flows. Exactly one of `vectorValues` (numeric
+ * array) or `vectorFp32` (base64-encoded little-endian IEEE-754 blob) must be
+ * supplied; the backend dispatches `VADD ... VALUES ...` or
+ * `VADD ... FP32 <buf> ...` accordingly.
+ */
 export interface AddVectorSetElementsData {
   keyName: RedisResponseBuffer
   elements: {
     name: string
-    vector: number[]
+    vectorValues?: number[]
+    vectorFp32?: string
     attributes?: string
   }[]
 }
@@ -42,7 +49,8 @@ export interface CreateVectorSetWithExpireDto {
   keyName: RedisResponseBuffer
   elements: {
     name: RedisResponseBuffer
-    vector: number[]
+    vectorValues?: number[]
+    vectorFp32?: string
     attributes?: string
   }[]
   expire?: number

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1789,7 +1789,9 @@ describe('keys slice', () => {
       it('success to add vector set key', async () => {
         const data = {
           keyName: stringToBuffer('myVectorSet'),
-          elements: [{ name: stringToBuffer('el-1'), vector: [0.1, 0.2, 0.3] }],
+          elements: [
+            { name: stringToBuffer('el-1'), vectorValues: [0.1, 0.2, 0.3] },
+          ],
         }
         const responsePayload = { status: 200 }
 
@@ -1812,7 +1814,9 @@ describe('keys slice', () => {
       it('calls onFailAction and dispatches failure on error', async () => {
         const data = {
           keyName: stringToBuffer('myVectorSet'),
-          elements: [{ name: stringToBuffer('el-1'), vector: [0.1, 0.2, 0.3] }],
+          elements: [
+            { name: stringToBuffer('el-1'), vectorValues: [0.1, 0.2, 0.3] },
+          ],
         }
         const errorMessage = 'Something went wrong'
         const responsePayload = {

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -981,9 +981,7 @@ describe('vectorSet slice', () => {
 
       const onSuccess = jest.fn()
 
-      await store.dispatch<any>(
-        addVectorSetElements(elementsData as any, onSuccess),
-      )
+      await store.dispatch<any>(addVectorSetElements(elementsData, onSuccess))
 
       const expectedActions = [addElements(), addElementsSuccess()]
 
@@ -991,6 +989,19 @@ describe('vectorSet slice', () => {
         expectedActions,
       )
       expect(onSuccess).toHaveBeenCalledTimes(1)
+
+      expect(apiService.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          keyName: elementsData.keyName,
+          elements: elementsData.elements.map((el) =>
+            expect.objectContaining({
+              vectorValues: el.vectorValues,
+            }),
+          ),
+        }),
+        expect.any(Object),
+      )
     })
 
     it('should dispatch failure actions when add fails', async () => {
@@ -1006,7 +1017,7 @@ describe('vectorSet slice', () => {
       const onFail = jest.fn()
 
       await store.dispatch<any>(
-        addVectorSetElements(elementsData as any, undefined, onFail),
+        addVectorSetElements(elementsData, undefined, onFail),
       )
 
       const expectedActions = [


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Extends the vector set element form (used by both **Add Key → Vector Set** and **Key Details → Add Elements**) to accept vector embeddings in two equivalent formats, matching the new BE contract:
- Numeric array — existing path, sent as `vectorValues: number[]`.
- FP32 escaped-byte string (e.g. `\x00\x00\x80\x3f...`) — new path, decoded into a `Uint8Array`, base64-encoded, sent as `vectorFp32: string`.
The form auto-detects which format the user entered, shows a live hint under the field (`Detected numeric vector (N dimensions).` / `Detected FP32 vector (N dimensions).`), and surfaces FP32-specific validation errors ("Invalid FP32 byte string", "FP32 byte length must be a multiple of 4"). Dimension inference is unified via a new `getRowDim` helper, so a FP32 first row correctly constrains a numeric second row (and vice-versa) to the same dimension. Numeric payload field on the wire was renamed `vector` → `vectorValues` to pair symmetrically with `vectorFp32`.
Under the hood: new FP32 parsing/encoding utilities in the form's `utils.ts`, a widened `SubmitElement` / slice interfaces, the `addVectorSetElements` and `addVectorSetKey` thunks forwarding the correct field, and a shared `FP32_VECTOR_FIXTURE_1_2_3` test fixture reused across all three FE specs.

| Light | Dark |
| --- | --- |
| <img width="649" height="703" alt="image" src="https://github.com/user-attachments/assets/e327833a-721b-4718-89d2-43cd8d51c707" /> | <img width="649" height="703" alt="image" src="https://github.com/user-attachments/assets/01ab286c-4d84-4434-b776-3f029312dfdd" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Click Add Key
2. Choose Vector set from the dropdown
3. Use this 3 dimensional vector `\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40` and this for the 4 dimensional - `\x4d\x61\x9f\x3e\x82\x5c\x2f\xbf\x0e\x8a\x55\x3f\x7c\x21\x10\xbe` to reproduce the scenario on the screenshots

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the vector-set create/add payload contract (renaming `vector` to `vectorValues` and adding `vectorFp32`) and adds new parsing/validation logic that could reject previously-accepted inputs if edge cases are missed.
> 
> **Overview**
> Adds UI support for FP32 vector embeddings in the vector-set element form: the vector field now auto-detects numeric vs escaped-byte FP32 input, validates FP32 format/byte-length, and shows format-specific dimension hints/errors.
> 
> Updates submit/DTO shapes and thunks to send **either** `vectorValues` (numeric) **or** `vectorFp32` (base64-encoded bytes) instead of the previous `vector` field, and unifies dimension inference across rows via `getRowDim` so mixed-format entries share a single inferred dimension.
> 
> Extends factories and unit tests to cover FP32 parsing, dimension inference, and correct payload mapping for both Add Key and Add Elements flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67e9a13902852ff77e88bf14ef3107f4d2ba08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->