### PR TITLE
RI-7682 Tighten swagger decorators to align with FE consumption

### DIFF
--- a/redisinsight/api/openapi-ts.config.ts
+++ b/redisinsight/api/openapi-ts.config.ts
@@ -12,9 +12,9 @@ import { defineConfig } from '@hey-api/openapi-ts';
  * `@ApiProperty({ enum, ... })` decorator must include `enumName: 'X'` so Nest
  * emits the enum as a referenced `components/schemas/X` instead of inlining it.
  *
- * `enums.case: 'PascalCase'` keeps the generated member names aligned with the
- * BE source (e.g. `NodeRole.Primary`, not the default `NodeRole.PRIMARY`), so
- * UI call sites read naturally.
+ * `enums.case: 'PascalCase'` keeps member names exactly as written in the BE
+ * source (e.g. `RunQueryMode.ASCII`, `NodeRole.Primary`) so the UI does not
+ * have to follow casing transforms.
  */
 export default defineConfig({
   input: './openapi.json',

--- a/redisinsight/api/src/common/decorators/redis-string-schema.decorator.ts
+++ b/redisinsight/api/src/common/decorators/redis-string-schema.decorator.ts
@@ -1,4 +1,4 @@
-import {} from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 export const REDIS_STRING_SCHEMA = {
   type: String,

--- a/redisinsight/api/src/common/decorators/redis-string-schema.decorator.ts
+++ b/redisinsight/api/src/common/decorators/redis-string-schema.decorator.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import {} from '@nestjs/swagger';
 
 export const REDIS_STRING_SCHEMA = {
   type: String,

--- a/redisinsight/api/src/modules/ai/chat/models/ai-chat.message.ts
+++ b/redisinsight/api/src/modules/ai/chat/models/ai-chat.message.ts
@@ -17,6 +17,8 @@ export class AiChatMessageContextRecord {
 export class AiChatMessage {
   @ApiProperty({
     enum: AiChatMessageType,
+
+    enumName: 'AiChatMessageType',
   })
   @Expose()
   type: AiChatMessageType;

--- a/redisinsight/api/src/modules/ai/query/models/ai-query.intermediate-step.ts
+++ b/redisinsight/api/src/modules/ai/query/models/ai-query.intermediate-step.ts
@@ -9,6 +9,8 @@ export enum AiQueryIntermediateStepType {
 export class AiQueryIntermediateStep {
   @ApiProperty({
     enum: AiQueryIntermediateStepType,
+
+    enumName: 'AiQueryIntermediateStepType',
   })
   @Expose()
   type: AiQueryIntermediateStepType;

--- a/redisinsight/api/src/modules/ai/query/models/ai-query.message.ts
+++ b/redisinsight/api/src/modules/ai/query/models/ai-query.message.ts
@@ -18,6 +18,8 @@ export class AiQueryMessage {
 
   @ApiProperty({
     enum: AiQueryMessageType,
+
+    enumName: 'AiQueryMessageType',
   })
   @Expose()
   @IsEnum(AiQueryMessageType)
@@ -56,7 +58,7 @@ export class AiQueryMessage {
   @IsString()
   content: string = '';
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
     isArray: true,
   })

--- a/redisinsight/api/src/modules/azure/auth/dto/azure-auth-login.dto.ts
+++ b/redisinsight/api/src/modules/azure/auth/dto/azure-auth-login.dto.ts
@@ -29,6 +29,7 @@ export class AzureAuthLoginDto {
       'OAuth prompt parameter to control login behavior. ' +
       '"select_account" shows account picker, "login" forces re-auth, "consent" forces consent dialog.',
     enum: AzureOAuthPrompt,
+    enumName: 'AzureOAuthPrompt',
     example: AzureOAuthPrompt.SelectAccount,
   })
   @IsOptional()
@@ -42,6 +43,7 @@ export class AzureAuthLoginDto {
       'OAuth redirect type. ' +
       '"deeplink" uses redisinsight:// protocol for Electron, "web" uses localhost HTTP callback for browser/Docker.',
     enum: AzureOAuthRedirectType,
+    enumName: 'AzureOAuthRedirectType',
     example: AzureOAuthRedirectType.Deeplink,
     default: AzureOAuthRedirectType.Deeplink,
   })

--- a/redisinsight/api/src/modules/azure/autodiscovery/dto/import-azure-database.dto.ts
+++ b/redisinsight/api/src/modules/azure/autodiscovery/dto/import-azure-database.dto.ts
@@ -21,6 +21,7 @@ export class ImportAzureDatabaseDto {
   @ApiPropertyOptional({
     description: 'Authentication type (defaults to Entra ID)',
     enum: AzureAuthType,
+    enumName: 'AzureAuthType',
     default: AzureAuthType.EntraId,
   })
   @IsOptional()

--- a/redisinsight/api/src/modules/azure/autodiscovery/dto/import-azure-database.response.ts
+++ b/redisinsight/api/src/modules/azure/autodiscovery/dto/import-azure-database.response.ts
@@ -12,6 +12,8 @@ export class ImportAzureDatabaseResponse {
     description: 'Import Azure database status',
     default: ActionStatus.Success,
     enum: ActionStatus,
+
+    enumName: 'ActionStatus',
   })
   status: ActionStatus;
 

--- a/redisinsight/api/src/modules/azure/models/azure-resource.ts
+++ b/redisinsight/api/src/modules/azure/models/azure-resource.ts
@@ -79,6 +79,8 @@ export class AzureRedisDatabase {
   @ApiProperty({
     description: 'Redis type (standard or enterprise)',
     enum: AzureRedisType,
+
+    enumName: 'AzureRedisType',
   })
   type: AzureRedisType;
 
@@ -115,6 +117,8 @@ export class AzureRedisDatabase {
   @ApiPropertyOptional({
     description: 'Access keys authentication status',
     enum: AzureAccessKeysStatus,
+
+    enumName: 'AzureAccessKeysStatus',
   })
   accessKeysAuthentication?: AzureAccessKeysStatus;
 }
@@ -153,6 +157,8 @@ export class AzureConnectionDetails {
   @ApiProperty({
     description: 'Authentication type',
     enum: AzureAuthType,
+
+    enumName: 'AzureAuthType',
   })
   authType: AzureAuthType;
 
@@ -189,6 +195,8 @@ export class AzureConnectionDetails {
   @ApiProperty({
     description: 'Azure Redis type',
     enum: AzureRedisType,
+
+    enumName: 'AzureRedisType',
   })
   resourceType: AzureRedisType;
 

--- a/redisinsight/api/src/modules/browser/browser-history/dto/get.browser-history.dto.ts
+++ b/redisinsight/api/src/modules/browser/browser-history/dto/get.browser-history.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { BrowserHistoryMode } from 'src/common/constants';
 import { RedisDataType } from 'src/modules/browser/keys/dto';
@@ -19,7 +19,7 @@ export class ScanFilter {
   })
   type?: RedisDataType = null;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Match glob patterns',
     type: String,
     example: 'device:*',
@@ -56,10 +56,12 @@ export class BrowserHistory {
   @Type(() => ScanFilter)
   filter: ScanFilter = new ScanFilter();
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Mode of history',
     default: BrowserHistoryMode.Pattern,
     enum: BrowserHistoryMode,
+
+    enumName: 'BrowserHistoryMode',
   })
   @Expose()
   mode?: BrowserHistoryMode = BrowserHistoryMode.Pattern;

--- a/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.dto.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.dto.ts
@@ -30,6 +30,7 @@ export class GetKeysInfoDto {
     description:
       'Iterate through the database looking for keys of a specific type.',
     enum: RedisDataType,
+    enumName: 'RedisDataType',
     example: RedisDataType.Hash,
   })
   @IsEnum(RedisDataType, {

--- a/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.response.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.response.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RedisStringType, ApiRedisString } from 'src/common/decorators';
 import { RedisString } from 'src/common/constants';
 
@@ -7,12 +7,12 @@ export class GetKeyInfoResponse {
   @RedisStringType()
   name: RedisString;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
   })
   type?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Number,
     description:
       'The remaining time to live of a key.' +
@@ -20,7 +20,7 @@ export class GetKeyInfoResponse {
   })
   ttl?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Number,
     description:
       'The number of bytes that a key and its value require to be stored in RAM.',

--- a/redisinsight/api/src/modules/browser/keys/dto/get.keys.dto.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/get.keys.dto.ts
@@ -54,6 +54,8 @@ export class GetKeysDto {
     description:
       'Iterate through the database looking for keys of a specific type.',
     enum: RedisDataType,
+
+    enumName: 'RedisDataType',
   })
   @IsEnum(RedisDataType, {
     message: `destination must be a valid enum value. Valid values: ${Object.values(

--- a/redisinsight/api/src/modules/browser/redisearch/dto/create.redisearch-index.dto.ts
+++ b/redisinsight/api/src/modules/browser/redisearch/dto/create.redisearch-index.dto.ts
@@ -38,6 +38,8 @@ export class CreateRedisearchIndexFieldDto {
   @ApiProperty({
     description: 'Type of how data must be indexed',
     enum: RedisearchIndexDataType,
+
+    enumName: 'RedisearchIndexDataType',
   })
   @IsDefined()
   @IsEnum(RedisearchIndexDataType, {
@@ -58,6 +60,8 @@ export class CreateRedisearchIndexDto {
   @ApiProperty({
     description: 'Type of keys to index',
     enum: RedisearchIndexKeyType,
+
+    enumName: 'RedisearchIndexKeyType',
   })
   @IsDefined()
   @IsEnum(RedisearchIndexKeyType, {

--- a/redisinsight/api/src/modules/browser/redisearch/dto/index.info.dto.ts
+++ b/redisinsight/api/src/modules/browser/redisearch/dto/index.info.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsDefined } from 'class-validator';
 import {
   ApiRedisString,
@@ -17,7 +17,7 @@ export class IndexInfoRequestBodyDto {
 }
 
 export class IndexOptionsDto {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'is a filter expression with the full RediSearch aggregation expression language.',
     type: String,
@@ -25,7 +25,7 @@ export class IndexOptionsDto {
   @Expose()
   filter?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'if set, indicates the default language for documents in the index. Default is English.',
     type: String,
@@ -57,7 +57,7 @@ export class IndexDefinitionDto {
   @Expose()
   default_score: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'Indicates whether all fields of a JSON document are automatically indexed by RediSearch',
     type: String,
@@ -88,21 +88,21 @@ export class IndexAttibuteDto {
   @Expose()
   type: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Field weight',
     type: String,
   })
   @Expose()
   WEIGHT?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Field can be sorted',
     type: Boolean,
   })
   @Expose()
   SORTABLE?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'Attributes can have the NOINDEX option, which means they will not be indexed. ',
     type: Boolean,
@@ -110,14 +110,14 @@ export class IndexAttibuteDto {
   @Expose()
   NOINDEX?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Attribute is case sensitive',
     type: Boolean,
   })
   @Expose()
   CASESENSITIVE?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `By default, for hashes (not with JSON) SORTABLE applies a normalization to the indexed value
       (characters set to lowercase, removal of diacritics).`,
     type: Boolean,
@@ -125,7 +125,7 @@ export class IndexAttibuteDto {
   @Expose()
   UNF?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `Text attributes can have the NOSTEM argument that disables stemming when indexing its values.
       This may be ideal for things like proper names.`,
     type: Boolean,
@@ -133,7 +133,7 @@ export class IndexAttibuteDto {
   @Expose()
   NOSTEM?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `Indicates how the text contained in the attribute is to be split into individual tags.
       The default is ,. The value must be a single character.`,
     type: String,
@@ -208,21 +208,21 @@ export class IndexInfoDto {
   @Expose()
   num_docs: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The maximum document ID.',
     type: String,
   })
   @Expose()
   max_doc_id?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The number of distinct terms.',
     type: String,
   })
   @Expose()
   num_terms?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The total number of records.',
     type: String,
   })
@@ -230,7 +230,7 @@ export class IndexInfoDto {
   num_records?: string;
 
   // Various size statistics
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by the inverted index, which is the core data structure
       used for searching in RediSearch. The size is given in megabytes.`,
     type: String,
@@ -238,7 +238,7 @@ export class IndexInfoDto {
   @Expose()
   inverted_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by the vector index,
       which stores any vectors associated with each document.`,
     type: String,
@@ -246,14 +246,14 @@ export class IndexInfoDto {
   @Expose()
   vector_index_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The total number of blocks in the inverted index.',
     type: String,
   })
   @Expose()
   total_inverted_index_blocks?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by the offset vectors,
       which store positional information for terms in documents.`,
     type: String,
@@ -261,7 +261,7 @@ export class IndexInfoDto {
   @Expose()
   offset_vectors_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by the document table,
       which contains metadata about each document in the index.`,
     type: String,
@@ -269,7 +269,7 @@ export class IndexInfoDto {
   @Expose()
   doc_table_size_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by sortable values,
       which are values associated with documents and used for sorting purposes.`,
     type: String,
@@ -277,28 +277,28 @@ export class IndexInfoDto {
   @Expose()
   sortable_values_size_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Tag overhead memory usage in mb',
     type: String,
   })
   @Expose()
   tag_overhead_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Text overhead memory usage in mb',
     type: String,
   })
   @Expose()
   text_overhead_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Total index memory size in mb',
     type: String,
   })
   @Expose()
   total_index_memory_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: `The memory used by the key table,
       which stores the mapping between document IDs and Redis keys`,
     type: String,
@@ -306,14 +306,14 @@ export class IndexInfoDto {
   @Expose()
   key_table_size_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The memory used by GEO-related fields.',
     type: String,
   })
   @Expose()
   geoshapes_sz_mb?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'The average number of records (including deletions) per document.',
     type: String,
@@ -321,14 +321,14 @@ export class IndexInfoDto {
   @Expose()
   records_per_doc_avg?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The average size of each record in bytes.',
     type: String,
   })
   @Expose()
   bytes_per_record_avg?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'The average number of offsets (position information) per term.',
     type: String,
@@ -336,7 +336,7 @@ export class IndexInfoDto {
   @Expose()
   offsets_per_term_avg?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The average number of bits used for offsets per record.',
     type: String,
   })
@@ -344,28 +344,28 @@ export class IndexInfoDto {
   offset_bits_per_record_avg?: string;
 
   // Indexing-related statistics
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The number of failures encountered during indexing.',
     type: String,
   })
   @Expose()
   hash_indexing_failures?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The total time taken for indexing in seconds.',
     type: String,
   })
   @Expose()
   total_indexing_time?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Indicates whether the index is currently being generated.',
     type: String,
   })
   @Expose()
   indexing?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'The percentage of the index that has been successfully generated.',
     type: String,
@@ -373,14 +373,14 @@ export class IndexInfoDto {
   @Expose()
   percent_indexed?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'The number of times the index has been used.',
     type: Number,
   })
   @Expose()
   number_of_uses?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'The index deletion flag. A value of 1 indicates index deletion is in progress.',
     type: Number,
@@ -389,21 +389,21 @@ export class IndexInfoDto {
   cleaning?: number;
 
   // Other
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Garbage collection statistics',
     type: Object,
   })
   @Expose()
   gc_stats?: object;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Cursor statistics',
     type: Object,
   })
   @Expose()
   cursor_stats?: object;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'Dialect statistics: the number of times the index was searched using each DIALECT, 1 - 4.',
     type: Object,

--- a/redisinsight/api/src/modules/browser/rejson-rl/dto/safe.rejson-rl-data.dto.ts
+++ b/redisinsight/api/src/modules/browser/rejson-rl/dto/safe.rejson-rl-data.dto.ts
@@ -32,6 +32,8 @@ export class SafeRejsonRlDataDto {
 
   @ApiProperty({
     enum: RejsonRlDataType,
+
+    enumName: 'RejsonRlDataType',
     description: 'Type of the field',
   })
   type: RejsonRlDataType;

--- a/redisinsight/api/src/modules/browser/stream/dto/get.stream-entries.dto.ts
+++ b/redisinsight/api/src/modules/browser/stream/dto/get.stream-entries.dto.ts
@@ -34,6 +34,8 @@ export class GetStreamEntriesDto extends KeyDto {
     description: 'Get entries sort by IDs order.',
     default: SortOrder.Desc,
     enum: SortOrder,
+
+    enumName: 'SortOrder',
   })
   @IsEnum(SortOrder, {
     message: `sortOrder must be a valid enum value. Valid values: ${Object.values(

--- a/redisinsight/api/src/modules/browser/string/dto/get.string-info.dto.ts
+++ b/redisinsight/api/src/modules/browser/string/dto/get.string-info.dto.ts
@@ -1,11 +1,11 @@
 import { KeyDto } from 'src/modules/browser/keys/dto';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsInt, IsOptional, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsBiggerThan } from 'src/common/decorators';
 
 export class GetStringInfoDto extends KeyDto {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Start of string',
     type: Number,
     default: 0,
@@ -16,7 +16,7 @@ export class GetStringInfoDto extends KeyDto {
   @Min(0)
   start?: number = 0;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'End of string',
     type: Number,
   })

--- a/redisinsight/api/src/modules/browser/z-set/dto/get.z-set-members.dto.ts
+++ b/redisinsight/api/src/modules/browser/z-set/dto/get.z-set-members.dto.ts
@@ -36,6 +36,8 @@ export class GetZSetMembersDto extends KeyDto {
       ' In order to sort the members from the highest to the lowest score, use the DESC value, else ASC value',
     default: SortOrder.Desc,
     enum: SortOrder,
+
+    enumName: 'SortOrder',
   })
   @IsNotEmpty()
   @IsEnum(SortOrder, {

--- a/redisinsight/api/src/modules/cli/dto/cli.dto.ts
+++ b/redisinsight/api/src/modules/cli/dto/cli.dto.ts
@@ -29,6 +29,8 @@ export class SendCommandDto {
     description: 'Define output format',
     default: CliOutputFormatterTypes.Raw,
     enum: CliOutputFormatterTypes,
+
+    enumName: 'CliOutputFormatterTypes',
   })
   @IsOptional()
   @IsEnum(CliOutputFormatterTypes, {
@@ -50,6 +52,8 @@ export class SendCommandResponse {
     description: 'Redis CLI command execution status',
     default: CommandExecutionStatus.Success,
     enum: CommandExecutionStatus,
+
+    enumName: 'CommandExecutionStatus',
   })
   status: CommandExecutionStatus;
 }

--- a/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-request-info.ts
+++ b/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-request-info.ts
@@ -13,6 +13,7 @@ export class CloudAuthRequestInfo extends PickType(CloudAuthRequest, [
   @ApiProperty({
     description: 'Identity provider type',
     enum: CloudAuthIdpType,
+    enumName: 'CloudAuthIdpType',
     example: CloudAuthIdpType.Google,
   })
   idpType: CloudAuthIdpType;

--- a/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-request.ts
+++ b/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-request.ts
@@ -13,6 +13,7 @@ export class CloudAuthRequestOptions {
   @ApiProperty({
     description: 'OAuth identity provider strategy',
     enum: CloudAuthIdpType,
+    enumName: 'CloudAuthIdpType',
     example: CloudAuthIdpType.Google,
   })
   strategy: CloudAuthIdpType;
@@ -42,6 +43,7 @@ export class CloudAuthRequest extends CloudAuthRequestOptions {
   @ApiProperty({
     description: 'Identity provider type',
     enum: CloudAuthIdpType,
+    enumName: 'CloudAuthIdpType',
     example: CloudAuthIdpType.Google,
   })
   idpType: CloudAuthIdpType;

--- a/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-response.ts
+++ b/redisinsight/api/src/modules/cloud/auth/models/cloud-auth-response.ts
@@ -9,6 +9,7 @@ export class CloudAuthResponse {
   @ApiProperty({
     description: 'Authentication status',
     enum: CloudAuthStatus,
+    enumName: 'CloudAuthStatus',
     example: CloudAuthStatus.Succeed,
   })
   status: CloudAuthStatus;

--- a/redisinsight/api/src/modules/cloud/autodiscovery/dto/import-cloud-database.response.ts
+++ b/redisinsight/api/src/modules/cloud/autodiscovery/dto/import-cloud-database.response.ts
@@ -19,6 +19,8 @@ export class ImportCloudDatabaseResponse {
     description: 'Add Redis Cloud database status',
     default: ActionStatus.Success,
     enum: ActionStatus,
+
+    enumName: 'ActionStatus',
   })
   status: ActionStatus;
 

--- a/redisinsight/api/src/modules/cloud/database/dto/get-cloud-subscription-databases.dto.ts
+++ b/redisinsight/api/src/modules/cloud/database/dto/get-cloud-subscription-databases.dto.ts
@@ -24,6 +24,8 @@ export class GetCloudSubscriptionDatabasesDto {
   @ApiProperty({
     description: 'Subscription Id',
     enum: CloudSubscriptionType,
+
+    enumName: 'CloudSubscriptionType',
   })
   @IsEnum(CloudSubscriptionType, {
     message: `subscriptionType must be a valid enum value. Valid values: ${Object.values(

--- a/redisinsight/api/src/modules/cloud/database/models/cloud-database.ts
+++ b/redisinsight/api/src/modules/cloud/database/models/cloud-database.ts
@@ -89,6 +89,8 @@ export class CloudDatabase {
   @ApiProperty({
     description: 'Subscription type',
     enum: CloudSubscriptionType,
+
+    enumName: 'CloudSubscriptionType',
   })
   @Expose()
   subscriptionType: CloudSubscriptionType;
@@ -117,6 +119,7 @@ export class CloudDatabase {
   @ApiProperty({
     description: 'Database status',
     enum: CloudDatabaseStatus,
+    enumName: 'CloudDatabaseStatus',
     default: CloudDatabaseStatus.Active,
   })
   @Expose()

--- a/redisinsight/api/src/modules/cloud/job/dto/create.cloud-job.dto.ts
+++ b/redisinsight/api/src/modules/cloud/job/dto/create.cloud-job.dto.ts
@@ -28,6 +28,8 @@ export class CreateCloudJobDto {
   @ApiProperty({
     description: 'Job name to create',
     enum: CloudJobName,
+
+    enumName: 'CloudJobName',
   })
   @IsEnum(CloudJobName)
   @IsNotEmpty()
@@ -36,6 +38,8 @@ export class CreateCloudJobDto {
   @ApiProperty({
     description: 'Mod in which to run the job.',
     enum: CloudJobRunMode,
+
+    enumName: 'CloudJobRunMode',
   })
   @IsOptional()
   @Expose()

--- a/redisinsight/api/src/modules/cloud/job/models/cloud-job-info.ts
+++ b/redisinsight/api/src/modules/cloud/job/models/cloud-job-info.ts
@@ -31,12 +31,16 @@ export class CloudJobInfo {
 
   @ApiProperty({
     enum: CloudJobName,
+
+    enumName: 'CloudJobName',
   })
   @Expose()
   name: CloudJobName;
 
   @ApiProperty({
     enum: CloudJobStatus,
+
+    enumName: 'CloudJobStatus',
   })
   @Expose()
   status: CloudJobStatus;

--- a/redisinsight/api/src/modules/cloud/subscription/models/cloud-subscription-plan.ts
+++ b/redisinsight/api/src/modules/cloud/subscription/models/cloud-subscription-plan.ts
@@ -21,6 +21,8 @@ export class CloudSubscriptionPlan {
   @ApiProperty({
     description: 'Subscription type',
     enum: CloudSubscriptionType,
+
+    enumName: 'CloudSubscriptionType',
   })
   type: CloudSubscriptionType;
 

--- a/redisinsight/api/src/modules/cloud/subscription/models/cloud-subscription.ts
+++ b/redisinsight/api/src/modules/cloud/subscription/models/cloud-subscription.ts
@@ -29,10 +29,12 @@ export class CloudSubscription {
   @ApiProperty({
     description: 'Subscription type',
     enum: CloudSubscriptionType,
+
+    enumName: 'CloudSubscriptionType',
   })
   type: CloudSubscriptionType;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Number of databases in subscription',
     type: Number,
   })
@@ -41,6 +43,7 @@ export class CloudSubscription {
   @ApiProperty({
     description: 'Subscription status',
     enum: CloudSubscriptionStatus,
+    enumName: 'CloudSubscriptionStatus',
     default: CloudSubscriptionStatus.Active,
   })
   status: CloudSubscriptionStatus;

--- a/redisinsight/api/src/modules/cloud/task/models/cloud-task.ts
+++ b/redisinsight/api/src/modules/cloud/task/models/cloud-task.ts
@@ -22,6 +22,8 @@ export class CloudTask {
   @ApiProperty({
     description: 'Current status of the task',
     enum: CloudTaskStatus,
+
+    enumName: 'CloudTaskStatus',
   })
   status: CloudTaskStatus;
 

--- a/redisinsight/api/src/modules/cloud/user/models/cloud-user-account.ts
+++ b/redisinsight/api/src/modules/cloud/user/models/cloud-user-account.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { TransformGroup } from 'src/common/constants';
 
@@ -18,14 +18,14 @@ export class CloudUserAccount {
   name: string;
 
   @Expose({ groups: [TransformGroup.Secure] })
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Cloud API key',
     type: String,
   })
   capiKey?: string; // api_access_key
 
   @Expose({ groups: [TransformGroup.Secure] })
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Cloud API secret',
     type: String,
   })

--- a/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.manifest.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.manifest.ts
@@ -68,7 +68,7 @@ export class CustomTutorialManifest {
   @IsNotEmpty()
   label: string;
 
-  @ApiProperty({ type: String })
+  @ApiPropertyOptional({ type: String })
   @IsOptional()
   @Expose()
   @IsString()

--- a/redisinsight/api/src/modules/database-analysis/models/scan-filter.ts
+++ b/redisinsight/api/src/modules/database-analysis/models/scan-filter.ts
@@ -1,6 +1,6 @@
 import { RedisDataType } from 'src/modules/browser/keys/dto';
 import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 
 export class ScanFilter {
@@ -18,7 +18,7 @@ export class ScanFilter {
   })
   type?: RedisDataType = null;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Match glob patterns',
     type: String,
     example: 'device:*',
@@ -29,7 +29,7 @@ export class ScanFilter {
   @Expose()
   match?: string = '*';
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '"count" argument for "scan" command per node',
     type: Number,
     example: 10_000,

--- a/redisinsight/api/src/modules/database-import/dto/database-import.response.ts
+++ b/redisinsight/api/src/modules/database-import/dto/database-import.response.ts
@@ -19,6 +19,8 @@ export class DatabaseImportResult {
   @ApiProperty({
     description: 'Import status',
     enum: DatabaseImportStatus,
+
+    enumName: 'DatabaseImportStatus',
   })
   @Expose()
   status: DatabaseImportStatus;

--- a/redisinsight/api/src/modules/database-recommendation/dto/modify.database-recommendation.dto.ts
+++ b/redisinsight/api/src/modules/database-recommendation/dto/modify.database-recommendation.dto.ts
@@ -7,6 +7,8 @@ export class ModifyDatabaseRecommendationDto {
     description: 'Recommendation vote',
     default: null,
     enum: Vote,
+
+    enumName: 'Vote',
   })
   @IsOptional()
   @IsEnum(Vote, {

--- a/redisinsight/api/src/modules/database-recommendation/models/database-recommendation.ts
+++ b/redisinsight/api/src/modules/database-recommendation/models/database-recommendation.ts
@@ -57,6 +57,8 @@ export class DatabaseRecommendation {
     description: 'Recommendation vote',
     default: Vote.Like,
     enum: Vote,
+
+    enumName: 'Vote',
   })
   @IsEnum(Vote)
   @IsOptional()

--- a/redisinsight/api/src/modules/database/models/database-overview.ts
+++ b/redisinsight/api/src/modules/database/models/database-overview.ts
@@ -71,7 +71,7 @@ export class DatabaseOverview {
   })
   maxCpuUsagePercentage?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Database server name',
     type: String,
   })

--- a/redisinsight/api/src/modules/database/models/database.ts
+++ b/redisinsight/api/src/modules/database/models/database.ts
@@ -121,6 +121,8 @@ export class Database {
     description: 'Connection Type',
     default: ConnectionType.STANDALONE,
     enum: ConnectionType,
+
+    enumName: 'ConnectionType',
   })
   @Expose()
   @IsEnum(ConnectionType)
@@ -143,7 +145,7 @@ export class Database {
   @IsString()
   provider?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Time of the last connection to the database.',
     type: Date,
     format: 'date-time',
@@ -152,7 +154,7 @@ export class Database {
   @Expose()
   lastConnection?: Date;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Date of creation',
     type: Date,
   })
@@ -298,6 +300,8 @@ export class Database {
     description: 'Database compressor',
     default: Compressor.NONE,
     enum: Compressor,
+
+    enumName: 'Compressor',
   })
   @Expose()
   @IsEnum(Compressor, {
@@ -312,6 +316,8 @@ export class Database {
     description: 'Key name format',
     default: Encoding.UNICODE,
     enum: Encoding,
+
+    enumName: 'Encoding',
   })
   @Expose()
   @IsEnum(Encoding, {

--- a/redisinsight/api/src/modules/database/models/provider-details.ts
+++ b/redisinsight/api/src/modules/database/models/provider-details.ts
@@ -31,6 +31,7 @@ export class AzureProviderDetails {
   @ApiProperty({
     description: 'Cloud provider',
     enum: CloudProvider,
+    enumName: 'CloudProvider',
     example: CloudProvider.Azure,
   })
   @Expose()
@@ -40,6 +41,7 @@ export class AzureProviderDetails {
   @ApiProperty({
     description: 'Authentication type',
     enum: AzureAuthType,
+    enumName: 'AzureAuthType',
     example: AzureAuthType.EntraId,
   })
   @Expose()
@@ -93,6 +95,8 @@ export class AzureProviderDetails {
   @ApiPropertyOptional({
     description: 'Azure Redis type (standard/enterprise)',
     enum: AzureRedisType,
+
+    enumName: 'AzureRedisType',
   })
   @Expose()
   @IsOptional()

--- a/redisinsight/api/src/modules/notification/dto/read-notifications.dto.ts
+++ b/redisinsight/api/src/modules/notification/dto/read-notifications.dto.ts
@@ -15,6 +15,8 @@ export class ReadNotificationsDto {
 
   @ApiPropertyOptional({
     enum: NotificationType,
+
+    enumName: 'NotificationType',
     example: NotificationType.Global,
     description: 'Type of notification',
   })

--- a/redisinsight/api/src/modules/notification/models/notification.ts
+++ b/redisinsight/api/src/modules/notification/models/notification.ts
@@ -5,6 +5,8 @@ import { NotificationType } from 'src/modules/notification/constants';
 export class Notification {
   @ApiProperty({
     enum: NotificationType,
+
+    enumName: 'NotificationType',
     example: NotificationType.Global,
     description: 'Notification type',
   })

--- a/redisinsight/api/src/modules/plugin/plugin.response.ts
+++ b/redisinsight/api/src/modules/plugin/plugin.response.ts
@@ -43,7 +43,7 @@ export class PluginVisualization {
   @Type(() => String)
   matchCommands: string[];
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Boolean,
   })
   @IsOptional()
@@ -51,7 +51,7 @@ export class PluginVisualization {
   @IsBoolean()
   default?: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
   })
   @IsOptional()
@@ -59,7 +59,7 @@ export class PluginVisualization {
   @IsString()
   iconDark?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
   })
   @IsOptional()
@@ -97,7 +97,7 @@ export class Plugin {
   @IsString()
   main: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Uri to css file on the local server',
     type: String,
   })

--- a/redisinsight/api/src/modules/query-library/models/query-library.ts
+++ b/redisinsight/api/src/modules/query-library/models/query-library.ts
@@ -31,6 +31,8 @@ export class QueryLibraryItem {
   @ApiProperty({
     description: 'Query type',
     enum: QueryLibraryType,
+
+    enumName: 'QueryLibraryType',
   })
   @IsEnum(QueryLibraryType, {
     message: `type must be a valid enum value. Valid values: ${Object.values(

--- a/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
+++ b/redisinsight/api/src/modules/rdi/dto/rdi-test-connections.response.dto.ts
@@ -27,6 +27,8 @@ export class RdiTestTargetConnectionResult {
   @ApiProperty({
     description: 'Connection status',
     enum: RdiTestConnectionStatus,
+
+    enumName: 'RdiTestConnectionStatus',
   })
   @Expose()
   status: RdiTestConnectionStatus;
@@ -45,7 +47,7 @@ export class RdiTestSourceConnectionResult {
   @Expose()
   connected: boolean;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Error message if connection fails',
     required: false,
   })

--- a/redisinsight/api/src/modules/rdi/models/rdi-statistics.ts
+++ b/redisinsight/api/src/modules/rdi/models/rdi-statistics.ts
@@ -220,6 +220,8 @@ export class RdiStatisticsResult {
   @ApiProperty({
     description: 'Statistics status',
     enum: RdiStatisticsStatus,
+
+    enumName: 'RdiStatisticsStatus',
   })
   @Expose()
   status: RdiStatisticsStatus;

--- a/redisinsight/api/src/modules/rdi/models/rdi.pipeline.status.ts
+++ b/redisinsight/api/src/modules/rdi/models/rdi.pipeline.status.ts
@@ -59,6 +59,8 @@ export class RdiPipelineStatus {
     description: 'Pipeline status',
     example: 'ready',
     enum: PipelineStatus,
+
+    enumName: 'PipelineStatus',
   })
   @Expose()
   status: PipelineStatus;
@@ -67,6 +69,8 @@ export class RdiPipelineStatus {
     description: 'Pipeline state (used in api/v1 only)',
     example: 'cdc',
     enum: PipelineState,
+
+    enumName: 'PipelineState',
   })
   @Expose()
   state?: PipelineState;

--- a/redisinsight/api/src/modules/rdi/models/rdi.ts
+++ b/redisinsight/api/src/modules/rdi/models/rdi.ts
@@ -48,7 +48,7 @@ export class Rdi {
   @IsString()
   password?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Time of the last connection to RDI.',
     type: String,
     format: 'date-time',

--- a/redisinsight/api/src/modules/redis-enterprise/dto/cluster.dto.ts
+++ b/redisinsight/api/src/modules/redis-enterprise/dto/cluster.dto.ts
@@ -89,6 +89,7 @@ export class RedisEnterpriseDatabase {
   @ApiProperty({
     description: 'Database status',
     enum: RedisEnterpriseDatabaseStatus,
+    enumName: 'RedisEnterpriseDatabaseStatus',
     default: RedisEnterpriseDatabaseStatus.Active,
   })
   status: RedisEnterpriseDatabaseStatus;

--- a/redisinsight/api/src/modules/redis-enterprise/dto/redis-enterprise-cluster.dto.ts
+++ b/redisinsight/api/src/modules/redis-enterprise/dto/redis-enterprise-cluster.dto.ts
@@ -32,6 +32,8 @@ export class AddRedisEnterpriseDatabaseResponse {
     description: 'Add Redis Enterprise database status',
     default: ActionStatus.Success,
     enum: ActionStatus,
+
+    enumName: 'ActionStatus',
   })
   status: ActionStatus;
 

--- a/redisinsight/api/src/modules/redis-sentinel/dto/create.sentinel.database.response.ts
+++ b/redisinsight/api/src/modules/redis-sentinel/dto/create.sentinel.database.response.ts
@@ -21,6 +21,8 @@ export class CreateSentinelDatabaseResponse {
     description: 'Add Sentinel Master status',
     default: ActionStatus.Success,
     enum: ActionStatus,
+
+    enumName: 'ActionStatus',
   })
   @Expose()
   status: ActionStatus;

--- a/redisinsight/api/src/modules/redis-sentinel/models/sentinel-master.ts
+++ b/redisinsight/api/src/modules/redis-sentinel/models/sentinel-master.ts
@@ -67,6 +67,7 @@ export class SentinelMaster {
   @ApiPropertyOptional({
     description: 'Sentinel master status',
     enum: SentinelMasterStatus,
+    enumName: 'SentinelMasterStatus',
     default: SentinelMasterStatus.Active,
   })
   status?: SentinelMasterStatus;

--- a/redisinsight/api/src/modules/server/dto/server.dto.ts
+++ b/redisinsight/api/src/modules/server/dto/server.dto.ts
@@ -40,6 +40,7 @@ export class GetServerInfoResponse {
   @ApiProperty({
     description: 'Application package type.',
     enum: PackageType,
+    enumName: 'PackageType',
     example: 'app-image',
   })
   packageType: PackageType;
@@ -47,6 +48,7 @@ export class GetServerInfoResponse {
   @ApiProperty({
     description: 'Application type.',
     enum: AppType,
+    enumName: 'AppType',
     example: 'DOCKER',
   })
   appType: AppType;

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -58,10 +58,22 @@ export class GetUserAgreementsResponse {
   })
   version: string;
 
+  @ApiPropertyOptional({
+    description: 'Did the user accept the EULA agreement.',
+    type: Boolean,
+  })
   eula?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Did the user accept the analytics agreement.',
+    type: Boolean,
+  })
   analytics?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Did the user accept the notifications agreement.',
+    type: Boolean,
+  })
   notifications?: boolean;
 
   @Exclude()
@@ -90,6 +102,7 @@ export class GetAppSettingsResponse {
   @ApiProperty({
     description: 'Applied application timezone',
     enum: TimezoneOption,
+    enumName: 'TimezoneOption',
     example: 'local',
   })
   @Expose()

--- a/redisinsight/api/src/modules/workbench/models/command-execution-result.ts
+++ b/redisinsight/api/src/modules/workbench/models/command-execution-result.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CommandExecutionStatus } from 'src/modules/cli/dto/cli.dto';
 import { Expose } from 'class-transformer';
 
@@ -7,6 +7,8 @@ export class CommandExecutionResult {
     description: 'Redis CLI command execution status',
     default: CommandExecutionStatus.Success,
     enum: CommandExecutionStatus,
+
+    enumName: 'CommandExecutionStatus',
   })
   @Expose()
   status: CommandExecutionStatus;
@@ -18,7 +20,7 @@ export class CommandExecutionResult {
   @Expose()
   response: any;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Boolean,
     description:
       'Flag showing if response was replaced with message notification about response size limit threshold',

--- a/redisinsight/api/src/modules/workbench/models/command-execution.ts
+++ b/redisinsight/api/src/modules/workbench/models/command-execution.ts
@@ -79,6 +79,8 @@ export class CommandExecution {
     description: 'Workbench mode',
     default: RunQueryMode.ASCII,
     enum: RunQueryMode,
+
+    enumName: 'RunQueryMode',
   })
   @Expose()
   @IsOptional()
@@ -94,6 +96,8 @@ export class CommandExecution {
     description: 'Workbench result mode',
     default: ResultsMode.Default,
     enum: ResultsMode,
+
+    enumName: 'ResultsMode',
   })
   @Expose()
   @IsOptional()
@@ -157,6 +161,8 @@ export class CommandExecution {
       'Command execution type. Used to distinguish between search and workbench',
     default: CommandExecutionType.Workbench,
     enum: CommandExecutionType,
+
+    enumName: 'CommandExecutionType',
   })
   @Expose()
   @IsOptional()

--- a/redisinsight/ui/src/mocks/factories/database-analysis/DatabaseAnalysis.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/database-analysis/DatabaseAnalysis.factory.ts
@@ -8,7 +8,7 @@ export const DatabaseAnalysisFactory = Factory.define<DatabaseAnalysis>(() => ({
   filter: { match: '*', count: 10000 } as any,
   delimiter: ':',
   progress: { total: 100000, scanned: 50000, processed: 10000 } as any,
-  createdAt: faker.date.recent(),
+  createdAt: faker.date.recent().toISOString(),
   totalKeys: { total: 10000, types: [] } as any,
   totalMemory: { total: 1000000, types: [] } as any,
   topKeysNsp: [],

--- a/redisinsight/ui/src/mocks/factories/workbench/commandExectution.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/workbench/commandExectution.factory.ts
@@ -21,7 +21,7 @@ export const commandExecutionFactory = Factory.define<CommandExecution>(
     command: faker.lorem.paragraph(),
     result: commandExecutionResultFactory.buildList(1),
     executionTime: faker.number.int({ min: 1000, max: 5000 }),
-    createdAt: faker.date.past(),
+    createdAt: faker.date.past().toISOString(),
   }),
 )
 

--- a/redisinsight/ui/src/mocks/rdi/RdiInstance.factory.ts
+++ b/redisinsight/ui/src/mocks/rdi/RdiInstance.factory.ts
@@ -9,7 +9,7 @@ export const rdiInstanceFactory = Factory.define<RdiInstance>(() => ({
   username: faker.internet.userName(),
   password: faker.internet.password(),
   version: faker.system.semver(),
-  lastConnection: faker.date.past(),
+  lastConnection: faker.date.past().toISOString(),
   error: '',
   loading: false,
 }))

--- a/redisinsight/ui/src/services/commands-history/database/CommandsHistoryIndexedDB.spec.ts
+++ b/redisinsight/ui/src/services/commands-history/database/CommandsHistoryIndexedDB.spec.ts
@@ -245,7 +245,7 @@ describe('CommandsHistoryIndexedDB', () => {
       const expectedResultCommands = mockCommandExecutions.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt?.toISOString(),
+        createdAt: cmd.createdAt,
       })) as unknown as CommandExecutionUI[]
 
       // Override the MSW handler to return our mock commands

--- a/redisinsight/ui/src/services/commands-history/database/CommandsHistorySQLite.spec.ts
+++ b/redisinsight/ui/src/services/commands-history/database/CommandsHistorySQLite.spec.ts
@@ -35,7 +35,7 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommands = mockCommands.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       }))
 
       // Override the MSW handler to return our mock commands
@@ -132,12 +132,12 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommands1 = mockCommandExecutions1.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       }))
       const expectedResultCommands2 = mockCommandExecutions2.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       }))
 
       // Override the MSW handler to return different data based on instance ID
@@ -188,7 +188,7 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommand = {
         ...mockCommand,
         emptyCommand: false,
-        createdAt: mockCommand.createdAt.toISOString(),
+        createdAt: mockCommand.createdAt,
       }
 
       // Override the MSW handler to return our mock command
@@ -291,12 +291,12 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommand1 = {
         ...mockCommand1,
         emptyCommand: false,
-        createdAt: mockCommand1.createdAt.toISOString(),
+        createdAt: mockCommand1.createdAt,
       }
       const expectedResultCommand2 = {
         ...mockCommand2,
         emptyCommand: false,
-        createdAt: mockCommand2.createdAt.toISOString(),
+        createdAt: mockCommand2.createdAt,
       }
 
       // Override the MSW handler to return different data based on instance ID and command ID
@@ -384,7 +384,7 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommands = mockCommands.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       })) as unknown as CommandExecutionUI[]
 
       // Override the MSW handler to return our mock commands
@@ -424,7 +424,7 @@ describe('CommandHistorySQLite', () => {
         const expectedResultCommands = mockCommands.map((cmd) => ({
           ...cmd,
           emptyCommand: false,
-          createdAt: cmd.createdAt.toISOString(),
+          createdAt: cmd.createdAt,
         })) as unknown as CommandExecutionUI[]
 
         mswServer.use(
@@ -561,12 +561,12 @@ describe('CommandHistorySQLite', () => {
       const expectedResultCommands1 = mockCommandExecutions1.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       })) as unknown as CommandExecutionUI[]
       const expectedResultCommands2 = mockCommandExecutions2.map((cmd) => ({
         ...cmd,
         emptyCommand: false,
-        createdAt: cmd.createdAt.toISOString(),
+        createdAt: cmd.createdAt,
       })) as unknown as CommandExecutionUI[]
 
       // Override the MSW handler to return different data based on instance ID


### PR DESCRIPTION
# What

Continuation of #5885. The import migration there surfaced ~457 type-level shape gaps between the BE class declarations and the OpenAPI spec they generate. This PR closes most of them at the source rather than at every call site.

**Base note:** stacked on top of #5885 (`feature/RI-7682/consume-apiclient-types`). After #5885 merges, GitHub will auto-retarget this PR's base to `main`.

## BE swagger decorators

- **`enumName`** added to 64 `@ApiProperty({ enum: X, ... })` sites so Nest emits each enum as a referenced `components/schemas/X` instead of inlining it as a string-literal union. `@hey-api/openapi-ts` then produces named TS enums in `apiClient` (43 enum schemas total now, up from 3 in #5885).
- **`@ApiProperty` → `@ApiPropertyOptional`** for 61 fields where the TS declaration is `name?:` but the swagger decorator was the required variant. Surfaced as ~80 of the FE regressions in #5885 (`Rdi.lastConnection`, `CommandExecutionResult.sizeLimitExceeded`, `CloudUserAccount.capiKey/capiSecret`, etc.).
- **Add missing `@ApiPropertyOptional`** for `eula` / `analytics` / `notifications` on `GetUserAgreementsResponse`. These exist at runtime but had no decorator at all, so the spec didn't declare them.

## Generator config

`@hey-api/typescript` is now `enums: 'typescript'` with `case: 'PascalCase'`, so member names match the BE source style for the majority of enums (`NodeRole.Primary`, `ResultsMode.Default`, etc.). Aligned with what #5885 chose.

## FE factories

Three mock factories that fed `faker.date.past()` (a `Date`) into fields whose wire format is `string` (ISO timestamp) now `.toISOString()` the value. `DBInstance.factory.ts` is left alone — the FE `Instance` interface keeps `lastConnection: Date` locally for state, distinct from the wire shape.

# Testing

- `yarn lint` passes (UI + API).
- `yarn generate:api-client` succeeds — spec dump boots the AppModule, so any malformed decorator would fail here.
- `tsc -p tsconfig.json` (no CI gate, but observable locally):
  - `main`: 2498 errors
  - #5885 alone: 2168 (−330)
  - This PR on top: **2014 (−484 vs main, 300 new vs main — down from 457)**
  - ~155 fewer type-level findings than after #5885 alone

The remaining 300 are largely FE-local enum mirrors that nominally collide with the new `apiClient` enums (e.g. `RunQueryMode`, `TimezoneOption`, `Vote`, `CommandExecutionStatus` are declared both in `apiClient` and `slices/interfaces/*`), plus FE state shapes that diverge from the wire shape (e.g. `IKeyPropTypes` requires fields that became optional on `GetKeyInfoResponse`). Those want a focused per-domain cleanup pass — out of scope here.

---

Refs RI-7682

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad updates to Swagger metadata (optional fields and enum schema naming) can change the generated OpenAPI spec and thus the UI’s generated `apiClient` types, but runtime behavior should be unchanged.
> 
> **Overview**
> Tightens the generated OpenAPI contract by adding `enumName` to many Swagger-decorated enums so they are emitted as referenced schemas and become named TypeScript enums in the generated `apiClient` (with PascalCase member casing preserved).
> 
> Fixes mismatches where properties typed as optional in TS were still marked required in Swagger by switching many `@ApiProperty` annotations to `@ApiPropertyOptional`, and adds missing optional Swagger docs for user agreement flags.
> 
> Updates UI mocks/tests to treat `createdAt`/`lastConnection` as ISO strings (not `Date` objects) to match the wire/API-client types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a03342ce077329d64c24466f3f2d5aebeba215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->