### PR TITLE
fix: query theme parser

### DIFF
--- a/redisinsight/ui/src/contexts/themeContext.tsx
+++ b/redisinsight/ui/src/contexts/themeContext.tsx
@@ -27,6 +27,7 @@ const getQueryTheme = () => {
   const queryThemeParam = new URLSearchParams(window.location.search)
     .get('theme')
     ?.toUpperCase()
+    .split('-')[0]
 
   return THEMES.find(({ value }) => value === queryThemeParam)?.value
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
SM passes theme as "light-1" for example, wheres we expect explicit "light/dark" values.

## Fix
Strip everything after the dash. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

https://github.com/user-attachments/assets/f0f738bd-1d03-4773-aa8b-5501974f82da


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to URL query parsing that only affects initial theme selection from `?theme=` and does not touch persistence or theming application logic.
> 
> **Overview**
> Updates `getQueryTheme` in `themeContext.tsx` to accept theme values like `light-1` by uppercasing and **discarding any suffix after `-`** before matching against supported themes. This makes initial theme selection via the `theme` URL query param more tolerant of variant formats while preserving existing fallback behavior (stored theme/system theme).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b365d800db0693c45db36dbb49ef10be6ac70e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->