### PR TITLE
RI-8160: Magnifying icon search element

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -14,12 +14,16 @@ import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
+import { VectorSetElement } from 'uiSrc/slices/interfaces'
 import { VectorSetElementForm, SubmitElement } from './vector-set-element-form'
 import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 import { VectorSetElementList } from './vector-set-element-list'
 import { VectorSetKeySubheader } from './vector-set-key-subheader'
 import { ElementDetails } from './element-details'
-import { SimilaritySearchForm } from './similarity-search-form'
+import {
+  SimilaritySearchForm,
+  SimilaritySearchPrefill,
+} from './similarity-search-form'
 import {
   SimilarityColumnsPopover,
   SimilaritySearchResultsTable,
@@ -69,6 +73,20 @@ const VectorSetDetails = (props: Props) => {
     dispatch(clearSimilaritySearch())
   }, [dispatch])
 
+  // Drives the similarity-search form's Element-mode prefill when a user
+  // clicks "Search similar" on an element row. The nonce lets the same value
+  // be re-applied on repeat clicks.
+  const [similarityPrefill, setSimilarityPrefill] =
+    useState<SimilaritySearchPrefill>()
+
+  const handleSearchByElement = useCallback((element: VectorSetElement) => {
+    const value = bufferToString(element.name)
+    setSimilarityPrefill((prev) => ({
+      value,
+      nonce: (prev?.nonce ?? 0) + 1,
+    }))
+  }, [])
+
   // Single source of truth shared by the results table and the Columns popover.
   const {
     columns: similarityColumns,
@@ -117,7 +135,7 @@ const VectorSetDetails = (props: Props) => {
   return (
     <S.Container>
       <KeyDetailsHeader {...props} key="key-details-header" />
-      <SimilaritySearchForm key={keyName} />
+      <SimilaritySearchForm key={keyName} prefillElement={similarityPrefill} />
       <VectorSetKeySubheader
         openAddItemPanel={openAddItemPanel}
         showPreview={showPreview}
@@ -141,6 +159,7 @@ const VectorSetDetails = (props: Props) => {
               <VectorSetElementList
                 onRemoveKey={onRemoveKey}
                 onViewElement={handleViewElement}
+                onSearchByElement={handleSearchByElement}
               />
             )}
           </S.ListWrapper>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
@@ -33,6 +33,7 @@ const MIN_COLUMN_WIDTH = 100
 export const useVectorSetElementListData = ({
   onRemoveKey,
   onViewElement,
+  onSearchByElement,
 }: UseVectorSetElementListDataParams): UseVectorSetElementListDataResult => {
   const { loading } = useSelector(vectorSetSelector)
   const { elements, nextCursor, total, isPaginationSupported } = useSelector(
@@ -98,6 +99,7 @@ export const useVectorSetElementListData = ({
       viewFormat,
       elementDeleteConfig: deleteConfig,
       onViewElement,
+      onSearchByElement,
     }
     return getVectorSetColumns(listConfig)
   }, [
@@ -109,6 +111,7 @@ export const useVectorSetElementListData = ({
     closePopover,
     showPopover,
     onViewElement,
+    onSearchByElement,
   ])
 
   const tableMinWidth = useMemo(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.types.ts
@@ -6,6 +6,7 @@ import { VectorSetElement } from 'uiSrc/slices/interfaces'
 export interface UseVectorSetElementListDataParams {
   onRemoveKey: () => void
   onViewElement: (element: VectorSetElement) => void
+  onSearchByElement: (element: VectorSetElement) => void
 }
 
 export interface UseVectorSetElementListDataResult {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/index.ts
@@ -1,2 +1,6 @@
 export { SimilaritySearchForm } from './similarity-search-form'
-export type { SimilaritySearchFormState } from './similarity-search-form'
+export type {
+  SimilaritySearchFormProps,
+  SimilaritySearchFormState,
+  SimilaritySearchPrefill,
+} from './similarity-search-form'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
@@ -231,6 +231,45 @@ describe('SimilaritySearchForm', () => {
     })
   })
 
+  describe('prefillElement prop', () => {
+    it('switches to Element mode and seeds the element input when a prefill is provided', () => {
+      render(
+        <SimilaritySearchForm prefillElement={{ value: 'alpha', nonce: 1 }} />,
+      )
+
+      expect(
+        screen.queryByTestId(`${TEST_ID}-vector-input`),
+      ).not.toBeInTheDocument()
+      expect(
+        (screen.getByTestId(`${TEST_ID}-element-input`) as HTMLInputElement)
+          .value,
+      ).toBe('alpha')
+    })
+
+    it('re-applies the same value when only the nonce changes', () => {
+      const { rerender } = render(
+        <SimilaritySearchForm prefillElement={{ value: 'alpha', nonce: 1 }} />,
+      )
+
+      fireEvent.change(screen.getByTestId(`${TEST_ID}-element-input`), {
+        target: { value: 'beta' },
+      })
+      expect(
+        (screen.getByTestId(`${TEST_ID}-element-input`) as HTMLInputElement)
+          .value,
+      ).toBe('beta')
+
+      rerender(
+        <SimilaritySearchForm prefillElement={{ value: 'alpha', nonce: 2 }} />,
+      )
+
+      expect(
+        (screen.getByTestId(`${TEST_ID}-element-input`) as HTMLInputElement)
+          .value,
+      ).toBe('alpha')
+    })
+  })
+
   it('opens the filter syntax help popover when the trigger is clicked', () => {
     render(<SimilaritySearchForm />)
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -33,11 +33,14 @@ import {
 } from './constants'
 import { initialFormState, isQueryReady } from './SimilaritySearchForm.utils'
 import {
+  SimilaritySearchFormProps,
   SimilaritySearchFormState,
   SimilaritySearchMode,
 } from './SimilaritySearchForm.types'
 
-export const SimilaritySearchForm = () => {
+export const SimilaritySearchForm = ({
+  prefillElement,
+}: SimilaritySearchFormProps = {}) => {
   const {
     loading,
     previewLoading,
@@ -50,6 +53,18 @@ export const SimilaritySearchForm = () => {
 
   const [state, setState] =
     useState<SimilaritySearchFormState>(initialFormState)
+
+  // React to external prefill requests: switch to Element mode and seed the
+  // element input. Keyed on `nonce` so re-requesting the same value still
+  // re-applies the prefill (e.g. clicking the same row's search icon twice).
+  useEffect(() => {
+    if (!prefillElement) return
+    setState((prev) => ({
+      ...prev,
+      mode: 'element',
+      elementInput: prefillElement.value,
+    }))
+  }, [prefillElement?.nonce, prefillElement?.value])
 
   const setMode = (mode: SimilaritySearchMode) => {
     setState((prev) => ({ ...prev, mode }))

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.types.ts
@@ -7,3 +7,18 @@ export interface SimilaritySearchFormState {
   count: number | null
   filter: string
 }
+
+/**
+ * Request to prefill the form with an existing element name and switch to the
+ * Element search mode. The `nonce` lets the same value be requested more than
+ * once (e.g. clicking the same row's search icon twice still re-applies the
+ * prefill even though `value` is unchanged).
+ */
+export interface SimilaritySearchPrefill {
+  value: string
+  nonce: number
+}
+
+export interface SimilaritySearchFormProps {
+  prefillElement?: SimilaritySearchPrefill
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/index.ts
@@ -1,2 +1,6 @@
 export { SimilaritySearchForm } from './SimilaritySearchForm'
-export type { SimilaritySearchFormState } from './SimilaritySearchForm.types'
+export type {
+  SimilaritySearchFormProps,
+  SimilaritySearchFormState,
+  SimilaritySearchPrefill,
+} from './SimilaritySearchForm.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.config.tsx
@@ -9,8 +9,11 @@ import {
 } from 'uiSrc/utils'
 import HelpTexts from 'uiSrc/constants/help-texts'
 import { Row } from 'uiSrc/components/base/layout/flex'
-import { ElementNameCell } from './components/ElementNameCell/ElementNameCell'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
+import { SearchIcon } from 'uiSrc/components/base/icons'
+import { RiTooltip } from 'uiSrc/components'
 import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
+import { ElementNameCell } from './components/ElementNameCell/ElementNameCell'
 import {
   ElementsListConfig,
   VectorSetColumn,
@@ -52,6 +55,7 @@ const createActionsColumn = (
       viewFormat,
       elementDeleteConfig: deleteConfig,
       onViewElement,
+      onSearchByElement,
     } = listConfig
     const {
       deleting,
@@ -76,6 +80,15 @@ const createActionsColumn = (
         >
           View
         </S.StyledTextButton>
+        <RiTooltip content="Find similar elements" position="top">
+          <IconButton
+            size="S"
+            icon={SearchIcon}
+            onClick={() => onSearchByElement(row.original)}
+            aria-label="Find similar elements"
+            data-testid={`vector-set-search-similar-btn-${name}`}
+          />
+        </RiTooltip>
         <PopoverDelete
           header={createDeleteFieldHeader(nameBuffer)}
           text={createDeleteFieldMessage(keyName)}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
@@ -31,11 +31,13 @@ describe('VectorSetElementList', () => {
   const defaultProps = {
     onRemoveKey: jest.fn(),
     onViewElement: jest.fn(),
+    onSearchByElement: jest.fn(),
   }
 
   beforeEach(() => {
     jest.mocked(deleteVectorSetElements).mockClear()
     defaultProps.onViewElement.mockClear()
+    defaultProps.onSearchByElement.mockClear()
   })
 
   it('should render', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
@@ -71,6 +71,21 @@ describe('VectorSetElementList', () => {
     expect(defaultProps.onViewElement).toHaveBeenCalledTimes(1)
   })
 
+  it('should render a "Find similar elements" button for each element row', () => {
+    render(<VectorSetElementList {...defaultProps} />)
+    expect(
+      screen.getAllByRole('button', { name: 'Find similar elements' }),
+    ).toHaveLength(3)
+  })
+
+  it('should call onSearchByElement when the search-similar button is clicked', () => {
+    render(<VectorSetElementList {...defaultProps} />)
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Find similar elements' })[0],
+    )
+    expect(defaultProps.onSearchByElement).toHaveBeenCalledTimes(1)
+  })
+
   it('should open delete confirmation after clicking remove on a row', () => {
     render(<VectorSetElementList {...defaultProps} />)
     fireEvent.click(screen.getAllByLabelText(/remove field/i)[0])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.tsx
@@ -7,37 +7,44 @@ import * as S from './VectorSetElementList.styles'
 export interface Props {
   onRemoveKey: () => void
   onViewElement: (element: VectorSetElement) => void
+  onSearchByElement: (element: VectorSetElement) => void
 }
 
-const VectorSetElementList = memo(({ onRemoveKey, onViewElement }: Props) => {
-  const {
-    columns,
-    currentPageData,
-    tableMinWidth,
-    pagination,
-    setPagination,
-    emptyMessage,
-    isPaginationSupported,
-    total,
-  } = useVectorSetElementListData({ onRemoveKey, onViewElement })
+const VectorSetElementList = memo(
+  ({ onRemoveKey, onViewElement, onSearchByElement }: Props) => {
+    const {
+      columns,
+      currentPageData,
+      tableMinWidth,
+      pagination,
+      setPagination,
+      emptyMessage,
+      isPaginationSupported,
+      total,
+    } = useVectorSetElementListData({
+      onRemoveKey,
+      onViewElement,
+      onSearchByElement,
+    })
 
-  return (
-    <S.Container data-testid="vector-set-details">
-      <S.StyledTable
-        columns={columns}
-        data={currentPageData}
-        stripedRows
-        minWidth={tableMinWidth}
-        paginationEnabled={isPaginationSupported}
-        manualPagination={isPaginationSupported}
-        totalRowCount={isPaginationSupported ? total : undefined}
-        pagination={pagination}
-        onPaginationChange={setPagination}
-        emptyState={emptyMessage}
-        data-testid="vector-set-details-table"
-      />
-    </S.Container>
-  )
-})
+    return (
+      <S.Container data-testid="vector-set-details">
+        <S.StyledTable
+          columns={columns}
+          data={currentPageData}
+          stripedRows
+          minWidth={tableMinWidth}
+          paginationEnabled={isPaginationSupported}
+          manualPagination={isPaginationSupported}
+          totalRowCount={isPaginationSupported ? total : undefined}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          emptyState={emptyMessage}
+          data-testid="vector-set-details-table"
+        />
+      </S.Container>
+    )
+  },
+)
 
 export { VectorSetElementList }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.types.ts
@@ -23,6 +23,7 @@ export interface ElementsListConfig {
   viewFormat: KeyValueFormat
   elementDeleteConfig: ElementDeleteConfig
   onViewElement: (element: VectorSetElement) => void
+  onSearchByElement: (element: VectorSetElement) => void
 }
 
 export interface ElementNameCellProps {


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Add a magnifying-glass action on each vector-set element row to trigger a similarity search for that element
- Extend `SimilaritySearchForm` with a `prefillElement` prop so the form opens pre-populated from the clicked row
- Wire the action through `VectorSetDetails` and `useVectorSetElementListData`

https://github.com/user-attachments/assets/fa4969fe-0f57-450a-9a53-506681211524

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that wires a new per-row action into existing similarity search flow; main risk is minor regressions in form state and table actions.
> 
> **Overview**
> Adds a new magnifying-glass action on each vector-set element row to trigger a similarity search seeded with that element.
> 
> `SimilaritySearchForm` now accepts a `prefillElement` prop (with a `nonce`) to switch to Element mode and re-apply the same prefill on repeated clicks, and `VectorSetDetails` threads this callback/state through `VectorSetElementList`/`useVectorSetElementListData`. Associated unit tests were updated/added to cover the new button and prefill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9cd9e2392de6aa21511ab36141ee9969e0d4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->