### PR TITLE
RI-8160: Add columns toggle popover for similarity-search results

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -20,12 +20,11 @@ import { VectorSetElementList } from './vector-set-element-list'
 import { VectorSetKeySubheader } from './vector-set-key-subheader'
 import { ElementDetails } from './element-details'
 import { SimilaritySearchForm } from './similarity-search-form'
-import { SimilaritySearchResultsTable } from './similarity-search-results'
-import { buildSimilarityResultsColumns } from './similarity-search-results/SimilaritySearchResultsTable.config'
 import {
-  buildParsedAttributesCache,
-  collectAttributeKeys,
-} from './similarity-search-results/utils/parseAttributes'
+  SimilarityColumnsPopover,
+  SimilaritySearchResultsTable,
+  useSimilarityResultColumns,
+} from './similarity-search-results'
 import {
   useAddElementPanel,
   useAddElements,
@@ -70,22 +69,30 @@ const VectorSetDetails = (props: Props) => {
     dispatch(clearSimilaritySearch())
   }, [dispatch])
 
-  // Cache parsed attribute payloads + derive the union of attribute keys in
-  // one pass, so each row pays the JSON-parse cost once across the key
-  // collector and every attribute column it renders. Stable alphabetical
-  // ordering keeps the resulting column list referentially stable.
-  const { similarityParsedAttributesCache, similarityAttributeKeys } =
-    useMemo(() => {
-      const cache = buildParsedAttributesCache(similarityMatches)
-      return {
-        similarityParsedAttributesCache: cache,
-        similarityAttributeKeys: collectAttributeKeys(similarityMatches, cache),
-      }
-    }, [similarityMatches])
-  const similarityColumns = useMemo(
-    () => buildSimilarityResultsColumns(similarityAttributeKeys),
-    [similarityAttributeKeys],
-  )
+  // Single source of truth shared by the results table and the Columns popover.
+  const {
+    columns: similarityColumns,
+    columnVisibility: similarityColumnVisibility,
+    columnsMap: similarityColumnsMap,
+    shownColumns: similarityShownColumns,
+    onShownColumnsChange: handleSimilarityColumnsChange,
+    parsedAttributesCache: similarityParsedAttributesCache,
+  } = useSimilarityResultColumns(similarityMatches)
+
+  // Hide the Columns popover when there are no toggleable (attribute) columns.
+  const showSimilarityColumnsPopover =
+    hasSimilarityResults && similarityColumnsMap.size > 0
+
+  const similarityAdditionalActions = showSimilarityColumnsPopover
+    ? (width: number) => (
+        <SimilarityColumnsPopover
+          width={width}
+          columnsMap={similarityColumnsMap}
+          shownColumns={similarityShownColumns}
+          onShownColumnsChange={handleSimilarityColumnsChange}
+        />
+      )
+    : undefined
 
   const {
     total = 0,
@@ -118,6 +125,7 @@ const VectorSetDetails = (props: Props) => {
         total={total}
         hasSimilarityResults={hasSimilarityResults}
         onClearResults={handleClearResults}
+        additionalActions={similarityAdditionalActions}
       />
       <S.DetailsBody>
         {!loading && (
@@ -126,6 +134,7 @@ const VectorSetDetails = (props: Props) => {
               <SimilaritySearchResultsTable
                 matches={similarityMatches}
                 columns={similarityColumns}
+                columnVisibility={similarityColumnVisibility}
                 parsedAttributesCache={similarityParsedAttributesCache}
               />
             ) : (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -19,8 +19,8 @@ import {
   SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
 } from './constants'
 import {
-  SimilarityResultsCellMeta,
   SimilarityResultsColumn,
+  SimilarityResultsListConfig,
 } from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
 import { KeyValueFormat } from 'uiSrc/constants'
@@ -33,9 +33,6 @@ const nameColumn: ColumnDef<VectorSetSimilarityMatch> = {
   minSize: SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
   size: SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE,
   sizeUnit: 'px',
-  // Auto-size the header cell so leftover horizontal space is absorbed by
-  // the name column (the only flexible one) instead of being distributed
-  // across all columns.
   getHeaderCellProps: () => ({
     style: {
       width: 'auto',
@@ -44,7 +41,7 @@ const nameColumn: ColumnDef<VectorSetSimilarityMatch> = {
   }),
   cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
     const { compressor = null, viewFormat } = table.options
-      .meta as SimilarityResultsCellMeta
+      .meta as SimilarityResultsListConfig
     return (
       <ElementNameCell
         element={row.original}
@@ -60,11 +57,11 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   accessorKey: SimilarityResultsColumn.Similarity,
   header: SIMILARITY_RESULTS_COLUMN_HEADERS[SimilarityResultsColumn.Similarity],
   enableSorting: false,
-  enableResizing: false,
   size: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
   minSize: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
   maxSize: SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
   sizeUnit: 'px',
+  enableResizing: false,
   cell: ({ row }: { row: TableRow<VectorSetSimilarityMatch> }) => {
     const { score } = row.original
     const isHigh = Number.isFinite(score) && score >= HIGH_SIMILARITY_THRESHOLD
@@ -79,11 +76,7 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   },
 }
 
-/**
- * Build a column for a single attribute key. The cell reads the
- * pre-parsed payload from `meta.parsedAttributesCache` so each row pays the
- * JSON-parse cost once instead of once per attribute column it renders.
- */
+/** Build a column for a single attribute key. */
 const buildAttributeColumn = (
   key: string,
 ): ColumnDef<VectorSetSimilarityMatch> => ({
@@ -92,12 +85,8 @@ const buildAttributeColumn = (
   enableSorting: false,
   size: SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
   sizeUnit: 'px',
-  cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
-    const { parsedAttributesCache } = table.options
-      .meta as SimilarityResultsCellMeta
-    const attrs =
-      parsedAttributesCache.get(row.original) ??
-      parseAttributes(row.original.attributes)
+  cell: ({ row }: CellContext<VectorSetSimilarityMatch, unknown>) => {
+    const attrs = parseAttributes(row.original.attributes)
     return (
       <S.AttributeCell
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}
@@ -119,3 +108,7 @@ export const buildSimilarityResultsColumns = (
   similarityColumn,
   ...attributeKeys.map(buildAttributeColumn),
 ]
+
+/** Static-only column list (for call sites that don't thread attribute keys). */
+export const SIMILARITY_RESULTS_COLUMNS: ColumnDef<VectorSetSimilarityMatch>[] =
+  buildSimilarityResultsColumns([])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -117,7 +117,3 @@ export const buildSimilarityResultsColumns = (
   similarityColumn,
   ...attributeKeys.map(buildAttributeColumn),
 ]
-
-/** Static-only column list (for call sites that don't thread attribute keys). */
-export const SIMILARITY_RESULTS_COLUMNS: ColumnDef<VectorSetSimilarityMatch>[] =
-  buildSimilarityResultsColumns([])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -19,6 +19,7 @@ import {
   SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
 } from './constants'
 import {
+  SimilarityResultsCellMeta,
   SimilarityResultsColumn,
   SimilarityResultsListConfig,
 } from './SimilaritySearchResultsTable.types'
@@ -76,7 +77,11 @@ const similarityColumn: ColumnDef<VectorSetSimilarityMatch> = {
   },
 }
 
-/** Build a column for a single attribute key. */
+/**
+ * Build a column for a single attribute key. The cell reads the
+ * pre-parsed payload from `meta.parsedAttributesCache` so each row pays the
+ * JSON-parse cost once instead of once per attribute column it renders.
+ */
 const buildAttributeColumn = (
   key: string,
 ): ColumnDef<VectorSetSimilarityMatch> => ({
@@ -85,8 +90,12 @@ const buildAttributeColumn = (
   enableSorting: false,
   size: SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE,
   sizeUnit: 'px',
-  cell: ({ row }: CellContext<VectorSetSimilarityMatch, unknown>) => {
-    const attrs = parseAttributes(row.original.attributes)
+  cell: ({ row, table }: CellContext<VectorSetSimilarityMatch, unknown>) => {
+    const { parsedAttributesCache } = table.options
+      .meta as SimilarityResultsCellMeta
+    const attrs =
+      parsedAttributesCache.get(row.original) ??
+      parseAttributes(row.original.attributes)
     return (
       <S.AttributeCell
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -7,10 +7,7 @@ import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/v
 
 import { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
 import { buildSimilarityResultsColumns } from './SimilaritySearchResultsTable.config'
-import {
-  buildParsedAttributesCache,
-  collectAttributeKeys,
-} from './utils/parseAttributes'
+import { collectAttributeKeys, parseAttributes } from './utils/parseAttributes'
 
 const buildMatch = (
   name: string,
@@ -25,17 +22,27 @@ const buildMatch = (
 
 /**
  * Build the table props the same way `VectorSetDetails` does in production —
- * keeps the spec realistic and means a single change to the column-builder
- * signature surfaces here too.
+ * keeps the spec realistic and means a single change to the hook signature
+ * surfaces here too.
  */
-const renderTable = (matches: VectorSetSimilarityMatch[]) => {
-  const parsedAttributesCache = buildParsedAttributesCache(matches)
-  const attributeKeys = collectAttributeKeys(matches, parsedAttributesCache)
+const renderTable = (
+  matches: VectorSetSimilarityMatch[],
+  options: { columnVisibility?: Record<string, boolean> } = {},
+) => {
+  const attributeKeys = collectAttributeKeys(matches)
   const columns = buildSimilarityResultsColumns(attributeKeys)
+  const parsedAttributesCache = new WeakMap<
+    VectorSetSimilarityMatch,
+    Record<string, unknown>
+  >()
+  for (const match of matches) {
+    parsedAttributesCache.set(match, parseAttributes(match.attributes))
+  }
   return render(
     <SimilaritySearchResultsTable
       matches={matches}
       columns={columns}
+      columnVisibility={options.columnVisibility ?? {}}
       parsedAttributesCache={parsedAttributesCache}
     />,
   )
@@ -161,6 +168,20 @@ describe('SimilaritySearchResultsTable', () => {
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-count'),
       ).toHaveTextContent('')
+    })
+
+    it('hides columns whose visibility is explicitly false', () => {
+      const matches = [buildMatch('a', 0.9, '{"city":"NYC","count":3}')]
+
+      renderTable(matches, {
+        columnVisibility: { attr_city: false },
+      })
+
+      // The `city` header should be hidden, `count` should still render.
+      const headers = screen
+        .getAllByRole('columnheader')
+        .map((h) => h.textContent?.trim())
+      expect(headers).toEqual(['Element', 'Similarity', 'count'])
     })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -7,7 +7,11 @@ import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/v
 
 import { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
 import { buildSimilarityResultsColumns } from './SimilaritySearchResultsTable.config'
-import { collectAttributeKeys, parseAttributes } from './utils/parseAttributes'
+import { ParsedAttributesCache } from './SimilaritySearchResultsTable.types'
+import {
+  buildParsedAttributesCache,
+  collectAttributeKeys,
+} from './utils/parseAttributes'
 
 const buildMatch = (
   name: string,
@@ -29,15 +33,9 @@ const renderTable = (
   matches: VectorSetSimilarityMatch[],
   options: { columnVisibility?: Record<string, boolean> } = {},
 ) => {
-  const attributeKeys = collectAttributeKeys(matches)
+  const parsedAttributesCache = buildParsedAttributesCache(matches)
+  const attributeKeys = collectAttributeKeys(matches, parsedAttributesCache)
   const columns = buildSimilarityResultsColumns(attributeKeys)
-  const parsedAttributesCache = new WeakMap<
-    VectorSetSimilarityMatch,
-    Record<string, unknown>
-  >()
-  for (const match of matches) {
-    parsedAttributesCache.set(match, parseAttributes(match.attributes))
-  }
   return render(
     <SimilaritySearchResultsTable
       matches={matches}
@@ -182,6 +180,31 @@ describe('SimilaritySearchResultsTable', () => {
         .getAllByRole('columnheader')
         .map((h) => h.textContent?.trim())
       expect(headers).toEqual(['Element', 'Similarity', 'count'])
+    })
+
+    // Regression: attribute cells must read from `parsedAttributesCache`
+    // instead of re-parsing `row.original.attributes` on every render.
+    // We seed the cache with a value that diverges from the raw JSON so a
+    // cache-bypassing implementation would render the wrong text.
+    it('renders attribute values from the parsed-attributes cache', () => {
+      const match = buildMatch('a', 0.9, '{"city":"RAW"}')
+      const attributeKeys = collectAttributeKeys([match])
+      const columns = buildSimilarityResultsColumns(attributeKeys)
+      const parsedAttributesCache: ParsedAttributesCache = new WeakMap()
+      parsedAttributesCache.set(match, { city: 'FROM_CACHE' })
+
+      render(
+        <SimilaritySearchResultsTable
+          matches={[match]}
+          columns={columns}
+          columnVisibility={{}}
+          parsedAttributesCache={parsedAttributesCache}
+        />,
+      )
+
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-0-city'),
+      ).toHaveTextContent('FROM_CACHE')
     })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -12,7 +12,7 @@ import {
   SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
 } from './constants'
 import {
-  SimilarityResultsListConfig,
+  SimilarityResultsCellMeta,
   SimilaritySearchResultsTableProps,
 } from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
@@ -40,7 +40,7 @@ const SimilaritySearchResultsTable = memo(
           compressor,
           viewFormat,
           parsedAttributesCache,
-        }) as SimilarityResultsListConfig,
+        }) as SimilarityResultsCellMeta,
       [compressor, viewFormat, parsedAttributesCache],
     )
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -12,7 +12,7 @@ import {
   SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE,
 } from './constants'
 import {
-  SimilarityResultsCellMeta,
+  SimilarityResultsListConfig,
   SimilaritySearchResultsTableProps,
 } from './SimilaritySearchResultsTable.types'
 import * as S from './SimilaritySearchResultsTable.styles'
@@ -40,7 +40,7 @@ const SimilaritySearchResultsTable = memo(
           compressor,
           viewFormat,
           parsedAttributesCache,
-        }) as SimilarityResultsCellMeta,
+        }) as SimilarityResultsListConfig,
       [compressor, viewFormat, parsedAttributesCache],
     )
 
@@ -49,15 +49,18 @@ const SimilaritySearchResultsTable = memo(
     // every column. The min-width is the actual sum of column widths so the
     // browser only stretches the auto-sized name column with leftover space.
     const tableMinWidth = useMemo(() => {
-      const attributeCount = columns.filter((column) =>
-        column.id?.startsWith(SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX),
+      const visibleAttributeCount = columns.filter(
+        (column) =>
+          column.id?.startsWith(
+            SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX,
+          ) && columnVisibility[column.id] !== false,
       ).length
       const total =
         SIMILARITY_RESULTS_NAME_COLUMN_MIN_SIZE +
         SIMILARITY_RESULTS_SIMILARITY_COLUMN_SIZE +
-        attributeCount * SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE
+        visibleAttributeCount * SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_SIZE
       return `${total}px`
-    }, [columns])
+    }, [columns, columnVisibility])
 
     return (
       <S.Container data-testid={TEST_ID}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -23,6 +23,7 @@ const SimilaritySearchResultsTable = memo(
   ({
     matches,
     columns,
+    columnVisibility,
     parsedAttributesCache,
   }: SimilaritySearchResultsTableProps) => {
     const { compressor = null } = useSelector(connectedInstanceSelector)
@@ -64,6 +65,7 @@ const SimilaritySearchResultsTable = memo(
           columns={columns}
           data={sortedMatches}
           meta={meta}
+          columnVisibility={columnVisibility}
           stripedRows
           enableColumnResizing
           minWidth={tableMinWidth}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
@@ -13,17 +13,13 @@ export interface SimilarityResultsListConfig {
   viewFormat: KeyValueFormat
 }
 
-export type ParsedAttributesCache = WeakMap<
-  VectorSetSimilarityMatch,
-  Record<string, unknown>
->
-
-export interface SimilarityResultsCellMeta extends SimilarityResultsListConfig {
-  parsedAttributesCache: ParsedAttributesCache
-}
-
 export interface SimilaritySearchResultsTableProps {
   matches: VectorSetSimilarityMatch[]
   columns: ColumnDef<VectorSetSimilarityMatch>[]
-  parsedAttributesCache: ParsedAttributesCache
+  /** `@redis-ui/table` visibility map (`{ [columnId]: false }`). */
+  columnVisibility: Record<string, boolean>
+  parsedAttributesCache: WeakMap<
+    VectorSetSimilarityMatch,
+    Record<string, unknown>
+  >
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.types.ts
@@ -13,13 +13,19 @@ export interface SimilarityResultsListConfig {
   viewFormat: KeyValueFormat
 }
 
+export type ParsedAttributesCache = WeakMap<
+  VectorSetSimilarityMatch,
+  Record<string, unknown>
+>
+
+export interface SimilarityResultsCellMeta extends SimilarityResultsListConfig {
+  parsedAttributesCache: ParsedAttributesCache
+}
+
 export interface SimilaritySearchResultsTableProps {
   matches: VectorSetSimilarityMatch[]
   columns: ColumnDef<VectorSetSimilarityMatch>[]
   /** `@redis-ui/table` visibility map (`{ [columnId]: false }`). */
   columnVisibility: Record<string, boolean>
-  parsedAttributesCache: WeakMap<
-    VectorSetSimilarityMatch,
-    Record<string, unknown>
-  >
+  parsedAttributesCache: ParsedAttributesCache
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
+
+import { SimilarityColumnsPopover } from './SimilarityColumnsPopover'
+import {
+  COLUMNS_BUTTON_TEST_ID,
+  COLUMNS_POPOVER_TEST_ID,
+  DEFAULT_TITLE,
+} from './constants'
+
+/** Width above the small-screen breakpoint. */
+const WIDE = MIDDLE_SCREEN_RESOLUTION + 100
+/** Width at/below the small-screen breakpoint. */
+const NARROW = MIDDLE_SCREEN_RESOLUTION
+
+const attrColumnsMap = new Map<string, string>([
+  ['attr_city', 'city'],
+  ['attr_count', 'count'],
+])
+
+const anchoredShownColumns = ['name', 'similarity', 'attr_city', 'attr_count']
+
+describe('SimilarityColumnsPopover', () => {
+  describe('responsive trigger', () => {
+    it('renders the trigger with label on wide screens', () => {
+      render(
+        <SimilarityColumnsPopover
+          width={WIDE}
+          columnsMap={attrColumnsMap}
+          shownColumns={anchoredShownColumns}
+          onShownColumnsChange={jest.fn()}
+        />,
+      )
+
+      const btn = screen.getByTestId(COLUMNS_BUTTON_TEST_ID)
+      expect(btn).toBeInTheDocument()
+      expect(btn).toHaveTextContent(DEFAULT_TITLE)
+    })
+
+    it('renders icon-only trigger on narrow screens', () => {
+      render(
+        <SimilarityColumnsPopover
+          width={NARROW}
+          columnsMap={attrColumnsMap}
+          shownColumns={anchoredShownColumns}
+          onShownColumnsChange={jest.fn()}
+        />,
+      )
+
+      const btn = screen.getByTestId(COLUMNS_BUTTON_TEST_ID)
+      expect(btn).toBeInTheDocument()
+      expect(btn).not.toHaveTextContent(DEFAULT_TITLE)
+      expect(btn).toHaveAttribute('aria-label', DEFAULT_TITLE)
+    })
+  })
+
+  describe('popover content', () => {
+    it('opens the popover and lists only the columnsMap entries (no Element/Similarity)', () => {
+      render(
+        <SimilarityColumnsPopover
+          width={WIDE}
+          columnsMap={attrColumnsMap}
+          shownColumns={anchoredShownColumns}
+          onShownColumnsChange={jest.fn()}
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId(COLUMNS_BUTTON_TEST_ID))
+
+      expect(screen.getByTestId(COLUMNS_POPOVER_TEST_ID)).toBeInTheDocument()
+      expect(screen.getByTestId('show-attr_city')).toBeChecked()
+      expect(screen.getByTestId('show-attr_count')).toBeChecked()
+      // Element + Similarity are anchored and never offered as a toggle.
+      expect(screen.queryByTestId('show-name')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('show-similarity')).not.toBeInTheDocument()
+    })
+
+    it('invokes onShownColumnsChange with the next shown ids when a checkbox toggles', () => {
+      const onChange = jest.fn()
+      render(
+        <SimilarityColumnsPopover
+          width={WIDE}
+          columnsMap={attrColumnsMap}
+          shownColumns={anchoredShownColumns}
+          onShownColumnsChange={onChange}
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId(COLUMNS_BUTTON_TEST_ID))
+      fireEvent.click(screen.getByTestId('show-attr_city'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      // `attr_city` is removed; anchors and the other attribute key stay.
+      expect(onChange.mock.calls[0][0]).toEqual([
+        'name',
+        'similarity',
+        'attr_count',
+      ])
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react'
+
+import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
+import { RiPopover } from 'uiSrc/components/base'
+import { RiTooltip } from 'uiSrc/components'
+import { ColumnsIcon } from 'uiSrc/components/base/icons'
+import { EmptyButton, IconButton } from 'uiSrc/components/base/forms/buttons'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+import {
+  COLUMNS_BUTTON_TEST_ID,
+  COLUMNS_POPOVER_TEST_ID,
+  DEFAULT_TITLE,
+} from './constants'
+import { Props } from './SimilarityColumnsPopover.types'
+
+/**
+ * Columns popover for the similarity-search results table.
+ *
+ * Built locally (instead of reusing the shared `ColumnsConfigPopover`) so the
+ * trigger can collapse to an icon-only `IconButton` on narrow viewports,
+ * mirroring `ClearResultsAction`.
+ */
+const SimilarityColumnsPopover = ({
+  width,
+  columnsMap,
+  shownColumns,
+  onShownColumnsChange,
+  title = DEFAULT_TITLE,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const showLabel = width > MIDDLE_SCREEN_RESOLUTION
+
+  const toggle = () => setIsOpen((v) => !v)
+  const close = () => setIsOpen(false)
+
+  const handleToggle = (checked: boolean, col: string) => {
+    if (!checked && shownColumns.length === 1 && shownColumns.includes(col)) {
+      return
+    }
+
+    const next = checked
+      ? [...shownColumns, col]
+      : shownColumns.filter((c) => c !== col)
+    onShownColumnsChange(next)
+  }
+
+  const trigger = showLabel ? (
+    <EmptyButton
+      size="small"
+      icon={ColumnsIcon}
+      onClick={toggle}
+      data-testid={COLUMNS_BUTTON_TEST_ID}
+      aria-label={title}
+    >
+      {title}
+    </EmptyButton>
+  ) : (
+    <IconButton
+      icon={ColumnsIcon}
+      onClick={toggle}
+      data-testid={COLUMNS_BUTTON_TEST_ID}
+      aria-label={title}
+    />
+  )
+
+  return (
+    <RiTooltip content={showLabel ? '' : title} position="left">
+      <RiPopover
+        ownFocus={false}
+        anchorPosition="downLeft"
+        isOpen={isOpen}
+        closePopover={close}
+        data-testid={COLUMNS_POPOVER_TEST_ID}
+        button={trigger}
+      >
+        <Col gap="m">
+          {Array.from(columnsMap.entries()).map(([field, name]) => (
+            <Checkbox
+              key={`show-${field}`}
+              id={`show-${field}`}
+              name={`show-${field}`}
+              label={name}
+              checked={shownColumns.includes(field)}
+              disabled={
+                shownColumns.includes(field) && shownColumns.length === 1
+              }
+              onChange={(e) => handleToggle(e.target.checked, field)}
+              data-testid={`show-${field}`}
+            />
+          ))}
+        </Col>
+      </RiPopover>
+    </RiTooltip>
+  )
+}
+
+export { SimilarityColumnsPopover }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.types.ts
@@ -1,0 +1,11 @@
+export interface Props {
+  /** Container width (px) — drives the icon-only / icon-and-label switch. */
+  width: number
+  /** Toggleable columns only (`columnId → label`). */
+  columnsMap: Map<string, string>
+  /** Currently-visible column ids (includes Element + Similarity anchors). */
+  shownColumns: string[]
+  onShownColumnsChange: (next: string[]) => void
+  /** Override the trigger label / tooltip / aria-label. */
+  title?: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/constants.ts
@@ -1,0 +1,3 @@
+export const COLUMNS_BUTTON_TEST_ID = 'similarity-search-columns-btn'
+export const COLUMNS_POPOVER_TEST_ID = 'similarity-search-columns-popover'
+export const DEFAULT_TITLE = 'Columns'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/index.ts
@@ -1,0 +1,3 @@
+export { SimilarityColumnsPopover } from './SimilarityColumnsPopover'
+export type { Props as SimilarityColumnsPopoverProps } from './SimilarityColumnsPopover.types'
+export { COLUMNS_BUTTON_TEST_ID, COLUMNS_POPOVER_TEST_ID } from './constants'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
@@ -1,0 +1,168 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { stringToBuffer } from 'uiSrc/utils'
+import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
+
+import {
+  attributeColumnId,
+  useSimilarityResultColumns,
+} from './useSimilarityResultColumns'
+import { SimilarityResultsColumn } from '../SimilaritySearchResultsTable.types'
+
+/** Positional shorthand around the shared factory — tests here always care
+ *  about a specific name + score, so the factory's random defaults add noise. */
+const match = (
+  name: string,
+  score: number,
+  attributes?: string,
+): VectorSetSimilarityMatch =>
+  vectorSetSimilarityMatchFactory.build({
+    name: stringToBuffer(name),
+    score,
+    attributes,
+  })
+
+describe('useSimilarityResultColumns', () => {
+  it('returns static columns + alphabetical attribute columns', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([
+        match('a', 0.9, '{"zeta":1,"alpha":2}'),
+        match('b', 0.8, '{"beta":3}'),
+      ]),
+    )
+
+    const ids = result.current.columns.map((c) => c.id)
+    expect(ids).toEqual([
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      attributeColumnId('alpha'),
+      attributeColumnId('beta'),
+      attributeColumnId('zeta'),
+    ])
+    expect(result.current.attributeKeys).toEqual(['alpha', 'beta', 'zeta'])
+  })
+
+  it('builds a columnsMap that only contains toggleable attribute columns', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9, '{"foo":1}')]),
+    )
+
+    // Element + Similarity are intentionally absent so the popover never
+    // offers a way to hide them.
+    expect(Array.from(result.current.columnsMap.entries())).toEqual([
+      [attributeColumnId('foo'), 'foo'],
+    ])
+  })
+
+  it('returns an empty columnsMap when matches have no attributes', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9), match('b', 0.8)]),
+    )
+
+    expect(result.current.columnsMap.size).toBe(0)
+  })
+
+  it('keeps Element + Similarity anchored in shownColumns alongside visible attribute keys', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9, '{"foo":1}')]),
+    )
+
+    expect(result.current.shownColumns).toEqual([
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      attributeColumnId('foo'),
+    ])
+    expect(result.current.columnVisibility).toEqual({})
+  })
+
+  it('hides columns when onShownColumnsChange omits them', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9, '{"foo":1,"bar":2}')]),
+    )
+
+    act(() => {
+      result.current.onShownColumnsChange([
+        SimilarityResultsColumn.Name,
+        SimilarityResultsColumn.Similarity,
+        attributeColumnId('bar'),
+      ])
+    })
+
+    expect(result.current.shownColumns).toEqual([
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      attributeColumnId('bar'),
+    ])
+    expect(result.current.columnVisibility).toEqual({
+      [attributeColumnId('foo')]: false,
+    })
+  })
+
+  it('keeps Element + Similarity visible even if onShownColumnsChange forgets them', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9, '{"foo":1}')]),
+    )
+
+    // Simulate a buggy/legacy caller that passes only attribute ids.
+    act(() => {
+      result.current.onShownColumnsChange([attributeColumnId('foo')])
+    })
+
+    expect(result.current.shownColumns).toEqual([
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      attributeColumnId('foo'),
+    ])
+    expect(result.current.columnVisibility).toEqual({})
+  })
+
+  it('preserves hidden state when new matches surface new attribute keys', () => {
+    const initial = [match('a', 0.9, '{"foo":1}')]
+    const { result, rerender } = renderHook(
+      (matches: VectorSetSimilarityMatch[]) =>
+        useSimilarityResultColumns(matches),
+      { initialProps: initial },
+    )
+
+    act(() => {
+      result.current.onShownColumnsChange([
+        SimilarityResultsColumn.Name,
+        SimilarityResultsColumn.Similarity,
+      ])
+    })
+    expect(result.current.columnVisibility).toEqual({
+      [attributeColumnId('foo')]: false,
+    })
+
+    // New search introduces a `bar` attribute → it should default to visible
+    // while the user's existing decision to hide `foo` is preserved.
+    rerender([match('c', 0.7, '{"foo":1,"bar":2}')])
+    expect(result.current.shownColumns).toEqual([
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      attributeColumnId('bar'),
+    ])
+    expect(result.current.columnVisibility).toEqual({
+      [attributeColumnId('foo')]: false,
+    })
+  })
+
+  it('populates the parsed-attributes cache up front', () => {
+    const a = match('a', 0.9, '{"foo":1}')
+    const b = match('b', 0.8, '{"bar":"x"}')
+    const { result } = renderHook(() => useSimilarityResultColumns([a, b]))
+
+    expect(result.current.parsedAttributesCache.get(a)).toEqual({ foo: 1 })
+    expect(result.current.parsedAttributesCache.get(b)).toEqual({ bar: 'x' })
+  })
+
+  it('returns no attribute columns when matches have no attributes', () => {
+    const { result } = renderHook(() =>
+      useSimilarityResultColumns([match('a', 0.9), match('b', 0.8)]),
+    )
+
+    expect(result.current.attributeKeys).toEqual([])
+    expect(result.current.columns).toHaveLength(2)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
@@ -1,0 +1,110 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import { ColumnDef } from 'uiSrc/components/base/layout/table'
+import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+
+import { SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX } from '../constants'
+import { SimilarityResultsColumn } from '../SimilaritySearchResultsTable.types'
+import { buildSimilarityResultsColumns } from '../SimilaritySearchResultsTable.config'
+import { collectAttributeKeys, parseAttributes } from '../utils/parseAttributes'
+
+export interface UseSimilarityResultColumnsResult {
+  columns: ColumnDef<VectorSetSimilarityMatch>[]
+  columnVisibility: Record<string, boolean>
+  /** Toggleable attribute columns only (Element + Similarity are always shown). */
+  columnsMap: Map<string, string>
+  shownColumns: string[]
+  onShownColumnsChange: (next: string[]) => void
+  attributeKeys: string[]
+  /**
+   * Per-match cache of the parsed `attributes` JSON. Populated once per
+   * match so each row pays the JSON-parse cost a single time regardless
+   * of how many attribute columns it renders.
+   */
+  parsedAttributesCache: WeakMap<
+    VectorSetSimilarityMatch,
+    Record<string, unknown>
+  >
+}
+
+/** `foo` → `attr_foo`. */
+export const attributeColumnId = (key: string): string =>
+  `${SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX}${key}`
+
+/**
+ * Column-visibility state for the similarity-search results table.
+ *
+ * Tracks *hidden* ids (not shown) so new attribute keys default to visible
+ * while previously-hidden ones stay hidden across re-searches. Element +
+ * Similarity are always visible and excluded from `columnsMap`.
+ */
+export const useSimilarityResultColumns = (
+  matches: VectorSetSimilarityMatch[],
+): UseSimilarityResultColumnsResult => {
+  const attributeKeys = useMemo(() => collectAttributeKeys(matches), [matches])
+
+  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
+    () => new Set(),
+  )
+
+  const columns = useMemo(
+    () => buildSimilarityResultsColumns(attributeKeys),
+    [attributeKeys],
+  )
+
+  const columnsMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const key of attributeKeys) {
+      map.set(attributeColumnId(key), key)
+    }
+    return map
+  }, [attributeKeys])
+
+  const shownColumns = useMemo(
+    () => [
+      SimilarityResultsColumn.Name,
+      SimilarityResultsColumn.Similarity,
+      ...Array.from(columnsMap.keys()).filter((id) => !hiddenColumns.has(id)),
+    ],
+    [columnsMap, hiddenColumns],
+  )
+
+  const onShownColumnsChange = useCallback(
+    (next: string[]) => {
+      const nextShown = new Set(next)
+      const nextHidden = new Set<string>()
+      for (const id of columnsMap.keys()) {
+        if (!nextShown.has(id)) nextHidden.add(id)
+      }
+      setHiddenColumns(nextHidden)
+    },
+    [columnsMap],
+  )
+
+  const columnVisibility = useMemo<Record<string, boolean>>(() => {
+    const out: Record<string, boolean> = {}
+    for (const id of hiddenColumns) out[id] = false
+    return out
+  }, [hiddenColumns])
+
+  const parsedAttributesCache = useMemo(() => {
+    const cache = new WeakMap<
+      VectorSetSimilarityMatch,
+      Record<string, unknown>
+    >()
+    for (const match of matches) {
+      cache.set(match, parseAttributes(match.attributes))
+    }
+    return cache
+  }, [matches])
+
+  return {
+    columns,
+    columnVisibility,
+    columnsMap,
+    shownColumns,
+    onShownColumnsChange,
+    attributeKeys,
+    parsedAttributesCache,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
@@ -4,9 +4,15 @@ import { ColumnDef } from 'uiSrc/components/base/layout/table'
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
 
 import { SIMILARITY_RESULTS_ATTRIBUTE_COLUMN_ID_PREFIX } from '../constants'
-import { SimilarityResultsColumn } from '../SimilaritySearchResultsTable.types'
+import {
+  ParsedAttributesCache,
+  SimilarityResultsColumn,
+} from '../SimilaritySearchResultsTable.types'
 import { buildSimilarityResultsColumns } from '../SimilaritySearchResultsTable.config'
-import { collectAttributeKeys, parseAttributes } from '../utils/parseAttributes'
+import {
+  buildParsedAttributesCache,
+  collectAttributeKeys,
+} from '../utils/parseAttributes'
 
 export interface UseSimilarityResultColumnsResult {
   columns: ColumnDef<VectorSetSimilarityMatch>[]
@@ -21,10 +27,7 @@ export interface UseSimilarityResultColumnsResult {
    * match so each row pays the JSON-parse cost a single time regardless
    * of how many attribute columns it renders.
    */
-  parsedAttributesCache: WeakMap<
-    VectorSetSimilarityMatch,
-    Record<string, unknown>
-  >
+  parsedAttributesCache: ParsedAttributesCache
 }
 
 /** `foo` → `attr_foo`. */
@@ -41,7 +44,15 @@ export const attributeColumnId = (key: string): string =>
 export const useSimilarityResultColumns = (
   matches: VectorSetSimilarityMatch[],
 ): UseSimilarityResultColumnsResult => {
-  const attributeKeys = useMemo(() => collectAttributeKeys(matches), [matches])
+  const parsedAttributesCache = useMemo<ParsedAttributesCache>(
+    () => buildParsedAttributesCache(matches),
+    [matches],
+  )
+
+  const attributeKeys = useMemo(
+    () => collectAttributeKeys(matches, parsedAttributesCache),
+    [matches, parsedAttributesCache],
+  )
 
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
     () => new Set(),
@@ -86,17 +97,6 @@ export const useSimilarityResultColumns = (
     for (const id of hiddenColumns) out[id] = false
     return out
   }, [hiddenColumns])
-
-  const parsedAttributesCache = useMemo(() => {
-    const cache = new WeakMap<
-      VectorSetSimilarityMatch,
-      Record<string, unknown>
-    >()
-    for (const match of matches) {
-      cache.set(match, parseAttributes(match.attributes))
-    }
-    return cache
-  }, [matches])
 
   return {
     columns,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/index.ts
@@ -1,1 +1,5 @@
 export { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
+export { SimilarityColumnsPopover } from './components/SimilarityColumnsPopover'
+export type { SimilarityColumnsPopoverProps } from './components/SimilarityColumnsPopover'
+export { useSimilarityResultColumns } from './hooks/useSimilarityResultColumns'
+export type { UseSimilarityResultColumnsResult } from './hooks/useSimilarityResultColumns'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.spec.ts
@@ -3,7 +3,6 @@ import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
 import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 
 import {
-  buildParsedAttributesCache,
   collectAttributeKeys,
   parseAttributes,
   renderAttributeValue,
@@ -84,45 +83,6 @@ describe('collectAttributeKeys', () => {
       match('e', 0.5, '{"y":2}'),
     ])
     expect(keys).toEqual(['x', 'y'])
-  })
-
-  it('reads from the provided cache instead of re-parsing attributes', () => {
-    const a = match('a', 0.9, '{"x":1}')
-    const b = match('b', 0.8, '{"y":2}')
-    const cache = buildParsedAttributesCache([a, b])
-    const parseSpy = jest.spyOn(JSON, 'parse')
-
-    const keys = collectAttributeKeys([a, b], cache)
-
-    expect(keys).toEqual(['x', 'y'])
-    expect(parseSpy).not.toHaveBeenCalled()
-    parseSpy.mockRestore()
-  })
-
-  it('falls back to re-parsing when the cache lacks an entry', () => {
-    const a = match('a', 0.9, '{"x":1}')
-    const cache = buildParsedAttributesCache([])
-    expect(collectAttributeKeys([a], cache)).toEqual(['x'])
-  })
-})
-
-describe('buildParsedAttributesCache', () => {
-  it('caches parsed payloads keyed on the match reference', () => {
-    const a = match('a', 0.9, '{"x":1}')
-    const b = match('b', 0.8, '{"y":"two"}')
-    const cache = buildParsedAttributesCache([a, b])
-
-    expect(cache.get(a)).toEqual({ x: 1 })
-    expect(cache.get(b)).toEqual({ y: 'two' })
-  })
-
-  it('stores `{}` for matches with missing/malformed attributes', () => {
-    const a = match('a', 0.9, 'not-json')
-    const b = match('b', 0.8)
-    const cache = buildParsedAttributesCache([a, b])
-
-    expect(cache.get(a)).toEqual({})
-    expect(cache.get(b)).toEqual({})
   })
 })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
@@ -1,5 +1,4 @@
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
-import { ParsedAttributesCache } from '../SimilaritySearchResultsTable.types'
 
 /** Parse a match's `attributes` JSON string; returns `{}` on any failure. */
 export const parseAttributes = (
@@ -22,32 +21,15 @@ export const parseAttributes = (
 }
 
 /**
- * Build a `WeakMap<match, parsedAttributes>` so callers (key-collector + table
- * cells) can share a single JSON-parse per match.
- */
-export const buildParsedAttributesCache = (
-  matches: VectorSetSimilarityMatch[],
-): ParsedAttributesCache => {
-  const cache: ParsedAttributesCache = new WeakMap()
-  for (const match of matches) {
-    cache.set(match, parseAttributes(match.attributes))
-  }
-  return cache
-}
-
-/**
  * Union of top-level attribute keys across `matches`, alphabetically sorted.
  * Stable ordering keeps the column list referentially stable across renders.
- *
- * Pass a pre-built `cache` to avoid re-parsing `attributes` strings here.
  */
 export const collectAttributeKeys = (
   matches: VectorSetSimilarityMatch[],
-  cache?: ParsedAttributesCache,
 ): string[] => {
   const keys = new Set<string>()
   for (const match of matches) {
-    const attrs = cache?.get(match) ?? parseAttributes(match.attributes)
+    const attrs = parseAttributes(match.attributes)
     for (const key of Object.keys(attrs)) {
       keys.add(key)
     }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/utils/parseAttributes.ts
@@ -1,4 +1,5 @@
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
+import { ParsedAttributesCache } from '../SimilaritySearchResultsTable.types'
 
 /** Parse a match's `attributes` JSON string; returns `{}` on any failure. */
 export const parseAttributes = (
@@ -21,15 +22,32 @@ export const parseAttributes = (
 }
 
 /**
+ * Build a `WeakMap<match, parsedAttributes>` so callers (key-collector + table
+ * cells) can share a single JSON-parse per match.
+ */
+export const buildParsedAttributesCache = (
+  matches: VectorSetSimilarityMatch[],
+): ParsedAttributesCache => {
+  const cache: ParsedAttributesCache = new WeakMap()
+  for (const match of matches) {
+    cache.set(match, parseAttributes(match.attributes))
+  }
+  return cache
+}
+
+/**
  * Union of top-level attribute keys across `matches`, alphabetically sorted.
  * Stable ordering keeps the column list referentially stable across renders.
+ *
+ * Pass a pre-built `cache` to avoid re-parsing `attributes` strings here.
  */
 export const collectAttributeKeys = (
   matches: VectorSetSimilarityMatch[],
+  cache?: ParsedAttributesCache,
 ): string[] => {
   const keys = new Set<string>()
   for (const match of matches) {
-    const attrs = parseAttributes(match.attributes)
+    const attrs = cache?.get(match) ?? parseAttributes(match.attributes)
     for (const key of Object.keys(attrs)) {
       keys.add(key)
     }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
@@ -4,13 +4,13 @@ import AutoSizer from 'react-virtualized-auto-sizer'
 import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
-import Divider from 'uiSrc/components/divider/Divider'
 import { KeyDetailsHeaderFormatter } from 'uiSrc/pages/browser/modules/key-details-header/components/key-details-header-formatter'
 import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
 
 import { ClearResultsAction } from '../clear-results-action'
 import * as S from './VectorSetKeySubheader.styles'
 import { Props } from './VectorSetKeySubheader.types'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
 
 const VectorSetKeySubheader = ({
   openAddItemPanel,
@@ -19,6 +19,7 @@ const VectorSetKeySubheader = ({
   total,
   hasSimilarityResults,
   onClearResults,
+  additionalActions,
 }: Props) => {
   return (
     <S.Container>
@@ -41,7 +42,6 @@ const VectorSetKeySubheader = ({
               )}
               <Row align="center" grow={false}>
                 <KeyDetailsHeaderFormatter width={width} />
-                <Divider orientation="vertical" />
                 {hasSimilarityResults ? (
                   <ClearResultsAction
                     width={width}
@@ -55,6 +55,12 @@ const VectorSetKeySubheader = ({
                     openAddItemPanel={openAddItemPanel}
                   />
                 )}
+                {additionalActions ? (
+                  <>
+                    <Spacer size="l" direction="horizontal" />
+                    {additionalActions(width)}
+                  </>
+                ) : null}
               </Row>
             </Row>
           </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.types.ts
@@ -1,18 +1,19 @@
+import { ReactNode } from 'react'
+
 export interface Props {
   openAddItemPanel: () => void
-  /** Whether to render the "Previewing X out of Y" summary. */
+  /** Render the "Previewing X out of Y" summary. */
   showPreview: boolean
-  /** X — number of items currently displayed (elements or similarity matches). */
+  /** X — items currently displayed. */
   previewCount: number
-  /** Y — total number of items in the vector set. */
+  /** Y — total items in the vector set. */
   total: number
-  /**
-   * When `true`, the subheader replaces the "Add Elements" action with a
-   * "Clear results" action wired to {@link onClearResults}. The browse-mode
-   * affordances (formatter, add panel trigger) are hidden because they don't
-   * make sense in the similarity-search context.
-   */
+  /** Swaps "Add Elements" for "Clear results" when `true`. */
   hasSimilarityResults: boolean
-  /** Callback fired when the "Clear results" button is clicked. */
   onClearResults: () => void
+  /**
+   * Extra actions rendered at the right end of the actions row.
+   * Render-prop so callers can react to the AutoSizer-reported width.
+   */
+  additionalActions?: (width: number) => ReactNode
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Add a "Columns" popover to toggle visibility of attribute columns in similarity search results
- Extract column logic into a `useSimilarityResultColumns` hook (centralizes base + dynamic attribute columns and visibility state)
- Simplify `parseAttributes` and update related types/wiring in `VectorSetDetails` and `VectorSetKeySubheader`

https://github.com/user-attachments/assets/06c734dd-558f-44d3-b704-749ac4503abc

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new column-visibility state and UI controls for the similarity results table, which can affect rendering/layout and user interactions in the key browser. Risk is moderate due to new stateful behavior and integration with the table component, but scope is limited to the vector-set similarity results UI.
> 
> **Overview**
> Adds a **Columns** popover to similarity-search results so users can toggle visibility of dynamic *attribute* columns, while keeping `Element` and `Similarity` anchored.
> 
> Refactors similarity results column handling into a new `useSimilarityResultColumns` hook that centralizes attribute-key discovery, parsed-attributes caching, and the `columnVisibility` map; wires this through `VectorSetDetails`, `VectorSetKeySubheader` (via a new `additionalActions` render-prop), and `SimilaritySearchResultsTable` (including min-width calculations based on visible columns).
> 
> Updates and expands tests to cover column hiding, cache-backed attribute rendering, the new hook behavior, and the new popover UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cd384c4dfe852bfd0bc702bad4778b2fb954d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->