### PR TITLE
RI-8178 Add skipConfirmationsForNonProduction global setting

### DIFF
--- a/redisinsight/api/src/constants/telemetry-events.ts
+++ b/redisinsight/api/src/constants/telemetry-events.ts
@@ -5,6 +5,7 @@ export enum TelemetryEvents {
   AnalyticsPermission = 'ANALYTICS_PERMISSION',
   SettingsScanThresholdChanged = 'SETTINGS_KEYS_TO_SCAN_CHANGED',
   SettingsWorkbenchPipelineChanged = 'SETTINGS_WORKBENCH_PIPELINE_CHANGED',
+  SettingsSkipConfirmationsNonProdToggled = 'SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED',
   DatabaseConnectedClientList = 'DATABASE_CONNECTED_CLIENT_LIST',
 
   // Events for redis instances

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -138,6 +138,16 @@ export class GetAppSettingsResponse {
   acceptTermsAndConditionsOverwritten: boolean = false;
 
   @ApiProperty({
+    description:
+      'Skip confirmation dialogs for non-production database connections.',
+    type: Boolean,
+    example: false,
+  })
+  @Expose()
+  @Default(false)
+  skipConfirmationsForNonProduction: boolean = false;
+
+  @ApiProperty({
     description: 'Agreements set by the user.',
     type: GetUserAgreementsResponse,
     example: {
@@ -227,4 +237,14 @@ export class UpdateSettingsDto {
   @IsString()
   @IsEnum(ToggleAnalyticsReason)
   analyticsReason?: ToggleAnalyticsReasonType;
+
+  @ApiPropertyOptional({
+    description:
+      'Skip confirmation dialogs for non-production database connections.',
+    type: Boolean,
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  skipConfirmationsForNonProduction?: boolean;
 }

--- a/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
@@ -132,6 +132,7 @@ describe('SettingsAnalytics', () => {
   describe('sendSettingsUpdatedEvent', () => {
     const defaultSettings: GetAppSettingsResponse = {
       acceptTermsAndConditionsOverwritten: false,
+      skipConfirmationsForNonProduction: false,
       agreements: null,
       scanThreshold: 10000,
       batchSize: 5,
@@ -198,6 +199,41 @@ describe('SettingsAnalytics', () => {
         mockSessionMetadata,
         { ...defaultSettings, scanThreshold: 10000 },
         undefined,
+      );
+
+      expect(sendEventMethod).not.toHaveBeenCalled();
+    });
+    it('should emit [SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED] when enabled', async () => {
+      service.sendSettingsUpdatedEvent(
+        mockSessionMetadata,
+        { ...defaultSettings, skipConfirmationsForNonProduction: true },
+        { ...defaultSettings, skipConfirmationsForNonProduction: false },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.SettingsSkipConfirmationsNonProdToggled,
+        { newValue: true },
+      );
+    });
+    it('should emit [SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED] when disabled', async () => {
+      service.sendSettingsUpdatedEvent(
+        mockSessionMetadata,
+        { ...defaultSettings, skipConfirmationsForNonProduction: false },
+        { ...defaultSettings, skipConfirmationsForNonProduction: true },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.SettingsSkipConfirmationsNonProdToggled,
+        { newValue: false },
+      );
+    });
+    it('should not emit [SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED] for the same value', async () => {
+      service.sendSettingsUpdatedEvent(
+        mockSessionMetadata,
+        { ...defaultSettings, skipConfirmationsForNonProduction: true },
+        { ...defaultSettings, skipConfirmationsForNonProduction: true },
       );
 
       expect(sendEventMethod).not.toHaveBeenCalled();

--- a/redisinsight/api/src/modules/settings/settings.analytics.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.ts
@@ -45,6 +45,12 @@ export class SettingsAnalytics extends TelemetryBaseService {
           oldSettings.batchSize,
         );
       }
+      if (has(dif, 'skipConfirmationsForNonProduction')) {
+        this.sendSkipConfirmationsNonProdToggled(
+          sessionMetadata,
+          dif.skipConfirmationsForNonProduction,
+        );
+      }
     } catch (e) {
       // continue regardless of error
     }
@@ -111,6 +117,19 @@ export class SettingsAnalytics extends TelemetryBaseService {
         newValueSize: newValue,
         currentValue: getIsPipelineEnable(currentValue),
         currentValueSize: currentValue,
+      },
+    );
+  }
+
+  private sendSkipConfirmationsNonProdToggled(
+    sessionMetadata: SessionMetadata,
+    newValue: boolean,
+  ): void {
+    this.sendEvent(
+      sessionMetadata,
+      TelemetryEvents.SettingsSkipConfirmationsNonProdToggled,
+      {
+        newValue,
       },
     );
   }

--- a/redisinsight/api/src/modules/settings/settings.service.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.spec.ts
@@ -117,6 +117,7 @@ describe('SettingsService', () => {
         timezone: null,
         agreements: null,
         acceptTermsAndConditionsOverwritten: false,
+        skipConfirmationsForNonProduction: false,
       });
 
       expect(eventEmitter.emit).not.toHaveBeenCalled();
@@ -131,6 +132,7 @@ describe('SettingsService', () => {
       expect(result).toEqual({
         ...mockSettings.data,
         acceptTermsAndConditionsOverwritten: false,
+        skipConfirmationsForNonProduction: false,
         agreements: {
           version: mockAgreements.version,
           ...mockAgreements.data,
@@ -251,6 +253,25 @@ describe('SettingsService', () => {
 
       // not first run so shouldn't run database discovery
       expect(databaseDiscoveryService.discover).not.toHaveBeenCalled();
+    });
+    it('should persist skipConfirmationsForNonProduction toggle', async () => {
+      const dto: UpdateSettingsDto = {
+        skipConfirmationsForNonProduction: true,
+      };
+
+      await service.updateAppSettings(mockSessionMetadata, dto);
+
+      expect(settingsRepository.update).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        {
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            skipConfirmationsForNonProduction: true,
+          },
+        },
+      );
+      expect(analyticsService.sendSettingsUpdatedEvent).toHaveBeenCalled();
     });
     it('should update agreements only', async () => {
       const dto: UpdateSettingsDto = {

--- a/redisinsight/api/test/api/settings/GET-settings.test.ts
+++ b/redisinsight/api/test/api/settings/GET-settings.test.ts
@@ -25,6 +25,7 @@ const responseSchema = Joi.object()
     dateFormat: Joi.string().allow(null),
     timezone: Joi.string().allow(null),
     acceptTermsAndConditionsOverwritten: Joi.bool().required(),
+    skipConfirmationsForNonProduction: Joi.bool().required(),
     agreements: Joi.object()
       .keys({
         version: Joi.string().required(),

--- a/redisinsight/api/test/api/settings/PATCH-settings.test.ts
+++ b/redisinsight/api/test/api/settings/PATCH-settings.test.ts
@@ -25,6 +25,7 @@ const responseSchema = Joi.object()
     dateFormat: Joi.string().allow(null),
     timezone: Joi.string().allow(null),
     acceptTermsAndConditionsOverwritten: Joi.bool().required(),
+    skipConfirmationsForNonProduction: Joi.bool().required(),
     agreements: Joi.object()
       .keys({
         version: Joi.string().required(),
@@ -43,6 +44,7 @@ const dataSchema = Joi.object({
   scanThreshold: Joi.number().allow(null).min(500).optional(),
   dateFormat: Joi.string().allow(null),
   timezone: Joi.string().allow(null),
+  skipConfirmationsForNonProduction: Joi.boolean().allow(null).optional(),
   agreements: Joi.object()
     .keys({
       eula: Joi.boolean().label('.eula').optional(),
@@ -127,6 +129,24 @@ describe('PATCH /settings', () => {
             constants.APP_DEFAULT_SETTINGS;
 
           expect(body).to.include(defaultSettings);
+        },
+      },
+      {
+        name: 'Should enable skipConfirmationsForNonProduction',
+        statusCode: 200,
+        data: { skipConfirmationsForNonProduction: true },
+        responseSchema,
+        checkFn: ({ body }) => {
+          expect(body.skipConfirmationsForNonProduction).to.eql(true);
+        },
+      },
+      {
+        name: 'Should disable skipConfirmationsForNonProduction',
+        statusCode: 200,
+        data: { skipConfirmationsForNonProduction: false },
+        responseSchema,
+        checkFn: ({ body }) => {
+          expect(body.skipConfirmationsForNonProduction).to.eql(false);
         },
       },
     ].map(mainCheckFn);

--- a/redisinsight/api/test/helpers/constants.ts
+++ b/redisinsight/api/test/helpers/constants.ts
@@ -27,6 +27,7 @@ const APP_DEFAULT_SETTINGS = {
   timezone: null,
   agreements: null,
   acceptTermsAndConditionsOverwritten: false,
+  skipConfirmationsForNonProduction: false,
 };
 const TEST_LIBRARY_NAME = 'lib';
 const TEST_ANALYTICS_PAGE = 'Settings';


### PR DESCRIPTION
# What

Adds a new `skipConfirmationsForNonProduction` boolean setting (default `false`) to `GetAppSettingsResponse` and `UpdateSettingsDto`. The settings entity stores JSON, so no migration needed.

Telemetry: a new `SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED` event is emitted on change. Implemented by reusing the existing `sendSettingsUpdatedEvent` diff helper in `SettingsAnalytics` — same pattern as `scanThreshold` / `batchSize`.

Part of epic RI-6594 (Prod vs non-prod modes).

# Testing

- Unit: `SettingsAnalytics` covers enabled / disabled / no-change cases; `SettingsService` covers persistence + event emission.
- Integration: `PATCH /settings` exercises enable + disable round-trips; `GET /settings` schema and `APP_DEFAULT_SETTINGS` updated.

```
yarn --cwd redisinsight/api test --testPathPattern="modules/settings"
```

---

Closes #RI-8178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new boolean settings flag and a telemetry event without changing auth, data access patterns, or migrations; primary risk is minor API contract expansion affecting clients expecting strict schemas.
> 
> **Overview**
> Adds a new global boolean setting `skipConfirmationsForNonProduction` (default `false`) to the `/settings` API, including DTO validation and default response shape updates.
> 
> Extends settings analytics to emit a new telemetry event `SETTINGS_SKIP_CONFIRMATIONS_NON_PROD_TOGGLED` when this flag changes.
> 
> Updates unit and API integration tests (including `APP_DEFAULT_SETTINGS` and Joi schemas) to cover persistence, response contract, and telemetry emission for enable/disable/no-change cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a553114a966187e255d0742f497a565f6512cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->