### PR TITLE
Fix database list border when scrollable

### DIFF
--- a/redisinsight/ui/src/pages/home/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/styles.module.scss
@@ -10,6 +10,9 @@
   :global {
     .homePage {
       height: calc(100% - 60px);
+      overflow-y: auto;
+      /* Prevents @redis-ui/table container chrome from clipping at the scrollport top */
+      padding-top: 2px;
     }
   }
 }

--- a/redisinsight/ui/src/pages/home/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/styles.module.scss
@@ -10,7 +10,6 @@
   :global {
     .homePage {
       height: calc(100% - 60px);
-      overflow-y: auto;
     }
   }
 }

--- a/redisinsight/ui/src/pages/home/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/styles.module.scss
@@ -11,8 +11,8 @@
     .homePage {
       height: calc(100% - 60px);
       overflow-y: auto;
-      /* Prevents @redis-ui/table container chrome from clipping at the scrollport top */
-      padding-top: 2px;
+      /* Inset on all sides so table card chrome is not clipped by this scrollport */
+      padding: 1px;
     }
   }
 }


### PR DESCRIPTION
# What

Adds a small uniform inset (`padding: 1px`) on `.homePage` so the `@redis-ui/table` card chrome (rounded corners / shadow) is not clipped by the scroll container on the top or sides.

| Before | After |
| - | - |  
<img width="1480" height="498" alt="2026-04-29_13-46" src="https://github.com/user-attachments/assets/8a152dea-f313-4bb6-b6dc-eade5e05aa5f" />|<img width="1483" height="473" alt="2026-04-29_13-58" src="https://github.com/user-attachments/assets/f17af0f4-d812-49b9-a68d-13021d311b2c" />


# Testing

- Open Home with a non-empty database list - confirm the table frame looks complete while scrolling vertically.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 79ba55fbe2a30a52b4e0fcf67ed84f16c07806ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->