### PR TITLE
RI-8005 Add е2е tests for Browser - Keys List view

### DIFF
--- a/tests/e2e-playwright/TEST_PLAN.md
+++ b/tests/e2e-playwright/TEST_PLAN.md
@@ -210,20 +210,20 @@ The test plan is organized by feature area. Tests are grouped for parallel execu
 ### 2.1 Key List View
 | Status | Group | Test Case |
 |--------|-------|-----------|
-| 🔲 | main | View key list |
-| 🔲 | main | Search/filter keys by pattern |
-| 🔲 | main | Filter by key type |
-| 🔲 | main | Filter keys by exact name |
-| 🔲 | main | Clear search filter |
-| 🔲 | main | Click on key to view details |
-| 🔲 | main | Refresh key list |
-| 🔲 | main | Show no results message for non-matching pattern |
-| 🔲 | main | Delete key |
-| 🔲 | main | Delete multiple keys (bulk) |
-| 🔲 | main | Search by Values of Keys |
-| 🔲 | main | Configure columns visibility |
-| 🔲 | main | Configure auto-refresh |
-| 🔲 | main | View database stats (CPU, Keys, Memory, Clients) |
+| ✅ | main | View key list |
+| ✅ | main | Search/filter keys by pattern |
+| ✅ | main | Filter by key type, then narrow by exact key name |
+| ✅ | main | Clear search filter |
+| ✅ | main | Click on key to view details |
+| ✅ | main | Refresh key list |
+| ✅ | main | Show no results message for non-matching pattern |
+| ✅ | main | Delete key |
+| ✅ | main | Delete multiple keys (bulk) |
+| ✅ | main | Search by Values of Keys |
+| ✅ | main | Configure columns visibility |
+| ✅ | main | Configure auto-refresh |
+| ✅ | main | Show empty database welcome and open Add key manually |
+| ✅ | main | Display keys summary and scroll key list in list view |
 
 ### 2.2 Key Tree View
 | Status | Group | Test Case |

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -190,6 +190,13 @@ export class KeyList {
    * @param delimiter tree delimiter (default `:`)
    */
   async selectKeyInTree(keyName: string, delimiter = ':'): Promise<void> {
+    // browserViewType persists in localStorage across specs in the same Electron instance.
+    // If list view leaked from a previous spec, switch to tree view here so the rest of this
+    // helper (which only matches tree-view test ids) doesn't time out.
+    if (await this.keyListTable.isVisible()) {
+      await this.switchToTreeView();
+    }
+
     const delimiterIndex = keyName.lastIndexOf(delimiter);
     const leafName = keyName.substring(delimiterIndex + delimiter.length) || keyName;
     const leafNode = this.keyListContainer.getByRole('treeitem').filter({ hasText: leafName });

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -175,12 +175,13 @@ export class KeyList {
    */
   async clickKey(keyName: string): Promise<void> {
     const keyEl = this.getKeyRow(keyName);
-    try {
+    const isListRowVisible = await keyEl.isVisible();
+    if (isListRowVisible) {
       await keyEl.scrollIntoViewIfNeeded();
       await keyEl.click();
-    } catch {
-      await this.selectKeyInTree(keyName);
+      return;
     }
+    await this.selectKeyInTree(keyName);
   }
 
   /**

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -19,7 +19,12 @@ export class KeyList {
   readonly listViewButton: Locator;
   readonly treeViewButton: Locator;
   readonly columnsButton: Locator;
+  /** Keys browser panel refresh (distinct from instance header refresh) */
   readonly refreshButton: Locator;
+  readonly keysAutoRefreshConfigButton: Locator;
+  readonly keysAutoRefreshSwitch: Locator;
+  readonly emptyDatabasePanel: Locator;
+  readonly addKeyFromEmptyButton: Locator;
   readonly treeSettingsButton: Locator;
 
   // Results info
@@ -31,7 +36,10 @@ export class KeyList {
 
   // Key list container
   readonly keyListContainer: Locator;
-  readonly container: Locator;
+  readonly keysBrowserPanel: Locator;
+  /** List view table root — present in both legacy left panel and `devBrowser` keys-browser-panel */
+  readonly keyListTable: Locator;
+  readonly keysSummary: Locator;
   readonly noKeysMessage: Locator;
 
   // Index selector (Redisearch mode)
@@ -58,8 +66,12 @@ export class KeyList {
     // View controls
     this.listViewButton = page.getByTestId('view-type-browser-btn');
     this.treeViewButton = page.getByTestId('view-type-list-btn');
-    this.columnsButton = page.getByRole('button', { name: 'columns' });
-    this.refreshButton = page.getByRole('button', { name: /refresh/i }).first();
+    this.columnsButton = page.getByTestId('btn-columns-actions');
+    this.refreshButton = page.getByTestId('keys-refresh-btn');
+    this.keysAutoRefreshConfigButton = page.getByTestId('keys-auto-refresh-config-btn');
+    this.keysAutoRefreshSwitch = page.getByTestId('keys-auto-refresh-switch');
+    this.emptyDatabasePanel = page.getByTestId('no-result-found-msg');
+    this.addKeyFromEmptyButton = page.getByTestId('add-key-msg-btn');
     this.treeSettingsButton = page.getByTestId('tree-view-settings-btn');
 
     // Results info
@@ -73,9 +85,9 @@ export class KeyList {
     this.keyListContainer = page.locator(
       '[data-testid="keys-browser-panel"], [data-testid="keyList-table"], [data-testid="virtual-tree"]',
     );
-    this.container = page.locator(
-      '[data-testid="keys-browser-panel"], [data-testid="keyList-table"], [data-testid="virtual-tree"]',
-    );
+    this.keysBrowserPanel = page.getByTestId('keys-browser-panel');
+    this.keyListTable = page.getByTestId('keyList-table');
+    this.keysSummary = page.getByTestId('keys-summary');
     this.noKeysMessage = page.getByText(/no keys/i);
   }
 
@@ -97,8 +109,9 @@ export class KeyList {
   async searchKeys(pattern: string): Promise<void> {
     await this.searchInput.fill(pattern);
     await this.searchButton.click();
-    // Wait for "Results:" to appear (indicates filter is applied)
-    await this.resultsCount.waitFor({ state: 'visible', timeout: 10000 });
+    // Search can end with either "Results:" or an empty-state message; reset button confirms filter applied.
+    await expect(this.resetFilterButton).toBeVisible();
+    await expect(this.resultsCount.or(this.emptyDatabasePanel).first()).toBeVisible();
   }
 
   /**
@@ -107,7 +120,7 @@ export class KeyList {
   async clearSearch(): Promise<void> {
     await this.resetFilterButton.click();
     // Wait for reset button to disappear (indicates filter is cleared)
-    await this.resetFilterButton.waitFor({ state: 'hidden', timeout: 10000 });
+    await expect(this.resetFilterButton).toBeHidden();
   }
 
   /**
@@ -132,12 +145,7 @@ export class KeyList {
    * Check if scan more button is visible
    */
   async isScanMoreVisible(): Promise<boolean> {
-    try {
-      await this.scanMoreButton.waitFor({ state: 'visible', timeout: 3000 });
-      return true;
-    } catch {
-      return false;
-    }
+    return this.scanMoreButton.isVisible();
   }
 
   /**
@@ -166,16 +174,11 @@ export class KeyList {
    * Click on a key by name
    */
   async clickKey(keyName: string): Promise<void> {
-    const escapedKeyName = keyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-    // Try grid row first (list view), then treeitem (tree view)
-    const gridRow = this.page.getByRole('row', { name: new RegExp(escapedKeyName) });
-    const treeItem = this.page.getByRole('treeitem', { name: new RegExp(escapedKeyName) });
-    const keyElement = gridRow.or(treeItem);
-
-    if (await keyElement.isVisible()) {
-      await keyElement.click();
-    } else {
+    const keyEl = this.getKeyRow(keyName);
+    try {
+      await keyEl.scrollIntoViewIfNeeded();
+      await keyEl.click();
+    } catch {
       await this.selectKeyInTree(keyName);
     }
   }
@@ -188,7 +191,7 @@ export class KeyList {
   async selectKeyInTree(keyName: string, delimiter = ':'): Promise<void> {
     const delimiterIndex = keyName.lastIndexOf(delimiter);
     const leafName = keyName.substring(delimiterIndex + delimiter.length) || keyName;
-    const leafNode = this.container.getByRole('treeitem').filter({ hasText: leafName });
+    const leafNode = this.keyListContainer.getByRole('treeitem').filter({ hasText: leafName });
 
     if (delimiterIndex !== -1) {
       const folder = keyName.substring(0, delimiterIndex);
@@ -216,17 +219,7 @@ export class KeyList {
    */
   async keyExists(keyName: string, timeout = 5000): Promise<boolean> {
     try {
-      // Escape special regex characters in key name
-      const escapedKeyName = keyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-      // Try grid cell (list view) - look for exact key name in gridcell
-      const gridCell = this.page.getByRole('gridcell', { name: keyName });
-
-      // Try treeitem (tree view) - key name appears in the treeitem accessible name
-      const treeItem = this.page.getByRole('treeitem', { name: new RegExp(escapedKeyName) });
-
-      const keyElement = gridCell.or(treeItem);
-      await keyElement.waitFor({ state: 'visible', timeout });
+      await this.getKeyLocator(keyName).waitFor({ state: 'visible', timeout });
       return true;
     } catch {
       return false;
@@ -241,6 +234,10 @@ export class KeyList {
    * trigger a Playwright strict-mode violation.
    */
   getKeyRow(keyName: string): Locator {
+    return this.getKeyLocator(keyName);
+  }
+
+  private getKeyLocator(keyName: string): Locator {
     const escapedKeyName = keyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     return this.page
@@ -275,10 +272,67 @@ export class KeyList {
   }
 
   /**
+   * Parsed integer from footer spans (handles thousand separators and leading ~).
+   */
+  private parseFormattedCount(text: string): number {
+    const digitsOnly = text.replace(/\D/g, '');
+    return digitsOnly ? parseInt(digitsOnly, 10) : 0;
+  }
+
+  /**
+   * "Results" count from keys summary (tree view / search); matches `keys-number-of-results`.
+   */
+  async getFooterResultsCount(): Promise<number> {
+    const el = this.keysSummary.getByTestId('keys-number-of-results');
+    await el.waitFor({ state: 'visible' });
+    return this.parseFormattedCount(await el.innerText());
+  }
+
+  /**
+   * "Scanned" count from keys summary; matches `keys-number-of-scanned`.
+   */
+  async getFooterScannedCount(): Promise<number> {
+    const el = this.keysSummary.getByTestId('keys-number-of-scanned');
+    await el.waitFor({ state: 'visible' });
+    return this.parseFormattedCount(await el.innerText());
+  }
+
+  /**
+   * Total keys in DB shown in footer (`keys-total`), when present.
+   */
+  async getFooterTotalCount(): Promise<number | null> {
+    const el = this.keysSummary.getByTestId('keys-total');
+    if (!(await el.isVisible().catch(() => false))) {
+      return null;
+    }
+    const text = await el.innerText();
+    if (!text?.trim()) {
+      return null;
+    }
+    return this.parseFormattedCount(text);
+  }
+
+  /**
    * Refresh the key list
    */
   async refresh(): Promise<void> {
     await this.refreshButton.click();
+  }
+
+  /**
+   * Open the Columns popover (TTL / Key size toggles)
+   */
+  async openColumnsPopover(): Promise<void> {
+    await this.columnsButton.click();
+    await expect(this.page.getByTestId('show-key-size')).toBeVisible();
+  }
+
+  /**
+   * Open keys Auto Refresh configuration popover
+   */
+  async openKeysAutoRefreshPopover(): Promise<void> {
+    await this.keysAutoRefreshConfigButton.click();
+    await expect(this.keysAutoRefreshSwitch).toBeVisible();
   }
 
   /**
@@ -449,5 +503,23 @@ export class KeyList {
     const sortByDropdown = this.page.getByRole('combobox', { name: 'Sort by' });
     await sortByDropdown.click();
     await this.page.getByRole('option', { name: option }).click();
+  }
+
+  /**
+   * Close columns popover by clicking outside (Escape)
+   */
+  async closeColumnsPopover(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.page.getByTestId('show-key-size')).toBeHidden();
+  }
+
+  /**
+   * Scroll the keys browser panel (virtualized list/tree) with the mouse wheel.
+   * Hovers the virtual table area — not the top of the panel (summary/header), so the wheel reaches the grid.
+   */
+  async scrollKeysPanelVertically(deltaY: number): Promise<void> {
+    const grid = this.keyListTable.getByRole('grid').first();
+    await grid.hover({ position: { x: 120, y: 160 } });
+    await this.page.mouse.wheel(0, deltaY);
   }
 }

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -306,21 +306,6 @@ export class KeyList {
   }
 
   /**
-   * Total keys in DB shown in footer (`keys-total`), when present.
-   */
-  async getFooterTotalCount(): Promise<number | null> {
-    const el = this.keysSummary.getByTestId('keys-total');
-    if (!(await el.isVisible().catch(() => false))) {
-      return null;
-    }
-    const text = await el.innerText();
-    if (!text?.trim()) {
-      return null;
-    }
-    return this.parseFormattedCount(text);
-  }
-
-  /**
    * Refresh the key list
    */
   async refresh(): Promise<void> {

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-empty.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-empty.spec.ts
@@ -21,6 +21,13 @@ test.describe('Browser > Key List View (empty database)', () => {
     }
   });
 
+  test.afterEach(async ({ browserPage }) => {
+    // browserViewType is persisted in localStorage and shared across all specs in the same Electron
+    // instance. Clear it so the next spec gets the app's true default (Tree) instead of the list view
+    // this test forces.
+    await browserPage.page.evaluate(() => localStorage.removeItem('browserViewType'));
+  });
+
   test('should show empty database welcome and open Add key from message', async ({ browserPage }) => {
     await browserPage.goto(database.id);
     await browserPage.keyList.switchToListView();

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-empty.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-empty.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { StandaloneEmptyConfigFactory } from 'e2eSrc/test-data/databases';
+import { DatabaseInstance } from 'e2eSrc/types';
+
+/**
+ * Empty Redis instance (dedicated port, default 8105) — zero-key welcome / CTAs.
+ */
+test.describe('Browser > Key List View (empty database)', () => {
+  let database: DatabaseInstance;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    const config = StandaloneEmptyConfigFactory.build({
+      name: `test-key-list-empty-${Date.now().toString(36)}`,
+    });
+    database = await apiHelper.createDatabase(config);
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteDatabase(database.id);
+    }
+  });
+
+  test('should show empty database welcome and open Add key from message', async ({ browserPage }) => {
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    await expect(browserPage.keyList.emptyDatabasePanel).toBeVisible();
+    await expect(browserPage.page.getByText(/Let's start working/i)).toBeVisible();
+
+    await browserPage.keyList.addKeyFromEmptyButton.click();
+    await expect(browserPage.addKeyDialog.title).toBeVisible();
+    await browserPage.closeAddKeyDialog();
+  });
+});

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { databaseFactories } from 'e2eSrc/test-data/databases';
+import { ConnectionType, DatabaseInstance } from 'e2eSrc/types';
+
+test.describe('Browser > Key List View (large dataset)', () => {
+  let bigDatabase: DatabaseInstance;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    const config = databaseFactories[ConnectionType.StandaloneBig].build();
+    bigDatabase = await apiHelper.createDatabase(config);
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    if (bigDatabase?.id) {
+      await apiHelper.deleteDatabase(bigDatabase.id);
+    }
+  });
+
+  test('should display keys summary and scroll key list in list view', async ({ browserPage }) => {
+    await browserPage.goto(bigDatabase.id);
+    await browserPage.keyList.switchToListView();
+    await browserPage.keyList.waitForKeysLoaded();
+
+    await expect(browserPage.keyList.keysSummary).toBeVisible();
+    await expect(browserPage.keyList.totalCount.first()).toBeVisible();
+
+    const topKey = browserPage.keyList.keyListTable
+      .getByTestId('virtual-table-container')
+      .locator('[data-testid^="key-"]')
+      .first();
+
+    await expect(topKey).toBeVisible();
+    const idBefore = await topKey.getAttribute('data-testid');
+    expect(idBefore).toBeTruthy();
+
+    await browserPage.keyList.scrollKeysPanelVertically(800);
+
+    await expect(topKey).not.toHaveAttribute('data-testid', idBefore!);
+  });
+
+  test('should increase Results or Scanned after Scan more in tree view on large dataset', async ({ browserPage }) => {
+    await browserPage.goto(bigDatabase.id);
+    await browserPage.keyList.switchToTreeView();
+    await browserPage.keyList.waitForKeysLoaded();
+
+    await expect(browserPage.keyList.keysSummary).toBeVisible();
+
+    const resultsBefore = await browserPage.keyList.getFooterResultsCount();
+    const scannedBefore = await browserPage.keyList.getFooterScannedCount();
+    expect(resultsBefore).toBeGreaterThan(0);
+
+    await expect(browserPage.keyList.scanMoreButton).toBeVisible();
+    await browserPage.keyList.scanMore();
+
+    await expect
+      .poll(async () => {
+        const results = await browserPage.keyList.getFooterResultsCount();
+        const scanned = await browserPage.keyList.getFooterScannedCount();
+        return results > resultsBefore || scanned > scannedBefore;
+      })
+      .toBe(true);
+  });
+});

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
@@ -17,8 +17,10 @@ test.describe('Browser > Key List View (large dataset)', () => {
   });
 
   test.afterEach(async ({ browserPage }) => {
-    // Restore the default list view so this suite doesn't leak tree-view state to other specs in the same worker.
-    await browserPage.keyList.switchToListView();
+    // browserViewType is persisted in localStorage and shared across all specs in the same Electron
+    // instance. Clear it so the next spec gets the app's true default (Tree) instead of whatever this
+    // suite last set.
+    await browserPage.page.evaluate(() => localStorage.removeItem('browserViewType'));
   });
 
   test('should display keys summary and scroll key list in list view', async ({ browserPage }) => {

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-scan-more.spec.ts
@@ -16,6 +16,11 @@ test.describe('Browser > Key List View (large dataset)', () => {
     }
   });
 
+  test.afterEach(async ({ browserPage }) => {
+    // Restore the default list view so this suite doesn't leak tree-view state to other specs in the same worker.
+    await browserPage.keyList.switchToListView();
+  });
+
   test('should display keys summary and scroll key list in list view', async ({ browserPage }) => {
     await browserPage.goto(bigDatabase.id);
     await browserPage.keyList.switchToListView();

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
@@ -31,10 +31,14 @@ test.describe('Browser > Key List View', () => {
     database = await apiHelper.createDatabase(config);
   });
 
-  test.afterEach(async ({ apiHelper }) => {
+  test.afterEach(async ({ apiHelper, browserPage }) => {
     if (database?.id) {
       await apiHelper.deleteKeysByPattern(database.id, allTestKeysPattern);
     }
+    // browserViewType is persisted in localStorage and shared across all specs in the same Electron
+    // instance. Clear it so the next spec gets the app's true default (Tree) instead of the list view
+    // these tests force at the start.
+    await browserPage.page.evaluate(() => localStorage.removeItem('browserViewType'));
   });
 
   test.afterAll(async ({ apiHelper }) => {

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
@@ -1,0 +1,243 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
+import { TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
+import { DatabaseInstance } from 'e2eSrc/types';
+
+/**
+ * Browser Key List View — consolidated E2E (TEST_PLAN 2.1).
+ * Pattern/wildcard matrix lives in ../key-filtering/key-filtering.spec.ts (2.14).
+ *
+ * Serial: shared database with destructive tests (delete / bulk delete).
+ */
+test.describe('Browser > Key List View', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let database: DatabaseInstance;
+  const suffix = Date.now().toString(36);
+  const stringKey = `${TEST_KEY_PREFIX}kl-str-${suffix}`;
+  const refreshKey = `${TEST_KEY_PREFIX}kl-refresh-${suffix}`;
+  const hashKey = `${TEST_KEY_PREFIX}kl-hash-${suffix}`;
+  const hashKeyExtra = `${TEST_KEY_PREFIX}kl-hash-extra-${suffix}`;
+  const deleteMeKey = `${TEST_KEY_PREFIX}kl-del-${suffix}`;
+  const bulkKey1 = `${TEST_KEY_PREFIX}kl-bulk-a-${suffix}`;
+  const bulkKey2 = `${TEST_KEY_PREFIX}kl-bulk-b-${suffix}`;
+  const bulkPattern = `${TEST_KEY_PREFIX}kl-bulk-*-${suffix}`;
+  const allTestKeysPattern = `${TEST_KEY_PREFIX}*`;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    const config = StandaloneConfigFactory.build({
+      name: `test-key-list-${suffix}`,
+    });
+    database = await apiHelper.createDatabase(config);
+  });
+
+  test.afterEach(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteKeysByPattern(database.id, allTestKeysPattern);
+    }
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteDatabase(database.id);
+    }
+  });
+
+  test('should show key list with seeded keys in list view', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify the seeded key is visible in the list
+    await expect(browserPage.keyList.keyListContainer).toBeVisible();
+    await expect(browserPage.keyList.keysSummary).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).toBeVisible();
+  });
+
+  test('should filter by key type, then exact name, and open key details', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+    await apiHelper.createHashKey(database.id, hashKey, [{ field: 'f1', value: 'v1' }]);
+    await apiHelper.createHashKey(database.id, hashKeyExtra, [{ field: 'f2', value: 'v2' }]);
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify key type filtering first
+    await browserPage.keyList.filterByType('Hash');
+    await expect(browserPage.keyList.getKeyRow(hashKey)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(hashKeyExtra)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();
+
+    // Verify exact-name search narrows results on top of key-type filter
+    await browserPage.keyList.searchKeys(hashKey);
+    await expect(browserPage.keyList.getKeyRow(hashKey)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(hashKeyExtra)).not.toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();
+
+    // Verify key details can be opened from the narrowed result
+    await browserPage.keyList.clickKey(hashKey);
+    await browserPage.keyDetails.waitForKeyDetails();
+    expect(await browserPage.keyDetails.getKeyName()).toContain(hashKey);
+
+    // Verify reset path back to all key types
+    await browserPage.keyList.clearSearch();
+    await browserPage.keyList.filterByType('All Key Types');
+    await browserPage.keyList.waitForKeysLoaded();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(hashKey)).toBeVisible();
+  });
+
+  test('should refresh key list', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify Refresh loads data created after the page has already rendered
+    expect(await browserPage.keyList.keyExists(refreshKey, 1000)).toBe(false);
+    await apiHelper.createStringKey(database.id, refreshKey, 'from-refresh-check');
+    expect(await browserPage.keyList.keyExists(refreshKey, 1000)).toBe(false);
+
+    await browserPage.keyList.refresh();
+    await browserPage.keyList.waitForKeysLoaded();
+    await expect(browserPage.keyList.getKeyRow(refreshKey)).toBeVisible();
+  });
+
+  test('should configure auto-refresh and update key list automatically', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Configure auto-refresh to 1 second and enable it
+    await browserPage.keyList.openKeysAutoRefreshPopover();
+    await expect(browserPage.keyList.keysAutoRefreshSwitch).toBeVisible();
+    await browserPage.page.getByTestId('keys-refresh-rate').click();
+    await browserPage.page.getByTestId('inline-item-editor').fill('1');
+    await browserPage.page.getByTestId('apply-btn').click();
+    await browserPage.keyList.keysAutoRefreshSwitch.click();
+    await browserPage.page.keyboard.press('Escape');
+
+    // Verify list updates without manual refresh
+    await expect(browserPage.keyList.getKeyRow(refreshKey)).not.toBeVisible();
+    await apiHelper.createStringKey(database.id, refreshKey, 'from-auto-refresh-check');
+    await expect(browserPage.keyList.getKeyRow(refreshKey)).toBeVisible();
+  });
+
+  test('should show no results message for non-matching pattern', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify no-results state for a non-existing pattern
+    await browserPage.keyList.searchKeys(`nonexistent-kl-${suffix}-zzz`);
+    expect(await browserPage.keyList.isNoKeysMessageVisible()).toBe(true);
+  });
+
+  test('should configure columns visibility', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify TTL column visibility toggle in Columns popover
+    await browserPage.keyList.openColumnsPopover();
+
+    const ttlCheckbox = browserPage.page.getByTestId('show-ttl');
+    const ttlColumnHeader = browserPage.page.getByRole('columnheader', { name: 'TTL' });
+
+    // Start from a known state: enable TTL in popover, close, verify visible in table
+    await ttlCheckbox.check();
+    await browserPage.keyList.closeColumnsPopover();
+    await expect(ttlColumnHeader).toBeVisible();
+
+    // Hide TTL in popover, close, verify hidden in table
+    await browserPage.keyList.openColumnsPopover();
+    await ttlCheckbox.uncheck();
+    await browserPage.keyList.closeColumnsPopover();
+    await expect(ttlColumnHeader).toBeHidden();
+
+    // Restore TTL in popover, close, verify visible in table
+    await browserPage.keyList.openColumnsPopover();
+    await ttlCheckbox.check();
+    await browserPage.keyList.closeColumnsPopover();
+    await expect(ttlColumnHeader).toBeVisible();
+  });
+
+  test('should switch UI when opening search by values', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify switching between Pattern search and Search by values UI
+    await browserPage.keyList.searchByValuesButton.click();
+    const indexOrHint = browserPage.keyList.indexSelector.or(
+      browserPage.page.getByText(/Redis Query Engine|Select an index|Query Engine/i),
+    );
+    await expect(indexOrHint.first()).toBeVisible();
+    await browserPage.keyList.filterByNameButton.click();
+    await browserPage.keyList.waitForKeysLoaded();
+  });
+
+  test('should delete key', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, deleteMeKey, 'delete-me');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify deleting a single key removes it from the list
+    await browserPage.keyList.searchKeys(deleteMeKey);
+    await browserPage.keyList.clickKey(deleteMeKey);
+    await browserPage.keyDetails.waitForKeyDetails();
+    await browserPage.keyDetails.deleteKey();
+
+    await browserPage.keyList.clearSearch();
+    await browserPage.keyList.waitForKeysLoaded();
+    expect(await browserPage.keyList.keyExists(deleteMeKey)).toBe(false);
+  });
+
+  test('should delete multiple keys (bulk)', async ({ apiHelper, browserPage }) => {
+    // Seed data for this test
+    await apiHelper.createStringKey(database.id, bulkKey1, 'b1');
+    await apiHelper.createStringKey(database.id, bulkKey2, 'b2');
+
+    // Open the Browser page in List view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+
+    // Verify bulk delete removes all keys matching the pattern
+    await browserPage.keyList.searchKeys(bulkPattern);
+    await expect(browserPage.keyList.getKeyRow(bulkKey1)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(bulkKey2)).toBeVisible();
+
+    await browserPage.bulkActionsPanel.open();
+    await browserPage.bulkActionsPanel.selectDeleteKeysTab();
+    await browserPage.bulkActionsPanel.performBulkDelete();
+
+    await browserPage.bulkActionsPanel.close();
+
+    await browserPage.keyList.searchKeys(bulkPattern);
+    await expect(browserPage.keyList.emptyDatabasePanel).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(bulkKey1)).not.toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(bulkKey2)).not.toBeVisible();
+  });
+});

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
@@ -35,10 +35,13 @@ test.describe('Browser > Key List View', () => {
     if (database?.id) {
       await apiHelper.deleteKeysByPattern(database.id, allTestKeysPattern);
     }
-    // browserViewType is persisted in localStorage and shared across all specs in the same Electron
-    // instance. Clear it so the next spec gets the app's true default (Tree) instead of the list view
-    // these tests force at the start.
-    await browserPage.page.evaluate(() => localStorage.removeItem('browserViewType'));
+    // These keys are persisted in localStorage and shared across all specs in the same Electron
+    // instance. Clear them so the next spec gets the app's true defaults instead of the state these
+    // tests force (browserViewType -> list view; autoRefreshRatekeys -> 1s rate from the auto-refresh test).
+    await browserPage.page.evaluate(() => {
+      localStorage.removeItem('browserViewType');
+      localStorage.removeItem('autoRefreshRatekeys');
+    });
   });
 
   test.afterAll(async ({ apiHelper }) => {
@@ -135,6 +138,11 @@ test.describe('Browser > Key List View', () => {
     await expect(browserPage.keyList.getKeyRow(refreshKey)).not.toBeVisible();
     await apiHelper.createStringKey(database.id, refreshKey, 'from-auto-refresh-check');
     await expect(browserPage.keyList.getKeyRow(refreshKey)).toBeVisible();
+
+    // Disable auto-refresh so the 1s interval stops firing before the next serial test runs.
+    await browserPage.keyList.openKeysAutoRefreshPopover();
+    await browserPage.keyList.keysAutoRefreshSwitch.click();
+    await browserPage.page.keyboard.press('Escape');
   });
 
   test('should show no results message for non-matching pattern', async ({ apiHelper, browserPage }) => {


### PR DESCRIPTION
# What

Adds e2e test for the Browser - Keys List view, including list-view behavior, empty database behavior, and large-dataset list/tree scan flows.

# Testing

Run the Docker containers with the test database instances

```
cd tests/e2e
docker-compose -f rte.docker-compose.yml up -d
```

And then you can run the tests

```
cd tests/e2e-playwright
npm run test:chromium -- tests/e2e-playwright/tests/main/browser/key-list
```

<img width="1003" height="356" alt="image" src="https://github.com/user-attachments/assets/8579e02d-b07b-4d3a-9b57-54662ffd6707" />
<img width="1015" height="606" alt="image" src="https://github.com/user-attachments/assets/84b6598a-3480-4586-8100-e7ebef8110c8" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright E2E coverage and page-object locator/utility updates, with no production runtime impact. Main risk is potential test flakiness due to new selectors and localStorage-dependent state handling.
> 
> **Overview**
> Adds a consolidated Playwright E2E suite for **Browser → Key List view** covering list rendering, type + exact-name filtering, refresh/auto-refresh, columns visibility, search-by-values toggle, single & bulk delete, plus dedicated scenarios for *empty databases* and *large datasets* (scroll + tree-view scan-more behavior).
> 
> Updates the `KeyList` page object to use more specific `data-testid` selectors and adds helpers for empty-state handling, footer count parsing, popover open/close, scrolling the virtualized grid, and more robust tree selection across persisted `browserViewType` state.
> 
> Marks the corresponding `TEST_PLAN.md` cases as implemented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1f8c217313c9be956db32dacb5ce59f185592f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->