### PR TITLE
RI-8160: enable column resizing

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -25,7 +25,7 @@ const nameColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Name,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Name],
   enableSorting: false,
-  size: 200,
+  size: 150,
   cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
     const { compressor = null, viewFormat } = table.options
       .meta as SimilarityResultsListConfig
@@ -44,7 +44,8 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Similarity,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Similarity],
   enableSorting: false,
-  size: 120,
+  enableResizing: false,
+  size: 10,
   cell: ({ row }: { row: TableRow<VectorSetSimilarityMatch> }) => {
     const { score } = row.original
     const isHigh = Number.isFinite(score) && score >= HIGH_SIMILARITY_THRESHOLD

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -28,6 +28,7 @@ const SimilaritySearchResultsTable = memo(
           data={sortedMatches}
           meta={{ compressor, viewFormat }}
           stripedRows
+          enableColumnResizing
           paginationEnabled={false}
           emptyState={SIMILARITY_RESULTS_EMPTY_MESSAGE}
           data-testid={`${TEST_ID}-table`}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
@@ -44,6 +44,7 @@ const createActionsColumn = (
   id: VectorSetColumn.Actions,
   header: VECTOR_SET_COLUMN_HEADERS[VectorSetColumn.Actions],
   enableSorting: false,
+  enableResizing: false,
   size: 10,
   cell: ({ row }: { row: TableRow<VectorSetElement> }) => {
     const { name: nameBuffer } = row.original

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
@@ -27,6 +27,7 @@ const VectorSetElementList = memo(({ onRemoveKey, onViewElement }: Props) => {
         columns={columns}
         data={currentPageData}
         stripedRows
+        enableColumnResizing
         minWidth={tableMinWidth}
         paginationEnabled={isPaginationSupported}
         manualPagination={isPaginationSupported}


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Enable column resizing for Element List table and Similarity Search table (plus adjust current column size). 
Note: this will be visible in the PR with more columns present. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts table layout/interaction without touching data fetching or persistence; main risk is minor layout regression in these views.
> 
> **Overview**
> Enables **column resizing** for the Vector Set *Element List* and *Similarity Search Results* tables via the `enableColumnResizing` table option.
> 
> Adjusts default column sizing to better fit resizable layouts (e.g., `Name` column width reduced) and explicitly disables resizing on narrow utility columns like `Actions` and `Similarity` (setting them to fixed small widths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf0aee4044f5f9fa05f707e43f8c1936a6ea092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->