### PR TITLE
CI cleanup: deprecate sqlite mirror input naming

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -10,8 +10,11 @@ inputs:
     description: Keytar binary host mirror
     required: false
 
+  native-addon-host-mirror:
+    description: Native addons binary host mirror (legacy sqlite3 naming)
+    required: false
   sqlite3-host-mirror:
-    description: SQLite3 binary host mirror
+    description: Deprecated. Use native-addon-host-mirror
     required: false
 
 runs:
@@ -63,7 +66,7 @@ runs:
       with:
         dir-path: './redisinsight'
         keytar-host-mirror: ${{ inputs.keytar-host-mirror }}
-        sqlite3-host-mirror: ${{ inputs.sqlite3-host-mirror }}
+        native-addon-host-mirror: ${{ inputs.native-addon-host-mirror || inputs.sqlite3-host-mirror }}
 
     - name: Install dependencies for BE package.js
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -77,4 +80,4 @@ runs:
       with:
         dir-path: './'
         keytar-host-mirror: ${{ inputs.keytar-host-mirror }}
-        sqlite3-host-mirror: ${{ inputs.sqlite3-host-mirror }}
+        native-addon-host-mirror: ${{ inputs.native-addon-host-mirror || inputs.sqlite3-host-mirror }}

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,8 +7,11 @@ inputs:
   keytar-host-mirror:
     description: Keytar binary host mirror
     required: false
+  native-addon-host-mirror:
+    description: Native addons binary host mirror (legacy sqlite3 naming)
+    required: false
   sqlite3-host-mirror:
-    description: SQLite3 binary host mirror
+    description: Deprecated. Use native-addon-host-mirror
     required: false
   skip-postinstall:
     description: Skip postinstall
@@ -28,6 +31,6 @@ runs:
       run: |
         # todo: uncomment after build our binaries
         # export npm_config_keytar_binary_host_mirror=${{ inputs.keytar-host-mirror }}
-        # export npm_config_node_sqlite3_binary_host_mirror=${{ inputs.sqlite3-host-mirror }}
+        # export npm_config_node_sqlite3_binary_host_mirror=${{ inputs.native-addon-host-mirror || inputs.sqlite3-host-mirror }}
 
         yarn install --frozen-lockfile --network-timeout 1000000

--- a/.github/workflows/pipeline-build-docker.yml
+++ b/.github/workflows/pipeline-build-docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/install-all-build-libs
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
-          sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          native-addon-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
 
       - name: Build sources
         run: ./.github/build/build.sh

--- a/.github/workflows/pipeline-build-macos.yml
+++ b/.github/workflows/pipeline-build-macos.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/install-all-build-libs
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
-          sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          native-addon-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics


### PR DESCRIPTION
# What

- Added `native-addon-host-mirror` as the preferred input in dependency install composite actions.
- Kept `sqlite3-host-mirror` as a deprecated backward-compatible alias.
- Updated macOS and Docker workflows to pass the new input name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only input renaming with backward-compatible fallback; the main risk is misconfiguration causing CI dependency installs to fetch binaries from the wrong mirror.
> 
> **Overview**
> Updates the composite GitHub Actions used for dependency installation to prefer a new input, `native-addon-host-mirror`, while keeping `sqlite3-host-mirror` as a deprecated alias.
> 
> Adjusts the macOS and Docker build workflows to pass the new input name, and wires the install steps to fall back to the deprecated value when the new one is not provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec51dff44c5ab4edb3b8d0539f64a5423febea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->