### PR TITLE
Always upload Playwright artifacts so timeouts produce reports

### DIFF
--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -103,7 +103,7 @@ jobs:
           CI: true
 
       - name: Upload test results
-        if: ${{ !cancelled() }}
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report-chromium

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -116,7 +116,7 @@ jobs:
           OSS_CLUSTER_HOSTNAME_HOST: 'host.docker.internal'
 
       - name: Upload test results
-        if: ${{ !cancelled() }}
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report-docker

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -173,7 +173,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: '0'
 
       - name: Upload test results
-        if: ${{ !cancelled() }}
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report-electron-linux


### PR DESCRIPTION
# What

Switches the **Upload test results** step from `if: !cancelled()` to `if: always()` in the three E2E sub-workflows:

- [`.github/workflows/tests-e2e-playwright-chromium.yml`](.github/workflows/tests-e2e-playwright-chromium.yml)
- [`.github/workflows/tests-e2e-playwright-docker.yml`](.github/workflows/tests-e2e-playwright-docker.yml)
- [`.github/workflows/tests-e2e-playwright-electron.yml`](.github/workflows/tests-e2e-playwright-electron.yml)

Three lines total.

# Why

`!cancelled()` evaluates to `false` when a job is cancelled — and a job timing out at the 60-minute job-level cap is treated as cancellation. As a result, runs that hit the cap silently discard `test-results/` and `playwright-report/`, leaving us nothing to investigate slow or hanging tests with.

Example: [run 25474311719 / job 74956330889](https://github.com/redis/RedisInsight/actions/runs/25474311719/job/74956330889?pr=5851) — Chromium (Dev) was cancelled at 60m28s, no playwright report uploaded, no way to see which tests were slow.

`if: always()` runs the upload step on success / failure / cancellation, so we get the partial report and trace data even when the run was killed for taking too long.

# Testing

After merge, any nightly (or PR-labeled / `workflow_dispatch`) E2E run that hits the 60-min cap will produce uploaded artifacts. To observe the change with no artificial slowdown, just rebase any open PR onto this and re-run the suite — even a fast green run will upload artifacts as before. The behavior change only matters on cancelled / failed runs.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it only adjusts workflow step conditions to ensure artifacts upload even when jobs are cancelled/time out.
> 
> **Overview**
> Ensures Playwright E2E workflows always upload `test-results/` and `playwright-report/` artifacts by changing the **Upload test results** step condition from `!cancelled()` to `always()` in the Chromium, Docker, and Electron GitHub Actions workflows.
> 
> This makes partial reports/traces available for debugging when jobs are cancelled (including timeout-driven cancellations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07750bf4498332dd2107890c1fd2c487ac2bb2ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->