### PR TITLE
RI-8160: implement preview x out of y for similarity search results

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -5,6 +5,7 @@ import {
   selectedKeyDataSelector,
   selectedKeySelector,
 } from 'uiSrc/slices/browser/keys'
+import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
 import { bufferToString } from 'uiSrc/utils'
 import {
   KeyDetailsHeader,
@@ -56,6 +57,21 @@ const VectorSetDetails = (props: Props) => {
   const { hasResults: hasSimilarityResults, matches: similarityMatches } =
     useSimilaritySearchResults()
 
+  const {
+    total = 0,
+    elements: vectorSetElements = [],
+    isPaginationSupported,
+  } = useSelector(vectorSetDataSelector) ?? {}
+
+  // Similarity-search results take precedence over the element-list preview:
+  // when results are visible we always show "Previewing matches/total".
+  // Otherwise we keep the original element-list preview, which is only shown
+  // for non-paginated vector sets.
+  const showPreview = hasSimilarityResults || isPaginationSupported === false
+  const previewCount = hasSimilarityResults
+    ? similarityMatches.length
+    : vectorSetElements.length
+
   const handleSubmitElements = useCallback(
     (elements: SubmitElement[]) => {
       submitElements(elements, () => closeAddItemPanel())
@@ -67,7 +83,12 @@ const VectorSetDetails = (props: Props) => {
     <S.Container>
       <KeyDetailsHeader {...props} key="key-details-header" />
       <SimilaritySearchForm key={keyName} />
-      <VectorSetKeySubheader openAddItemPanel={openAddItemPanel} />
+      <VectorSetKeySubheader
+        openAddItemPanel={openAddItemPanel}
+        showPreview={showPreview}
+        previewCount={previewCount}
+        total={total}
+      />
       <S.DetailsBody>
         {!loading && (
           <S.ListWrapper>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
@@ -1,14 +1,8 @@
-import { faker } from '@faker-js/faker'
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
-import { vectorSetElementFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
-import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
+
 import { VectorSetKeySubheader } from './VectorSetKeySubheader'
 import { Props } from './VectorSetKeySubheader.types'
-
-jest.mock('uiSrc/slices/browser/vectorSet', () => ({
-  vectorSetDataSelector: jest.fn(),
-}))
 
 jest.mock(
   'uiSrc/pages/browser/modules/key-details-header/components/key-details-header-formatter',
@@ -23,94 +17,46 @@ jest.mock(
   },
 )
 
+const PREVIEW_TEST_ID = 'vector-set-preview-summary'
+const ADD_BUTTON_TEST_ID = 'add-key-value-items-btn'
+
 const defaultProps: Props = {
   openAddItemPanel: jest.fn(),
+  showPreview: false,
+  previewCount: 0,
+  total: 0,
+}
+
+const renderComponent = (propsOverride?: Partial<Props>) => {
+  const props = { ...defaultProps, ...propsOverride }
+  return render(<VectorSetKeySubheader {...props} />)
 }
 
 describe('VectorSetKeySubheader', () => {
-  const getMockedSelector = () => vectorSetDataSelector as jest.Mock
+  it('does not render preview summary when showPreview is false', () => {
+    renderComponent({ showPreview: false, previewCount: 5, total: 50 })
 
-  const renderComponent = (propsOverride?: Partial<Props>) => {
-    const props = { ...defaultProps, ...propsOverride }
-    return render(<VectorSetKeySubheader {...props} />)
-  }
-
-  beforeEach(() => {
-    getMockedSelector().mockReset()
+    expect(screen.queryByTestId(PREVIEW_TEST_ID)).not.toBeInTheDocument()
   })
 
-  it('does not render preview summary when isPaginationSupported is true', () => {
-    const elements = vectorSetElementFactory.buildList(
-      faker.number.int({ min: 1, max: 6 }),
-    )
-    getMockedSelector().mockReturnValue({
-      total: faker.number.int({ min: elements.length, max: 50 }),
-      elements,
-      isPaginationSupported: true,
-    })
+  it('renders "Previewing X out of Y" when showPreview is true', () => {
+    renderComponent({ showPreview: true, previewCount: 7, total: 42 })
 
-    renderComponent()
-
-    expect(
-      screen.queryByTestId('vector-set-preview-summary'),
-    ).not.toBeInTheDocument()
-  })
-
-  it('does not render preview summary when isPaginationSupported is undefined', () => {
-    const elements = vectorSetElementFactory.buildList(3)
-    getMockedSelector().mockReturnValue({
-      total: 10,
-      elements,
-    })
-
-    renderComponent()
-
-    expect(
-      screen.queryByTestId('vector-set-preview-summary'),
-    ).not.toBeInTheDocument()
-  })
-
-  it('renders preview summary when isPaginationSupported is false', () => {
-    const elements = vectorSetElementFactory.buildList(
-      faker.number.int({ min: 1, max: 8 }),
-    )
-    const total = faker.number.int({ min: elements.length + 1, max: 500 })
-    getMockedSelector().mockReturnValue({
-      total,
-      elements,
-      isPaginationSupported: false,
-    })
-
-    renderComponent()
-
-    expect(screen.getByTestId('vector-set-preview-summary')).toHaveTextContent(
-      `${elements.length} out of ${total}`,
-    )
+    expect(screen.getByTestId(PREVIEW_TEST_ID)).toHaveTextContent('7 out of 42')
   })
 
   it('renders the Add Elements button', () => {
-    getMockedSelector().mockReturnValue({
-      total: 5,
-      elements: vectorSetElementFactory.buildList(3),
-      isPaginationSupported: true,
-    })
-
     renderComponent()
 
-    expect(screen.getByTestId('add-key-value-items-btn')).toBeInTheDocument()
+    expect(screen.getByTestId(ADD_BUTTON_TEST_ID)).toBeInTheDocument()
   })
 
   it('calls openAddItemPanel when Add Elements button is clicked', () => {
     const openAddItemPanel = jest.fn()
-    getMockedSelector().mockReturnValue({
-      total: 5,
-      elements: vectorSetElementFactory.buildList(3),
-      isPaginationSupported: true,
-    })
 
     renderComponent({ openAddItemPanel })
 
-    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    fireEvent.click(screen.getByTestId(ADD_BUTTON_TEST_ID))
     expect(openAddItemPanel).toHaveBeenCalledTimes(1)
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
-import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
 import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
@@ -13,12 +11,12 @@ import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/componen
 import * as S from './VectorSetKeySubheader.styles'
 import { Props } from './VectorSetKeySubheader.types'
 
-const VectorSetKeySubheader = ({ openAddItemPanel }: Props) => {
-  const { total, elements, isPaginationSupported } = useSelector(
-    vectorSetDataSelector,
-  )
-  const showPreview = isPaginationSupported === false
-
+const VectorSetKeySubheader = ({
+  openAddItemPanel,
+  showPreview,
+  previewCount,
+  total,
+}: Props) => {
   return (
     <S.Container>
       <AutoSizer disableHeight>
@@ -33,8 +31,8 @@ const VectorSetKeySubheader = ({ openAddItemPanel }: Props) => {
                     data-testid="vector-set-preview-summary"
                   >
                     {width > MIDDLE_SCREEN_RESOLUTION
-                      ? `Previewing ${elements.length} out of ${total}`
-                      : `${elements.length} out of ${total}`}
+                      ? `Previewing ${previewCount} out of ${total}`
+                      : `${previewCount} out of ${total}`}
                   </Text>
                 </FlexItem>
               )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
@@ -1,3 +1,9 @@
 export interface Props {
   openAddItemPanel: () => void
+  /** Whether to render the "Previewing X out of Y" summary. */
+  showPreview: boolean
+  /** X — number of items currently displayed (elements or similarity matches). */
+  previewCount: number
+  /** Y — total number of items in the vector set. */
+  total: number
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Add X out of Y in the subheader for similarity search results, where X is result count, and Y is the total elements count.

<img width="1301" height="858" alt="image" src="https://github.com/user-attachments/assets/e5241df4-90de-4de8-88b8-3ac70a958b30" />


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how the vector-set subheader preview text is computed and displayed, plus associated unit test updates.
> 
> **Overview**
> Adds a dynamic subheader preview summary for vector-set similarity search: when matches are shown, the UI now displays **"Previewing X out of Y"** where *X* is the number of matches and *Y* is the vector set total.
> 
> Refactors `VectorSetKeySubheader` to be a presentational component that receives `showPreview`, `previewCount`, and `total` via props (computed in `VectorSetDetails` from `vectorSetDataSelector` and similarity search results), and updates tests to cover the new prop-driven behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc72783def3d46d84a85c39f05767060626c77d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->