### PR TITLE
Visual enhancements to the Redis Cloud section in the Settings

### DIFF
--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/CloudSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/CloudSettings.tsx
@@ -107,6 +107,7 @@ const CloudSettings = () => {
                 {'To delete API keys from Redis Cloud, '}
                 <Link
                   target="_blank"
+                  variant="inline"
                   color="text"
                   tabIndex={-1}
                   href="https://redis.io/redis-enterprise-cloud/overview/?utm_source=redisinsight&utm_medium=settings&utm_campaign=clear_keys"

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
@@ -221,13 +221,12 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
             Cloud database.
           </Text>
           <Spacer />
-          <div className={styles.actions}>
+          <Row align="center" justify="end" grow={false} gap="s">
             <OAuthSsoHandlerDialog>
               {(socialCloudHandlerClick) => (
                 <EmptyButton
                   size="small"
                   color="ghost"
-                  className={styles.autodiscoverBtn}
                   onClick={(e: React.MouseEvent) =>
                     socialCloudHandlerClick(e, {
                       source: OAuthSocialSource.SettingsPage,
@@ -256,7 +255,7 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
                 </PrimaryButton>
               )}
             </OAuthSsoHandlerDialog>
-          </div>
+          </Row>
         </div>
         <Spacer />
       </>

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
@@ -142,12 +142,17 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
       header: '',
       id: 'actions',
       accessorKey: 'id',
+      size: 48,
+      sizeUnit: 'px',
+      maxSize: 48,
+      enableResizing: false,
+      enableSorting: false,
       cell: ({
         row: {
           original: { id, name },
         },
       }) => (
-        <Row align="center" justify="start" grow={false} gap="s">
+        <Row align="center" justify="start" grow={false} gap="xs">
           <CopyButton
             copy={name || ''}
             onCopy={handleCopy}
@@ -262,6 +267,7 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
     <Table
       columns={columns}
       data={items}
+      enableColumnResizing
       defaultSorting={[
         {
           id: 'createdAt',

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
@@ -152,7 +152,7 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
           original: { id, name },
         },
       }) => (
-        <Row align="center" justify="start" grow={false} gap="xs">
+        <Row align="center" justify="start" grow={false} gap="s">
           <CopyButton
             copy={name || ''}
             onCopy={handleCopy}

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/styles.module.scss
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/styles.module.scss
@@ -30,17 +30,6 @@
   margin-right: 8px;
 }
 
-.actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-}
-
-.autodiscoverBtn {
-  font-size: 13px !important;
-  margin-right: 8px;
-}
-
 .copyBtnAnchor {
   display: inline !important;
 }


### PR DESCRIPTION
# What

Polishes the Redis Cloud API keys settings UI:
- tightening the table actions column
- enabling column resizing for that table
- aligning the remove-all popover link style with inline popover links
- add gap between the buttons when there are no keys available

# Testing

## Resizable Table

| Before | After |
| - | - |
<img width="1616" height="756" alt="image" src="https://github.com/user-attachments/assets/0ee564ea-09c0-4150-9103-92d388a6a285" />|<img width="1622" height="750" alt="image" src="https://github.com/user-attachments/assets/d703608d-86a9-4dba-a4fd-a20283d67a15" />

## Remove all API keys tooltip

| Before | After |
| - | - |
<img width="1880" height="758" alt="image" src="https://github.com/user-attachments/assets/481d045f-52a3-406f-bf08-ffec02f73600" />|<img width="1860" height="756" alt="image" src="https://github.com/user-attachments/assets/83b9f423-f644-4c53-8b0f-7f16bcf375f2" />

## No API keys available

| Before | After |
| - | - |
<img width="1620" height="754" alt="image" src="https://github.com/user-attachments/assets/7ae27818-7761-4800-88bc-300f2efee92a" />|<img width="1612" height="752" alt="image" src="https://github.com/user-attachments/assets/29c44a86-47bc-4a1e-a9f7-919e5aeba255" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes (layout/table configuration and styling) with no changes to data fetching, mutations, or auth flows.
> 
> **Overview**
> Polishes the Redis Cloud API keys area in Settings with small layout/UX improvements.
> 
> The “remove all keys” popover link is now styled as an inline link, the API keys table enables column resizing while constraining the actions column to a fixed 48px and disabling sorting/resizing for it, and the no-keys empty state buttons are re-laid out in a `Row` with spacing (removing now-unused SCSS styles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5172b53ca0a6d547539029910e9d4bfcbc1f19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->