### PR TITLE
Fix Linux ARM native binary packaging

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -34,9 +34,9 @@ runs:
           node_modules
           redisinsight/node_modules
           redisinsight/api/node_modules
-        key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock', 'redisinsight/yarn.lock', 'redisinsight/api/yarn.lock') }}
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', 'redisinsight/yarn.lock', 'redisinsight/api/yarn.lock') }}
         restore-keys: |
-          node-modules-${{ runner.os }}-
+          node-modules-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -25,136 +25,49 @@ on:
         type: boolean
 
 jobs:
-  build-x64:
-    name: Build linux x64
+  build-linux:
+    name: Build linux ${{ matrix.arch }}
     if: |
       inputs.target == 'all' ||
       inputs.target == 'linux' ||
-      contains(inputs.target, 'build_linux_appimage_x64') ||
-      contains(inputs.target, 'build_linux_deb_x64') ||
-      contains(inputs.target, 'build_linux_rpm_x64') ||
-      contains(inputs.target, 'build_linux_snap_x64')
-    runs-on: ubuntu-24.04
+      contains(inputs.target, format('build_linux_appimage_{0}', matrix.arch)) ||
+      contains(inputs.target, format('build_linux_deb_{0}', matrix.arch)) ||
+      contains(inputs.target, format('build_linux_rpm_{0}', matrix.arch)) ||
+      (matrix.arch == 'x64' && contains(inputs.target, 'build_linux_snap_x64'))
+    runs-on: ${{ matrix.runner }}
     environment: ${{ inputs.environment }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # SSH Debug
-      - name: Enable SSH
-        uses: mxschmitt/action-tmate@v3
-        if: inputs.debug
-        with:
-          detached: true
-
-      - name: Install all libs and dependencies
-        uses: ./.github/actions/install-all-build-libs
-        with:
-          keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
-          sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
-
-      # TODO: Is it needed?
-      # - run: |
-      #     mkdir electron
-      #     CURRENT_VERSION=$(jq -r ".version" redisinsight/package.json)
-      #     echo "Build version: $CURRENT_VERSION"
-      #     cp ./redisinsight/package.json ./electron/package.json
-      #     echo "$VERSION" > electron/version
-      #     exit 0
-      # - uses: actions/download-artifact@v4.1.0
-      #   with:
-      #     path: "."
-      # - run: cp ./electron/package.json ./redisinsight/
-
-      - name: Install plugins dependencies and build plugins
-        run: yarn build:statics
-
-      - name: Build linux packages (production)
-        if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
-        run: yarn package:prod --linux appimage:x64 deb:x64 rpm:x64 snap:x64
-
-      - name: Build linux packages (staging)
-        if: (vars.ENV == 'staging' || vars.ENV == 'development') && (inputs.target == vars.ALL || inputs.target == 'linux')
-        run: yarn package:stage --linux appimage:x64 deb:x64 rpm:x64 snap:x64
-
-      - name: Build linux packages (custom x64)
-        if: inputs.target != vars.ALL && inputs.target != 'linux'
-        env:
-          IS_PRODUCTION: ${{ vars.ENV == 'production' }}
-          TARGET_INPUT: ${{ inputs.target }}
-        run: |
-          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk '/:x64$/' | sort -u | paste -sd ' ' -)
-
-          if [ -z "$target" ]; then
-            echo "No x64 linux targets selected."
-            exit 0
-          fi
-
-          if [ "$IS_PRODUCTION" == "true" ]; then
-            yarn package:prod --linux $target
-          else
-            yarn package:stage --linux $target
-          fi
-
-      - name: Verify native binaries (x64)
-        run: node ./scripts/verify-native-modules-linux.js --arch=x64
-
-      - uses: actions/upload-artifact@v4
-        name: Upload vendor for plugins
-        with:
-          name: vendor-plugins-x64
-          path: |
-            ./vendor
-
-      - uses: actions/upload-artifact@v4
-        name: Upload linux x64 builds
-        with:
-          name: linux-builds-x64
-          path: |
-            ./release/latest-linux*.yml
-            ./release/Redis-Insight*x64*.AppImage
-            ./release/Redis-Insight*x86_64*.AppImage
-            ./release/Redis-Insight*x64*.deb
-            ./release/Redis-Insight*amd64*.deb
-            ./release/Redis-Insight*x64*.rpm
-            ./release/Redis-Insight*x86_64*.rpm
-            ./release/Redis-Insight*x64*.snap
-            ./release/Redis-Insight*amd64*.snap
-
-    env:
-      RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}
-      RI_AI_QUERY_PASS: ${{ secrets.RI_AI_QUERY_PASS }}
-      RI_AI_QUERY_USER: ${{ secrets.RI_AI_QUERY_USER }}
-      RI_CLOUD_API_URL: ${{ secrets.RI_CLOUD_API_URL }}
-      RI_CLOUD_API_TOKEN: ${{ secrets.RI_CLOUD_API_TOKEN }}
-      RI_CLOUD_CAPI_URL: ${{ secrets.RI_CLOUD_CAPI_URL }}
-      RI_CLOUD_IDP_AUTHORIZE_URL: ${{ secrets.RI_CLOUD_IDP_AUTHORIZE_URL }}
-      RI_CLOUD_IDP_CLIENT_ID: ${{ secrets.RI_CLOUD_IDP_CLIENT_ID }}
-      RI_CLOUD_IDP_GH_ID: ${{ secrets.RI_CLOUD_IDP_GH_ID }}
-      RI_CLOUD_IDP_GOOGLE_ID: ${{ secrets.RI_CLOUD_IDP_GOOGLE_ID }}
-      RI_CLOUD_IDP_ISSUER: ${{ secrets.RI_CLOUD_IDP_ISSUER }}
-      RI_CLOUD_IDP_REVOKE_TOKEN_URL: ${{ secrets.RI_CLOUD_IDP_REVOKE_TOKEN_URL }}
-      RI_CLOUD_IDP_REDIRECT_URI: ${{ secrets.RI_CLOUD_IDP_REDIRECT_URI }}
-      RI_CLOUD_IDP_TOKEN_URL: ${{ secrets.RI_CLOUD_IDP_TOKEN_URL }}
-      RI_SEGMENT_WRITE_KEY: ${{ secrets.RI_SEGMENT_WRITE_KEY }}
-      RI_SERVER_TLS_CERT: ${{ secrets.RI_SERVER_TLS_CERT }}
-      RI_SERVER_TLS_KEY: ${{ secrets.RI_SERVER_TLS_KEY }}
-      RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
-      RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK_NEW }}
-      RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == false }}
-      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise }}
-      RI_APP_TYPE: ${{ inputs.enterprise && 'ELECTRON_ENTERPRISE' || 'ELECTRON' }}
-
-  build-arm64:
-    name: Build linux arm64
-    if: |
-      inputs.target == 'all' ||
-      inputs.target == 'linux' ||
-      contains(inputs.target, 'build_linux_appimage_arm64') ||
-      contains(inputs.target, 'build_linux_deb_arm64') ||
-      contains(inputs.target, 'build_linux_rpm_arm64')
-    runs-on: ubuntu-24.04-arm
-    environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+            defaultTargets: appimage:x64 deb:x64 rpm:x64 snap:x64
+            customArchFilter: ':x64$'
+            uploadArtifactName: linux-builds-x64
+            uploadPaths: |
+              ./release/latest-linux*.yml
+              ./release/Redis-Insight*x64*.AppImage
+              ./release/Redis-Insight*x86_64*.AppImage
+              ./release/Redis-Insight*x64*.deb
+              ./release/Redis-Insight*amd64*.deb
+              ./release/Redis-Insight*x64*.rpm
+              ./release/Redis-Insight*x86_64*.rpm
+              ./release/Redis-Insight*x64*.snap
+              ./release/Redis-Insight*amd64*.snap
+            needsSystemFpm: false
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            defaultTargets: appimage:arm64 deb:arm64 rpm:arm64
+            customArchFilter: ':arm64$'
+            uploadArtifactName: linux-builds-arm64
+            uploadPaths: |
+              ./release/latest-linux*.yml
+              ./release/Redis-Insight*arm64*.AppImage
+              ./release/Redis-Insight*aarch64*.AppImage
+              ./release/Redis-Insight*arm64*.deb
+              ./release/Redis-Insight*arm64*.rpm
+              ./release/Redis-Insight*aarch64*.rpm
+            needsSystemFpm: true
 
     steps:
       - uses: actions/checkout@v4
@@ -176,6 +89,7 @@ jobs:
         run: yarn build:statics
 
       - name: Install system fpm for arm64
+        if: matrix.needsSystemFpm
         run: |
           sudo apt-get update -qy
           sudo apt-get install -qy ruby ruby-dev build-essential
@@ -183,22 +97,24 @@ jobs:
 
       - name: Build linux packages (production)
         if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
-        run: yarn package:prod --linux appimage:arm64 deb:arm64 rpm:arm64
+        run: yarn package:prod --linux ${{ matrix.defaultTargets }}
 
       - name: Build linux packages (staging)
         if: (vars.ENV == 'staging' || vars.ENV == 'development') && (inputs.target == vars.ALL || inputs.target == 'linux')
-        run: yarn package:stage --linux appimage:arm64 deb:arm64 rpm:arm64
+        run: yarn package:stage --linux ${{ matrix.defaultTargets }}
 
-      - name: Build linux packages (custom arm64)
+      - name: Build linux packages (custom)
         if: inputs.target != vars.ALL && inputs.target != 'linux'
         env:
           IS_PRODUCTION: ${{ vars.ENV == 'production' }}
           TARGET_INPUT: ${{ inputs.target }}
+          TARGET_FILTER: ${{ matrix.customArchFilter }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk '/:arm64$/' | sort -u | paste -sd ' ' -)
+          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk "/$TARGET_FILTER/" | sort -u | paste -sd ' ' -)
 
           if [ -z "$target" ]; then
-            echo "No arm64 linux targets selected."
+            echo "No $ARCH linux targets selected."
             exit 0
           fi
 
@@ -208,27 +124,21 @@ jobs:
             yarn package:stage --linux $target
           fi
 
-      - name: Verify native binaries (arm64)
-        run: node ./scripts/verify-native-modules-linux.js --arch=arm64
+      - name: Verify native binaries
+        run: node ./scripts/verify-native-modules-linux.js --arch=${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         name: Upload vendor for plugins
         with:
-          name: vendor-plugins-arm64
+          name: vendor-plugins-${{ matrix.arch }}
           path: |
             ./vendor
 
       - uses: actions/upload-artifact@v4
-        name: Upload linux arm64 builds
+        name: Upload linux builds
         with:
-          name: linux-builds-arm64
-          path: |
-            ./release/latest-linux*.yml
-            ./release/Redis-Insight*arm64*.AppImage
-            ./release/Redis-Insight*aarch64*.AppImage
-            ./release/Redis-Insight*arm64*.deb
-            ./release/Redis-Insight*arm64*.rpm
-            ./release/Redis-Insight*aarch64*.rpm
+          name: ${{ matrix.uploadArtifactName }}
+          path: ${{ matrix.uploadPaths }}
 
     env:
       RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}
@@ -253,13 +163,13 @@ jobs:
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == false }}
       RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise }}
       RI_APP_TYPE: ${{ inputs.enterprise && 'ELECTRON_ENTERPRISE' || 'ELECTRON' }}
-      USE_SYSTEM_FPM: true
+      USE_SYSTEM_FPM: ${{ matrix.needsSystemFpm }}
 
   publish-artifacts:
     name: Publish linux artifacts
     runs-on: ubuntu-24.04
-    needs: [build-x64, build-arm64]
-    if: always() && (needs.build-x64.result == 'success' || needs.build-arm64.result == 'success')
+    needs: [build-linux]
+    if: always() && needs.build-linux.result == 'success'
     steps:
       - uses: actions/download-artifact@v4
         name: Download vendor artifacts

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -107,10 +107,13 @@ jobs:
           path: |
             ./release/latest-linux*.yml
             ./release/Redis-Insight*x64*.AppImage
+            ./release/Redis-Insight*x86_64*.AppImage
             ./release/Redis-Insight*x64*.deb
             ./release/Redis-Insight*amd64*.deb
             ./release/Redis-Insight*x64*.rpm
+            ./release/Redis-Insight*x86_64*.rpm
             ./release/Redis-Insight*x64*.snap
+            ./release/Redis-Insight*amd64*.snap
 
     env:
       RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -27,13 +27,7 @@ on:
 jobs:
   build-linux:
     name: Build linux ${{ matrix.arch }}
-    if: |
-      inputs.target == 'all' ||
-      inputs.target == 'linux' ||
-      contains(inputs.target, format('build_linux_appimage_{0}', matrix.arch)) ||
-      contains(inputs.target, format('build_linux_deb_{0}', matrix.arch)) ||
-      contains(inputs.target, format('build_linux_rpm_{0}', matrix.arch)) ||
-      (matrix.arch == 'x64' && contains(inputs.target, 'build_linux_snap_x64'))
+    if: contains(inputs.target, 'linux') || inputs.target == 'all'
     runs-on: ${{ matrix.runner }}
     environment: ${{ inputs.environment }}
     strategy:
@@ -88,47 +82,64 @@ jobs:
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics
 
+      - name: Resolve linux targets for matrix arch
+        id: resolve-targets
+        env:
+          TARGET_INPUT: ${{ inputs.target }}
+          TARGET_FILTER: ${{ matrix.customArchFilter }}
+        run: |
+          if [ "$TARGET_INPUT" = "all" ] || [ "$TARGET_INPUT" = "linux" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "mode=default" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk "/$TARGET_FILTER/" | sort -u | paste -sd ' ' -)
+
+          if [ -z "$target" ]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_build=true" >> "$GITHUB_OUTPUT"
+          echo "mode=custom" >> "$GITHUB_OUTPUT"
+          echo "custom_targets=$target" >> "$GITHUB_OUTPUT"
+
       - name: Install system fpm for arm64
-        if: matrix.needsSystemFpm
+        if: matrix.needsSystemFpm && steps.resolve-targets.outputs.should_build == 'true'
         run: |
           sudo apt-get update -qy
           sudo apt-get install -qy ruby ruby-dev build-essential
           sudo gem install --no-document fpm
 
       - name: Build linux packages (production)
-        if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
+        if: vars.ENV == 'production' && steps.resolve-targets.outputs.mode == 'default'
         run: yarn package:prod --linux ${{ matrix.defaultTargets }}
 
       - name: Build linux packages (staging)
-        if: (vars.ENV == 'staging' || vars.ENV == 'development') && (inputs.target == vars.ALL || inputs.target == 'linux')
+        if: (vars.ENV == 'staging' || vars.ENV == 'development') && steps.resolve-targets.outputs.mode == 'default'
         run: yarn package:stage --linux ${{ matrix.defaultTargets }}
 
       - name: Build linux packages (custom)
-        if: inputs.target != vars.ALL && inputs.target != 'linux'
+        if: steps.resolve-targets.outputs.mode == 'custom'
         env:
           IS_PRODUCTION: ${{ vars.ENV == 'production' }}
-          TARGET_INPUT: ${{ inputs.target }}
-          TARGET_FILTER: ${{ matrix.customArchFilter }}
-          ARCH: ${{ matrix.arch }}
+          CUSTOM_TARGETS: ${{ steps.resolve-targets.outputs.custom_targets }}
         run: |
-          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk "/$TARGET_FILTER/" | sort -u | paste -sd ' ' -)
-
-          if [ -z "$target" ]; then
-            echo "No $ARCH linux targets selected."
-            exit 0
-          fi
-
           if [ "$IS_PRODUCTION" == "true" ]; then
-            yarn package:prod --linux $target
+            yarn package:prod --linux $CUSTOM_TARGETS
           else
-            yarn package:stage --linux $target
+            yarn package:stage --linux $CUSTOM_TARGETS
           fi
 
       - name: Verify native binaries
+        if: steps.resolve-targets.outputs.should_build == 'true'
         run: node ./scripts/verify-native-modules-linux.js --arch=${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         name: Upload vendor for plugins
+        if: steps.resolve-targets.outputs.should_build == 'true'
         with:
           name: vendor-plugins-${{ matrix.arch }}
           path: |
@@ -136,6 +147,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         name: Upload linux builds
+        if: steps.resolve-targets.outputs.should_build == 'true'
         with:
           name: ${{ matrix.uploadArtifactName }}
           path: ${{ matrix.uploadPaths }}

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -25,8 +25,9 @@ on:
         type: boolean
 
 jobs:
-  build:
-    name: Build linux
+  build-x64:
+    name: Build linux x64
+    if: inputs.target == 'all' || inputs.target == 'linux' || contains(inputs.target, '_x64')
     runs-on: ubuntu-24.04
     environment: ${{ inputs.environment }}
 
@@ -64,19 +65,24 @@ jobs:
 
       - name: Build linux packages (production)
         if: vars.ENV == 'production' && inputs.target == vars.ALL
-        run: yarn package:prod
+        run: yarn package:prod --linux appimage:x64 deb:x64 rpm:x64 snap:x64
 
       - name: Build linux packages (staging)
         if: (vars.ENV == 'staging' || vars.ENV == 'development') && inputs.target == vars.ALL
-        run: yarn package:stage
+        run: yarn package:stage --linux appimage:x64 deb:x64 rpm:x64 snap:x64
 
-      - name: Build linux packages (custom)
-        if: inputs.target != vars.ALL
+      - name: Build linux packages (custom x64)
+        if: inputs.target != vars.ALL && inputs.target != 'linux'
         env:
           IS_PRODUCTION: ${{ vars.ENV == 'production' }}
           TARGET_INPUT: ${{ inputs.target }}
         run: |
-          target=$(echo "$TARGET_INPUT" | grep -oE 'build_linux_[^ ]+' | sed 's/build_linux_//;s/_/:/' | sort -u | paste -sd ' ' -)
+          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk '/:x64$/' | sort -u | paste -sd ' ' -)
+
+          if [ -z "$target" ]; then
+            echo "No x64 linux targets selected."
+            exit 0
+          fi
 
           if [ "$IS_PRODUCTION" == "true" ]; then
             yarn package:prod --linux $target
@@ -84,23 +90,27 @@ jobs:
             yarn package:stage --linux $target
           fi
 
+      - name: Verify native binaries (x64)
+        run: node ./scripts/verify-native-modules-linux.js --arch=x64
+
       - uses: actions/upload-artifact@v4
         name: Upload vendor for plugins
         with:
-          name: vendor-plugins
+          name: vendor-plugins-x64
           path: |
             ./vendor
 
       - uses: actions/upload-artifact@v4
-        name: Upload linux builds
+        name: Upload linux x64 builds
         with:
-          name: linux-builds
+          name: linux-builds-x64
           path: |
             ./release/latest-linux*.yml
-            ./release/Redis-Insight*.AppImage
-            ./release/Redis-Insight*.deb
-            ./release/Redis-Insight*.rpm
-            ./release/Redis-Insight*.snap
+            ./release/Redis-Insight*x64*.AppImage
+            ./release/Redis-Insight*x64*.deb
+            ./release/Redis-Insight*amd64*.deb
+            ./release/Redis-Insight*x64*.rpm
+            ./release/Redis-Insight*x64*.snap
 
     env:
       RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}
@@ -125,3 +135,146 @@ jobs:
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == false }}
       RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise }}
       RI_APP_TYPE: ${{ inputs.enterprise && 'ELECTRON_ENTERPRISE' || 'ELECTRON' }}
+
+  build-arm64:
+    name: Build linux arm64
+    if: inputs.target == 'all' || inputs.target == 'linux' || contains(inputs.target, '_arm64')
+    runs-on: ubuntu-24.04-arm
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # SSH Debug
+      - name: Enable SSH
+        uses: mxschmitt/action-tmate@v3
+        if: inputs.debug
+        with:
+          detached: true
+
+      - name: Install all libs and dependencies
+        uses: ./.github/actions/install-all-build-libs
+        with:
+          keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
+          sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+
+      - name: Install plugins dependencies and build plugins
+        run: yarn build:statics
+
+      - name: Build linux packages (production)
+        if: vars.ENV == 'production' && inputs.target == vars.ALL
+        run: yarn package:prod --linux appimage:arm64 deb:arm64 rpm:arm64
+
+      - name: Build linux packages (staging)
+        if: (vars.ENV == 'staging' || vars.ENV == 'development') && inputs.target == vars.ALL
+        run: yarn package:stage --linux appimage:arm64 deb:arm64 rpm:arm64
+
+      - name: Build linux packages (custom arm64)
+        if: inputs.target != vars.ALL && inputs.target != 'linux'
+        env:
+          IS_PRODUCTION: ${{ vars.ENV == 'production' }}
+          TARGET_INPUT: ${{ inputs.target }}
+        run: |
+          target=$(echo "$TARGET_INPUT" | tr ' ' '\n' | sed -n 's/^build_linux_//p' | sed 's/_/:/g' | awk '/:arm64$/' | sort -u | paste -sd ' ' -)
+
+          if [ -z "$target" ]; then
+            echo "No arm64 linux targets selected."
+            exit 0
+          fi
+
+          if [ "$IS_PRODUCTION" == "true" ]; then
+            yarn package:prod --linux $target
+          else
+            yarn package:stage --linux $target
+          fi
+
+      - name: Verify native binaries (arm64)
+        run: node ./scripts/verify-native-modules-linux.js --arch=arm64
+
+      - uses: actions/upload-artifact@v4
+        name: Upload vendor for plugins
+        with:
+          name: vendor-plugins-arm64
+          path: |
+            ./vendor
+
+      - uses: actions/upload-artifact@v4
+        name: Upload linux arm64 builds
+        with:
+          name: linux-builds-arm64
+          path: |
+            ./release/latest-linux*.yml
+            ./release/Redis-Insight*arm64*.AppImage
+            ./release/Redis-Insight*aarch64*.AppImage
+            ./release/Redis-Insight*arm64*.deb
+            ./release/Redis-Insight*arm64*.rpm
+
+    env:
+      RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}
+      RI_AI_QUERY_PASS: ${{ secrets.RI_AI_QUERY_PASS }}
+      RI_AI_QUERY_USER: ${{ secrets.RI_AI_QUERY_USER }}
+      RI_CLOUD_API_URL: ${{ secrets.RI_CLOUD_API_URL }}
+      RI_CLOUD_API_TOKEN: ${{ secrets.RI_CLOUD_API_TOKEN }}
+      RI_CLOUD_CAPI_URL: ${{ secrets.RI_CLOUD_CAPI_URL }}
+      RI_CLOUD_IDP_AUTHORIZE_URL: ${{ secrets.RI_CLOUD_IDP_AUTHORIZE_URL }}
+      RI_CLOUD_IDP_CLIENT_ID: ${{ secrets.RI_CLOUD_IDP_CLIENT_ID }}
+      RI_CLOUD_IDP_GH_ID: ${{ secrets.RI_CLOUD_IDP_GH_ID }}
+      RI_CLOUD_IDP_GOOGLE_ID: ${{ secrets.RI_CLOUD_IDP_GOOGLE_ID }}
+      RI_CLOUD_IDP_ISSUER: ${{ secrets.RI_CLOUD_IDP_ISSUER }}
+      RI_CLOUD_IDP_REVOKE_TOKEN_URL: ${{ secrets.RI_CLOUD_IDP_REVOKE_TOKEN_URL }}
+      RI_CLOUD_IDP_REDIRECT_URI: ${{ secrets.RI_CLOUD_IDP_REDIRECT_URI }}
+      RI_CLOUD_IDP_TOKEN_URL: ${{ secrets.RI_CLOUD_IDP_TOKEN_URL }}
+      RI_SEGMENT_WRITE_KEY: ${{ secrets.RI_SEGMENT_WRITE_KEY }}
+      RI_SERVER_TLS_CERT: ${{ secrets.RI_SERVER_TLS_CERT }}
+      RI_SERVER_TLS_KEY: ${{ secrets.RI_SERVER_TLS_KEY }}
+      RI_FEATURES_CONFIG_URL: ${{ secrets.RI_FEATURES_CONFIG_URL }}
+      RI_UPGRADES_LINK: ${{ secrets.RI_UPGRADES_LINK_NEW }}
+      RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == false }}
+      RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise }}
+      RI_APP_TYPE: ${{ inputs.enterprise && 'ELECTRON_ENTERPRISE' || 'ELECTRON' }}
+
+  publish-artifacts:
+    name: Publish linux artifacts
+    runs-on: ubuntu-24.04
+    needs: [build-x64, build-arm64]
+    if: always() && (needs.build-x64.result == 'success' || needs.build-arm64.result == 'success')
+    steps:
+      - uses: actions/download-artifact@v4
+        name: Download vendor artifacts
+        with:
+          pattern: vendor-plugins-*
+          merge-multiple: true
+          path: ./vendor
+
+      - uses: actions/upload-artifact@v4
+        name: Upload vendor for plugins
+        with:
+          name: vendor-plugins
+          path: ./vendor
+
+      - uses: actions/download-artifact@v4
+        name: Download linux build artifacts
+        with:
+          pattern: linux-builds-*
+          merge-multiple: true
+          path: ./release
+
+      - name: Print native binary paths from artifacts
+        run: |
+          if [ -d "./release" ]; then
+            find ./release -type f \( -name "*.node" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" -o -name "*.snap" \) | sort
+          else
+            echo "Release directory is missing"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        name: Upload linux builds
+        with:
+          name: linux-builds
+          path: |
+            ./release/latest-linux*.yml
+            ./release/Redis-Insight*.AppImage
+            ./release/Redis-Insight*.deb
+            ./release/Redis-Insight*.rpm
+            ./release/Redis-Insight*.snap

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -64,11 +64,11 @@ jobs:
         run: yarn build:statics
 
       - name: Build linux packages (production)
-        if: vars.ENV == 'production' && inputs.target == vars.ALL
+        if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
         run: yarn package:prod --linux appimage:x64 deb:x64 rpm:x64 snap:x64
 
       - name: Build linux packages (staging)
-        if: (vars.ENV == 'staging' || vars.ENV == 'development') && inputs.target == vars.ALL
+        if: (vars.ENV == 'staging' || vars.ENV == 'development') && (inputs.target == vars.ALL || inputs.target == 'linux')
         run: yarn package:stage --linux appimage:x64 deb:x64 rpm:x64 snap:x64
 
       - name: Build linux packages (custom x64)
@@ -165,11 +165,11 @@ jobs:
         run: yarn build:statics
 
       - name: Build linux packages (production)
-        if: vars.ENV == 'production' && inputs.target == vars.ALL
+        if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
         run: yarn package:prod --linux appimage:arm64 deb:arm64 rpm:arm64
 
       - name: Build linux packages (staging)
-        if: (vars.ENV == 'staging' || vars.ENV == 'development') && inputs.target == vars.ALL
+        if: (vars.ENV == 'staging' || vars.ENV == 'development') && (inputs.target == vars.ALL || inputs.target == 'linux')
         run: yarn package:stage --linux appimage:arm64 deb:arm64 rpm:arm64
 
       - name: Build linux packages (custom arm64)

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -27,7 +27,13 @@ on:
 jobs:
   build-x64:
     name: Build linux x64
-    if: inputs.target == 'all' || inputs.target == 'linux' || contains(inputs.target, '_x64')
+    if: |
+      inputs.target == 'all' ||
+      inputs.target == 'linux' ||
+      contains(inputs.target, 'build_linux_appimage_x64') ||
+      contains(inputs.target, 'build_linux_deb_x64') ||
+      contains(inputs.target, 'build_linux_rpm_x64') ||
+      contains(inputs.target, 'build_linux_snap_x64')
     runs-on: ubuntu-24.04
     environment: ${{ inputs.environment }}
 
@@ -141,7 +147,12 @@ jobs:
 
   build-arm64:
     name: Build linux arm64
-    if: inputs.target == 'all' || inputs.target == 'linux' || contains(inputs.target, '_arm64')
+    if: |
+      inputs.target == 'all' ||
+      inputs.target == 'linux' ||
+      contains(inputs.target, 'build_linux_appimage_arm64') ||
+      contains(inputs.target, 'build_linux_deb_arm64') ||
+      contains(inputs.target, 'build_linux_rpm_arm64')
     runs-on: ubuntu-24.04-arm
     environment: ${{ inputs.environment }}
 
@@ -217,6 +228,7 @@ jobs:
             ./release/Redis-Insight*aarch64*.AppImage
             ./release/Redis-Insight*arm64*.deb
             ./release/Redis-Insight*arm64*.rpm
+            ./release/Redis-Insight*aarch64*.rpm
 
     env:
       RI_AI_CONVAI_TOKEN: ${{ secrets.RI_AI_CONVAI_TOKEN }}

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -164,6 +164,12 @@ jobs:
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics
 
+      - name: Install system fpm for arm64
+        run: |
+          sudo apt-get update -qy
+          sudo apt-get install -qy ruby ruby-dev build-essential
+          sudo gem install --no-document fpm
+
       - name: Build linux packages (production)
         if: vars.ENV == 'production' && (inputs.target == vars.ALL || inputs.target == 'linux')
         run: yarn package:prod --linux appimage:arm64 deb:arm64 rpm:arm64
@@ -235,6 +241,7 @@ jobs:
       RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG: ${{ inputs.enterprise == false }}
       RI_DISABLE_AUTO_UPGRADE: ${{ inputs.enterprise }}
       RI_APP_TYPE: ${{ inputs.enterprise && 'ELECTRON_ENTERPRISE' || 'ELECTRON' }}
+      USE_SYSTEM_FPM: true
 
   publish-artifacts:
     name: Publish linux artifacts

--- a/scripts/native-modules.config.json
+++ b/scripts/native-modules.config.json
@@ -1,0 +1,7 @@
+{
+  "asarUnpackModules": ["node_modules/keytar", "node_modules/better-sqlite3"],
+  "linuxRequiredNodeBinaries": [
+    "node_modules/keytar/build/Release/keytar.node",
+    "node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+  ]
+}

--- a/scripts/verify-native-modules-linux.js
+++ b/scripts/verify-native-modules-linux.js
@@ -1,0 +1,111 @@
+const fs = require('fs')
+const path = require('path')
+
+const repoRoot = path.resolve(__dirname, '..')
+const releaseDir = path.join(repoRoot, 'release')
+const configPath = path.join(repoRoot, 'scripts', 'native-modules.config.json')
+const builderConfigPath = path.join(repoRoot, 'electron-builder.json')
+
+const getArgValue = (name) => {
+  const arg = process.argv.find((entry) => entry.startsWith(`${name}=`))
+
+  return arg ? arg.split('=').slice(1).join('=') : ''
+}
+
+const targetArch = getArgValue('--arch') || 'x64'
+const archMatchPattern =
+  targetArch === 'arm64' ? /(arm64|aarch64)/i : /(x64|amd64)/i
+
+const hasPath = (targetPath) => fs.existsSync(targetPath)
+
+const loadJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
+
+const assertAsarUnpackInSync = (config) => {
+  const electronBuilder = loadJson(builderConfigPath)
+  const unpackList = electronBuilder.asarUnpack || []
+  const missingFromBuilder = config.asarUnpackModules.filter(
+    (modulePath) => !unpackList.includes(modulePath),
+  )
+
+  if (missingFromBuilder.length) {
+    throw new Error(
+      `electron-builder asarUnpack is missing modules: ${missingFromBuilder.join(', ')}`,
+    )
+  }
+}
+
+const discoverAsarUnpackedDirs = () => {
+  if (!hasPath(releaseDir)) {
+    return []
+  }
+
+  const unpackedCandidates = fs
+    .readdirSync(releaseDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith('-unpacked'))
+    .map((entry) => ({
+      name: entry.name,
+      asarUnpackedPath: path.join(
+        releaseDir,
+        entry.name,
+        'resources',
+        'app.asar.unpacked',
+      ),
+    }))
+    .filter((entry) => hasPath(entry.asarUnpackedPath))
+
+  const archSpecific = unpackedCandidates.filter((entry) =>
+    archMatchPattern.test(entry.name),
+  )
+
+  if (archSpecific.length) {
+    return archSpecific
+  }
+
+  return unpackedCandidates.filter(
+    (entry) => targetArch === 'x64' && entry.name === 'linux-unpacked',
+  )
+}
+
+const verifyBinaries = (config, unpackedDirs) => {
+  if (!unpackedDirs.length) {
+    throw new Error(
+      `No unpacked Linux app directories found for arch "${targetArch}" under ${releaseDir}`,
+    )
+  }
+
+  const checks = []
+  unpackedDirs.forEach((entry) => {
+    config.linuxRequiredNodeBinaries.forEach((binaryPath) => {
+      checks.push({
+        unpackedDirName: entry.name,
+        expectedPath: binaryPath,
+        absolutePath: path.join(entry.asarUnpackedPath, binaryPath),
+      })
+    })
+  })
+
+  const missing = checks.filter((item) => !hasPath(item.absolutePath))
+  if (missing.length) {
+    const details = missing
+      .map((item) => `${item.unpackedDirName}: ${item.expectedPath}`)
+      .join('\n')
+    throw new Error(`Missing required native binaries:\n${details}`)
+  }
+
+  console.log(`Verified native binaries for arch=${targetArch}`)
+  checks.forEach((item) => {
+    console.log(`- ${item.unpackedDirName}: ${item.expectedPath}`)
+  })
+}
+
+try {
+  const nativeModulesConfig = loadJson(configPath)
+
+  assertAsarUnpackInSync(nativeModulesConfig)
+
+  const asarUnpackedDirs = discoverAsarUnpackedDirs()
+  verifyBinaries(nativeModulesConfig, asarUnpackedDirs)
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}


### PR DESCRIPTION
# What

- Refactored Linux packaging into a single matrix job (x64, arm64) in `pipeline-build-linux.yml`, removing duplicated job logic while keeping arch-specific behavior in matrix fields.
- Added matrix target resolution (resolve-targets) to decide per-arch execution (default for all/linux, custom for `build_linux_*`) and avoid false build/verify runs.
- Kept ARM-specific RPM handling in the ARM matrix leg (`USE_SYSTEM_FPM` + system fpm) to avoid electron-builder x86 FPM exec-format failures on ARM.
- Added deterministic native addon checks by running `verify-native-modules-linux.js` only when an arch actually built packages.
- Preserved artifact compatibility: matrix legs upload linux-builds-{arch} / vendor-plugins-{arch}, then publish-artifacts merges and republishes legacy artifact names (linux-builds, vendor-plugins) used by downstream workflows.
- Kept expected Linux filename variants in uploads (x86_64/amd64 and arm64/aarch64) so release/upload pipelines continue finding the same deliverables.

# Why

We split Linux packaging into separate x64 and arm64 jobs because our ARM desktop artifacts are currently unreliable - the app starts, but DB initialization fails at runtime with:

```
better_sqlite3.node: cannot open shared object file: No such file or directory
```

## Why this happens
After migrating from `sqlite3` to `better-sqlite3`, we now depend on native `.node` binaries being present inside `app.asar.unpacked`.

When Linux artifacts for multiple architectures are built together on an x64 runner, native addon resolution/rebuild/packaging can produce incomplete ARM outputs, and the required ARM native binary may be missing from the final package.

## Why splitting by architecture helps
- x64 artifacts are built on x64 runner
- arm64 artifacts are built on native ARM runner

This aligns build environment with target architecture and reduces cross-arch native module packaging issues.

## Additional safety in this PR
We also added deterministic post-package verification that fails CI if required native binaries are missing from packaged output (at least `better-sqlite3` and `keytar`).

That moves failure from customer runtime to CI time.

## Important non-goal
This change does not alter published artifact names/consumption contracts.
Final linux-builds artifact content remains compatible with existing release/upload/manual pipelines and external links.

# Testing

Verified via a manual build on both x86 and ARM

https://github.com/redis/RedisInsight/actions/runs/25048225683

---

References  #5637




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI packaging and artifact publication for Linux, which can break releases if matrix target resolution or artifact merging is incorrect. No production runtime code changes, but build outputs and caches are affected across architectures.
> 
> **Overview**
> Fixes unreliable Linux ARM packaging by splitting the Linux build workflow into an `x64`/`arm64` matrix that runs ARM builds on native ARM runners, with arch-specific target selection, artifact naming, and an extra `publish-artifacts` job to merge outputs back into the existing `linux-builds`/`vendor-plugins` artifacts.
> 
> Adds deterministic post-build validation (`scripts/verify-native-modules-linux.js` + `scripts/native-modules.config.json`) to fail CI if required native `.node` binaries (e.g., `better-sqlite3`, `keytar`) are missing from `app.asar.unpacked`, and updates the dependency cache key to include `runner.arch` to avoid cross-arch `node_modules` reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca81bff3cb36ae6ea2f13fcbc4bc78381fb4424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->