### PR TITLE
Enable TCP keep-alive on Redis client sockets

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -175,6 +175,7 @@ export default {
     retryDelay: parseInt(process.env.RI_CLIENTS_RETRY_DELAY, 10) || 500,
     maxRetriesPerRequest:
       parseInt(process.env.RI_CLIENTS_MAX_RETRIES_PER_REQUEST, 10) || 1,
+    keepAlive: parseInt(process.env.RI_CLIENTS_KEEP_ALIVE, 10) || 10_000, // 10s
     maxRedirections: parseInt(process.env.RI_CLIENTS_MAX_REDIRECTIONS, 10) || 3,
     slotsRefreshTimeout:
       parseInt(process.env.RI_CLIENTS_SLOTS_REQUEST_TIMEOUT, 10) || 5000,

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -175,7 +175,9 @@ export default {
     retryDelay: parseInt(process.env.RI_CLIENTS_RETRY_DELAY, 10) || 500,
     maxRetriesPerRequest:
       parseInt(process.env.RI_CLIENTS_MAX_RETRIES_PER_REQUEST, 10) || 1,
-    keepAlive: parseInt(process.env.RI_CLIENTS_KEEP_ALIVE, 10) || 10_000, // 10s
+    keepAlive: Number.isFinite(parseInt(process.env.RI_CLIENTS_KEEP_ALIVE, 10))
+      ? parseInt(process.env.RI_CLIENTS_KEEP_ALIVE, 10)
+      : 10_000, // 10s; set 0 to disable
     maxRedirections: parseInt(process.env.RI_CLIENTS_MAX_REDIRECTIONS, 10) || 3,
     slotsRefreshTimeout:
       parseInt(process.env.RI_CLIENTS_SLOTS_REQUEST_TIMEOUT, 10) || 5000,

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
@@ -65,6 +65,7 @@ export class IoredisRedisConnectionStrategy extends RedisConnectionStrategy {
         : this.dummyFn.bind(this),
       autoResendUnfulfilledCommands: false,
       enableReadyCheck: options.enableReadyCheck ?? true,
+      keepAlive: REDIS_CLIENTS_CONFIG.keepAlive,
     };
 
     if (tls) {

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
@@ -59,6 +59,7 @@ export class NodeRedisConnectionStrategy extends RedisConnectionStrategy {
         port,
         family: 0, // Enable dual-stack IPv4/IPv6 (auto-detect)
         connectTimeout: timeout,
+        keepAlive: REDIS_CLIENTS_CONFIG.keepAlive,
         ...tlsOptions,
         reconnectStrategy: options?.useRetry
           ? this.retryStrategy.bind(this)


### PR DESCRIPTION
# What

Fixes a bug where the UI's loading indicator hangs forever after the laptop switches network interface (e.g. Ethernet → Wi-Fi) and the user clicks Refresh on the key details panel.

### Before

https://github.com/user-attachments/assets/a4c15914-a998-4a3c-a7ef-65bf051383d2

### After

https://github.com/user-attachments/assets/50869ed4-805c-478f-95fe-8c2a55a2cb14

## Root cause

Redis clients are pooled and reused across requests. After an interface change the cached TCP socket becomes half-open: the OS still considers it `ESTABLISHED`, ioredis still reports `client.status === 'ready'`, so `RedisClientStorage.get()` happily returns the dead client. With `keepAlive` unset, the kernel never probes the peer, and any command written to that socket sits in ioredis' queue indefinitely. There is no `commandTimeout` and no HTTP timeout on the keys endpoints, so the spinner never resolves until something else (e.g. the OS giving up after ~2h) tears the socket down.

## Fix

Single config knob, applied to both connection strategies:

- `redis_clients.keepAlive` (default `10_000` ms, env var `RI_CLIENTS_KEEP_ALIVE`)
- ioredis: passed via `RedisOptions.keepAlive` in [`ioredis.redis.connection.strategy.ts`](redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts) — propagates to standalone, cluster (via `getRedisClusterOptions`) and sentinel (via `getRedisSentinelOptions`) clients.
- node-redis: passed via `socket.keepAlive` in [`node.redis.connection.strategy.ts`](redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts).

When `keepAlive > 0`, the underlying `net.Socket.setKeepAlive(true, ms)` is called. After ~10s of idleness the OS starts probing, the dead peer is detected, the driver fires `error`/`end`, `RedisClientStorage` evicts the client, and the next request creates a fresh connection over the new (Wi-Fi) interface.

## Comparison vs [#5816](https://github.com/redis/RedisInsight/pull/5816)

PR #5816 takes a more sophisticated, real-time approach: it adds a `NetworkChangeMonitor` that polls `os.networkInterfaces()` every 2 s, computes a stable signature, and proactively calls `RedisClientStorage.removeAll()` the moment the interface set changes. It also maps runtime driver errors to HTTP 424 so the UI shows the "Connection Lost" banner.

This PR is intentionally minimal in comparison: no polling, no new monitor, no error-mapping changes — just three lines that hand TCP keep-alive off to the underlying driver and let the library manage the connection lifecycle. The trade-off is that after unplugging the cable, the user has to wait up to ~10 s before the first Refresh click succeeds (vs sub-second with the monitor approach). That is acceptable for our case because nobody realistically unplugs the cable and instantly hits Refresh; by the time they reach for the mouse the socket has already failed and the next click opens a fresh connection.

In short: we accept a small "first click after network change" delay in exchange for a much smaller, lower-risk patch.

# Testing

1. Connect to a Redis DB over a wired connection, open the Browser, select a key.
2. Unplug the Ethernet cable; the laptop falls over to Wi-Fi (Redis host reachable on the new network).
3. Wait ~10s, then click Refresh on the key details panel.
4. Expected: the request returns key data (instead of hanging forever as before). The first click may surface a brief "Connection Lost" notification while the dead socket is being torn down; subsequent clicks work normally.
5. Optional: tune `RI_CLIENTS_KEEP_ALIVE` via env var (set to `0` to reproduce the previous broken behavior).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change that only adjusts Redis socket options via a new config knob; low likelihood of regressions beyond potential connection behavior differences if keep-alive is misconfigured.
> 
> **Overview**
> Adds a new `redis_clients.keepAlive` configuration (env `RI_CLIENTS_KEEP_ALIVE`, default `10_000` ms, `0` to disable).
> 
> Plumbs this keep-alive value into both Redis connection strategies: ioredis now sets `RedisOptions.keepAlive`, and node-redis now sets `socket.keepAlive`, improving detection/eviction of dead pooled connections after network interface changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d126ebb4e18cc5d5c36354e283fb237116e7a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->