### PR TITLE
Unify Search page title with navigation tab

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.spec.tsx
@@ -178,7 +178,7 @@ describe('VectorSearchPage', () => {
     renderComponent()
 
     expect(document.title).toBe(
-      `${INSTANCES_MOCK[0].name} [db${INSTANCES_MOCK[0].db}] - Vector Search`,
+      `${INSTANCES_MOCK[0].name} [db${INSTANCES_MOCK[0].db}] - Search`,
     )
   })
 })

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
@@ -48,7 +48,7 @@ export const VectorSearchPage = () => {
   })
 
   setTitle(
-    `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)} - Vector Search`,
+    `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)} - Search`,
   )
 
   if (indexesLoading !== false) {


### PR DESCRIPTION
# What

Make the title of the page for the Vector Search consistent with the actual nav tab.

<img width="2770" height="1672" alt="image" src="https://github.com/user-attachments/assets/94970dc9-33b1-4b2d-b555-dba878882335" />

Notes: Scope was deliberately limited to the user-visible string:
- The telemetry enum value (`TelemetryPageView.VECTOR_SEARCH_PAGE = 'Vector Search'`) is unchanged to preserve analytics continuity.
- Internal identifiers (folder/component/route names, `vector-search-*` data-testids, e2e page object) are unchanged — pure-refactor with no user benefit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string-only change to the Vector Search page `document.title`, plus an updated unit test expectation; no routing, telemetry, or data logic is modified.
> 
> **Overview**
> Updates the Vector Search page browser/tab title suffix from **"Vector Search"** to **"Search"** so it matches the left-nav tab label.
> 
> Adjusts the `VectorSearchPage` unit test to assert the new `document.title` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a182363ace8bd7ddbe4a6623794824645c68e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->