### PR TITLE
RI-8176 Add dev-prodMode feature flag scaffold

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.7,
+  "version": 3.8,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -140,6 +140,10 @@
       "perc": [[0, 100]]
     },
     "dev-vectorSet": {
+      "flag": false,
+      "perc": [[0, 100]]
+    },
+    "dev-prodMode": {
       "flag": false,
       "perc": [[0, 100]]
     }

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -36,6 +36,7 @@ export enum KnownFeatures {
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
   DevVectorSet = 'dev-vectorSet',
+  DevProdMode = 'dev-prodMode',
 }
 
 export interface IFeatureFlag {

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -79,4 +79,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevVectorSet,
     storage: FeatureStorage.Database,
   },
+  [KnownFeatures.DevProdMode]: {
+    name: KnownFeatures.DevProdMode,
+    storage: FeatureStorage.Database,
+  },
 };

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -103,6 +103,10 @@ export class FeatureFlagProvider {
       KnownFeatures.DevVectorSet,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
+    this.strategies.set(
+      KnownFeatures.DevProdMode,
+      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
+    );
   }
 
   getStrategy(name: string): FeatureFlagStrategy {

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -14,4 +14,5 @@ export enum FeatureFlags {
   devVectorSet = 'dev-vectorSet',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
+  devProdMode = 'dev-prodMode',
 }

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -71,6 +71,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devBrowser]: {
         flag: false,
       },
+      [FeatureFlags.devProdMode]: {
+        flag: false,
+      },
     },
   },
 }


### PR DESCRIPTION
# What

Registers the `dev-prodMode` dev feature flag end-to-end so subsequent prod-vs-dev mode tickets can gate behind it. No consumers yet — flag is off by default and produces no user-visible change.

- BE: adds entry to `features-config.json` (version bumped 3.7 → 3.8), registers `KnownFeatures.DevProdMode` with `CommonFlagStrategy`.
- FE: adds `devProdMode` to `FeatureFlags` enum and `{ flag: false }` default in the redux features slice.

# Testing

- `yarn --cwd redisinsight/api test src/modules/feature/providers` passes.
- `jest redisinsight/ui/src/slices/tests/app/features.spec.ts` passes.
- No consumers — verify via redux devtools that `features.featureFlags.features['dev-prodMode'].flag === false` after fetching `/features`.

---

Closes #RI-8176

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only registers a new feature flag (default-off) across config/BE/FE with no behavioral consumers, so it should not affect runtime behavior unless explicitly enabled.
> 
> **Overview**
> Adds a new `dev-prodMode` feature flag scaffold across backend and frontend, defaulting to **off**.
> 
> Backend bumps `features-config.json` version to `3.8`, registers `KnownFeatures.DevProdMode` in `knownFeatures`, and wires it to `CommonFlagStrategy` so it’s returned by `/features`.
> 
> Frontend adds `devProdMode` to the `FeatureFlags` enum and includes it in the Redux `initialState` defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6619bc528b52de5d8ca781624c949dc3269d7e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->