### PR TITLE
Fix stale E2E test commands in Cursor rules

### DIFF
--- a/.ai/rules/e2e-testing.md
+++ b/.ai/rules/e2e-testing.md
@@ -433,13 +433,18 @@ await page.goto('/');
 
 ## Running Tests
 
+Run these commands from the E2E package directory:
+
 ```bash
-npm test                    # Main project tests (default)
-npm run test:main           # Main project tests only
-npm run test:electron       # Electron tests (auto-detects platform)
-npm run test:all            # All projects
-ENV=ci npm test             # CI environment
-ENV=staging npm test        # Staging environment
+cd tests/e2e-playwright
+
+npx playwright test                           # All Playwright projects
+npx playwright test --project=chromium        # Chromium browser tests
+npx playwright test --project=electron        # Electron desktop tests
+npx playwright test --project=main            # Main parallel tests only
+npx playwright test --project=auto-update     # Auto-update tests only
+ENV=ci npx playwright test                    # CI environment
+ENV=staging npx playwright test               # Staging environment
 ```
 
 ## Code Quality (IMPORTANT)
@@ -448,7 +453,7 @@ ENV=staging npm test        # Staging environment
 
 ```bash
 npm run lint                # ESLint check
-npx tsc --noEmit            # TypeScript type check
+npm run type-check          # TypeScript type check
 ```
 
 Both must pass before committing. Common issues:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating command examples; no runtime code paths are modified.
> 
> **Overview**
> Updates `.ai/rules/e2e-testing.md` to reflect the current Playwright E2E workflow by **pointing test execution to `tests/e2e-playwright/` and listing `npx playwright test` project commands**, replacing stale root-level `npm test` examples.
> 
> Also updates the code-quality guidance to use the package script `npm run type-check` (instead of `npx tsc --noEmit`) alongside `npm run lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6ac68c16d8a018564701032dd57e292dee268f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->