### PR TITLE
RI-8007 Add e2e tests for Browser - String Key details view

### DIFF
--- a/tests/e2e-playwright/TEST_PLAN.md
+++ b/tests/e2e-playwright/TEST_PLAN.md
@@ -255,13 +255,9 @@ The test plan is organized by feature area. Tests are grouped for parallel execu
 ### 2.4 Key Details - String
 | Status | Group | Test Case |
 |--------|-------|-----------|
-| 🔲 | main | View string value |
-| 🔲 | main | Edit string value |
-| 🔲 | main | View/edit TTL |
-| 🔲 | main | Copy key name (covered by "should show copy key name button on hover" test) |
-| 🔲 | main | Change value format (text/binary/hex) |
-| 🔲 | main | Rename key and confirm new name propagates across Browser |
-| 🔲 | main | Confirm TTL countdown updates in real time |
+| ✅ | main | should view, edit, rename a String key and show copy-on-hover |
+| ✅ | main | should view, edit TTL and have the key expire after countdown |
+| ✅ | main | should change value format between Unicode, HEX and Binary |
 
 ### 2.5 Key Details - Hash
 | Status | Group | Test Case |

--- a/tests/e2e-playwright/tests/main/browser/key-details/string-details.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-details/string-details.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
+import { StringKeyFactory, TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
+import { DatabaseInstance } from 'e2eSrc/types';
+
+const parseTtl = (ttlText: string): number => {
+  const match = ttlText.match(/\d+/);
+  return match ? parseInt(match[0], 10) : 0;
+};
+
+/**
+ * Browser > Key Details - String Tests
+ *
+ * Tests for viewing and editing String keys via the Key Details panel:
+ * value view/edit, rename, copy-on-hover, TTL view/edit/countdown,
+ * and value format switching (Unicode/HEX/Binary).
+ */
+test.describe('Browser > Key Details - String', () => {
+  let database: DatabaseInstance;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    // Create a test database for all tests in this file
+    const config = StandaloneConfigFactory.build({ name: 'test-key-details-string-db' });
+    database = await apiHelper.createDatabase(config);
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    // Clean up the test database
+    if (database?.id) {
+      await apiHelper.deleteDatabase(database.id);
+    }
+  });
+
+  test.beforeEach(async ({ browserPage }) => {
+    await browserPage.goto(database.id);
+  });
+
+  test.afterEach(async ({ apiHelper }) => {
+    // Clean up test keys created during the test
+    await apiHelper.deleteKeysByPattern(database.id, `${TEST_KEY_PREFIX}*`);
+  });
+
+  test('should view, edit, rename a String key and show copy-on-hover', async ({ apiHelper, browserPage }) => {
+    // Seed: create the String key via API
+    const keyData = StringKeyFactory.build();
+    const newValue = `${keyData.value}-edited`;
+    const newKeyName = `${TEST_KEY_PREFIX}string-renamed-${Date.now()}`;
+
+    await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);
+
+    // Open the key in the details panel
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+
+    // Verify the seeded value is displayed
+    expect(await browserPage.keyDetails.getStringValue()).toBe(keyData.value);
+
+    // Verify copy-key-name button appears on hover
+    expect(await browserPage.keyDetails.isCopyKeyNameButtonVisible()).toBe(true);
+
+    // Edit the value and verify it persists in both UI and Redis
+    await browserPage.keyDetails.editStringValue(newValue);
+    expect(await browserPage.keyDetails.getStringValue()).toBe(newValue);
+    const persistedValue = await apiHelper.sendCommand(database.id, `GET ${keyData.keyName}`);
+    expect(persistedValue).toBe(newValue);
+
+    // Rename the key and verify the new name propagates to the Key List
+    await browserPage.keyDetails.renameKey(newKeyName);
+    await browserPage.keyList.searchKeys(newKeyName);
+    await browserPage.expectKeyInList(newKeyName);
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.expectKeyNotInList(keyData.keyName);
+  });
+
+  test('should view, edit TTL and have the key expire after countdown', async ({ apiHelper, browserPage }) => {
+    const keyData = StringKeyFactory.build();
+
+    // Seed: create the key with no TTL
+    await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);
+
+    // Open the key in the details panel
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+
+    // Verify the initial TTL shows "No limit"
+    expect(await browserPage.keyDetails.getTtlValue()).toMatch(/No limit/i);
+
+    // Edit TTL to a short value and verify it is reflected in the panel
+    await browserPage.keyDetails.editTtl('5');
+    const editedTtl = parseTtl(await browserPage.keyDetails.getTtlValue());
+    expect(editedTtl).toBeGreaterThan(0);
+    expect(editedTtl).toBeLessThanOrEqual(5);
+
+    // Verify the key counts down and disappears from the Key List once it expires
+    await expect
+      .poll(
+        async () => {
+          await browserPage.keyList.searchKeys(keyData.keyName);
+          return browserPage.keyList.keyExists(keyData.keyName, 1000);
+        },
+        {
+          timeout: 15000,
+          intervals: [2000, 2000, 2000, 2000],
+          message: 'Key should expire and disappear from the Key List after TTL',
+        },
+      )
+      .toBe(false);
+  });
+
+  test('should change value format between Unicode, HEX and Binary', async ({ apiHelper, browserPage }) => {
+    // Seed with deterministic ASCII so HEX bytes are predictable (h=0x68, i=0x69)
+    const keyData = StringKeyFactory.build({ value: 'hi' });
+    await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);
+
+    // Open the key in the details panel
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+
+    // Verify default Unicode rendering shows the original text
+    expect(await browserPage.keyDetails.getStringValue()).toBe('hi');
+
+    // Switch to HEX and verify the value is rendered as hex bytes
+    await browserPage.keyDetails.changeValueFormat('HEX');
+    expect(await browserPage.keyDetails.getValueFormat()).toBe('HEX');
+    const hexValue = (await browserPage.keyDetails.getStringValue()).toLowerCase();
+    expect(hexValue).toContain('68');
+    expect(hexValue).toContain('69');
+
+    // Switch to Binary and verify the rendering differs from both Unicode and HEX
+    await browserPage.keyDetails.changeValueFormat('Binary');
+    expect(await browserPage.keyDetails.getValueFormat()).toBe('Binary');
+    const binaryValue = await browserPage.keyDetails.getStringValue();
+    expect(binaryValue).not.toBe('hi');
+    expect(binaryValue.toLowerCase()).not.toBe(hexValue);
+
+    // Round-trip back to Unicode and verify the original text is restored
+    await browserPage.keyDetails.changeValueFormat('Unicode');
+    expect(await browserPage.keyDetails.getValueFormat()).toBe('Unicode');
+    expect(await browserPage.keyDetails.getStringValue()).toBe('hi');
+  });
+});


### PR DESCRIPTION
# What

Adds e2e tests for the Browser - Key Details (String) view, covering view of the seeded value, copy-key-name button on hover, value edit with a Redis-side cross-check via `GET`, rename and propagation back to the Key List, view / edit TTL with countdown to expiry (the key disappears from the list once the TTL ticks down), and value format switching across Unicode / HEX / Binary.

Follow-up of #5865 — based on `e2e/RI-8005/key-tree-view-tests` so the diff stays scoped to key-details (String) changes.

# Testing

Run the Docker containers with the test database instances

```
cd tests/e2e
docker-compose -f rte.docker-compose.yml up -d
```

And then you can run the tests

```
cd tests/e2e-playwright
npm run test:chromium -- tests/main/browser/key-details/string-details.spec.ts
```

<img width="996" height="253" alt="image" src="https://github.com/user-attachments/assets/3a8a84f5-b246-443d-aeeb-3f667091af67" />

---

Closes #RI-8007

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to Playwright E2E tests and the test plan, though the TTL-expiry assertion may be somewhat timing-sensitive and could introduce CI flakiness.
> 
> **Overview**
> Adds new Playwright E2E coverage for Browser **String key details**: view seeded value, show copy-key-name button on hover, edit value (with Redis `GET` verification), rename and confirm it propagates to the key list, edit TTL and assert expiry/removal after countdown, and switch value format between Unicode/HEX/Binary.
> 
> Updates `TEST_PLAN.md` to mark the String key-details scenarios as implemented and consolidate them into three passing test cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31fe333bcc4a30517c0e6ba6b87b8212eff90db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->