### PR TITLE
RI-8005 Add e2e tests for Browser - Keys Tree view

### DIFF
--- a/tests/e2e-playwright/TEST_PLAN.md
+++ b/tests/e2e-playwright/TEST_PLAN.md
@@ -228,19 +228,14 @@ The test plan is organized by feature area. Tests are grouped for parallel execu
 ### 2.2 Key Tree View
 | Status | Group | Test Case |
 |--------|-------|-----------|
-| 🔲 | main | Switch to tree view |
-| 🔲 | main | Expand/collapse tree nodes |
-| 🔲 | main | Configure delimiter |
-| 🔲 | main | Sort tree nodes |
-| 🔲 | main | View folder percentage and count |
-| 🔲 | main | Scan more keys (covered by "should show scan more button when searching" test) |
-| 🔲 | main | Open tree view settings |
-| 🔲 | main | Tree view mode state persists after page refresh |
-| 🔲 | main | Filter state preserved when switching between Browser and Tree view |
-| 🔲 | main | Key type filter state preserved when switching views |
-| 🔲 | main | Configure multiple delimiters in tree view |
-| 🔲 | main | Cancel delimiter change reverts to previous value |
-| 🔲 | main | Verify namespace tooltip shows key pattern and delimiter |
+| ✅ | main | Group keys into folders, expand/collapse them, and show folder badges/tooltip |
+| ✅ | main | Open tree view settings, change the delimiter and regroup folders |
+| ✅ | main | Sort tree nodes ascending and descending |
+| ✅ | main | Scan more keys |
+| ✅ | main | Selected view (List/Tree) persists after page refresh |
+| ✅ | main | Pattern and key-type filters preserved when switching List <-> Tree |
+| ✅ | main | Configure multiple delimiters in tree view |
+| ✅ | main | Cancel delimiter change reverts to previous value |
 | 🔲 | main | Scan DB by 10K keys in tree view |
 
 ### 2.3 Add Keys

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -366,136 +366,188 @@ export class KeyList {
   }
 
   /**
-   * Open tree view settings dialog
+   * Open tree view settings popover
    */
   async openTreeViewSettings(): Promise<void> {
     await this.treeSettingsButton.click();
-    // Wait for dialog to appear
-    await this.page.getByRole('dialog').waitFor({ state: 'visible' });
+    await expect(this.page.getByTestId('tree-view-apply-btn')).toBeVisible();
   }
 
   /**
    * Hover over a folder node in the tree view (expanded or collapsed)
    */
   async hoverFolderNode(folderName: string): Promise<void> {
-    const collapsed = this.page.getByTestId(`node-item_${folderName}`);
-    const expanded = this.page.getByTestId(`node-item_${folderName}--expanded`);
-    const folderNode = expanded.or(collapsed);
-    await folderNode.hover();
+    const folder = this.getFolderByName(folderName);
+    await expect(folder).toBeVisible();
+
+    // Move the mouse off any previously hovered element so the next hover always
+    // dispatches a fresh `mouseenter` (Radix tooltips won't re-open otherwise,
+    // e.g. when this is called right after a click on the same folder).
+    await this.page.mouse.move(0, 0);
+    await folder.locator('.node-folder-anchor').first().hover();
   }
 
   /**
-   * Get folder by name in tree view
+   * Get the tree-view tooltip for a hovered folder.
+   */
+  async namespaceTooltip(folderName: string): Promise<Locator> {
+    await this.hoverFolderNode(folderName);
+    return this.page.getByRole('tooltip').filter({ hasText: folderName });
+  }
+
+  /**
+   * Get folder treeitem by name in tree view.
+   * Matches whether the folder is currently expanded or collapsed.
    */
   getFolderByName(folderName: string): Locator {
-    return this.page.getByRole('treeitem', { name: new RegExp(`Folder ${folderName}`) });
+    const collapsed = this.page.getByTestId(`node-item_${folderName}`);
+    const expanded = this.page.getByTestId(`node-item_${folderName}--expanded`);
+    return expanded.or(collapsed).first();
   }
 
   /**
-   * Expand folder in tree view
+   * Ordered, lower-case folder labels currently visible in the tree.
+   * Useful for asserting sort-order changes.
    */
-  async expandFolder(folderName: string): Promise<void> {
+  async getVisibleTreeFolderNames(): Promise<string[]> {
+    const folderLabels = this.page.locator('[data-testid^="folder-"]');
+    return folderLabels.allInnerTexts();
+  }
+
+  /**
+   * Expand a folder in tree view so its direct child becomes visible.
+   * Uses `childName` visibility as ground truth — the VirtualTree may auto-expand
+   * single-child folders while keeping the collapsed `node-item_*` testid, so the
+   * testid suffix alone is unreliable.
+   */
+  async expandFolder(folderName: string, childName: string): Promise<void> {
     const folder = this.getFolderByName(folderName);
+    await expect(folder).toBeVisible();
+
+    const isExpanded = await this.isFolderExpanded(folderName, childName);
+    if (isExpanded) {
+      return;
+    }
+
     await folder.click();
-    // Wait for chevron to change to down
-    await this.page
-      .getByRole('treeitem', { name: new RegExp(`Chevron Down.*${folderName}`) })
-      .waitFor({ state: 'visible' });
+    const child = this.getFolderByName(childName);
+    await expect(child).toBeVisible();
   }
 
   /**
-   * Collapse folder in tree view
+   * Collapse a folder in tree view so its direct child becomes hidden.
    */
-  async collapseFolder(folderName: string): Promise<void> {
+  async collapseFolder(folderName: string, childName: string): Promise<void> {
     const folder = this.getFolderByName(folderName);
+    await expect(folder).toBeVisible();
+
+    const isExpanded = await this.isFolderExpanded(folderName, childName);
+    if (!isExpanded) {
+      return;
+    }
+
     await folder.click();
-    // Wait for chevron to change to right
-    await this.page
-      .getByRole('treeitem', { name: new RegExp(`Chevron Right.*${folderName}`) })
-      .waitFor({ state: 'visible' });
+    const child = this.getFolderByName(childName);
+    await expect(child).toBeHidden();
   }
 
   /**
-   * Check if folder is expanded
+   * Whether a folder appears expanded (its direct child is rendered).
    */
-  async isFolderExpanded(folderName: string): Promise<boolean> {
-    const expandedFolder = this.page.getByRole('treeitem', { name: new RegExp(`Chevron Down.*${folderName}`) });
-    return expandedFolder.isVisible();
+  async isFolderExpanded(folderName: string, childName: string): Promise<boolean> {
+    if (!(await this.getFolderByName(folderName).isVisible())) {
+      return false;
+    }
+    return this.getFolderByName(childName).isVisible();
   }
 
   /**
-   * Get folder percentage text
+   * Folder percentage text (e.g. `33%`, `<1%`).
    */
   async getFolderPercentage(folderName: string): Promise<string | null> {
-    const folder = this.getFolderByName(folderName);
-    const percentageElement = folder
-      .locator('div')
-      .filter({ hasText: /\d+%|<1%/ })
-      .first();
-    return percentageElement.textContent();
+    return this.page.getByTestId(`percentage_${folderName}`).textContent();
   }
 
   /**
-   * Get folder count
+   * Folder key count text (number of keys under the folder).
    */
   async getFolderCount(folderName: string): Promise<string | null> {
-    const folder = this.getFolderByName(folderName);
-    // The count is the last number in the folder row
-    const countElement = folder.locator('div').last();
-    return countElement.textContent();
+    return this.page.getByTestId(`count_${folderName}`).textContent();
   }
 
   /**
-   * Get current delimiter from tree view settings
+   * All currently visible delimiter chips inside the tree-view settings popover.
+   */
+  delimiterChips(): Locator {
+    return this.page.locator('[data-testid="delimiter-combobox"] [data-test-subj="autoTagChip"]');
+  }
+
+  /**
+   * Read all configured delimiter labels (chip titles) in order.
+   */
+  async getCurrentDelimiters(): Promise<string[]> {
+    const chips = this.delimiterChips();
+    const titles = await chips.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('title') ?? node.textContent ?? ''),
+    );
+    return titles.map((title) => title.trim()).filter(Boolean);
+  }
+
+  /**
+   * Convenience helper for reading the first delimiter chip.
    */
   async getCurrentDelimiter(): Promise<string> {
-    const delimiterChip = this.page.getByRole('dialog').locator('[class*="chip"]').first();
-    const text = await delimiterChip.textContent();
-    return text?.replace('Remove', '').trim() || '';
+    const [first] = await this.getCurrentDelimiters();
+    return first ?? '';
   }
 
   /**
-   * Add delimiter in tree view settings
+   * Add a delimiter via the AutoTag input inside the tree-view settings popover.
    */
   async addDelimiter(delimiter: string): Promise<void> {
-    const delimiterInput = this.page.getByRole('textbox', { name: 'Delimiter' });
+    const delimiterInput = this.page.locator('[data-testid="delimiter-combobox"] [data-test-subj="autoTagInput"]');
     await delimiterInput.fill(delimiter);
     await delimiterInput.press('Enter');
+    await expect(
+      this.page.locator(`[data-testid="delimiter-combobox"] [data-test-subj="autoTagChip"][title="${delimiter}"]`),
+    ).toBeVisible();
   }
 
   /**
-   * Remove delimiter in tree view settings
+   * Remove a delimiter chip by its label.
    */
   async removeDelimiter(delimiter: string): Promise<void> {
-    const delimiterChip = this.page.getByRole('dialog').locator(`[class*="chip"]`).filter({ hasText: delimiter });
-    await delimiterChip.getByRole('button', { name: 'Remove' }).click();
+    const chip = this.page.locator(
+      `[data-testid="delimiter-combobox"] [data-test-subj="autoTagChip"][title="${delimiter}"]`,
+    );
+    await chip.locator('button').click();
+    await expect(chip).toBeHidden();
   }
 
   /**
-   * Apply tree view settings
+   * Apply tree view settings (closes popover).
    */
   async applyTreeViewSettings(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Apply' }).click();
-    // Wait for dialog to close
-    await this.page.getByRole('dialog').waitFor({ state: 'hidden' });
+    const applyButton = this.page.getByTestId('tree-view-apply-btn');
+    await applyButton.click();
+    await expect(applyButton).toBeHidden();
   }
 
   /**
-   * Cancel tree view settings
+   * Cancel tree view settings (closes popover, discards changes).
    */
   async cancelTreeViewSettings(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Cancel' }).click();
-    // Wait for dialog to close
-    await this.page.getByRole('dialog').waitFor({ state: 'hidden' });
+    const cancelButton = this.page.getByTestId('tree-view-cancel-btn');
+    await cancelButton.click();
+    await expect(cancelButton).toBeHidden();
   }
 
   /**
-   * Change sort by option in tree view settings
+   * Change sort order in tree view settings popover.
    */
-  async changeSortBy(option: string): Promise<void> {
-    const sortByDropdown = this.page.getByRole('combobox', { name: 'Sort by' });
-    await sortByDropdown.click();
-    await this.page.getByRole('option', { name: option }).click();
+  async changeSortBy(order: 'ASC' | 'DESC'): Promise<void> {
+    await this.page.getByTestId('tree-view-sorting-select').click();
+    await this.page.getByTestId(`tree-view-sorting-item-${order}`).click();
   }
 
   /**

--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -494,14 +494,6 @@ export class KeyList {
   }
 
   /**
-   * Convenience helper for reading the first delimiter chip.
-   */
-  async getCurrentDelimiter(): Promise<string> {
-    const [first] = await this.getCurrentDelimiters();
-    return first ?? '';
-  }
-
-  /**
    * Add a delimiter via the AutoTag input inside the tree-view settings popover.
    */
   async addDelimiter(delimiter: string): Promise<void> {

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
@@ -38,10 +38,14 @@ test.describe('Browser > Key Tree View', () => {
     database = await apiHelper.createDatabase(config);
   });
 
-  test.afterEach(async ({ apiHelper }) => {
+  test.afterEach(async ({ apiHelper, browserPage }) => {
     if (database?.id) {
       await apiHelper.deleteKeysByPattern(database.id, allTestKeysPattern);
     }
+    // browserViewType is persisted in localStorage and shared across all specs in the same Electron
+    // instance. Tests here briefly force list view; clear the key so the next spec gets the app's
+    // true default (Tree) even if a test fails before switching back.
+    await browserPage.page.evaluate(() => localStorage.removeItem('browserViewType'));
   });
 
   test.afterAll(async ({ apiHelper }) => {

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
@@ -1,0 +1,262 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
+import { TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
+import { DatabaseInstance } from 'e2eSrc/types';
+
+/**
+ * Browser Key Tree View — consolidated E2E (TEST_PLAN 2.2).
+ * Large-dataset "Scan more in tree" lives in ./key-list-scan-more.spec.ts.
+ *
+ * Serial: shared database, several tests mutate tree-view settings
+ * (delimiter / sort) and reset them before exiting.
+ */
+test.describe('Browser > Key Tree View', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let database: DatabaseInstance;
+  const suffix = Date.now().toString(36);
+
+  // Colon-delimited tree keys
+  const treeFolder = `${TEST_KEY_PREFIX}tree-${suffix}`;
+  const usersFolder = `${treeFolder}:users`;
+  const userAliceKey = `${usersFolder}:alice`;
+  const userBobKey = `${usersFolder}:bob`;
+  const flatLeafKey = `${TEST_KEY_PREFIX}leaf-${suffix}`;
+
+  // Underscore-delimited tree keys (used by delimiter-change tests)
+  const underscoreTreeFolder = `${TEST_KEY_PREFIX}utree-${suffix}`;
+  const underscoreUsersFolder = `${underscoreTreeFolder}_users`;
+  const underscoreAliceKey = `${underscoreUsersFolder}_alice`;
+  const underscoreBobKey = `${underscoreUsersFolder}_bob`;
+
+  const allTestKeysPattern = `${TEST_KEY_PREFIX}*`;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    const config = StandaloneConfigFactory.build({
+      name: `test-key-tree-${suffix}`,
+    });
+    database = await apiHelper.createDatabase(config);
+  });
+
+  test.afterEach(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteKeysByPattern(database.id, allTestKeysPattern);
+    }
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteDatabase(database.id);
+    }
+  });
+
+  test('should group keys into folders, expand/collapse them, and show folder badges/tooltip', async ({
+    apiHelper,
+    browserPage,
+  }) => {
+    // Seed namespaced keys plus a flat leaf
+    await apiHelper.createStringKey(database.id, userAliceKey, 'alice');
+    await apiHelper.createStringKey(database.id, userBobKey, 'bob');
+    await apiHelper.createStringKey(database.id, flatLeafKey, 'leaf');
+
+    // Open the Browser page in Tree view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToTreeView();
+
+    // Verify the namespaced folder is present and the flat leaf is rendered as a top-level row
+    await expect(browserPage.keyList.getFolderByName(treeFolder)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(flatLeafKey)).toBeVisible();
+
+    // Verify percentage and key-count badges render for the seeded folder
+    const percentage = await browserPage.keyList.getFolderPercentage(treeFolder);
+    expect(percentage).toMatch(/\d+%|<1%/);
+
+    const countText = await browserPage.keyList.getFolderCount(treeFolder);
+    const countNumber = Number((countText ?? '').replace(/\D/g, ''));
+    expect(countNumber).toBeGreaterThan(0);
+
+    // Verify the namespace tooltip surfaces the folder's key pattern (`<folder>:*`) and key count.
+    const tooltip = await browserPage.keyList.namespaceTooltip(treeFolder);
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText(`${treeFolder}:*`);
+    await expect(tooltip).toContainText(/key\(s\)/);
+
+    // Verify expand reveals the nested child folder
+    await browserPage.keyList.expandFolder(treeFolder, usersFolder);
+    await expect(browserPage.keyList.getFolderByName(usersFolder)).toBeVisible();
+
+    // Verify collapse hides the nested child folder
+    await browserPage.keyList.collapseFolder(treeFolder, usersFolder);
+    await expect(browserPage.keyList.getFolderByName(usersFolder)).toBeHidden();
+  });
+
+  test('should open tree view settings, change the delimiter and regroup folders', async ({
+    apiHelper,
+    browserPage,
+  }) => {
+    // Seed underscore-delimited keys (so they are flat under the default `:` delimiter)
+    await apiHelper.createStringKey(database.id, underscoreAliceKey, 'alice');
+    await apiHelper.createStringKey(database.id, underscoreBobKey, 'bob');
+
+    // Open the Browser page in Tree view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToTreeView();
+
+    // With `:` delimiter the underscore keys render as flat leaves (no `utree-*` folder)
+    await expect(browserPage.keyList.getKeyRow(underscoreAliceKey)).toBeVisible();
+    await expect(browserPage.keyList.getFolderByName(underscoreTreeFolder)).toBeHidden();
+
+    // Verify the settings popover opens with the default `:` delimiter chip
+    await browserPage.keyList.openTreeViewSettings();
+    expect(await browserPage.keyList.getCurrentDelimiters()).toEqual([':']);
+
+    // Switch the delimiter from `:` to `_`
+    await browserPage.keyList.removeDelimiter(':');
+    await browserPage.keyList.addDelimiter('_');
+    await browserPage.keyList.applyTreeViewSettings();
+
+    // Verify the underscore-delimited folder now appears
+    await expect(browserPage.keyList.getFolderByName(underscoreTreeFolder)).toBeVisible();
+
+    // Cleanup: restore default `:` delimiter
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.removeDelimiter('_');
+    await browserPage.keyList.addDelimiter(':');
+    await browserPage.keyList.applyTreeViewSettings();
+  });
+
+  test('should support multiple delimiters in tree view', async ({ apiHelper, browserPage }) => {
+    // Seed both colon- and underscore-delimited keys
+    await apiHelper.createStringKey(database.id, userAliceKey, 'alice');
+    await apiHelper.createStringKey(database.id, underscoreAliceKey, 'alice');
+
+    // Open the Browser page in Tree view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToTreeView();
+
+    // Add `_` as a second delimiter (alongside the default `:`)
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.addDelimiter('_');
+    expect(await browserPage.keyList.getCurrentDelimiters()).toEqual([':', '_']);
+    await browserPage.keyList.applyTreeViewSettings();
+
+    // Verify both folder hierarchies are rendered
+    await expect(browserPage.keyList.getFolderByName(treeFolder)).toBeVisible();
+    await expect(browserPage.keyList.getFolderByName(underscoreTreeFolder)).toBeVisible();
+
+    // Cleanup: remove `_` to restore the default single-delimiter setup
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.removeDelimiter('_');
+    await browserPage.keyList.applyTreeViewSettings();
+  });
+
+  test('should cancel delimiter change and keep previous delimiter', async ({ apiHelper, browserPage }) => {
+    // Seed at least one key so the tree settings button is enabled
+    await apiHelper.createStringKey(database.id, userAliceKey, 'alice');
+
+    // Open the Browser page in Tree view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToTreeView();
+
+    // Add a second delimiter, then cancel without applying
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.addDelimiter('_');
+    expect(await browserPage.keyList.getCurrentDelimiters()).toEqual([':', '_']);
+    await browserPage.keyList.cancelTreeViewSettings();
+
+    // Verify the original `:`-only configuration is preserved.
+    // The popover resets its local state asynchronously after closing, so poll
+    // until the chip set matches the saved (Redux) configuration.
+    await browserPage.keyList.openTreeViewSettings();
+    await expect.poll(() => browserPage.keyList.getCurrentDelimiters()).toEqual([':']);
+    await browserPage.keyList.cancelTreeViewSettings();
+  });
+
+  test('should sort tree nodes ascending and descending', async ({ apiHelper, browserPage }) => {
+    // Seed keys producing two top-level folders that sort in opposite orders for ASC/DESC
+    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}aaa-${suffix}:k1`, 'a');
+    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}zzz-${suffix}:k1`, 'z');
+
+    // Open the Browser page in Tree view
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToTreeView();
+
+    // Verify ASC order (default) — poll until both seeded folders are rendered and ordered
+    await expect
+      .poll(async () => {
+        const names = await browserPage.keyList.getVisibleTreeFolderNames();
+        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}aaa-${suffix}`));
+        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}zzz-${suffix}`));
+        return aaaIndex !== -1 && zzzIndex !== -1 && aaaIndex < zzzIndex;
+      })
+      .toBe(true);
+
+    // Switch to DESC and verify ordering flips
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.changeSortBy('DESC');
+    await browserPage.keyList.applyTreeViewSettings();
+
+    await expect
+      .poll(async () => {
+        const names = await browserPage.keyList.getVisibleTreeFolderNames();
+        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}aaa-${suffix}`));
+        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}zzz-${suffix}`));
+        return aaaIndex !== -1 && zzzIndex !== -1 && aaaIndex > zzzIndex;
+      })
+      .toBe(true);
+
+    // Cleanup: restore ASC sort
+    await browserPage.keyList.openTreeViewSettings();
+    await browserPage.keyList.changeSortBy('ASC');
+    await browserPage.keyList.applyTreeViewSettings();
+  });
+
+  test('should preserve pattern and key-type filters when switching List <-> Tree', async ({
+    apiHelper,
+    browserPage,
+  }) => {
+    // Seed mixed types so the type filter has something to narrow
+    const stringKey = `${TEST_KEY_PREFIX}filter-str-${suffix}`;
+    const hashKeyName = `${TEST_KEY_PREFIX}filter-hash-${suffix}`;
+    await apiHelper.createStringKey(database.id, stringKey, 'hello');
+    await apiHelper.createHashKey(database.id, hashKeyName, [{ field: 'f1', value: 'v1' }]);
+
+    // Open the Browser page in List view and apply pattern + Hash type filters
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+    await browserPage.keyList.filterByType('Hash');
+    await browserPage.keyList.searchKeys(`${TEST_KEY_PREFIX}filter-*-${suffix}`);
+
+    await expect(browserPage.keyList.getKeyRow(hashKeyName)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();
+
+    // Switch to Tree view; filters should persist
+    await browserPage.keyList.switchToTreeView();
+    await expect(browserPage.keyList.searchInput).toHaveValue(`${TEST_KEY_PREFIX}filter-*-${suffix}`);
+    await expect(browserPage.keyList.resetFilterButton).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(hashKeyName)).toBeVisible();
+    await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();
+  });
+
+  test('should keep the selected view active after page refresh', async ({ apiHelper, browserPage }) => {
+    // Seed a single namespaced key so List view renders a gridcell and Tree view renders a folder
+    await apiHelper.createStringKey(database.id, userAliceKey, 'alice');
+
+    // Open the Browser page in List view, reload — list-view rows should still render
+    await browserPage.goto(database.id);
+    await browserPage.keyList.switchToListView();
+    await expect(browserPage.keyList.getKeyRow(userAliceKey)).toBeVisible();
+
+    await browserPage.page.reload();
+    await browserPage.keyList.waitForKeysLoaded();
+    await expect(browserPage.keyList.getKeyRow(userAliceKey)).toBeVisible();
+
+    // Switch to Tree view, reload — tree-view folder should still render
+    await browserPage.keyList.switchToTreeView();
+    await expect(browserPage.keyList.getFolderByName(treeFolder)).toBeVisible();
+
+    await browserPage.page.reload();
+    await browserPage.keyList.waitForKeysLoaded();
+    await expect(browserPage.keyList.getFolderByName(treeFolder)).toBeVisible();
+  });
+});


### PR DESCRIPTION
# What

Adds e2e tests for the Browser - Keys Tree view, covering grouping, expand/collapse, folder badges and namespace tooltip, delimiter settings (incl. multi-delimiter and cancel), ASC/DESC sort, view persistence after refresh, and filter preservation when switching List <-> Tree.

Follow-up of #5851 — based on `e2e/RI-8005/key-list-view-tests` so the diff stays scoped to tree-view changes.

# Testing

Run the Docker containers with the test database instances

```
cd tests/e2e
docker-compose -f rte.docker-compose.yml up -d
```

And then you can run the tests

```
cd tests/e2e-playwright
npm run test:chromium -- tests/main/browser/key-list/key-tree-view.spec.ts
```

<img width="998" height="506" alt="image" src="https://github.com/user-attachments/assets/5e5a9074-d081-458d-9899-29cecffa506a" />

---

Closes #RI-8005

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it updates shared Playwright `KeyList` selectors/helpers used across browser E2E specs, which could introduce test flakiness or break existing tests if UI testids changed.
> 
> **Overview**
> Adds a new serial Playwright spec (`key-tree-view.spec.ts`) that covers key grouping into folders, expand/collapse behavior, folder badges/namespace tooltip, delimiter changes (including multi-delimiter and cancel), sort order switching, filter persistence when switching List↔Tree, and view persistence after refresh.
> 
> Updates the shared `KeyList` page object to align with the tree-view settings moving from a dialog to a popover and to provide more reliable tree assertions (folder lookup/hover + tooltip helper, delimiter chip interactions, sort selector, and expand/collapse based on child visibility). Also marks the corresponding Tree View items as implemented in `TEST_PLAN.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c04fe00d9b7df8512382fd01124ed85eed9201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->