### PR TITLE
Add empty-state fallback for FT.EXPLAIN visualization

### DIFF
--- a/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
@@ -12,6 +12,7 @@ import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import {
   EDGE_COLOR_BODY_DARK,
   EDGE_COLOR_BODY_LIGHT,
+  EMPTY_EXPLAIN_RESULT_MESSAGE,
   NODE_COLOR_BODY_DARK,
   NODE_COLOR_BODY_LIGHT,
 } from './constants'
@@ -33,6 +34,19 @@ import { ExplainNode, ProfileNode } from './Node'
 interface IExplain {
   command: string
   data: [{ response: string[] | string | any }]
+}
+
+const normalizeExplainOutput = (output: string) =>
+  output.trim().replace(/^"|"$/g, '').trim()
+
+const isEmptyExplainOutput = (output: string) => {
+  const normalizedOutput = normalizeExplainOutput(output)
+
+  return (
+    normalizedOutput === '' ||
+    normalizedOutput === '<WILDCARD>' ||
+    normalizedOutput === '<WILDCARD>}'
+  )
 }
 
 function getEdgeSize(c: number) {
@@ -130,10 +144,17 @@ export default function Explain({ command, data }: IExplain): JSX.Element {
   }
 
   const resp = data[0].response
+  const explainOutput = Array.isArray(resp)
+    ? resp.join('\n')
+    : String(resp ?? '')
+        .split('\\n')
+        .join('\n')
 
-  const explainDrawData = ParseExplain(
-    Array.isArray(resp) ? resp.join('\n') : resp.split('\\n').join('\n'),
-  )
+  if (isEmptyExplainOutput(explainOutput)) {
+    return <div className="responseInfo">{EMPTY_EXPLAIN_RESULT_MESSAGE}</div>
+  }
+
+  const explainDrawData = ParseExplain(explainOutput)
   return (
     <ExplainDraw
       data={explainDrawData}

--- a/redisinsight/ui/src/packages/ri-explain/src/constants.ts
+++ b/redisinsight/ui/src/packages/ri-explain/src/constants.ts
@@ -3,3 +3,6 @@ export const NODE_COLOR_BODY_LIGHT = '#8992B3'
 
 export const EDGE_COLOR_BODY_DARK = '#6B6B6B'
 export const EDGE_COLOR_BODY_LIGHT = '#8992B3'
+
+export const EMPTY_EXPLAIN_RESULT_MESSAGE =
+  'No execution plan to display for this FT.EXPLAIN result.'


### PR DESCRIPTION
## Summary

Add an explicit empty-state message for `FT.EXPLAIN` visualization output when no execution plan can be rendered

| Before | After |
| - | - |
<img width="2780" height="1502" alt="image" src="https://github.com/user-attachments/assets/c7c14357-f160-4cf2-9e6a-daa7daac65da" />|<img width="2778" height="1502" alt="image" src="https://github.com/user-attachments/assets/4a4f9e4c-a9bd-4dee-ad50-9c87ca6efb35" />


## Test plan

1. Build static plugins:
```bash
yarn build:static
```

2. Start the desktop app:
```
yarn dev:desktop
```

3. Open **Redis Insight** and connect to a database with **Redis Query Engine** enabled.
4. Go to **Search** page (open any index).
5. In the query editor, run a blank/wildcard search query (for example):

```
FT.SEARCH <index-name> "*"
```

6. Click **Explain** (or run equivalent `FT.EXPLAIN` flow from the UI).
7. Switch to **Visualization** mode for the explain output.

If there is no renderable explain plan (empty / wildcard-only output), the visualization should not be blank.
Instead, show the fallback message:

**No execution plan to display for this FT.EXPLAIN result.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only change that adds input normalization and an early empty/wildcard guard before parsing FT.EXPLAIN output, with minimal behavioral impact beyond the new fallback message.
> 
> **Overview**
> Adds an explicit empty-state for `FT.EXPLAIN` visualization: the response is normalized (handles arrays, `\n`-escaped strings, and quoted payloads) and treated as empty for blank or `<WILDCARD>` outputs.
> 
> When the output is empty, the component now renders `EMPTY_EXPLAIN_RESULT_MESSAGE` (moved into `ri-explain` `constants.ts`) instead of attempting `ParseExplain`, preventing blank/failed visualization panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf7dc338d62d6ced1ee668cb4112c23f0a8e1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->