### PR TITLE
Notify Slack when nightly E2E suite fails

### DIFF
--- a/.github/workflows/tests-e2e-playwright-v2.yml
+++ b/.github/workflows/tests-e2e-playwright-v2.yml
@@ -115,3 +115,56 @@ jobs:
       environment: ${{ inputs.environment || 'staging' }}
       debug: ${{ inputs.debug || false }}
 
+  # Slack notification on nightly failures only
+  notify-slack:
+    name: Notify Slack on nightly failure
+    needs:
+      - lint
+      - build-docker
+      - build-linux
+      - e2e-dev-chromium
+      - e2e-docker
+      - e2e-electron
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      (needs.lint.result == 'failure' ||
+       needs.build-docker.result == 'failure' ||
+       needs.build-linux.result == 'failure' ||
+       needs.e2e-dev-chromium.result == 'failure' ||
+       needs.e2e-docker.result == 'failure' ||
+       needs.e2e-electron.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
+          payload: |
+            channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
+            text: "<!here> *Nightly E2E failure* — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            attachments:
+              - color: "#cc0000"
+                title: "${{ github.workflow }}"
+                title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                fields:
+                  - title: "Lint"
+                    value: "${{ needs.lint.result }}"
+                    short: true
+                  - title: "Build Docker"
+                    value: "${{ needs.build-docker.result }}"
+                    short: true
+                  - title: "Build Linux"
+                    value: "${{ needs.build-linux.result }}"
+                    short: true
+                  - title: "Chromium (Dev)"
+                    value: "${{ needs.e2e-dev-chromium.result }}"
+                    short: true
+                  - title: "Docker"
+                    value: "${{ needs.e2e-docker.result }}"
+                    short: true
+                  - title: "Electron (Linux)"
+                    value: "${{ needs.e2e-electron.result }}"
+                    short: true
+


### PR DESCRIPTION
# What

Adds a `notify-slack` job to [`.github/workflows/tests-e2e-playwright-v2.yml`](.github/workflows/tests-e2e-playwright-v2.yml) that posts a single Slack message whenever the **nightly** E2E pipeline fails.

- **Trigger gate**: `github.event_name == 'schedule'` AND at least one of the six pipeline jobs (`lint`, `build-docker`, `build-linux`, `e2e-dev-chromium`, `e2e-docker`, `e2e-electron`) ended in `failure`. Manual `workflow_dispatch` and PR-label runs stay silent.
- **Implementation**: official [`slackapi/slack-github-action@v3.0.3`](https://github.com/slackapi/slack-github-action) calling `chat.postMessage`. No new helper files, no `curl`.
- **Secrets**: reuses the existing `SLACK_TEST_REPORT_KEY` (bot token) and `SLACK_TEST_REPORT_CHANNEL` (channel ID) that already drive the smoke / regression / critical-path / appimage E2E reports — no new secrets to provision.

# Testing

**Smoke the action itself locally** with a one-off `curl` to `chat.postMessage` using the same token + channel to confirm the bot is in the channel and the token has `chat:write`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a Slack notification job; main risk is noisy/incorrect alerts or failures if Slack secrets/permissions are misconfigured.
> 
> **Overview**
> Adds a new `notify-slack` job to `tests-e2e-playwright-v2.yml` that runs **only on scheduled nightly executions** and posts a single Slack message when any of `lint`, `build-*`, or E2E jobs fail.
> 
> The notification uses `slackapi/slack-github-action@v3.0.3` with existing Slack secrets and includes a run link plus a fielded summary of each job’s result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fcbb44d4dad3819fad9fe5a8470a9dc323b46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->