### PR TITLE
RI-8159: [BE] vector set similarity

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search Preview.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search Preview.bru
@@ -27,20 +27,18 @@ docs {
 
   ## Request Body
 
-  Same shape as `POST /vector-set/similarity-search`. The only difference is that all query fields are optional — when none is supplied the endpoint returns an empty preview instead of a `400`.
+  Same shape as `POST /vector-set/similarity-search` — exactly one of `elementName`, `vectorValues`, `vectorFp32` must be supplied.
 
   | Field | Type | Description |
   |-------|------|-------------|
   | `keyName` | string | The Vector Set key name. Required (`@IsDefined` on the DTO). |
-  | `elementName` | string | (Optional) Existing element's vector as the query |
-  | `vectorValues` | number[] | (Optional) Query vector as numeric values |
-  | `vectorFp32` | string | (Optional) Query vector as a base64-encoded little-endian FP32 blob |
+  | `elementName` | string | (One-of) Existing element's vector as the query |
+  | `vectorValues` | number[] | (One-of) Query vector as numeric values |
+  | `vectorFp32` | string | (One-of) Query vector as a base64-encoded little-endian FP32 blob |
   | `count` | number | Maximum number of results (omitted from preview when undefined) |
   | `filter` | string | Optional filter expression evaluated against element attributes |
 
-  At most one of `elementName`, `vectorValues`, `vectorFp32` may be present. Supplying more than one returns `400`.
-
-  When **none** of `elementName` / `vectorValues` / `vectorFp32` is supplied the response `preview` is an empty string — the FE treats that as "nothing to show yet" and hides the preview bar.
+  Exactly one of `elementName`, `vectorValues`, `vectorFp32` must be present — zero or more than one returns `400` (same rule as the search endpoint).
 
   ## Response
 
@@ -54,24 +52,9 @@ docs {
 
   | Status | Condition |
   |--------|-----------|
-  | `400` | More than one of `elementName` / `vectorValues` / `vectorFp32` supplied, invalid `count`, or invalid `vectorFp32` base64 |
+  | `400` | Zero or more than one of `elementName` / `vectorValues` / `vectorFp32` supplied, invalid `count`, or invalid `vectorFp32` base64 |
 
   ## Examples
-
-  ### Empty preview when no query payload is supplied
-
-  ```json
-  {
-    "keyName": "vset:small_3d",
-    "count": 10
-  }
-  ```
-
-  Returns:
-
-  ```json
-  { "preview": "" }
-  ```
 
   ### Preview for FP32 input
 
@@ -92,7 +75,7 @@ docs {
   ## Notes
 
   - `WITHSCORES` and `WITHATTRIBS` are always rendered (matches the search endpoint).
-  - When **no** query field is supplied, the response `preview` is an empty string instead of a placeholder command.
+  - The FE is expected to gate the call so the preview endpoint is only hit once the form has resolved to exactly one query mode.
 }
 
 settings {

--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search Preview.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search Preview.bru
@@ -1,0 +1,100 @@
+meta {
+  name: Similarity Search Preview
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/vector-set/similarity-search/preview
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "vset:small_3d",
+    "vectorValues": [0.1, 0.2, 0.3],
+    "count": 10
+  }
+}
+
+docs {
+  # Similarity Search Preview
+
+  Returns a human-readable preview of the `VSIM` command that the similarity-search endpoint would execute for the supplied DTO. Reuses the same internal command builder as `POST /vector-set/similarity-search` so the preview cannot drift from what is actually executed when the form is submitted.
+
+  Designed to be called (debounced) by the FE once the similarity-search form is valid so the UI always shows the exact command that will run.
+
+  ## Request Body
+
+  Same shape as `POST /vector-set/similarity-search`. The only difference is that all query fields are optional — when none is supplied the endpoint returns an empty preview instead of a `400`.
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The Vector Set key name. Required (`@IsDefined` on the DTO). |
+  | `elementName` | string | (Optional) Existing element's vector as the query |
+  | `vectorValues` | number[] | (Optional) Query vector as numeric values |
+  | `vectorFp32` | string | (Optional) Query vector as a base64-encoded little-endian FP32 blob |
+  | `count` | number | Maximum number of results (omitted from preview when undefined) |
+  | `filter` | string | Optional filter expression evaluated against element attributes |
+
+  At most one of `elementName`, `vectorValues`, `vectorFp32` may be present. Supplying more than one returns `400`.
+
+  When **none** of `elementName` / `vectorValues` / `vectorFp32` is supplied the response `preview` is an empty string — the FE treats that as "nothing to show yet" and hides the preview bar.
+
+  ## Response
+
+  ```json
+  {
+    "preview": "VSIM vset:small_3d VALUES 3 0.1 0.2 0.3 COUNT 10 WITHSCORES WITHATTRIBS"
+  }
+  ```
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | More than one of `elementName` / `vectorValues` / `vectorFp32` supplied, invalid `count`, or invalid `vectorFp32` base64 |
+
+  ## Examples
+
+  ### Empty preview when no query payload is supplied
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "count": 10
+  }
+  ```
+
+  Returns:
+
+  ```json
+  { "preview": "" }
+  ```
+
+  ### Preview for FP32 input
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "vectorFp32": "AACAPwAAAEAAAEBA",
+    "count": 10
+  }
+  ```
+
+  Returns the FP32 vector rendered as a quoted `\xHH` escape string so the command is copy-paste-safe into `redis-cli`:
+
+  ```
+  VSIM vset:small_3d FP32 "\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40" COUNT 10 WITHSCORES WITHATTRIBS
+  ```
+
+  ## Notes
+
+  - `WITHSCORES` and `WITHATTRIBS` are always rendered (matches the search endpoint).
+  - When **no** query field is supplied, the response `preview` is an empty string instead of a placeholder command.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search.bru
+++ b/redisinsight/api/bruno/RedisInsight/Vector Set/Similarity Search.bru
@@ -1,0 +1,110 @@
+meta {
+  name: Similarity Search
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/vector-set/similarity-search
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "vset:small_3d",
+    "elementName": "item_1",
+    "count": 10
+  }
+}
+
+docs {
+  # Similarity Search
+
+  Runs a vector similarity search against the Vector Set stored at `keyName`. Uses the Redis `VSIM` command with `WITHSCORES` and `WITHATTRIBS` always enabled, so each match returned by this endpoint includes its similarity score and any attributes stored on the element.
+
+  ## Request Body
+
+  Exactly one of `elementName`, `vectorValues`, or `vectorFp32` must be supplied:
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The Vector Set key name |
+  | `elementName` | string | (One-of) Use an existing element's vector as the query |
+  | `vectorValues` | number[] | (One-of) Query vector as numeric values |
+  | `vectorFp32` | string | (One-of) Query vector as a base64-encoded little-endian FP32 blob (length must be a non-zero multiple of 4 bytes) |
+  | `count` | number | Maximum number of results (default `10`, max `1000`) |
+  | `filter` | string | Optional filter expression evaluated against element attributes (passed verbatim to Redis after `FILTER`) |
+
+  ## Response
+
+  Returns `200 OK` with the matched elements ordered by descending similarity score.
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The Vector Set key name |
+  | `elements` | array | List of `{ name, score, attributes? }` matches |
+  | `elements[].name` | string | Matched element name |
+  | `elements[].score` | number | Similarity score returned by `VSIM ... WITHSCORES` |
+  | `elements[].attributes` | string | Attributes string stored on the element (omitted when the element has none) |
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Multiple or no query payloads (`elementName` / `vectorValues` / `vectorFp32`), or key exists but is not a Vector Set (WRONGTYPE) |
+  | `404` | Key does not exist |
+
+  ## Examples
+
+  ### Search by existing element
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "elementName": "item_1",
+    "count": 5
+  }
+  ```
+
+  ### Search by raw values
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "vectorValues": [0.1, 0.2, 0.3],
+    "count": 5
+  }
+  ```
+
+  ### Search by FP32 blob
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "vectorFp32": "AACAPwAAAEAAAEBA",
+    "count": 5
+  }
+  ```
+
+  ### Search with attribute filter
+
+  ```json
+  {
+    "keyName": "vset:small_3d",
+    "elementName": "item_1",
+    "count": 5,
+    "filter": "@color == 'red'"
+  }
+  ```
+
+  ## Notes
+
+  - `WITHSCORES` and `WITHATTRIBS` are always applied server-side; they are not exposed as request fields so the response shape is stable.
+  - Results are ordered by descending similarity score.
+  - When an element has no attributes, the `attributes` field is omitted from that match.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -111,6 +111,7 @@ export enum BrowserToolVectorSetCommands {
   VGetAttr = 'VGETATTR',
   VSetAttr = 'VSETATTR',
   VRem = 'VREM',
+  VSim = 'VSIM',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -1,5 +1,6 @@
 import { Factory } from 'fishery';
 import { faker } from '@faker-js/faker';
+import { BrowserToolVectorSetCommands } from 'src/modules/browser/constants/browser-tool-commands';
 import {
   AddElementsToVectorSetDto,
   AddVectorSetElementDto,
@@ -9,7 +10,10 @@ import {
   VectorSetElementKeyDto,
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
+  SearchVectorSetMatchDto,
+  SearchVectorSetResponse,
   SetVectorSetElementAttributeDto,
+  SimilaritySearchDto,
 } from 'src/modules/browser/vector-set/dto';
 
 export const vectorSetElementFactory =
@@ -132,3 +136,143 @@ export const getVectorSetElementsResponseFactory =
       elementNames,
     };
   });
+
+export const searchVectorSetByElementDtoFactory =
+  Factory.define<SimilaritySearchDto>(() => ({
+    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
+    elementName: Buffer.from(faker.string.alphanumeric(8)),
+    vectorValues: undefined,
+    vectorFp32: undefined,
+    count: faker.number.int({ min: 1, max: 100 }),
+  }));
+
+export const searchVectorSetByValuesDtoFactory =
+  Factory.define<SimilaritySearchDto>(() => ({
+    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
+    elementName: undefined,
+    vectorValues: [1, 2, 3],
+    vectorFp32: undefined,
+    count: faker.number.int({ min: 1, max: 100 }),
+  }));
+
+export const searchVectorSetByFp32DtoFactory =
+  Factory.define<SimilaritySearchDto>(() => ({
+    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
+    elementName: undefined,
+    vectorValues: undefined,
+    vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
+    count: faker.number.int({ min: 1, max: 100 }),
+  }));
+
+export const searchVectorSetMatchFactory =
+  Factory.define<SearchVectorSetMatchDto>(({ transientParams }) => {
+    const match: SearchVectorSetMatchDto = {
+      name: Buffer.from(faker.string.alphanumeric(8)),
+      score: parseFloat(
+        faker.number.float({ min: 0, max: 1, fractionDigits: 4 }).toFixed(4),
+      ),
+    };
+    if (transientParams.withAttributes) {
+      match.attributes = JSON.stringify({
+        [faker.string.alpha(5)]: faker.string.alpha(5),
+      });
+    }
+    return match;
+  });
+
+export const searchVectorSetResponseFactory =
+  Factory.define<SearchVectorSetResponse>(() => ({
+    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
+    elements: searchVectorSetMatchFactory.buildList(2),
+  }));
+
+/**
+ * Stable VSIM match fixtures used by `similaritySearch` service specs. These are
+ * exported as constants (instead of factory builds) so tests that compare the
+ * exact reply payload to the parsed response can rely on referential equality
+ * for the buffer/string fields.
+ */
+export const SEARCH_VSIM_MATCH_NAME_1 = Buffer.from('match_1');
+export const SEARCH_VSIM_MATCH_NAME_2 = Buffer.from('match_2');
+export const SEARCH_VSIM_MATCH_ATTRIBUTES_1 = JSON.stringify({ k: 'v' });
+
+/**
+ * Canonical flat VSIM reply for two matches, mirroring the Redis wire layout
+ * `name, score, attributes` per match (stride 3). The first match carries
+ * attributes; the second has `null` so specs cover both branches in one reply.
+ */
+export const SEARCH_VSIM_REPLY_TWO_MATCHES: Array<string | Buffer | null> = [
+  SEARCH_VSIM_MATCH_NAME_1,
+  '0.95',
+  SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+  SEARCH_VSIM_MATCH_NAME_2,
+  '0.81',
+  null,
+];
+
+type VsimCommandOptions = {
+  /** Append `COUNT <n>`. Defaults to true; set to false to omit the segment. */
+  includeCount?: boolean;
+  /** Append `FILTER <expr>` after `WITHSCORES`/`WITHATTRIBS`. */
+  filter?: string;
+};
+
+const appendCommonVsimSuffix = (
+  args: unknown[],
+  count: number | undefined,
+  options: VsimCommandOptions,
+): unknown[] => {
+  if (options.includeCount !== false && count !== undefined) {
+    args.push('COUNT', count);
+  }
+  args.push('WITHSCORES', 'WITHATTRIBS');
+  if (options.filter !== undefined) {
+    args.push('FILTER', options.filter);
+  }
+  return args;
+};
+
+/**
+ * Build the expected VSIM command array for an element-mode similarity
+ * search, in the exact order the production `buildVsimCommand` emits it.
+ * Specs use this both as a `when().calledWith(...)` matcher and as the
+ * argument passed to `expect(...).toHaveBeenCalledWith(...)`.
+ */
+export const buildVsimByElementCommand = (
+  dto: Pick<SimilaritySearchDto, 'keyName' | 'elementName' | 'count'>,
+  options: VsimCommandOptions = {},
+): unknown[] =>
+  appendCommonVsimSuffix(
+    [BrowserToolVectorSetCommands.VSim, dto.keyName, 'ELE', dto.elementName],
+    dto.count,
+    options,
+  );
+
+export const buildVsimByValuesCommand = (
+  dto: Pick<SimilaritySearchDto, 'keyName' | 'vectorValues' | 'count'>,
+  options: VsimCommandOptions = {},
+): unknown[] => {
+  const values = dto.vectorValues ?? [];
+  return appendCommonVsimSuffix(
+    [
+      BrowserToolVectorSetCommands.VSim,
+      dto.keyName,
+      'VALUES',
+      values.length,
+      ...values.map(String),
+    ],
+    dto.count,
+    options,
+  );
+};
+
+export const buildVsimByFp32Command = (
+  dto: Pick<SimilaritySearchDto, 'keyName' | 'count'>,
+  fp32Buffer: Buffer,
+  options: VsimCommandOptions = {},
+): unknown[] =>
+  appendCommonVsimSuffix(
+    [BrowserToolVectorSetCommands.VSim, dto.keyName, 'FP32', fp32Buffer],
+    dto.count,
+    options,
+  );

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -137,32 +137,24 @@ export const getVectorSetElementsResponseFactory =
     };
   });
 
-export const searchVectorSetByElementDtoFactory =
-  Factory.define<SimilaritySearchDto>(() => ({
-    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
-    elementName: Buffer.from(faker.string.alphanumeric(8)),
-    vectorValues: undefined,
-    vectorFp32: undefined,
-    count: faker.number.int({ min: 1, max: 100 }),
-  }));
+export const similaritySearchDtoFactory = Factory.define<
+  SimilaritySearchDto,
+  { variant?: 'element' | 'values' | 'fp32' }
+>(({ transientParams }) => {
+  const { variant = 'element' } = transientParams;
 
-export const searchVectorSetByValuesDtoFactory =
-  Factory.define<SimilaritySearchDto>(() => ({
+  return {
     keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
-    elementName: undefined,
-    vectorValues: [1, 2, 3],
-    vectorFp32: undefined,
+    elementName:
+      variant === 'element'
+        ? Buffer.from(faker.string.alphanumeric(8))
+        : undefined,
+    vectorValues: variant === 'values' ? [1, 2, 3] : undefined,
+    vectorFp32:
+      variant === 'fp32' ? FP32_VECTOR_FIXTURE_1_2_3.base64 : undefined,
     count: faker.number.int({ min: 1, max: 100 }),
-  }));
-
-export const searchVectorSetByFp32DtoFactory =
-  Factory.define<SimilaritySearchDto>(() => ({
-    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
-    elementName: undefined,
-    vectorValues: undefined,
-    vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
-    count: faker.number.int({ min: 1, max: 100 }),
-  }));
+  };
+});
 
 export const searchVectorSetMatchFactory =
   Factory.define<SearchVectorSetMatchDto>(({ transientParams }) => {

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -9,9 +9,6 @@ import {
   VectorSetElementDetailsDto,
   VectorSetElementKeyDto,
   GetVectorSetElementsDto,
-  GetVectorSetElementsResponse,
-  SearchVectorSetMatchDto,
-  SearchVectorSetResponse,
   SetVectorSetElementAttributeDto,
   SimilaritySearchDto,
 } from 'src/modules/browser/vector-set/dto';
@@ -122,21 +119,6 @@ export const createVectorSetDtoFactory = Factory.define<CreateVectorSetDto>(
   }),
 );
 
-export const getVectorSetElementsResponseFactory =
-  Factory.define<GetVectorSetElementsResponse>(({ transientParams }) => {
-    const elementNames =
-      transientParams.elementNames ??
-      vectorSetElementFactory.buildList(3).map((el) => el.name);
-
-    return {
-      keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
-      total: elementNames.length,
-      nextCursor: undefined,
-      isPaginationSupported: true,
-      elementNames,
-    };
-  });
-
 export const similaritySearchDtoFactory = Factory.define<
   SimilaritySearchDto,
   { variant?: 'element' | 'values' | 'fp32' }
@@ -155,28 +137,6 @@ export const similaritySearchDtoFactory = Factory.define<
     count: faker.number.int({ min: 1, max: 100 }),
   };
 });
-
-export const searchVectorSetMatchFactory =
-  Factory.define<SearchVectorSetMatchDto>(({ transientParams }) => {
-    const match: SearchVectorSetMatchDto = {
-      name: Buffer.from(faker.string.alphanumeric(8)),
-      score: parseFloat(
-        faker.number.float({ min: 0, max: 1, fractionDigits: 4 }).toFixed(4),
-      ),
-    };
-    if (transientParams.withAttributes) {
-      match.attributes = JSON.stringify({
-        [faker.string.alpha(5)]: faker.string.alpha(5),
-      });
-    }
-    return match;
-  });
-
-export const searchVectorSetResponseFactory =
-  Factory.define<SearchVectorSetResponse>(() => ({
-    keyName: Buffer.from(`vset:${faker.string.alphanumeric(6)}`),
-    elements: searchVectorSetMatchFactory.buildList(2),
-  }));
 
 /**
  * Stable VSIM match fixtures used by `similaritySearch` service specs. These are

--- a/redisinsight/api/src/modules/browser/vector-set/constants.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Stride of `VSIM ... WITHSCORES WITHATTRIBS` replies. The flat reply array
+ * contains 3 entries per match in the order `(name, score, attributes|null)`.
+ */
+export const VSIM_REPLY_STRIDE = 3;

--- a/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
@@ -9,3 +9,7 @@ export * from './delete.vector-set-elements.dto';
 export * from './delete.vector-set-elements.response';
 export * from './set.vector-set-element-attribute.dto';
 export * from './set.vector-set-element-attribute.response';
+export * from './similarity-search.dto';
+export * from './search.vector-set-match.dto';
+export * from './search.vector-set.response';
+export * from './search.vector-set.preview.response';

--- a/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set-match.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set-match.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+export class SearchVectorSetMatchDto {
+  @ApiProperty({
+    type: String,
+    description: 'Matched element name.',
+  })
+  @RedisStringType()
+  name: RedisString;
+
+  @ApiProperty({
+    type: Number,
+    description:
+      'Similarity score between the query vector and the matched element. ' +
+      'Returned by VSIM ... WITHSCORES.',
+  })
+  score: number;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Attributes string stored on the matched element (typically JSON). ' +
+      'Omitted when the element has no attributes.',
+  })
+  attributes?: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.preview.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.preview.response.ts
@@ -10,8 +10,9 @@ export class SearchVectorSetPreviewResponse {
     type: String,
     description:
       'Human-readable VSIM command preview built from the supplied DTO. ' +
-      'Missing fields (vector / element / key) are rendered as `<…>` ' +
-      'placeholders so the preview stays useful while the form is being filled in.',
+      'The endpoint requires exactly one of `elementName` / `vectorValues` ' +
+      '/ `vectorFp32` to be present — under- or over-specified payloads are ' +
+      'rejected with `400` (same rules as the search endpoint).',
   })
   preview: string;
 }

--- a/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.preview.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.preview.response.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Response from the VSIM preview endpoint. Returns the human-readable
+ * command string that would be sent to Redis if the user submitted the
+ * search with the supplied DTO right now.
+ */
+export class SearchVectorSetPreviewResponse {
+  @ApiProperty({
+    type: String,
+    description:
+      'Human-readable VSIM command preview built from the supplied DTO. ' +
+      'Missing fields (vector / element / key) are rendered as `<…>` ' +
+      'placeholders so the preview stays useful while the form is being filled in.',
+  })
+  preview: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/search.vector-set.response.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { KeyResponse } from 'src/modules/browser/keys/dto';
+import { SearchVectorSetMatchDto } from 'src/modules/browser/vector-set/dto/search.vector-set-match.dto';
+
+export class SearchVectorSetResponse extends KeyResponse {
+  @ApiProperty({
+    description: 'List of matches ordered by descending similarity score.',
+    type: [SearchVectorSetMatchDto],
+    isArray: true,
+  })
+  @Type(() => SearchVectorSetMatchDto)
+  elements: SearchVectorSetMatchDto[];
+}

--- a/redisinsight/api/src/modules/browser/vector-set/dto/similarity-search.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/similarity-search.dto.ts
@@ -25,12 +25,12 @@ export const VSIM_FILTER_MAX_LENGTH = 2048;
  *     that the search endpoint would execute for the same payload.
  *
  * All three query fields (`elementName`, `vectorValues`, `vectorFp32`) are
- * marked `@IsOptional` so that the preview endpoint can accept an empty
- * payload (and respond with an empty preview). The "exactly one of the three
- * must be supplied" rule is enforced uniformly at the service layer
- * (`resolveVsimQuery`), which raises `BadRequestException` with a clear
- * message if zero or more than one of the three is present. The search
- * endpoint therefore still rejects empty / over-specified payloads with `400`.
+ * marked `@IsOptional` because exactly one — not all — must be supplied;
+ * the "exactly one of the three" rule is enforced uniformly at the service
+ * layer (`resolveVsimQuery`), which raises `BadRequestException` with a
+ * clear message if zero or more than one of the three is present. Both
+ * the search and preview endpoints reject empty / over-specified payloads
+ * with `400`.
  */
 export class SimilaritySearchDto extends KeyDto {
   @ApiPropertyOptional({

--- a/redisinsight/api/src/modules/browser/vector-set/dto/similarity-search.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/similarity-search.dto.ts
@@ -1,0 +1,97 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBase64,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsRedisString, RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+
+export const VSIM_DEFAULT_COUNT = 10;
+export const VSIM_MAX_COUNT = 1000;
+export const VSIM_FILTER_MAX_LENGTH = 2048;
+
+/**
+ * Request DTO shared by both VSIM endpoints:
+ *   - `POST /vector-set/similarity-search` — executes the search.
+ *   - `POST /vector-set/similarity-search/preview` — renders the command
+ *     that the search endpoint would execute for the same payload.
+ *
+ * All three query fields (`elementName`, `vectorValues`, `vectorFp32`) are
+ * marked `@IsOptional` so that the preview endpoint can accept an empty
+ * payload (and respond with an empty preview). The "exactly one of the three
+ * must be supplied" rule is enforced uniformly at the service layer
+ * (`resolveVsimQuery`), which raises `BadRequestException` with a clear
+ * message if zero or more than one of the three is present. The search
+ * endpoint therefore still rejects empty / over-specified payloads with `400`.
+ */
+export class SimilaritySearchDto extends KeyDto {
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Run similarity search using an existing element name as the query ' +
+      'vector. Mutually exclusive with `vectorValues` and `vectorFp32`; ' +
+      'exactly one of the three must be supplied for the search endpoint.',
+  })
+  @IsOptional()
+  @IsRedisString()
+  @RedisStringType()
+  elementName?: RedisString;
+
+  @ApiPropertyOptional({
+    description:
+      'Query vector embedding as numeric values. Mutually exclusive with ' +
+      '`elementName` and `vectorFp32`; exactly one of the three must be ' +
+      'supplied for the search endpoint.',
+    type: [Number],
+    isArray: true,
+  })
+  @IsOptional()
+  @IsArray()
+  vectorValues?: number[];
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Query vector embedding as a base64-encoded little-endian IEEE-754 ' +
+      'FP32 blob. Decoded length must be a non-zero multiple of 4 bytes. ' +
+      'Mutually exclusive with `elementName` and `vectorValues`.',
+  })
+  @IsOptional()
+  @IsString()
+  @IsBase64()
+  vectorFp32?: string;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of similar elements to return.',
+    type: Number,
+    minimum: 1,
+    maximum: VSIM_MAX_COUNT,
+    default: VSIM_DEFAULT_COUNT,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(VSIM_MAX_COUNT)
+  @Type(() => Number)
+  count?: number = VSIM_DEFAULT_COUNT;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional filter expression evaluated against element attributes. ' +
+      'Passed verbatim to Redis after the `FILTER` token.',
+    type: String,
+    maxLength: VSIM_FILTER_MAX_LENGTH,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(VSIM_FILTER_MAX_LENGTH)
+  filter?: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
@@ -220,7 +220,7 @@ export class VectorSetController extends BrowserBaseController {
     description:
       'Build a human-readable preview of the VSIM command that the similarity-search endpoint would execute for the supplied DTO. ' +
       'Reuses the same internal command builder as the search endpoint so the preview cannot drift from what is actually executed. ' +
-      'Returns an empty `preview` string when no query payload (`elementName` / `vectorValues` / `vectorFp32`) is supplied.',
+      'Requires exactly one of `elementName` / `vectorValues` / `vectorFp32` — under- or over-specified payloads are rejected with `400`.',
     statusCode: 200,
     responses: [
       {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
@@ -21,6 +21,9 @@ import {
   DeleteVectorSetElementsResponse,
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
+  SimilaritySearchDto,
+  SearchVectorSetPreviewResponse,
+  SearchVectorSetResponse,
   SetVectorSetElementAttributeDto,
   SetVectorSetElementAttributeResponse,
   VectorSetElementDetailsDto,
@@ -188,5 +191,53 @@ export class VectorSetController extends BrowserBaseController {
     @Body() dto: DeleteVectorSetElementsDto,
   ): Promise<DeleteVectorSetElementsResponse> {
     return await this.vectorSetService.deleteElements(clientMetadata, dto);
+  }
+
+  @Post('/similarity-search')
+  @ApiRedisInstanceOperation({
+    description:
+      'Run a vector similarity search (VSIM) against the VectorSet stored at key. ' +
+      'WITHSCORES and WITHATTRIBS are always applied so each match carries a similarity score and the element attributes (when present).',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: SearchVectorSetResponse,
+      },
+    ],
+  })
+  @ApiQueryRedisStringEncoding()
+  async similaritySearch(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: SimilaritySearchDto,
+  ): Promise<SearchVectorSetResponse> {
+    return await this.vectorSetService.similaritySearch(clientMetadata, dto);
+  }
+
+  @Post('/similarity-search/preview')
+  @ApiRedisInstanceOperation({
+    description:
+      'Build a human-readable preview of the VSIM command that the similarity-search endpoint would execute for the supplied DTO. ' +
+      'Reuses the same internal command builder as the search endpoint so the preview cannot drift from what is actually executed. ' +
+      'Returns an empty `preview` string when no query payload (`elementName` / `vectorValues` / `vectorFp32`) is supplied.',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: SearchVectorSetPreviewResponse,
+      },
+    ],
+  })
+  @ApiQueryRedisStringEncoding()
+  async getSimilaritySearchPreview(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: SimilaritySearchDto,
+  ): Promise<SearchVectorSetPreviewResponse> {
+    return await this.vectorSetService.getSimilaritySearchPreview(
+      clientMetadata,
+      dto,
+    );
   }
 }

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -27,9 +27,7 @@ import {
   FP32_VECTOR_FIXTURE_1_2_3,
   getVectorSetElementsDtoFactory,
   getVectorSetElementDetailsDtoFactory,
-  searchVectorSetByElementDtoFactory,
-  searchVectorSetByFp32DtoFactory,
-  searchVectorSetByValuesDtoFactory,
+  similaritySearchDtoFactory,
   SEARCH_VSIM_MATCH_ATTRIBUTES_1,
   SEARCH_VSIM_MATCH_NAME_1,
   SEARCH_VSIM_MATCH_NAME_2,
@@ -779,9 +777,15 @@ describe('VectorSetService', () => {
   });
 
   describe('similaritySearch', () => {
-    const mockSearchByElementDto = searchVectorSetByElementDtoFactory.build();
-    const mockSearchByValuesDto = searchVectorSetByValuesDtoFactory.build();
-    const mockSearchByFp32Dto = searchVectorSetByFp32DtoFactory.build();
+    const mockSearchByElementDto = similaritySearchDtoFactory.build();
+    const mockSearchByValuesDto = similaritySearchDtoFactory.build(
+      {},
+      { transient: { variant: 'values' } },
+    );
+    const mockSearchByFp32Dto = similaritySearchDtoFactory.build(
+      {},
+      { transient: { variant: 'fp32' } },
+    );
 
     beforeEach(() => {
       when(client.sendCommand)

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -17,6 +17,9 @@ import { BrowserToolVectorSetCommands } from 'src/modules/browser/constants/brow
 import {
   addElementsToVectorSetDtoFactory,
   addVectorSetElementDtoFactory,
+  buildVsimByElementCommand,
+  buildVsimByFp32Command,
+  buildVsimByValuesCommand,
   createVectorSetDtoFactory,
   deleteVectorSetElementsDtoFactory,
   downloadVectorSetEmbeddingDtoFactory,
@@ -24,6 +27,13 @@ import {
   FP32_VECTOR_FIXTURE_1_2_3,
   getVectorSetElementsDtoFactory,
   getVectorSetElementDetailsDtoFactory,
+  searchVectorSetByElementDtoFactory,
+  searchVectorSetByFp32DtoFactory,
+  searchVectorSetByValuesDtoFactory,
+  SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+  SEARCH_VSIM_MATCH_NAME_1,
+  SEARCH_VSIM_MATCH_NAME_2,
+  SEARCH_VSIM_REPLY_TWO_MATCHES,
   setVectorSetElementAttributeDtoFactory,
   vectorSetElementFactory,
 } from 'src/modules/browser/vector-set/__tests__/vector-set.factory';
@@ -765,6 +775,398 @@ describe('VectorSetService', () => {
       await expect(
         service.downloadEmbedding(mockBrowserClientMetadata, mockDownloadDto),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('similaritySearch', () => {
+    const mockSearchByElementDto = searchVectorSetByElementDtoFactory.build();
+    const mockSearchByValuesDto = searchVectorSetByValuesDtoFactory.build();
+    const mockSearchByFp32Dto = searchVectorSetByFp32DtoFactory.build();
+
+    beforeEach(() => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockSearchByElementDto.keyName,
+        ])
+        .mockResolvedValue(true);
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockSearchByValuesDto.keyName,
+        ])
+        .mockResolvedValue(true);
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockSearchByFp32Dto.keyName,
+        ])
+        .mockResolvedValue(true);
+    });
+
+    it('should run VSIM by element with COUNT, WITHSCORES and WITHATTRIBS', async () => {
+      const expectedCommand = buildVsimByElementCommand(mockSearchByElementDto);
+      when(client.sendCommand)
+        .calledWith(expectedCommand)
+        .mockResolvedValue(SEARCH_VSIM_REPLY_TWO_MATCHES);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+      expect(result.keyName).toEqual(mockSearchByElementDto.keyName);
+      expect(result.elements).toHaveLength(2);
+      expect(result.elements[0]).toEqual({
+        name: SEARCH_VSIM_MATCH_NAME_1,
+        score: 0.95,
+        attributes: SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+      });
+      expect(result.elements[1]).toEqual({
+        name: SEARCH_VSIM_MATCH_NAME_2,
+        score: 0.81,
+      });
+      expect('attributes' in result.elements[1]).toBe(false);
+    });
+
+    it('should run VSIM by VALUES with stringified vector entries', async () => {
+      const expectedCommand = buildVsimByValuesCommand(mockSearchByValuesDto);
+      when(client.sendCommand)
+        .calledWith(expectedCommand)
+        .mockResolvedValue([]);
+
+      await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByValuesDto,
+      );
+
+      expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+    });
+
+    it('should run VSIM by FP32 with a Buffer payload', async () => {
+      const expectedCommand = buildVsimByFp32Command(
+        mockSearchByFp32Dto,
+        FP32_VECTOR_FIXTURE_1_2_3.buffer,
+      );
+      when(client.sendCommand)
+        .calledWith(expectedCommand)
+        .mockResolvedValue([]);
+
+      await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByFp32Dto,
+      );
+
+      expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+    });
+
+    it('should append FILTER after COUNT/WITHSCORES/WITHATTRIBS', async () => {
+      const dto = { ...mockSearchByElementDto, filter: '@score > 0.5' };
+      const expectedCommand = buildVsimByElementCommand(dto, {
+        filter: dto.filter,
+      });
+      when(client.sendCommand)
+        .calledWith(expectedCommand)
+        .mockResolvedValue([]);
+
+      await service.similaritySearch(mockBrowserClientMetadata, dto);
+
+      expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+    });
+
+    it('should omit COUNT when count is undefined but still send WITHSCORES/WITHATTRIBS', async () => {
+      const dto = { ...mockSearchByElementDto, count: undefined };
+      const expectedCommand = buildVsimByElementCommand(dto, {
+        includeCount: false,
+      });
+      when(client.sendCommand)
+        .calledWith(expectedCommand)
+        .mockResolvedValue([]);
+
+      await service.similaritySearch(mockBrowserClientMetadata, dto);
+
+      expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+    });
+
+    it('should parse a string score into a float number', async () => {
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([SEARCH_VSIM_MATCH_NAME_1, '0.952381', null]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(typeof result.elements[0].score).toBe('number');
+      expect(result.elements[0].score).toBeCloseTo(0.952381, 6);
+    });
+
+    it('should parse a Buffer score into a float number', async () => {
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([
+          SEARCH_VSIM_MATCH_NAME_1,
+          Buffer.from('0.4275'),
+          null,
+        ]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(typeof result.elements[0].score).toBe('number');
+      expect(result.elements[0].score).toBeCloseTo(0.4275, 6);
+    });
+
+    it('should pass through a numeric (RESP3 double) score unchanged', async () => {
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([SEARCH_VSIM_MATCH_NAME_1, 0.123456, null]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(typeof result.elements[0].score).toBe('number');
+      expect(result.elements[0].score).toBe(0.123456);
+    });
+
+    it('should decode a Buffer attributes payload into a string', async () => {
+      const attrs = JSON.stringify({ tag: 'red' });
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([
+          SEARCH_VSIM_MATCH_NAME_1,
+          '0.5',
+          Buffer.from(attrs),
+        ]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(result.elements[0].attributes).toBe(attrs);
+    });
+
+    it('should return empty elements array when VSIM returns []', async () => {
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(result.elements).toEqual([]);
+    });
+
+    it('should defensively truncate replies whose length is not a multiple of 3', async () => {
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockResolvedValue([
+          ...SEARCH_VSIM_REPLY_TWO_MATCHES,
+          Buffer.from('orphan'),
+        ]);
+
+      const result = await service.similaritySearch(
+        mockBrowserClientMetadata,
+        mockSearchByElementDto,
+      );
+
+      expect(result.elements).toHaveLength(2);
+    });
+
+    it('should throw BadRequestException when no query payload is supplied', async () => {
+      const dto = {
+        ...mockSearchByElementDto,
+        elementName: undefined,
+        vectorValues: undefined,
+        vectorFp32: undefined,
+      };
+
+      await expect(
+        service.similaritySearch(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when more than one query payload is supplied', async () => {
+      const dto = { ...mockSearchByElementDto, vectorValues: [1, 2, 3] };
+
+      await expect(
+        service.similaritySearch(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockSearchByElementDto.keyName,
+        ])
+        .mockResolvedValue(false);
+
+      await expect(
+        service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException for wrong type error', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'VSIM',
+      };
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockRejectedValue(replyError);
+
+      await expect(
+        service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException when user has no permissions', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'VSIM',
+      };
+      when(client.sendCommand)
+        .calledWith(buildVsimByElementCommand(mockSearchByElementDto))
+        .mockRejectedValue(replyError);
+
+      await expect(
+        service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('getSimilaritySearchPreview', () => {
+    it('should render VSIM preview with ELE clause and quote element when needed', async () => {
+      const dto = {
+        keyName: Buffer.from('mykey'),
+        elementName: Buffer.from('hello world'),
+        count: 10,
+      };
+
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        dto,
+      );
+
+      expect(preview).toBe(
+        'VSIM mykey ELE "hello world" COUNT 10 WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should render VSIM preview with VALUES clause for numeric vector input', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          vectorValues: [1, 2, 3],
+          count: 5,
+        },
+      );
+
+      expect(preview).toBe(
+        'VSIM mykey VALUES 3 1 2 3 COUNT 5 WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should render FP32 vector as a quoted `\\xHH...` escape string', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
+          count: 10,
+        },
+      );
+
+      const expectedEscape = Array.from(FP32_VECTOR_FIXTURE_1_2_3.buffer)
+        .map((byte) => `\\x${byte.toString(16).padStart(2, '0')}`)
+        .join('');
+      expect(preview).toBe(
+        `VSIM mykey FP32 "${expectedEscape}" COUNT 10 WITHSCORES WITHATTRIBS`,
+      );
+    });
+
+    it('should return an empty preview when no query payload is supplied', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          count: 10,
+        },
+      );
+
+      expect(preview).toBe('');
+    });
+
+    it('should return an empty preview even when only `keyName` and `filter` are supplied', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          filter: '.year > 2020',
+          count: 10,
+        },
+      );
+
+      expect(preview).toBe('');
+    });
+
+    it('should append FILTER clause after WITHSCORES/WITHATTRIBS', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          vectorValues: [1, 2, 3],
+          count: 10,
+          filter: '.year > 2020',
+        },
+      );
+
+      expect(preview).toBe(
+        'VSIM mykey VALUES 3 1 2 3 COUNT 10 WITHSCORES WITHATTRIBS FILTER ".year > 2020"',
+      );
+    });
+
+    it('should omit COUNT clause when count is undefined', async () => {
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          vectorValues: [1, 2],
+        },
+      );
+
+      expect(preview).toBe('VSIM mykey VALUES 2 1 2 WITHSCORES WITHATTRIBS');
+    });
+
+    it('should throw BadRequestException when more than one query payload is supplied', async () => {
+      await expect(
+        service.getSimilaritySearchPreview(mockBrowserClientMetadata, {
+          keyName: Buffer.from('mykey'),
+          elementName: Buffer.from('foo'),
+          vectorValues: [1, 2, 3],
+          count: 10,
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -1109,29 +1109,23 @@ describe('VectorSetService', () => {
       );
     });
 
-    it('should return an empty preview when no query payload is supplied', async () => {
-      const { preview } = await service.getSimilaritySearchPreview(
-        mockBrowserClientMetadata,
-        {
+    it('should throw BadRequestException when no query payload is supplied', async () => {
+      await expect(
+        service.getSimilaritySearchPreview(mockBrowserClientMetadata, {
           keyName: Buffer.from('mykey'),
           count: 10,
-        },
-      );
-
-      expect(preview).toBe('');
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
-    it('should return an empty preview even when only `keyName` and `filter` are supplied', async () => {
-      const { preview } = await service.getSimilaritySearchPreview(
-        mockBrowserClientMetadata,
-        {
+    it('should throw BadRequestException even when only `keyName` and `filter` are supplied', async () => {
+      await expect(
+        service.getSimilaritySearchPreview(mockBrowserClientMetadata, {
           keyName: Buffer.from('mykey'),
           filter: '.year > 2020',
           count: 10,
-        },
-      );
-
-      expect(preview).toBe('');
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should append FILTER clause after WITHSCORES/WITHATTRIBS', async () => {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -20,12 +20,14 @@ import {
   DeleteVectorSetElementsResponse,
   GetVectorSetElementsDto,
   GetVectorSetElementsResponse,
+  SimilaritySearchDto,
+  SearchVectorSetPreviewResponse,
+  SearchVectorSetResponse,
   SetVectorSetElementAttributeDto,
   SetVectorSetElementAttributeResponse,
   VectorSetElementDetailsDto,
   VectorSetElementKeyDto,
   VECTOR_EMBEDDING_MAX_DISPLAY_LENGTH,
-  AddVectorSetElementDto,
 } from 'src/modules/browser/vector-set/dto';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { Readable } from 'stream';
@@ -38,6 +40,12 @@ import {
   checkIfKeyExists,
   checkIfKeyNotExists,
 } from 'src/modules/browser/utils';
+import {
+  buildVaddCommand,
+  buildVsimCommand,
+  formatVsimCommandPreview,
+  parseVsimReply,
+} from 'src/modules/browser/vector-set/vector-set.utils';
 
 @Injectable()
 export class VectorSetService {
@@ -58,7 +66,7 @@ export class VectorSetService {
       await checkIfKeyExists(keyName, client);
 
       const commands: RedisClientCommand[] = elements.map((element) =>
-        this.buildVaddCommand(keyName, element),
+        buildVaddCommand(keyName, element),
       );
 
       if (expire) {
@@ -106,7 +114,7 @@ export class VectorSetService {
       await checkIfKeyNotExists(keyName, client);
 
       const commands: RedisClientCommand[] = elements.map((element) =>
-        this.buildVaddCommand(keyName, element),
+        buildVaddCommand(keyName, element),
       );
 
       const transactionResults = await client.sendPipeline(commands);
@@ -387,55 +395,74 @@ export class VectorSetService {
     }
   }
 
-  private buildVaddCommand(
-    keyName: Buffer | string,
-    element: AddVectorSetElementDto,
-  ): RedisClientCommand {
-    const args: Array<string | number | Buffer> = [
-      BrowserToolVectorSetCommands.VAdd,
-      keyName,
-    ];
-
-    // Dispatch explicitly on each payload rather than assuming `vectorValues`
-    // is defined. DTO validation should already guarantee exactly one of the
-    // two is present, but we stay defensive so any future internal caller
-    // that bypasses class-validator still fails loudly instead of crashing on
-    // an `undefined.length` read or silently dropping one of the two inputs.
-    const hasVectorFp32 =
-      typeof element.vectorFp32 === 'string' && element.vectorFp32.length > 0;
-    const hasVectorValues =
-      Array.isArray(element.vectorValues) && element.vectorValues.length > 0;
-
-    if (hasVectorFp32 && hasVectorValues) {
-      throw new BadRequestException(
-        'Vector element must supply either `vectorValues` (number[]) or `vectorFp32` (base64 string), not both.',
+  public async similaritySearch(
+    clientMetadata: ClientMetadata,
+    dto: SimilaritySearchDto,
+  ): Promise<SearchVectorSetResponse> {
+    try {
+      this.logger.debug(
+        'Running similarity search on the VectorSet data type.',
+        clientMetadata,
       );
+      const { keyName } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyNotExists(keyName, client);
+
+      const command = buildVsimCommand(dto);
+      const reply = (await client.sendCommand(command)) as Array<
+        string | Buffer | null
+      >;
+
+      const elements = parseVsimReply(reply, this.logger);
+
+      this.logger.debug(
+        'Succeed to run similarity search on the VectorSet data type.',
+        clientMetadata,
+      );
+
+      return plainToInstance(SearchVectorSetResponse, {
+        keyName,
+        elements,
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to run similarity search on the VectorSet data type.',
+        error,
+        clientMetadata,
+      );
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
     }
+  }
 
-    if (hasVectorFp32) {
-      args.push(
-        'FP32',
-        Buffer.from(element.vectorFp32, 'base64'),
-        element.name,
+  public async getSimilaritySearchPreview(
+    clientMetadata: ClientMetadata,
+    dto: SimilaritySearchDto,
+  ): Promise<SearchVectorSetPreviewResponse> {
+    try {
+      this.logger.debug(
+        'Building VSIM command preview for the VectorSet data type.',
+        clientMetadata,
       );
-    } else if (hasVectorValues) {
-      args.push(
-        'VALUES',
-        element.vectorValues.length,
-        ...element.vectorValues.map(String),
-        element.name,
+
+      const preview = formatVsimCommandPreview(dto);
+
+      return plainToInstance(SearchVectorSetPreviewResponse, { preview });
+    } catch (error) {
+      this.logger.error(
+        'Failed to build VSIM command preview for the VectorSet data type.',
+        error,
+        clientMetadata,
       );
-    } else {
-      throw new BadRequestException(
-        'Vector element requires either `vectorValues` (number[]) or `vectorFp32` (base64 string).',
-      );
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw catchAclError(error);
     }
-
-    if (element.attributes !== undefined) {
-      args.push('SETATTR', element.attributes);
-    }
-
-    return args as RedisClientCommand;
   }
 
   private async fetchElementDetails(

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
@@ -1,0 +1,401 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import { BrowserToolVectorSetCommands } from 'src/modules/browser/constants/browser-tool-commands';
+import {
+  addVectorSetElementDtoFactory,
+  FP32_VECTOR_FIXTURE_1_2_3,
+  fp32AddVectorSetElementDtoFactory,
+  searchVectorSetByElementDtoFactory,
+  searchVectorSetByFp32DtoFactory,
+  searchVectorSetByValuesDtoFactory,
+  SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+  SEARCH_VSIM_MATCH_NAME_1,
+  SEARCH_VSIM_MATCH_NAME_2,
+  SEARCH_VSIM_REPLY_TWO_MATCHES,
+} from 'src/modules/browser/vector-set/__tests__/vector-set.factory';
+import {
+  buildVaddCommand,
+  buildVsimCommand,
+  formatVsimCommandPreview,
+  parseVsimReply,
+} from 'src/modules/browser/vector-set/vector-set.utils';
+
+describe('vector-set.utils', () => {
+  describe('buildVaddCommand', () => {
+    const keyName = Buffer.from('vset:key');
+
+    it('should build VADD with VALUES, stringified entries, and trailing element name', () => {
+      const element = addVectorSetElementDtoFactory.build({
+        name: Buffer.from('e1'),
+        vectorValues: [0.1, 0.2, 0.3],
+      });
+
+      const command = buildVaddCommand(keyName, element);
+
+      expect(command).toEqual([
+        BrowserToolVectorSetCommands.VAdd,
+        keyName,
+        'VALUES',
+        3,
+        '0.1',
+        '0.2',
+        '0.3',
+        element.name,
+      ]);
+    });
+
+    it('should build VADD with FP32 Buffer payload when vectorFp32 is supplied', () => {
+      const element = fp32AddVectorSetElementDtoFactory.build({
+        name: Buffer.from('e1'),
+      });
+
+      const command = buildVaddCommand(keyName, element);
+
+      expect(command).toEqual([
+        BrowserToolVectorSetCommands.VAdd,
+        keyName,
+        'FP32',
+        FP32_VECTOR_FIXTURE_1_2_3.buffer,
+        element.name,
+      ]);
+    });
+
+    it('should append SETATTR <attributes> when attributes are supplied', () => {
+      const element = addVectorSetElementDtoFactory.build({
+        attributes: '{"color":"red"}',
+      });
+
+      const command = buildVaddCommand(keyName, element) as unknown[];
+
+      expect(command.slice(-2)).toEqual(['SETATTR', '{"color":"red"}']);
+    });
+
+    it('should throw BadRequestException when both vectorFp32 and vectorValues are supplied', () => {
+      const element = addVectorSetElementDtoFactory.build({
+        vectorValues: [1, 2, 3],
+        vectorFp32: FP32_VECTOR_FIXTURE_1_2_3.base64,
+      });
+
+      expect(() => buildVaddCommand(keyName, element)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when neither vectorFp32 nor vectorValues are supplied', () => {
+      const element = addVectorSetElementDtoFactory.build({
+        vectorValues: undefined,
+        vectorFp32: undefined,
+      });
+
+      expect(() => buildVaddCommand(keyName, element)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when vectorValues is an empty array', () => {
+      const element = addVectorSetElementDtoFactory.build({
+        vectorValues: [],
+        vectorFp32: undefined,
+      });
+
+      expect(() => buildVaddCommand(keyName, element)).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('buildVsimCommand', () => {
+    it('should emit ELE clause with WITHSCORES/WITHATTRIBS and COUNT for elementName mode', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: 5,
+      });
+
+      expect(buildVsimCommand(dto)).toEqual([
+        BrowserToolVectorSetCommands.VSim,
+        dto.keyName,
+        'ELE',
+        dto.elementName,
+        'COUNT',
+        5,
+        'WITHSCORES',
+        'WITHATTRIBS',
+      ]);
+    });
+
+    it('should stringify each numeric vector entry to preserve float precision on the wire', () => {
+      const dto = searchVectorSetByValuesDtoFactory.build({
+        vectorValues: [0.1, 0.2, 0.3],
+        count: 10,
+      });
+
+      const command = buildVsimCommand(dto) as unknown[];
+
+      expect(command).toEqual([
+        BrowserToolVectorSetCommands.VSim,
+        dto.keyName,
+        'VALUES',
+        3,
+        '0.1',
+        '0.2',
+        '0.3',
+        'COUNT',
+        10,
+        'WITHSCORES',
+        'WITHATTRIBS',
+      ]);
+    });
+
+    it('should pass FP32 as a raw Buffer (decoded from the base64 DTO field)', () => {
+      const dto = searchVectorSetByFp32DtoFactory.build({ count: 3 });
+
+      const command = buildVsimCommand(dto) as unknown[];
+
+      expect(command).toEqual([
+        BrowserToolVectorSetCommands.VSim,
+        dto.keyName,
+        'FP32',
+        FP32_VECTOR_FIXTURE_1_2_3.buffer,
+        'COUNT',
+        3,
+        'WITHSCORES',
+        'WITHATTRIBS',
+      ]);
+    });
+
+    it('should append FILTER <expr> after the WITHSCORES/WITHATTRIBS tail', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        count: 4,
+        filter: '.color == "red"',
+      });
+
+      const command = buildVsimCommand(dto) as unknown[];
+
+      expect(command.slice(-2)).toEqual(['FILTER', '.color == "red"']);
+      expect(command.indexOf('FILTER')).toBeGreaterThan(
+        command.indexOf('WITHATTRIBS'),
+      );
+    });
+
+    it('should omit the COUNT clause when count is undefined', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        count: undefined,
+      });
+
+      const command = buildVsimCommand(dto) as unknown[];
+
+      expect(command).not.toContain('COUNT');
+      expect(command).toContain('WITHSCORES');
+      expect(command).toContain('WITHATTRIBS');
+    });
+
+    it('should throw BadRequestException when no query payload is supplied', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        elementName: undefined,
+        vectorValues: undefined,
+        vectorFp32: undefined,
+      });
+
+      expect(() => buildVsimCommand(dto)).toThrow(BadRequestException);
+      expect(() => buildVsimCommand(dto)).toThrow(/requires one of/);
+    });
+
+    it('should throw BadRequestException when more than one query payload is supplied', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        elementName: Buffer.from('e'),
+        vectorValues: [1, 2, 3],
+      });
+
+      expect(() => buildVsimCommand(dto)).toThrow(BadRequestException);
+      expect(() => buildVsimCommand(dto)).toThrow(/exactly one/);
+    });
+  });
+
+  describe('formatVsimCommandPreview', () => {
+    it('should render an ELE preview with the key + element decoded from Buffers', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: 5,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe(
+        'VSIM vset:key ELE seed COUNT 5 WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should quote elements that contain whitespace or quotes for CLI safety', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('with space'),
+        count: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe(
+        'VSIM vset:key ELE "with space" WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should escape embedded double-quotes in elements with backslashes', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('a"b'),
+        count: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toContain('"a\\"b"');
+    });
+
+    it('should render numeric VALUES inline (stringified) without quoting', () => {
+      const dto = searchVectorSetByValuesDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        vectorValues: [0.1, 0.2, 0.3],
+        count: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe(
+        'VSIM vset:key VALUES 3 0.1 0.2 0.3 WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should render FP32 bytes as a quoted `\\xHH...` escape string', () => {
+      const dto = searchVectorSetByFp32DtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        count: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe(
+        'VSIM vset:key FP32 "\\x00\\x00\\x80\\x3f\\x00\\x00\\x00\\x40\\x00\\x00\\x40\\x40" WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should append FILTER <expr> as the last clause and quote when needed', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: undefined,
+        filter: '.color == "red"',
+      });
+
+      const preview = formatVsimCommandPreview(dto);
+
+      expect(preview.endsWith('FILTER ".color == \\"red\\""')).toBe(true);
+    });
+
+    it('should return empty string when no query payload is supplied', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        elementName: undefined,
+        vectorValues: undefined,
+        vectorFp32: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe('');
+    });
+
+    it('should return empty string even when keyName and filter are present but no query payload', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        elementName: undefined,
+        vectorValues: undefined,
+        vectorFp32: undefined,
+        filter: '.x > 1',
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe('');
+    });
+
+    it('should throw BadRequestException when more than one query payload is supplied', () => {
+      const dto = searchVectorSetByElementDtoFactory.build({
+        elementName: Buffer.from('e'),
+        vectorValues: [1, 2, 3],
+      });
+
+      expect(() => formatVsimCommandPreview(dto)).toThrow(BadRequestException);
+    });
+  });
+
+  describe('parseVsimReply', () => {
+    it('should return [] for null, undefined, or empty replies', () => {
+      expect(parseVsimReply(null)).toEqual([]);
+      expect(parseVsimReply(undefined)).toEqual([]);
+      expect(parseVsimReply([])).toEqual([]);
+    });
+
+    it('should parse the canonical two-match reply (stride 3) into name/score/attributes tuples', () => {
+      const matches = parseVsimReply(SEARCH_VSIM_REPLY_TWO_MATCHES);
+
+      expect(matches).toEqual([
+        {
+          name: SEARCH_VSIM_MATCH_NAME_1,
+          score: 0.95,
+          attributes: SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+        },
+        { name: SEARCH_VSIM_MATCH_NAME_2, score: 0.81 },
+      ]);
+    });
+
+    it('should parse a Buffer score into a float number', () => {
+      const matches = parseVsimReply([
+        Buffer.from('m'),
+        Buffer.from('0.42'),
+        null,
+      ]);
+
+      expect(matches[0].score).toBeCloseTo(0.42, 6);
+      expect(typeof matches[0].score).toBe('number');
+    });
+
+    it('should pass through a numeric (RESP3 double) score unchanged', () => {
+      const matches = parseVsimReply([Buffer.from('m'), 0.42 as never, null]);
+
+      expect(matches[0].score).toBe(0.42);
+    });
+
+    it('should decode a Buffer attributes payload via String()', () => {
+      const buf = Buffer.from('{"k":"v"}');
+      const matches = parseVsimReply([Buffer.from('m'), '0.5', buf]);
+
+      expect(matches[0].attributes).toBe('{"k":"v"}');
+    });
+
+    it('should drop a trailing partial tuple when reply length is not a multiple of 3', () => {
+      const reply: Array<string | Buffer | null> = [
+        Buffer.from('m1'),
+        '0.9',
+        null,
+        Buffer.from('m2'),
+      ];
+
+      const matches = parseVsimReply(reply);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].name).toEqual(Buffer.from('m1'));
+    });
+
+    it('should warn via the supplied logger when a partial tuple is dropped', () => {
+      const logger = { warn: jest.fn() } as unknown as Logger;
+      const reply: Array<string | Buffer | null> = [
+        Buffer.from('m1'),
+        '0.9',
+        null,
+        Buffer.from('m2'),
+      ];
+
+      parseVsimReply(reply, logger);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('not a multiple of 3'),
+      );
+    });
+
+    it('should not throw when no logger is supplied and reply length is misaligned', () => {
+      const reply: Array<string | Buffer | null> = [
+        Buffer.from('m1'),
+        '0.9',
+        null,
+        Buffer.from('m2'),
+      ];
+
+      expect(() => parseVsimReply(reply)).not.toThrow();
+    });
+  });
+});

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
@@ -4,9 +4,7 @@ import {
   addVectorSetElementDtoFactory,
   FP32_VECTOR_FIXTURE_1_2_3,
   fp32AddVectorSetElementDtoFactory,
-  searchVectorSetByElementDtoFactory,
-  searchVectorSetByFp32DtoFactory,
-  searchVectorSetByValuesDtoFactory,
+  similaritySearchDtoFactory,
   SEARCH_VSIM_MATCH_ATTRIBUTES_1,
   SEARCH_VSIM_MATCH_NAME_1,
   SEARCH_VSIM_MATCH_NAME_2,
@@ -105,7 +103,7 @@ describe('vector-set.utils', () => {
 
   describe('buildVsimCommand', () => {
     it('should emit ELE clause with WITHSCORES/WITHATTRIBS and COUNT for elementName mode', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),
         elementName: Buffer.from('seed'),
         count: 5,
@@ -124,10 +122,10 @@ describe('vector-set.utils', () => {
     });
 
     it('should stringify each numeric vector entry to preserve float precision on the wire', () => {
-      const dto = searchVectorSetByValuesDtoFactory.build({
-        vectorValues: [0.1, 0.2, 0.3],
-        count: 10,
-      });
+      const dto = similaritySearchDtoFactory.build(
+        { vectorValues: [0.1, 0.2, 0.3], count: 10 },
+        { transient: { variant: 'values' } },
+      );
 
       const command = buildVsimCommand(dto) as unknown[];
 
@@ -147,7 +145,10 @@ describe('vector-set.utils', () => {
     });
 
     it('should pass FP32 as a raw Buffer (decoded from the base64 DTO field)', () => {
-      const dto = searchVectorSetByFp32DtoFactory.build({ count: 3 });
+      const dto = similaritySearchDtoFactory.build(
+        { count: 3 },
+        { transient: { variant: 'fp32' } },
+      );
 
       const command = buildVsimCommand(dto) as unknown[];
 
@@ -164,7 +165,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should append FILTER <expr> after the WITHSCORES/WITHATTRIBS tail', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         count: 4,
         filter: '.color == "red"',
       });
@@ -178,7 +179,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should omit the COUNT clause when count is undefined', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         count: undefined,
       });
 
@@ -190,7 +191,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should throw BadRequestException when no query payload is supplied', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         elementName: undefined,
         vectorValues: undefined,
         vectorFp32: undefined,
@@ -201,7 +202,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should throw BadRequestException when more than one query payload is supplied', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         elementName: Buffer.from('e'),
         vectorValues: [1, 2, 3],
       });
@@ -213,7 +214,7 @@ describe('vector-set.utils', () => {
 
   describe('formatVsimCommandPreview', () => {
     it('should render an ELE preview with the key + element decoded from Buffers', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),
         elementName: Buffer.from('seed'),
         count: 5,
@@ -225,7 +226,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should quote elements that contain whitespace or quotes for CLI safety', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),
         elementName: Buffer.from('with space'),
         count: undefined,
@@ -237,7 +238,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should escape embedded double-quotes in elements with backslashes', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),
         elementName: Buffer.from('a"b'),
         count: undefined,
@@ -247,11 +248,14 @@ describe('vector-set.utils', () => {
     });
 
     it('should render numeric VALUES inline (stringified) without quoting', () => {
-      const dto = searchVectorSetByValuesDtoFactory.build({
-        keyName: Buffer.from('vset:key'),
-        vectorValues: [0.1, 0.2, 0.3],
-        count: undefined,
-      });
+      const dto = similaritySearchDtoFactory.build(
+        {
+          keyName: Buffer.from('vset:key'),
+          vectorValues: [0.1, 0.2, 0.3],
+          count: undefined,
+        },
+        { transient: { variant: 'values' } },
+      );
 
       expect(formatVsimCommandPreview(dto)).toBe(
         'VSIM vset:key VALUES 3 0.1 0.2 0.3 WITHSCORES WITHATTRIBS',
@@ -259,10 +263,13 @@ describe('vector-set.utils', () => {
     });
 
     it('should render FP32 bytes as a quoted `\\xHH...` escape string', () => {
-      const dto = searchVectorSetByFp32DtoFactory.build({
-        keyName: Buffer.from('vset:key'),
-        count: undefined,
-      });
+      const dto = similaritySearchDtoFactory.build(
+        {
+          keyName: Buffer.from('vset:key'),
+          count: undefined,
+        },
+        { transient: { variant: 'fp32' } },
+      );
 
       expect(formatVsimCommandPreview(dto)).toBe(
         'VSIM vset:key FP32 "\\x00\\x00\\x80\\x3f\\x00\\x00\\x00\\x40\\x00\\x00\\x40\\x40" WITHSCORES WITHATTRIBS',
@@ -270,7 +277,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should append FILTER <expr> as the last clause and quote when needed', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),
         elementName: Buffer.from('seed'),
         count: undefined,
@@ -283,7 +290,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should return empty string when no query payload is supplied', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         elementName: undefined,
         vectorValues: undefined,
         vectorFp32: undefined,
@@ -293,7 +300,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should return empty string even when keyName and filter are present but no query payload', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         elementName: undefined,
         vectorValues: undefined,
         vectorFp32: undefined,
@@ -304,7 +311,7 @@ describe('vector-set.utils', () => {
     });
 
     it('should throw BadRequestException when more than one query payload is supplied', () => {
-      const dto = searchVectorSetByElementDtoFactory.build({
+      const dto = similaritySearchDtoFactory.build({
         elementName: Buffer.from('e'),
         vectorValues: [1, 2, 3],
       });

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
@@ -237,6 +237,28 @@ describe('vector-set.utils', () => {
       );
     });
 
+    it('should quote keyName that contains whitespace for CLI safety', () => {
+      const dto = similaritySearchDtoFactory.build({
+        keyName: Buffer.from('my vector set'),
+        elementName: Buffer.from('seed'),
+        count: 5,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toBe(
+        'VSIM "my vector set" ELE seed COUNT 5 WITHSCORES WITHATTRIBS',
+      );
+    });
+
+    it('should escape embedded double-quotes in keyName with backslashes', () => {
+      const dto = similaritySearchDtoFactory.build({
+        keyName: Buffer.from('a"b'),
+        elementName: Buffer.from('seed'),
+        count: undefined,
+      });
+
+      expect(formatVsimCommandPreview(dto)).toContain('VSIM "a\\"b" ELE');
+    });
+
     it('should escape embedded double-quotes in elements with backslashes', () => {
       const dto = similaritySearchDtoFactory.build({
         keyName: Buffer.from('vset:key'),

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
@@ -311,17 +311,18 @@ describe('vector-set.utils', () => {
       expect(preview.endsWith('FILTER ".color == \\"red\\""')).toBe(true);
     });
 
-    it('should return empty string when no query payload is supplied', () => {
+    it('should throw BadRequestException when no query payload is supplied', () => {
       const dto = similaritySearchDtoFactory.build({
         elementName: undefined,
         vectorValues: undefined,
         vectorFp32: undefined,
       });
 
-      expect(formatVsimCommandPreview(dto)).toBe('');
+      expect(() => formatVsimCommandPreview(dto)).toThrow(BadRequestException);
+      expect(() => formatVsimCommandPreview(dto)).toThrow(/requires one of/);
     });
 
-    it('should return empty string even when keyName and filter are present but no query payload', () => {
+    it('should throw BadRequestException even when keyName and filter are present but no query payload', () => {
       const dto = similaritySearchDtoFactory.build({
         elementName: undefined,
         vectorValues: undefined,
@@ -329,7 +330,7 @@ describe('vector-set.utils', () => {
         filter: '.x > 1',
       });
 
-      expect(formatVsimCommandPreview(dto)).toBe('');
+      expect(() => formatVsimCommandPreview(dto)).toThrow(BadRequestException);
     });
 
     it('should throw BadRequestException when more than one query payload is supplied', () => {
@@ -339,6 +340,7 @@ describe('vector-set.utils', () => {
       });
 
       expect(() => formatVsimCommandPreview(dto)).toThrow(BadRequestException);
+      expect(() => formatVsimCommandPreview(dto)).toThrow(/exactly one/);
     });
   });
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -246,7 +246,7 @@ export function formatVsimCommandPreview(dto: SimilaritySearchDto): string {
 
   return writeVsimTokens<string>(dto, query, {
     literal: (token) => token,
-    key: (key) => bufferOrStringToString(key),
+    key: (key) => quoteForCli(bufferOrStringToString(key)),
     element: (element) => quoteForCli(bufferOrStringToString(element)),
     // Render the FP32 bytes back as the canonical `\xHH\xHH...` escape
     // string so the preview is copy-paste-safe into `redis-cli`. Wrapped in

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -93,6 +93,12 @@ function resolveVsimQuery(dto: SimilaritySearchDto): ResolvedVsimQuery | null {
     );
   }
 
+  if (suppliedCount === 0) {
+    throw new BadRequestException(
+      'Vector similarity search requires one of `elementName`, `vectorValues`, or `vectorFp32`.',
+    );
+  }
+
   if (hasElementName) {
     return { mode: 'ELE', element: dto.elementName };
   }
@@ -207,12 +213,6 @@ export function buildVaddCommand(
 
 export function buildVsimCommand(dto: SimilaritySearchDto): RedisClientCommand {
   const query = resolveVsimQuery(dto);
-
-  if (!query) {
-    throw new BadRequestException(
-      'Vector similarity search requires one of `elementName`, `vectorValues`, or `vectorFp32`.',
-    );
-  }
 
   return writeVsimTokens<string | number | Buffer>(dto, query, {
     literal: (token) => token,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -69,11 +69,12 @@ function quoteForCli(value: string): string {
 
 /**
  * Resolve which of the three mutually-exclusive query payloads the DTO
- * supplied. Returns `null` when none were supplied — callers decide whether
- * that is an error (search) or a no-op (preview). Throws for the genuinely
- * invalid case where more than one was supplied.
+ * supplied. Throws `BadRequestException` when zero or more than one of
+ * `elementName` / `vectorValues` / `vectorFp32` is present, so both the
+ * search and preview endpoints uniformly reject under- and over-specified
+ * payloads with `400`.
  */
-function resolveVsimQuery(dto: SimilaritySearchDto): ResolvedVsimQuery | null {
+function resolveVsimQuery(dto: SimilaritySearchDto): ResolvedVsimQuery {
   const hasElementName =
     dto.elementName !== undefined &&
     dto.elementName !== null &&
@@ -105,10 +106,7 @@ function resolveVsimQuery(dto: SimilaritySearchDto): ResolvedVsimQuery | null {
   if (hasVectorFp32) {
     return { mode: 'FP32', bytes: Buffer.from(dto.vectorFp32, 'base64') };
   }
-  if (hasVectorValues) {
-    return { mode: 'VALUES', values: dto.vectorValues };
-  }
-  return null;
+  return { mode: 'VALUES', values: dto.vectorValues };
 }
 
 /**
@@ -229,20 +227,13 @@ export function buildVsimCommand(dto: SimilaritySearchDto): RedisClientCommand {
  * Build the human-readable VSIM command preview for the supplied DTO.
  * Shares `resolveVsimQuery` and `writeVsimTokens` with `buildVsimCommand`
  * so the preview cannot drift from what the search endpoint would actually
- * execute.
- *
- * Returns an empty string when no query payload is supplied — the FE only
- * asks for a preview once the form is valid, so a missing query is treated
- * as "nothing to preview yet" rather than rendering a placeholder command.
- * `keyName` is guaranteed by `KeyDto` (`@IsDefined`) — requests without it
- * are rejected at the validation pipe before reaching this function.
+ * execute. Throws `BadRequestException` (via `resolveVsimQuery`) when zero
+ * or more than one of `elementName` / `vectorValues` / `vectorFp32` is
+ * supplied — the FE is expected to only call the preview endpoint once
+ * the form has resolved to exactly one query mode.
  */
 export function formatVsimCommandPreview(dto: SimilaritySearchDto): string {
   const query = resolveVsimQuery(dto);
-
-  if (!query) {
-    return '';
-  }
 
   return writeVsimTokens<string>(dto, query, {
     literal: (token) => token,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -1,0 +1,300 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import { RedisString } from 'src/common/constants';
+import { BrowserToolVectorSetCommands } from 'src/modules/browser/constants/browser-tool-commands';
+import { RedisClientCommand } from 'src/modules/redis/client';
+import {
+  AddVectorSetElementDto,
+  SearchVectorSetMatchDto,
+  SimilaritySearchDto,
+} from 'src/modules/browser/vector-set/dto';
+import { VSIM_REPLY_STRIDE } from 'src/modules/browser/vector-set/constants';
+
+/**
+ * Resolved query clause shared between the executable command builder and the
+ * preview formatter so the two paths cannot drift on which mode they pick or
+ * how they normalize their inputs.
+ */
+type ResolvedVsimQuery =
+  | { mode: 'ELE'; element: RedisString }
+  | { mode: 'VALUES'; values: number[] }
+  | { mode: 'FP32'; bytes: Buffer };
+
+/**
+ * Strategy passed to `writeVsimTokens` so the executable and preview paths
+ * can share the same token layout (clause order, count/filter handling,
+ * `WITHSCORES WITHATTRIBS` tail) and only diverge on how individual leaves
+ * are rendered. The executable path emits raw values straight to the Redis
+ * client; the preview path emits CLI-friendly strings.
+ */
+type VsimTokenWriter<T> = {
+  literal: (token: string) => T;
+  key: (key: RedisString) => T;
+  element: (element: RedisString) => T;
+  fp32: (bytes: Buffer) => T;
+  /** Length / count integers — passed verbatim to the executable command. */
+  number: (value: number) => T;
+  /**
+   * Individual entries of a numeric query vector. Stringified by the
+   * executable path so the underlying Redis client can't lose float
+   * precision on the wire; stringified by the preview path for display.
+   */
+  vectorValue: (value: number) => T;
+  filter: (filter: string) => T;
+};
+
+// ---------------------------------------------------------------------------
+// Module-private helpers
+// ---------------------------------------------------------------------------
+
+function bufferOrStringToString(value: RedisString): string {
+  if (typeof value === 'string') return value;
+  return value.toString('utf8');
+}
+
+function bytesToEscapeString(buf: Buffer): string {
+  let out = '';
+  for (let i = 0; i < buf.length; i += 1) {
+    out += `\\x${buf[i].toString(16).padStart(2, '0')}`;
+  }
+  return out;
+}
+
+function quoteForCli(value: string): string {
+  if (value.length === 0) return '""';
+  if (/[\s"'\\]/.test(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+/**
+ * Resolve which of the three mutually-exclusive query payloads the DTO
+ * supplied. Returns `null` when none were supplied — callers decide whether
+ * that is an error (search) or a no-op (preview). Throws for the genuinely
+ * invalid case where more than one was supplied.
+ */
+function resolveVsimQuery(dto: SimilaritySearchDto): ResolvedVsimQuery | null {
+  const hasElementName =
+    dto.elementName !== undefined &&
+    dto.elementName !== null &&
+    ((typeof dto.elementName === 'string' && dto.elementName.length > 0) ||
+      Buffer.isBuffer(dto.elementName));
+  const hasVectorFp32 =
+    typeof dto.vectorFp32 === 'string' && dto.vectorFp32.length > 0;
+  const hasVectorValues =
+    Array.isArray(dto.vectorValues) && dto.vectorValues.length > 0;
+
+  const suppliedCount =
+    Number(hasElementName) + Number(hasVectorFp32) + Number(hasVectorValues);
+
+  if (suppliedCount > 1) {
+    throw new BadRequestException(
+      'Vector similarity search must supply exactly one of `elementName`, `vectorValues`, or `vectorFp32`.',
+    );
+  }
+
+  if (hasElementName) {
+    return { mode: 'ELE', element: dto.elementName };
+  }
+  if (hasVectorFp32) {
+    return { mode: 'FP32', bytes: Buffer.from(dto.vectorFp32, 'base64') };
+  }
+  if (hasVectorValues) {
+    return { mode: 'VALUES', values: dto.vectorValues };
+  }
+  return null;
+}
+
+/**
+ * Lay out the canonical VSIM token sequence (header, query clause, COUNT,
+ * `WITHSCORES WITHATTRIBS` tail, FILTER) and delegate the rendering of
+ * each individual token to the supplied writer. Both the executable
+ * command builder and the preview formatter go through this helper so
+ * the two paths cannot drift on which clauses are emitted in what order.
+ */
+function writeVsimTokens<T>(
+  dto: SimilaritySearchDto,
+  query: ResolvedVsimQuery,
+  tokenWriter: VsimTokenWriter<T>,
+): T[] {
+  const tokens: T[] = [
+    tokenWriter.literal(BrowserToolVectorSetCommands.VSim),
+    tokenWriter.key(dto.keyName),
+  ];
+
+  if (query.mode === 'ELE') {
+    tokens.push(tokenWriter.literal('ELE'), tokenWriter.element(query.element));
+  } else if (query.mode === 'VALUES') {
+    tokens.push(
+      tokenWriter.literal('VALUES'),
+      tokenWriter.number(query.values.length),
+      ...query.values.map((n) => tokenWriter.vectorValue(n)),
+    );
+  } else {
+    tokens.push(tokenWriter.literal('FP32'), tokenWriter.fp32(query.bytes));
+  }
+
+  if (dto.count !== undefined && Number.isFinite(dto.count)) {
+    tokens.push(tokenWriter.literal('COUNT'), tokenWriter.number(dto.count));
+  }
+
+  // WITHSCORES and WITHATTRIBS are always appended so the response shape
+  // is stable; they are intentionally not part of the DTO.
+  tokens.push(
+    tokenWriter.literal('WITHSCORES'),
+    tokenWriter.literal('WITHATTRIBS'),
+  );
+
+  if (dto.filter !== undefined && dto.filter !== '') {
+    tokens.push(tokenWriter.literal('FILTER'), tokenWriter.filter(dto.filter));
+  }
+
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the VADD pipeline command for a single element. Stays defensive
+ * about which of `vectorValues` / `vectorFp32` is present even though DTO
+ * validation should already enforce exactly one — any future internal
+ * caller that bypasses class-validator will fail loudly here instead of
+ * crashing on an `undefined.length` read.
+ */
+export function buildVaddCommand(
+  keyName: Buffer | string,
+  element: AddVectorSetElementDto,
+): RedisClientCommand {
+  const args: Array<string | number | Buffer> = [
+    BrowserToolVectorSetCommands.VAdd,
+    keyName,
+  ];
+
+  const hasVectorFp32 =
+    typeof element.vectorFp32 === 'string' && element.vectorFp32.length > 0;
+  const hasVectorValues =
+    Array.isArray(element.vectorValues) && element.vectorValues.length > 0;
+
+  if (hasVectorFp32 && hasVectorValues) {
+    throw new BadRequestException(
+      'Vector element must supply either `vectorValues` (number[]) or `vectorFp32` (base64 string), not both.',
+    );
+  }
+
+  if (hasVectorFp32) {
+    args.push('FP32', Buffer.from(element.vectorFp32, 'base64'), element.name);
+  } else if (hasVectorValues) {
+    args.push(
+      'VALUES',
+      element.vectorValues.length,
+      ...element.vectorValues.map(String),
+      element.name,
+    );
+  } else {
+    throw new BadRequestException(
+      'Vector element requires either `vectorValues` (number[]) or `vectorFp32` (base64 string).',
+    );
+  }
+
+  if (element.attributes !== undefined) {
+    args.push('SETATTR', element.attributes);
+  }
+
+  return args as RedisClientCommand;
+}
+
+export function buildVsimCommand(dto: SimilaritySearchDto): RedisClientCommand {
+  const query = resolveVsimQuery(dto);
+
+  if (!query) {
+    throw new BadRequestException(
+      'Vector similarity search requires one of `elementName`, `vectorValues`, or `vectorFp32`.',
+    );
+  }
+
+  return writeVsimTokens<string | number | Buffer>(dto, query, {
+    literal: (token) => token,
+    key: (key) => key as string | Buffer,
+    element: (element) => element as string | Buffer,
+    fp32: (bytes) => bytes,
+    number: (value) => value,
+    vectorValue: (value) => String(value),
+    filter: (filter) => filter,
+  }) as RedisClientCommand;
+}
+
+/**
+ * Build the human-readable VSIM command preview for the supplied DTO.
+ * Shares `resolveVsimQuery` and `writeVsimTokens` with `buildVsimCommand`
+ * so the preview cannot drift from what the search endpoint would actually
+ * execute.
+ *
+ * Returns an empty string when no query payload is supplied — the FE only
+ * asks for a preview once the form is valid, so a missing query is treated
+ * as "nothing to preview yet" rather than rendering a placeholder command.
+ * `keyName` is guaranteed by `KeyDto` (`@IsDefined`) — requests without it
+ * are rejected at the validation pipe before reaching this function.
+ */
+export function formatVsimCommandPreview(dto: SimilaritySearchDto): string {
+  const query = resolveVsimQuery(dto);
+
+  if (!query) {
+    return '';
+  }
+
+  return writeVsimTokens<string>(dto, query, {
+    literal: (token) => token,
+    key: (key) => bufferOrStringToString(key),
+    element: (element) => quoteForCli(bufferOrStringToString(element)),
+    // Render the FP32 bytes back as the canonical `\xHH\xHH...` escape
+    // string so the preview is copy-paste-safe into `redis-cli`. Wrapped in
+    // double quotes for the same reason.
+    fp32: (bytes) => `"${bytesToEscapeString(bytes)}"`,
+    number: (value) => String(value),
+    vectorValue: (value) => String(value),
+    filter: (filter) => quoteForCli(filter),
+  }).join(' ');
+}
+
+export function parseVsimReply(
+  reply: Array<string | Buffer | null> | null | undefined,
+  logger?: Logger,
+): SearchVectorSetMatchDto[] {
+  if (!reply || reply.length === 0) {
+    return [];
+  }
+
+  // Defensive: drop any trailing partial tuple. Redis is expected to always
+  // return a multiple of `VSIM_REPLY_STRIDE`, so this only protects against
+  // unexpected server-side bugs.
+  const remainder = reply.length % VSIM_REPLY_STRIDE;
+  const usableLength =
+    remainder === 0 ? reply.length : reply.length - remainder;
+  if (remainder !== 0) {
+    logger?.warn(
+      `VSIM reply length ${reply.length} is not a multiple of ${VSIM_REPLY_STRIDE}; dropping trailing partial tuple.`,
+    );
+  }
+
+  const matches: SearchVectorSetMatchDto[] = [];
+  for (let i = 0; i < usableLength; i += VSIM_REPLY_STRIDE) {
+    const name = reply[i] as string | Buffer;
+    const rawScore = reply[i + 1];
+    const rawAttributes = reply[i + 2];
+
+    const score =
+      typeof rawScore === 'number' ? rawScore : parseFloat(String(rawScore));
+
+    const match: SearchVectorSetMatchDto = { name, score };
+    if (rawAttributes !== null && rawAttributes !== undefined) {
+      match.attributes =
+        typeof rawAttributes === 'string'
+          ? rawAttributes
+          : String(rawAttributes);
+    }
+    matches.push(match);
+  }
+  return matches;
+}

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -44,6 +44,7 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VGetAttr);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSetAttr);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VRem);
+    client.addBuiltinCommand(BrowserToolVectorSetCommands.VSim);
   }
 
   static prepareCommandOptions(options: IRedisClientCommandOptions): any {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Add two backend endpoints for the vector-set similarity-search feature:
- `POST /vector-set/similarity-search` — runs `VSIM` against the supplied key and returns the matches (`name` + `score` + optional `attributes`).
- `POST /vector-set/similarity-search/preview` — returns the same `VSIM` invocation as a CLI-friendly string so the FE can show users the command they're about to run.

Both endpoints accept a single `SimilaritySearchDto` and pick the query mode (`ELE` / `VALUES` / `FP32`) at runtime — exactly one of `elementName`, `vectorValues`, or `vectorFp32` must be supplied. `WITHSCORES` and `WITHATTRIBS` are always appended so the response shape is stable; `COUNT` / `FILTER` are forwarded only when present.
The command builder, preview formatter, reply parser, and shared `VsimTokenWriter` strategy live in `vector-set.utils.ts` so the executable command and its preview can't drift on clause order or rendering. `VSIM` is also registered as a built-in ioredis command.


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API endpoints that execute Redis `VSIM` and parse its flat reply format, so correctness depends on command construction and reply parsing across RESP2/RESP3 types. Risk is mitigated by extensive unit tests but touches runtime Redis command execution.
> 
> **Overview**
> Adds vector-set similarity search support via `POST /vector-set/similarity-search` (executes `VSIM` with mandatory `WITHSCORES WITHATTRIBS` and optional `COUNT`/`FILTER`) and `POST /vector-set/similarity-search/preview` (returns a CLI-safe command string preview).
> 
> Introduces new DTOs/responses for search results and preview, registers `VSIM` as a built-in ioredis command, and centralizes VSIM command building/preview formatting/reply parsing in `vector-set.utils.ts` with tests covering query-mode validation (`ELE`/`VALUES`/`FP32`), quoting/escaping, and score/attributes decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7c9718f9f41da05038d3b657cfe091c030e970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->