### PR TITLE
RI-8160: Render element attributes as columns in similarity-search result table

### DIFF
--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -5,6 +5,7 @@ import { stringToBuffer } from 'uiSrc/utils'
 import {
   AddVectorSetElementsData,
   VectorSetElement,
+  VectorSetSimilarityMatch,
 } from 'uiSrc/slices/interfaces'
 import { IVectorSetElementState } from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/interfaces'
 
@@ -38,6 +39,17 @@ export const vectorSetElementWithAttributesFactory =
   Factory.define<VectorSetElement>(() => ({
     ...buildBaseElement(),
     attributes: mockVectorSetElementAttributes(),
+  }))
+
+/**
+ * Builds a `VectorSetSimilarityMatch` with a buffered random name and a
+ * `[0, 1]` score. Pass overrides for any field; `attributes` defaults to
+ * `undefined` since most tests only assert on `name` + `score`.
+ */
+export const vectorSetSimilarityMatchFactory =
+  Factory.define<VectorSetSimilarityMatch>(() => ({
+    name: stringToBuffer(faker.word.noun()),
+    score: faker.number.float({ min: 0, max: 1, fractionDigits: 4 }),
   }))
 
 const buildMockVector = (dim = 3): number[] =>

--- a/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/vectorSet/vectorSetElement.factory.ts
@@ -43,8 +43,7 @@ export const vectorSetElementWithAttributesFactory =
 
 /**
  * Builds a `VectorSetSimilarityMatch` with a buffered random name and a
- * `[0, 1]` score. Pass overrides for any field; `attributes` defaults to
- * `undefined` since most tests only assert on `name` + `score`.
+ * `[0, 1]` score. Pass `attributes` via overrides when the test needs them.
  */
 export const vectorSetSimilarityMatchFactory =
   Factory.define<VectorSetSimilarityMatch>(() => ({

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -14,6 +14,7 @@ import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
+import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces'
 import { VectorSetElementForm, SubmitElement } from './vector-set-element-form'
 import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 import { VectorSetElementList } from './vector-set-element-list'
@@ -21,6 +22,11 @@ import { VectorSetKeySubheader } from './vector-set-key-subheader'
 import { ElementDetails } from './element-details'
 import { SimilaritySearchForm } from './similarity-search-form'
 import { SimilaritySearchResultsTable } from './similarity-search-results'
+import { buildSimilarityResultsColumns } from './similarity-search-results/SimilaritySearchResultsTable.config'
+import {
+  collectAttributeKeys,
+  parseAttributes,
+} from './similarity-search-results/utils/parseAttributes'
 import {
   useAddElementPanel,
   useAddElements,
@@ -65,16 +71,37 @@ const VectorSetDetails = (props: Props) => {
     dispatch(clearSimilaritySearch())
   }, [dispatch])
 
+  // Attribute columns are derived from the union of keys across matches.
+  // Stable alphabetical ordering keeps the column list referentially stable.
+  const similarityAttributeKeys = useMemo(
+    () => collectAttributeKeys(similarityMatches),
+    [similarityMatches],
+  )
+  const similarityColumns = useMemo(
+    () => buildSimilarityResultsColumns(similarityAttributeKeys),
+    [similarityAttributeKeys],
+  )
+  // Cache parsed attribute payloads so each row pays the JSON-parse cost once
+  // instead of once per attribute column it renders.
+  const similarityParsedAttributesCache = useMemo(() => {
+    const cache = new WeakMap<
+      VectorSetSimilarityMatch,
+      Record<string, unknown>
+    >()
+    for (const match of similarityMatches) {
+      cache.set(match, parseAttributes(match.attributes))
+    }
+    return cache
+  }, [similarityMatches])
+
   const {
     total = 0,
     elements: vectorSetElements = [],
     isPaginationSupported,
   } = useSelector(vectorSetDataSelector) ?? {}
 
-  // Similarity-search results take precedence over the element-list preview:
-  // when results are visible we always show "Previewing matches/total".
-  // Otherwise we keep the original element-list preview, which is only shown
-  // for non-paginated vector sets.
+  // Similarity-search results take precedence; otherwise fall back to the
+  // element-list preview, which is only shown for non-paginated vector sets.
   const showPreview = hasSimilarityResults || isPaginationSupported === false
   const previewCount = hasSimilarityResults
     ? similarityMatches.length
@@ -103,7 +130,11 @@ const VectorSetDetails = (props: Props) => {
         {!loading && (
           <S.ListWrapper>
             {hasSimilarityResults ? (
-              <SimilaritySearchResultsTable matches={similarityMatches} />
+              <SimilaritySearchResultsTable
+                matches={similarityMatches}
+                columns={similarityColumns}
+                parsedAttributesCache={similarityParsedAttributesCache}
+              />
             ) : (
               <VectorSetElementList
                 onRemoveKey={onRemoveKey}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -14,7 +14,6 @@ import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
-import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces'
 import { VectorSetElementForm, SubmitElement } from './vector-set-element-form'
 import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 import { VectorSetElementList } from './vector-set-element-list'
@@ -24,8 +23,8 @@ import { SimilaritySearchForm } from './similarity-search-form'
 import { SimilaritySearchResultsTable } from './similarity-search-results'
 import { buildSimilarityResultsColumns } from './similarity-search-results/SimilaritySearchResultsTable.config'
 import {
+  buildParsedAttributesCache,
   collectAttributeKeys,
-  parseAttributes,
 } from './similarity-search-results/utils/parseAttributes'
 import {
   useAddElementPanel,
@@ -71,28 +70,23 @@ const VectorSetDetails = (props: Props) => {
     dispatch(clearSimilaritySearch())
   }, [dispatch])
 
+  // Cache parsed attribute payloads so each row pays the JSON-parse cost once
+  // instead of once per attribute column (and key collector) it renders.
+  const similarityParsedAttributesCache = useMemo(
+    () => buildParsedAttributesCache(similarityMatches),
+    [similarityMatches],
+  )
   // Attribute columns are derived from the union of keys across matches.
   // Stable alphabetical ordering keeps the column list referentially stable.
   const similarityAttributeKeys = useMemo(
-    () => collectAttributeKeys(similarityMatches),
-    [similarityMatches],
+    () =>
+      collectAttributeKeys(similarityMatches, similarityParsedAttributesCache),
+    [similarityMatches, similarityParsedAttributesCache],
   )
   const similarityColumns = useMemo(
     () => buildSimilarityResultsColumns(similarityAttributeKeys),
     [similarityAttributeKeys],
   )
-  // Cache parsed attribute payloads so each row pays the JSON-parse cost once
-  // instead of once per attribute column it renders.
-  const similarityParsedAttributesCache = useMemo(() => {
-    const cache = new WeakMap<
-      VectorSetSimilarityMatch,
-      Record<string, unknown>
-    >()
-    for (const match of similarityMatches) {
-      cache.set(match, parseAttributes(match.attributes))
-    }
-    return cache
-  }, [similarityMatches])
 
   const {
     total = 0,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -70,19 +70,18 @@ const VectorSetDetails = (props: Props) => {
     dispatch(clearSimilaritySearch())
   }, [dispatch])
 
-  // Cache parsed attribute payloads so each row pays the JSON-parse cost once
-  // instead of once per attribute column (and key collector) it renders.
-  const similarityParsedAttributesCache = useMemo(
-    () => buildParsedAttributesCache(similarityMatches),
-    [similarityMatches],
-  )
-  // Attribute columns are derived from the union of keys across matches.
-  // Stable alphabetical ordering keeps the column list referentially stable.
-  const similarityAttributeKeys = useMemo(
-    () =>
-      collectAttributeKeys(similarityMatches, similarityParsedAttributesCache),
-    [similarityMatches, similarityParsedAttributesCache],
-  )
+  // Cache parsed attribute payloads + derive the union of attribute keys in
+  // one pass, so each row pays the JSON-parse cost once across the key
+  // collector and every attribute column it renders. Stable alphabetical
+  // ordering keeps the resulting column list referentially stable.
+  const { similarityParsedAttributesCache, similarityAttributeKeys } =
+    useMemo(() => {
+      const cache = buildParsedAttributesCache(similarityMatches)
+      return {
+        similarityParsedAttributesCache: cache,
+        similarityAttributeKeys: collectAttributeKeys(similarityMatches, cache),
+      }
+    }, [similarityMatches])
   const similarityColumns = useMemo(
     () => buildSimilarityResultsColumns(similarityAttributeKeys),
     [similarityAttributeKeys],

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -15,10 +15,12 @@ import {
   SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX,
   SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
   SIMILARITY_RESULTS_COLUMN_HEADERS,
+  SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
+  SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
 } from './constants'
 import {
+  SimilarityResultsCellMeta,
   SimilarityResultsColumn,
-  SimilarityResultsListConfig,
 } from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
 import { KeyValueFormat } from 'uiSrc/constants'
@@ -28,10 +30,21 @@ const nameColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Name,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Name],
   enableSorting: false,
-  size: 200,
+  minSize: SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
+  size: SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
+  sizeUnit: 'px',
+  // Auto-size the header cell so leftover horizontal space is absorbed by
+  // the name column (the only flexible one) instead of being distributed
+  // across all columns.
+  getHeaderCellProps: () => ({
+    style: {
+      width: 'auto',
+      minWidth: `${SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE}px`,
+    },
+  }),
   cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
     const { compressor = null, viewFormat } = table.options
-      .meta as SimilarityResultsListConfig
+      .meta as SimilarityResultsCellMeta
     return (
       <ElementNameCell
         element={row.original}
@@ -47,7 +60,10 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Similarity,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Similarity],
   enableSorting: false,
-  size: 70,
+  enableResizing: false,
+  size: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
+  minSize: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
+  maxSize: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
   sizeUnit: 'px',
   cell: ({ row }: { row: TableRow<VectorSetSimilarityMatch> }) => {
     const { score } = row.original
@@ -63,7 +79,11 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   },
 }
 
-/** Build a column for a single attribute key. */
+/**
+ * Build a column for a single attribute key. The cell reads the
+ * pre-parsed payload from `meta.parsedAttributesCache` so each row pays the
+ * JSON-parse cost once instead of once per attribute column it renders.
+ */
 const buildAttributeColumn = (
   key: string,
 ): ColumnDef<VectorSetSimilarityMatch> => ({
@@ -71,8 +91,13 @@ const buildAttributeColumn = (
   header: key,
   enableSorting: false,
   size: SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
-  cell: ({ row }: CellContext<VectorSetSimilarityMatch, unknown>) => {
-    const attrs = parseAttributes(row.original.attributes)
+  sizeUnit: 'px',
+  cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
+    const { parsedAttributesCache } = table.options
+      .meta as SimilarityResultsCellMeta
+    const attrs =
+      parsedAttributesCache.get(row.original) ??
+      parseAttributes(row.original.attributes)
     return (
       <S.AttributeCell
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}
@@ -94,7 +119,3 @@ export const buildSimilarityResultsColumns = (
   similarityColumn,
   ...attributeKeys.map(buildAttributeColumn),
 ]
-
-/** Static-only column list (for call sites that don't thread attribute keys). */
-export const SIMILARITY_RESULTS_COLUMNS: ColumnDef<VectorSetSimilarityMatch>[] =
-  buildSimilarityResultsColumns([])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -9,8 +9,11 @@ import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
 
 import { ElementNameCell } from '../vector-set-element-list/components/ElementNameCell/ElementNameCell'
 import { formatSimilarity } from './utils'
+import { parseAttributes, renderAttributeValue } from './utils/parseAttributes'
 import {
   HIGH_SIMILARITY_THRESHOLD,
+  SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX,
+  SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
   SIMILARITY_RESULTS_COLUMN_HEADERS,
 } from './constants'
 import {
@@ -25,7 +28,7 @@ const nameColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Name,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Name],
   enableSorting: false,
-  size: 150,
+  size: 200,
   cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
     const { compressor = null, viewFormat } = table.options
       .meta as SimilarityResultsListConfig
@@ -44,8 +47,8 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Similarity,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Similarity],
   enableSorting: false,
-  enableResizing: false,
-  size: 10,
+  size: 70,
+  sizeUnit: 'px',
   cell: ({ row }: { row: TableRow<VectorSetSimilarityMatch> }) => {
     const { score } = row.original
     const isHigh = Number.isFinite(score) && score >= HIGH_SIMILARITY_THRESHOLD
@@ -60,5 +63,38 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   },
 }
 
+/** Build a column for a single attribute key. */
+const buildAttributeColumn = (
+  key: string,
+): ColumnDef<VectorSetSimilarityMatch> => ({
+  id: `${SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX}${key}`,
+  header: key,
+  enableSorting: false,
+  size: SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
+  cell: ({ row }: CellContext<VectorSetSimilarityMatch, unknown>) => {
+    const attrs = parseAttributes(row.original.attributes)
+    return (
+      <S.AttributeCell
+        data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}
+      >
+        {renderAttributeValue(attrs[key])}
+      </S.AttributeCell>
+    )
+  },
+})
+
+/**
+ * Element + Similarity (sticky-left), followed by one column per attribute
+ * key. `attributeKeys` is expected to be in stable alphabetical order.
+ */
+export const buildSimilarityResultsColumns = (
+  attributeKeys: string[],
+): ColumnDef<VectorSetSimilarityMatch>[] => [
+  nameColumn,
+  similarityColumn,
+  ...attributeKeys.map(buildAttributeColumn),
+]
+
+/** Static-only column list (for call sites that don't thread attribute keys). */
 export const SIMILARITY_RESULTS_COLUMNS: ColumnDef<VectorSetSimilarityMatch>[] =
-  [nameColumn, similarityColumn]
+  buildSimilarityResultsColumns([])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -7,7 +7,10 @@ import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/v
 
 import { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
 import { buildSimilarityResultsColumns } from './SimilaritySearchResultsTable.config'
-import { collectAttributeKeys, parseAttributes } from './utils/parseAttributes'
+import {
+  buildParsedAttributesCache,
+  collectAttributeKeys,
+} from './utils/parseAttributes'
 
 const buildMatch = (
   name: string,
@@ -26,15 +29,9 @@ const buildMatch = (
  * signature surfaces here too.
  */
 const renderTable = (matches: VectorSetSimilarityMatch[]) => {
-  const attributeKeys = collectAttributeKeys(matches)
+  const parsedAttributesCache = buildParsedAttributesCache(matches)
+  const attributeKeys = collectAttributeKeys(matches, parsedAttributesCache)
   const columns = buildSimilarityResultsColumns(attributeKeys)
-  const parsedAttributesCache = new WeakMap<
-    VectorSetSimilarityMatch,
-    Record<string, unknown>
-  >()
-  for (const match of matches) {
-    parsedAttributesCache.set(match, parseAttributes(match.attributes))
-  }
   return render(
     <SimilaritySearchResultsTable
       matches={matches}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -1,22 +1,52 @@
 import React from 'react'
-import { faker } from '@faker-js/faker'
 
 import { render, screen } from 'uiSrc/utils/test-utils'
 import { stringToBuffer } from 'uiSrc/utils'
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 
 import { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
+import { buildSimilarityResultsColumns } from './SimilaritySearchResultsTable.config'
+import { collectAttributeKeys, parseAttributes } from './utils/parseAttributes'
 
-faker.seed(8158)
+const buildMatch = (
+  name: string,
+  score: number,
+  attributes?: string,
+): VectorSetSimilarityMatch =>
+  vectorSetSimilarityMatchFactory.build({
+    name: stringToBuffer(name),
+    score,
+    attributes,
+  })
 
-const buildMatch = (name: string, score: number): VectorSetSimilarityMatch => ({
-  name: stringToBuffer(name),
-  score,
-})
+/**
+ * Build the table props the same way `VectorSetDetails` does in production —
+ * keeps the spec realistic and means a single change to the column-builder
+ * signature surfaces here too.
+ */
+const renderTable = (matches: VectorSetSimilarityMatch[]) => {
+  const attributeKeys = collectAttributeKeys(matches)
+  const columns = buildSimilarityResultsColumns(attributeKeys)
+  const parsedAttributesCache = new WeakMap<
+    VectorSetSimilarityMatch,
+    Record<string, unknown>
+  >()
+  for (const match of matches) {
+    parsedAttributesCache.set(match, parseAttributes(match.attributes))
+  }
+  return render(
+    <SimilaritySearchResultsTable
+      matches={matches}
+      columns={columns}
+      parsedAttributesCache={parsedAttributesCache}
+    />,
+  )
+}
 
 describe('SimilaritySearchResultsTable', () => {
   it('renders the empty state when no matches are provided', () => {
-    render(<SimilaritySearchResultsTable matches={[]} />)
+    renderTable([])
 
     expect(
       screen.getByTestId('vector-set-similarity-results'),
@@ -27,9 +57,7 @@ describe('SimilaritySearchResultsTable', () => {
   it('renders one row per match with Element + Similarity columns', () => {
     const matches = [buildMatch('alpha', 0.9999), buildMatch('beta', 0.5)]
 
-    const { container } = render(
-      <SimilaritySearchResultsTable matches={matches} />,
-    )
+    const { container } = renderTable(matches)
 
     const rows = container.querySelectorAll('tbody tr')
     expect(rows).toHaveLength(2)
@@ -44,7 +72,7 @@ describe('SimilaritySearchResultsTable', () => {
       buildMatch('gamma', 0),
     ]
 
-    render(<SimilaritySearchResultsTable matches={matches} />)
+    renderTable(matches)
 
     expect(screen.getByText('99.99 %')).toBeInTheDocument()
     expect(screen.getByText('50.00 %')).toBeInTheDocument()
@@ -58,7 +86,7 @@ describe('SimilaritySearchResultsTable', () => {
       buildMatch('mid', 0.5),
     ]
 
-    render(<SimilaritySearchResultsTable matches={matches} />)
+    renderTable(matches)
 
     const cells = screen.getAllByTestId(/vector-set-similarity-cell-/)
     expect(cells.map((cell) => cell.textContent)).toEqual([
@@ -69,9 +97,7 @@ describe('SimilaritySearchResultsTable', () => {
   })
 
   it('falls back to a dash for non-finite scores', () => {
-    const matches = [buildMatch('broken', Number.NaN)]
-
-    render(<SimilaritySearchResultsTable matches={matches} />)
+    renderTable([buildMatch('broken', Number.NaN)])
 
     expect(screen.getByText('—')).toBeInTheDocument()
   })
@@ -83,7 +109,7 @@ describe('SimilaritySearchResultsTable', () => {
       buildMatch('low', 0.84),
     ]
 
-    render(<SimilaritySearchResultsTable matches={matches} />)
+    renderTable(matches)
 
     // Sorted desc by score → high (0.86), boundary (0.85), low (0.84). Cells
     // above the threshold get a different styled-component class than ones
@@ -92,5 +118,52 @@ describe('SimilaritySearchResultsTable', () => {
     const cells = screen.getAllByTestId(/vector-set-similarity-cell-/)
     expect(cells[0].className).toBe(cells[1].className)
     expect(cells[0].className).not.toBe(cells[2].className)
+  })
+
+  describe('attribute columns', () => {
+    it('renders one column per attribute key, alphabetically', () => {
+      const matches = [
+        buildMatch('a', 0.9, '{"zeta":1,"alpha":"x"}'),
+        buildMatch('b', 0.8, '{"beta":2}'),
+      ]
+
+      renderTable(matches)
+
+      // Header order: Element, Similarity, then attributes alphabetically.
+      const headers = screen
+        .getAllByRole('columnheader')
+        .map((h) => h.textContent?.trim())
+      expect(headers).toEqual([
+        'Element',
+        'Similarity',
+        'alpha',
+        'beta',
+        'zeta',
+      ])
+    })
+
+    it('renders attribute values per row', () => {
+      const matches = [
+        buildMatch('a', 0.9, '{"city":"NYC","count":3}'),
+        buildMatch('b', 0.8, '{"city":"LA"}'),
+      ]
+
+      renderTable(matches)
+
+      // a is first (higher score), so row 0 = a, row 1 = b.
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-0-city'),
+      ).toHaveTextContent('NYC')
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-0-count'),
+      ).toHaveTextContent('3')
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-1-city'),
+      ).toHaveTextContent('LA')
+      // b has no `count` attribute → empty cell
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-1-count'),
+      ).toHaveTextContent('')
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.styles.ts
@@ -32,3 +32,13 @@ export const SimilarityCell = styled.span<{
       ? theme.semantic.color.text.success600
       : theme.semantic.color.text.neutral800};
 `
+
+export const AttributeCell = styled.span<{
+  children?: React.ReactNode
+}>`
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -4,9 +4,17 @@ import { useSelector } from 'react-redux'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 
-import { SimilarityResultsCellMeta } from './SimilaritySearchResultsTable.config'
-import { SIMILARITY_RESULTS_EMPTY_MESSAGE } from './constants'
-import { SimilaritySearchResultsTableProps } from './SimilaritySearchResultsTable.types'
+import {
+  SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX,
+  SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
+  SIMILARITY_RESULTS_EMPTY_MESSAGE,
+  SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
+  SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
+} from './constants'
+import {
+  SimilarityResultsCellMeta,
+  SimilaritySearchResultsTableProps,
+} from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
 
 const TEST_ID = 'vector-set-similarity-results'
@@ -35,6 +43,21 @@ const SimilaritySearchResultsTable = memo(
       [compressor, viewFormat, parsedAttributesCache],
     )
 
+    // Force the table to overflow (and scroll horizontally) once the columns
+    // can no longer fit comfortably inside the container, instead of squishing
+    // every column. The min-width is the actual sum of column widths so the
+    // browser only stretches the auto-sized name column with leftover space.
+    const tableMinWidth = useMemo(() => {
+      const attributeCount = columns.filter((column) =>
+        column.id?.startsWith(SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX),
+      ).length
+      const total =
+        SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE +
+        SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE +
+        attributeCount * SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE
+      return `${total}px`
+    }, [columns])
+
     return (
       <S.Container data-testid={TEST_ID}>
         <S.StyledTable
@@ -43,6 +66,7 @@ const SimilaritySearchResultsTable = memo(
           meta={meta}
           stripedRows
           enableColumnResizing
+          minWidth={tableMinWidth}
           paginationEnabled={false}
           emptyState={SIMILARITY_RESULTS_EMPTY_MESSAGE}
           data-testid={`${TEST_ID}-table`}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 
-import { SIMILARITY_RESULTS_COLUMNS } from './SimilaritySearchResultsTable.config'
+import { SimilarityResultsCellMeta } from './SimilaritySearchResultsTable.config'
 import { SIMILARITY_RESULTS_EMPTY_MESSAGE } from './constants'
 import { SimilaritySearchResultsTableProps } from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
@@ -12,7 +12,11 @@ import * as S from './SimilaritySearchResultsTable.styles'
 const TEST_ID = 'vector-set-similarity-results'
 
 const SimilaritySearchResultsTable = memo(
-  ({ matches }: SimilaritySearchResultsTableProps) => {
+  ({
+    matches,
+    columns,
+    parsedAttributesCache,
+  }: SimilaritySearchResultsTableProps) => {
     const { compressor = null } = useSelector(connectedInstanceSelector)
     const { viewFormat } = useSelector(selectedKeySelector)
 
@@ -21,12 +25,22 @@ const SimilaritySearchResultsTable = memo(
       [matches],
     )
 
+    const meta = useMemo(
+      () =>
+        ({
+          compressor,
+          viewFormat,
+          parsedAttributesCache,
+        }) as SimilarityResultsCellMeta,
+      [compressor, viewFormat, parsedAttributesCache],
+    )
+
     return (
       <S.Container data-testid={TEST_ID}>
         <S.StyledTable
-          columns={SIMILARITY_RESULTS_COLUMNS}
+          columns={columns}
           data={sortedMatches}
-          meta={{ compressor, viewFormat }}
+          meta={meta}
           stripedRows
           enableColumnResizing
           paginationEnabled={false}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
@@ -13,11 +13,17 @@ export interface SimilarityResultsListConfig {
   viewFormat: KeyValueFormat
 }
 
+export type ParsedAttributesCache = WeakMap<
+  VectorSetSimilarityMatch,
+  Record<string, unknown>
+>
+
+export interface SimilarityResultsCellMeta extends SimilarityResultsListConfig {
+  parsedAttributesCache: ParsedAttributesCache
+}
+
 export interface SimilaritySearchResultsTableProps {
   matches: VectorSetSimilarityMatch[]
   columns: ColumnDef<VectorSetSimilarityMatch>[]
-  parsedAttributesCache: WeakMap<
-    VectorSetSimilarityMatch,
-    Record<string, unknown>
-  >
+  parsedAttributesCache: ParsedAttributesCache
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
@@ -1,4 +1,5 @@
 import { KeyValueCompressor, KeyValueFormat } from 'uiSrc/constants'
+import { ColumnDef } from 'uiSrc/components/base/layout/table'
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
 import { Nullable } from 'uiSrc/utils'
 
@@ -14,4 +15,9 @@ export interface SimilarityResultsListConfig {
 
 export interface SimilaritySearchResultsTableProps {
   matches: VectorSetSimilarityMatch[]
+  columns: ColumnDef<VectorSetSimilarityMatch>[]
+  parsedAttributesCache: WeakMap<
+    VectorSetSimilarityMatch,
+    Record<string, unknown>
+  >
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/constants.ts
@@ -16,3 +16,8 @@ export const SIMILARITY_RESULTS_EMPTY_MESSAGE = 'No matching elements found.'
  * Expressed in the same `[0, 1]` space the BE returns.
  */
 export const HIGH_SIMILARITY_THRESHOLD = 0.85
+
+/** Prefix for dynamic attribute column ids — avoids collision with `name` / `similarity`. */
+export const SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX = 'attr_'
+
+export const SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE = 10

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/constants.ts
@@ -20,4 +20,15 @@ export const HIGH_SIMILARITY_THRESHOLD = 0.85
 /** Prefix for dynamic attribute column ids — avoids collision with `name` / `similarity`. */
 export const SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX = 'attr_'
 
-export const SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE = 10
+/**
+ * Per-column widths (in px). Sized so each column comfortably fits its content
+ * without ellipsing for typical values. Combined with the per-table
+ * `minWidth` we compute, this lets the table grow wider than its container
+ * and scroll horizontally instead of squishing every column.
+ *
+ * `NAME_COLUMN_MIN_SIZE` is a floor — the name column is auto-sized via
+ * `getHeaderCellProps` and can grow to absorb leftover space.
+ */
+export const SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE = 200
+export const SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE = 100
+export const SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE = 140

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
@@ -1,0 +1,113 @@
+import { stringToBuffer } from 'uiSrc/utils'
+import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
+
+import {
+  collectAttributeKeys,
+  parseAttributes,
+  renderAttributeValue,
+} from './parseAttributes'
+
+const match = (
+  name: string,
+  score: number,
+  attributes?: string,
+): VectorSetSimilarityMatch =>
+  vectorSetSimilarityMatchFactory.build({
+    name: stringToBuffer(name),
+    score,
+    attributes,
+  })
+
+describe('parseAttributes', () => {
+  it('returns {} for undefined/null/empty input', () => {
+    expect(parseAttributes(undefined)).toEqual({})
+    expect(parseAttributes(null)).toEqual({})
+    expect(parseAttributes('')).toEqual({})
+  })
+
+  it('returns {} for malformed JSON', () => {
+    expect(parseAttributes('{not json')).toEqual({})
+    expect(parseAttributes('undefined')).toEqual({})
+  })
+
+  it('returns {} for non-object JSON roots', () => {
+    expect(parseAttributes('null')).toEqual({})
+    expect(parseAttributes('42')).toEqual({})
+    expect(parseAttributes('"foo"')).toEqual({})
+    expect(parseAttributes('[1, 2, 3]')).toEqual({})
+  })
+
+  it('returns the parsed object for valid JSON', () => {
+    expect(parseAttributes('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' })
+  })
+
+  it('preserves nested values without flattening', () => {
+    const raw = '{"meta":{"score":0.9,"tags":["t1","t2"]}}'
+    expect(parseAttributes(raw)).toEqual({
+      meta: { score: 0.9, tags: ['t1', 't2'] },
+    })
+  })
+})
+
+describe('collectAttributeKeys', () => {
+  it('returns an empty array for no matches', () => {
+    expect(collectAttributeKeys([])).toEqual([])
+  })
+
+  it('returns an empty array when no match has attributes', () => {
+    expect(
+      collectAttributeKeys([match('a', 0.9), match('b', 0.8, '')]),
+    ).toEqual([])
+  })
+
+  it('unions top-level keys across matches', () => {
+    const keys = collectAttributeKeys([
+      match('a', 0.9, '{"x":1,"y":2}'),
+      match('b', 0.8, '{"y":3,"z":4}'),
+    ])
+    expect(keys).toEqual(['x', 'y', 'z'])
+  })
+
+  it('returns keys in stable alphabetical order regardless of input', () => {
+    const keys = collectAttributeKeys([match('a', 0.9, '{"z":1,"a":2,"m":3}')])
+    expect(keys).toEqual(['a', 'm', 'z'])
+  })
+
+  it('skips malformed and non-object attributes', () => {
+    const keys = collectAttributeKeys([
+      match('a', 0.9, '{"x":1}'),
+      match('b', 0.8, 'not-json'),
+      match('c', 0.7, '[1,2,3]'),
+      match('d', 0.6, 'null'),
+      match('e', 0.5, '{"y":2}'),
+    ])
+    expect(keys).toEqual(['x', 'y'])
+  })
+})
+
+describe('renderAttributeValue', () => {
+  it('renders empty string for nullish values', () => {
+    expect(renderAttributeValue(null)).toBe('')
+    expect(renderAttributeValue(undefined)).toBe('')
+  })
+
+  it('stringifies primitives', () => {
+    expect(renderAttributeValue('foo')).toBe('foo')
+    expect(renderAttributeValue(42)).toBe('42')
+    expect(renderAttributeValue(0)).toBe('0')
+    expect(renderAttributeValue(true)).toBe('true')
+    expect(renderAttributeValue(false)).toBe('false')
+  })
+
+  it('JSON-stringifies arrays and objects', () => {
+    expect(renderAttributeValue([1, 2, 3])).toBe('[1,2,3]')
+    expect(renderAttributeValue({ a: 1 })).toBe('{"a":1}')
+  })
+
+  it('returns empty string for non-serialisable values', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    expect(renderAttributeValue(cyclic)).toBe('')
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
@@ -3,6 +3,7 @@ import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
 import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 
 import {
+  buildParsedAttributesCache,
   collectAttributeKeys,
   parseAttributes,
   renderAttributeValue,
@@ -83,6 +84,45 @@ describe('collectAttributeKeys', () => {
       match('e', 0.5, '{"y":2}'),
     ])
     expect(keys).toEqual(['x', 'y'])
+  })
+
+  it('reads from the provided cache instead of re-parsing attributes', () => {
+    const a = match('a', 0.9, '{"x":1}')
+    const b = match('b', 0.8, '{"y":2}')
+    const cache = buildParsedAttributesCache([a, b])
+    const parseSpy = jest.spyOn(JSON, 'parse')
+
+    const keys = collectAttributeKeys([a, b], cache)
+
+    expect(keys).toEqual(['x', 'y'])
+    expect(parseSpy).not.toHaveBeenCalled()
+    parseSpy.mockRestore()
+  })
+
+  it('falls back to re-parsing when the cache lacks an entry', () => {
+    const a = match('a', 0.9, '{"x":1}')
+    const cache = buildParsedAttributesCache([])
+    expect(collectAttributeKeys([a], cache)).toEqual(['x'])
+  })
+})
+
+describe('buildParsedAttributesCache', () => {
+  it('caches parsed payloads keyed on the match reference', () => {
+    const a = match('a', 0.9, '{"x":1}')
+    const b = match('b', 0.8, '{"y":"two"}')
+    const cache = buildParsedAttributesCache([a, b])
+
+    expect(cache.get(a)).toEqual({ x: 1 })
+    expect(cache.get(b)).toEqual({ y: 'two' })
+  })
+
+  it('stores `{}` for matches with missing/malformed attributes', () => {
+    const a = match('a', 0.9, 'not-json')
+    const b = match('b', 0.8)
+    const cache = buildParsedAttributesCache([a, b])
+
+    expect(cache.get(a)).toEqual({})
+    expect(cache.get(b)).toEqual({})
   })
 })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
@@ -1,0 +1,51 @@
+import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+
+/** Parse a match's `attributes` JSON string; returns `{}` on any failure. */
+export const parseAttributes = (
+  raw: string | undefined | null,
+): Record<string, unknown> => {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return {}
+    }
+    return parsed as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Union of top-level attribute keys across `matches`, alphabetically sorted.
+ * Stable ordering keeps the column list referentially stable across renders.
+ */
+export const collectAttributeKeys = (
+  matches: VectorSetSimilarityMatch[],
+): string[] => {
+  const keys = new Set<string>()
+  for (const match of matches) {
+    const attrs = parseAttributes(match.attributes)
+    for (const key of Object.keys(attrs)) {
+      keys.add(key)
+    }
+  }
+  return Array.from(keys).sort()
+}
+
+/** Stringify an attribute value for table-cell display. */
+export const renderAttributeValue = (value: unknown): string => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return ''
+    }
+  }
+  return String(value)
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
@@ -1,4 +1,5 @@
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+import { ParsedAttributesCache } from '../SimilaritySearchResultsTable.types'
 
 /** Parse a match's `attributes` JSON string; returns `{}` on any failure. */
 export const parseAttributes = (
@@ -21,15 +22,32 @@ export const parseAttributes = (
 }
 
 /**
+ * Build a `WeakMap<match, parsedAttributes>` so callers (key-collector + table
+ * cells) can share a single JSON-parse per match.
+ */
+export const buildParsedAttributesCache = (
+  matches: VectorSetSimilarityMatch[],
+): ParsedAttributesCache => {
+  const cache: ParsedAttributesCache = new WeakMap()
+  for (const match of matches) {
+    cache.set(match, parseAttributes(match.attributes))
+  }
+  return cache
+}
+
+/**
  * Union of top-level attribute keys across `matches`, alphabetically sorted.
  * Stable ordering keeps the column list referentially stable across renders.
+ *
+ * Pass a pre-built `cache` to avoid re-parsing `attributes` strings here.
  */
 export const collectAttributeKeys = (
   matches: VectorSetSimilarityMatch[],
+  cache?: ParsedAttributesCache,
 ): string[] => {
   const keys = new Set<string>()
   for (const match of matches) {
-    const attrs = parseAttributes(match.attributes)
+    const attrs = cache?.get(match) ?? parseAttributes(match.attributes)
     for (const key of Object.keys(attrs)) {
       keys.add(key)
     }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
@@ -27,7 +27,6 @@ const createNameColumn = (
     accessorKey: VectorSetColumn.Name,
     header: VECTOR_SET_COLUMN_HEADERS[VectorSetColumn.Name],
     enableSorting: false,
-    size: 150,
     cell: ({ row }: { row: TableRow<VectorSetElement> }) => (
       <ElementNameCell
         element={row.original}
@@ -45,7 +44,8 @@ const createActionsColumn = (
   header: VECTOR_SET_COLUMN_HEADERS[VectorSetColumn.Actions],
   enableSorting: false,
   enableResizing: false,
-  size: 10,
+  size: 100,
+  sizeUnit: 'px',
   cell: ({ row }: { row: TableRow<VectorSetElement> }) => {
     const { name: nameBuffer } = row.original
     const {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
@@ -27,7 +27,6 @@ const VectorSetElementList = memo(({ onRemoveKey, onViewElement }: Props) => {
         columns={columns}
         data={currentPageData}
         stripedRows
-        enableColumnResizing
         minWidth={tableMinWidth}
         paginationEnabled={isPaginationSupported}
         manualPagination={isPaginationSupported}


### PR DESCRIPTION

# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->


- Render vector element attributes as dynamic columns in the similarity search results table
- Parse attribute keys from results and generate columns on the fly (with sane defaults for type/width)
- Add `parseAttributes` util + unit tests, and factory helper for test data


https://github.com/user-attachments/assets/b6a3baf5-c63a-4194-9f55-ff66244aa7ca


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: the similarity results table now builds dynamic columns from JSON `attributes` and changes table sizing/scroll behavior, which could impact rendering/performance for large result sets or malformed attribute payloads.
> 
> **Overview**
> Similarity-search results for vector sets now render each match’s `attributes` JSON as **dynamic table columns**, using the union of top-level keys across matches (sorted alphabetically for stability).
> 
> `VectorSetDetails` precomputes a per-match parsed-attributes `WeakMap` cache and the derived attribute-key list, then passes both (plus a generated column set) into `SimilaritySearchResultsTable`, which now focuses on rendering and enforces horizontal scrolling via a computed `minWidth` and fixed per-column sizing.
> 
> Adds `parseAttributes` utilities with unit tests, extends table specs to cover attribute columns/values, and introduces a `VectorSetSimilarityMatch` test factory; also tweaks element list table sizing by widening the actions column and disabling column resizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7b74fa0334812c6fa30290b0d32d14d7ec4660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->