### PR TITLE
RI-8160: clear similarity search results

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import {
   selectedKeyDataSelector,
   selectedKeySelector,
 } from 'uiSrc/slices/browser/keys'
-import { vectorSetDataSelector } from 'uiSrc/slices/browser/vectorSet'
+import {
+  clearSimilaritySearch,
+  vectorSetDataSelector,
+} from 'uiSrc/slices/browser/vectorSet'
 import { bufferToString } from 'uiSrc/utils'
 import {
   KeyDetailsHeader,
@@ -35,6 +38,7 @@ export interface Props extends KeyDetailsHeaderProps {
 const VectorSetDetails = (props: Props) => {
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
+  const dispatch = useDispatch()
   const { loading } = useSelector(selectedKeySelector)
   const selectedKeyData = useSelector(selectedKeyDataSelector)
   const keyName = selectedKeyData?.name
@@ -56,6 +60,10 @@ const VectorSetDetails = (props: Props) => {
 
   const { hasResults: hasSimilarityResults, matches: similarityMatches } =
     useSimilaritySearchResults()
+
+  const handleClearResults = useCallback(() => {
+    dispatch(clearSimilaritySearch())
+  }, [dispatch])
 
   const {
     total = 0,
@@ -88,6 +96,8 @@ const VectorSetDetails = (props: Props) => {
         showPreview={showPreview}
         previewCount={previewCount}
         total={total}
+        hasSimilarityResults={hasSimilarityResults}
+        onClearResults={handleClearResults}
       />
       <S.DetailsBody>
         {!loading && (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
+import { ClearResultsAction } from './ClearResultsAction'
+import { Props } from './ClearResultsAction.types'
+import { BASE_TEST_ID } from './constants'
+
+const renderComponent = (propsOverride: Partial<Props> = {}) => {
+  const props: Props = {
+    width: MIDDLE_SCREEN_RESOLUTION + 1,
+    onClick: jest.fn(),
+    ...propsOverride,
+  }
+  return { props, ...render(<ClearResultsAction {...props} />) }
+}
+
+describe('ClearResultsAction', () => {
+  it('renders the button with the default title above the breakpoint', () => {
+    renderComponent({ width: MIDDLE_SCREEN_RESOLUTION + 50 })
+
+    const btn = screen.getByTestId(BASE_TEST_ID)
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveTextContent('Clear results')
+  })
+
+  it('renders the icon-only button below the breakpoint', () => {
+    renderComponent({ width: MIDDLE_SCREEN_RESOLUTION - 1 })
+
+    expect(screen.getByTestId(BASE_TEST_ID)).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClick = jest.fn()
+    renderComponent({ onClick })
+
+    fireEvent.click(screen.getByTestId(BASE_TEST_ID))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects a custom title override', () => {
+    renderComponent({
+      width: MIDDLE_SCREEN_RESOLUTION + 50,
+      title: 'Wipe results',
+    })
+
+    expect(screen.getByTestId(BASE_TEST_ID)).toHaveTextContent('Wipe results')
+  })
+
+  it('prefixes the test id when testIdPrefix is provided', () => {
+    renderComponent({ testIdPrefix: 'similarity-search' })
+
+    expect(
+      screen.getByTestId(`similarity-search-${BASE_TEST_ID}`),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId(BASE_TEST_ID)).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+// Anchor span for the tooltip + button. `position: relative` + `z-index`
+// preserve the stacking context the legacy action buttons relied on (so the
+// tooltip and button stay above sibling subheader content during overflow).
+export const ActionAnchor = styled.span`
+  position: relative;
+  z-index: 2;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
+import { RiTooltip } from 'uiSrc/components'
+import { EraserIcon } from 'uiSrc/components/base/icons'
+import { IconButton, EmptyButton } from 'uiSrc/components/base/forms/buttons'
+
+import { BASE_TEST_ID, DEFAULT_TITLE } from './constants'
+import { Props } from './ClearResultsAction.types'
+import * as S from './ClearResultsAction.styles'
+
+const ClearResultsAction = ({
+  width,
+  title = DEFAULT_TITLE,
+  onClick,
+  testIdPrefix,
+}: Props) => {
+  const showLabel = width > MIDDLE_SCREEN_RESOLUTION
+  const testId = testIdPrefix ? `${testIdPrefix}-${BASE_TEST_ID}` : BASE_TEST_ID
+  return (
+    <RiTooltip
+      content={showLabel ? '' : title}
+      position="left"
+      anchorClassName="clear-results-action-anchor"
+    >
+      <S.ActionAnchor>
+        {showLabel ? (
+          <EmptyButton
+            size="small"
+            icon={EraserIcon}
+            aria-label={title}
+            onClick={onClick}
+            data-testid={testId}
+          >
+            {title}
+          </EmptyButton>
+        ) : (
+          <IconButton
+            icon={EraserIcon}
+            aria-label={title}
+            onClick={onClick}
+            data-testid={testId}
+          />
+        )}
+      </S.ActionAnchor>
+    </RiTooltip>
+  )
+}
+
+export { ClearResultsAction }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/ClearResultsAction.types.ts
@@ -1,0 +1,11 @@
+export interface Props {
+  width: number
+  title?: string
+  onClick: () => void
+  /**
+   * Prefix prepended to the base `clear-results-btn` test id, so consumers
+   * can disambiguate multiple Clear actions on the same screen
+   * (e.g. `similarity-search` → `similarity-search-clear-results-btn`).
+   */
+  testIdPrefix?: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_TITLE = 'Clear results'
+export const BASE_TEST_ID = 'clear-results-btn'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/clear-results-action/index.ts
@@ -1,0 +1,2 @@
+export { ClearResultsAction } from './ClearResultsAction'
+export type { Props as ClearResultsActionProps } from './ClearResultsAction.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.spec.tsx
@@ -19,12 +19,15 @@ jest.mock(
 
 const PREVIEW_TEST_ID = 'vector-set-preview-summary'
 const ADD_BUTTON_TEST_ID = 'add-key-value-items-btn'
+const CLEAR_BUTTON_TEST_ID = 'similarity-search-clear-results-btn'
 
 const defaultProps: Props = {
   openAddItemPanel: jest.fn(),
   showPreview: false,
   previewCount: 0,
   total: 0,
+  hasSimilarityResults: false,
+  onClearResults: jest.fn(),
 }
 
 const renderComponent = (propsOverride?: Partial<Props>) => {
@@ -45,10 +48,11 @@ describe('VectorSetKeySubheader', () => {
     expect(screen.getByTestId(PREVIEW_TEST_ID)).toHaveTextContent('7 out of 42')
   })
 
-  it('renders the Add Elements button', () => {
-    renderComponent()
+  it('renders the Add Elements button when hasSimilarityResults is false', () => {
+    renderComponent({ hasSimilarityResults: false })
 
     expect(screen.getByTestId(ADD_BUTTON_TEST_ID)).toBeInTheDocument()
+    expect(screen.queryByTestId(CLEAR_BUTTON_TEST_ID)).not.toBeInTheDocument()
   })
 
   it('calls openAddItemPanel when Add Elements button is clicked', () => {
@@ -58,5 +62,21 @@ describe('VectorSetKeySubheader', () => {
 
     fireEvent.click(screen.getByTestId(ADD_BUTTON_TEST_ID))
     expect(openAddItemPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('swaps the Add button for the Clear results button when hasSimilarityResults is true', () => {
+    renderComponent({ hasSimilarityResults: true })
+
+    expect(screen.getByTestId(CLEAR_BUTTON_TEST_ID)).toBeInTheDocument()
+    expect(screen.queryByTestId(ADD_BUTTON_TEST_ID)).not.toBeInTheDocument()
+  })
+
+  it('calls onClearResults when the Clear results button is clicked', () => {
+    const onClearResults = jest.fn()
+
+    renderComponent({ hasSimilarityResults: true, onClearResults })
+
+    fireEvent.click(screen.getByTestId(CLEAR_BUTTON_TEST_ID))
+    expect(onClearResults).toHaveBeenCalledTimes(1)
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
@@ -8,6 +8,7 @@ import Divider from 'uiSrc/components/divider/Divider'
 import { KeyDetailsHeaderFormatter } from 'uiSrc/pages/browser/modules/key-details-header/components/key-details-header-formatter'
 import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
 
+import { ClearResultsAction } from '../clear-results-action'
 import * as S from './VectorSetKeySubheader.styles'
 import { Props } from './VectorSetKeySubheader.types'
 
@@ -16,6 +17,8 @@ const VectorSetKeySubheader = ({
   showPreview,
   previewCount,
   total,
+  hasSimilarityResults,
+  onClearResults,
 }: Props) => {
   return (
     <S.Container>
@@ -39,11 +42,19 @@ const VectorSetKeySubheader = ({
               <Row align="center" grow={false}>
                 <KeyDetailsHeaderFormatter width={width} />
                 <Divider orientation="vertical" />
-                <AddItemsAction
-                  title="Add Elements"
-                  width={width}
-                  openAddItemPanel={openAddItemPanel}
-                />
+                {hasSimilarityResults ? (
+                  <ClearResultsAction
+                    width={width}
+                    onClick={onClearResults}
+                    testIdPrefix="similarity-search"
+                  />
+                ) : (
+                  <AddItemsAction
+                    title="Add Elements"
+                    width={width}
+                    openAddItemPanel={openAddItemPanel}
+                  />
+                )}
               </Row>
             </Row>
           </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
@@ -6,4 +6,13 @@ export interface Props {
   previewCount: number
   /** Y — total number of items in the vector set. */
   total: number
+  /**
+   * When `true`, the subheader replaces the "Add Elements" action with a
+   * "Clear results" action wired to {@link onClearResults}. The browse-mode
+   * affordances (formatter, add panel trigger) are hidden because they don't
+   * make sense in the similarity-search context.
+   */
+  hasSimilarityResults: boolean
+  /** Callback fired when the "Clear results" button is clicked. */
+  onClearResults: () => void
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- New `ClearResultsAction` component (eraser icon, responsive `EmptyButton` / `IconButton`) — replaces the "+ Add elements" button in the vector-set subheader while similarity-search results are visible.
- `VectorSetKeySubheader` is now purely presentational: `showPreview`, `previewCount`, `total`, `hasSimilarityResults`, and `onClearResults` are passed in by `VectorSetDetails` (no more `vectorSetDataSelector` or `useSimilaritySearchResults` calls inside the subheader).
- `VectorSetDetails` dispatches only `clearSimilaritySearch` on click — the Redis command preview slice and the form state are intentionally left untouched so the user can still see / re-run the command after clearing.
- Test-ids follow the new `clear-results-btn` base + optional `testIdPrefix` pattern → subheader passes `testIdPrefix="similarity-search"` → final id `similarity-search-clear-results-btn`.


https://github.com/user-attachments/assets/b20b40dc-a711-4ae8-8f38-c9bdb8fe377c


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that only clears the vector-set similarity-search slice and swaps a subheader action based on result visibility. Main risk is minor UX regression if the clear button/visibility logic misfires across breakpoints.
> 
> **Overview**
> Adds a responsive **“Clear results”** action to the vector-set key details view that appears when similarity-search matches are shown and dispatches `clearSimilaritySearch()` to return to the normal element list.
> 
> Refactors `VectorSetKeySubheader` to be purely presentational by taking `hasSimilarityResults`/`onClearResults` as props, and introduces a reusable `ClearResultsAction` component (with tooltip + test-id prefixing) plus new/updated unit tests to cover the button swap and click behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217d3e0b1a2270bd3d59e0ac7e3ba9ed0f84e712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->