### PR TITLE
[RI-8112] fix: query theme parser

### DIFF
--- a/redisinsight/ui/src/contexts/themeContext.tsx
+++ b/redisinsight/ui/src/contexts/themeContext.tsx
@@ -27,6 +27,7 @@ const getQueryTheme = () => {
   const queryThemeParam = new URLSearchParams(window.location.search)
     .get('theme')
     ?.toUpperCase()
+    .split('-')[0]
 
   return THEMES.find(({ value }) => value === queryThemeParam)?.value
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->
SM passes theme as "light-1" for example, wheres we expect explicit "light/dark" values.

## Fix
Strip everything after the dash. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

https://github.com/user-attachments/assets/f0f738bd-1d03-4773-aa8b-5501974f82da



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to URL query parsing that only affects initial theme selection and should not impact persisted theme behavior.
> 
> **Overview**
> Improves `getQueryTheme()` in `themeContext.tsx` to handle `theme` query values with dash-delimited suffixes (e.g., `light-1`) by uppercasing and taking only the segment before `-`, ensuring the theme matches expected `LIGHT`/`DARK` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b365d800db0693c45db36dbb49ef10be6ac70e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->