### PR TITLE
RI-8179 Add ACL CAT dangerous commands service

### DIFF
--- a/redisinsight/api/src/modules/database/database-info.controller.ts
+++ b/redisinsight/api/src/modules/database/database-info.controller.ts
@@ -79,6 +79,33 @@ export class DatabaseInfoController {
     return this.databaseInfoService.getOverview(clientMetadata, keyspace);
   }
 
+  @Get(':id/dangerous-commands')
+  @UseInterceptors(new TimeoutInterceptor())
+  @ApiEndpoint({
+    description:
+      'Get the list of "dangerous" commands for the connected Redis instance (via ACL CAT dangerous). Returns an empty array on Redis versions that do not support ACL.',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Array of upper-case dangerous command names',
+        schema: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    ],
+  })
+  async getDangerousCommands(
+    @ClientMetadataParam({
+      databaseIdParam: 'id',
+      ignoreDbIndex: true,
+    })
+    clientMetadata: ClientMetadata,
+  ): Promise<string[]> {
+    return this.databaseInfoService.getDangerousCommands(clientMetadata);
+  }
+
   @Get(':id/db/:index')
   @UseInterceptors(new TimeoutInterceptor())
   @ApiEndpoint({

--- a/redisinsight/api/src/modules/database/database-info.service.spec.ts
+++ b/redisinsight/api/src/modules/database/database-info.service.spec.ts
@@ -20,6 +20,7 @@ import { DatabaseRecommendationService } from 'src/modules/database-recommendati
 import { RECOMMENDATION_NAMES } from 'src/constants';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { DatabaseInfoProvider } from 'src/modules/database/providers/database-info.provider';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 import { DatabaseService } from './database.service';
 
 describe('DatabaseInfoService', () => {
@@ -28,6 +29,7 @@ describe('DatabaseInfoService', () => {
   let databaseClientFactory: MockType<DatabaseClientFactory>;
   let recommendationService: MockType<DatabaseRecommendationService>;
   let databaseService: MockType<DatabaseService>;
+  let dangerousCommandsProvider: MockType<DangerousCommandsProvider>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -55,6 +57,12 @@ describe('DatabaseInfoService', () => {
           provide: DatabaseService,
           useFactory: mockDatabaseService,
         },
+        {
+          provide: DangerousCommandsProvider,
+          useFactory: () => ({
+            getDangerousCommands: jest.fn().mockResolvedValue([]),
+          }),
+        },
       ],
     }).compile();
 
@@ -62,6 +70,7 @@ describe('DatabaseInfoService', () => {
     databaseClientFactory = await module.get(DatabaseClientFactory);
     recommendationService = module.get(DatabaseRecommendationService);
     databaseService = module.get(DatabaseService);
+    dangerousCommandsProvider = module.get(DangerousCommandsProvider);
   });
 
   describe('getInfo', () => {
@@ -80,6 +89,23 @@ describe('DatabaseInfoService', () => {
           mockDatabaseOverviewCurrentKeyspace,
         ),
       ).toEqual(mockDatabaseOverview);
+    });
+  });
+
+  describe('getDangerousCommands', () => {
+    it('should create client and get dangerous commands', async () => {
+      dangerousCommandsProvider.getDangerousCommands.mockResolvedValueOnce([
+        'FLUSHALL',
+        'FLUSHDB',
+      ]);
+
+      expect(
+        await service.getDangerousCommands(mockCommonClientMetadata),
+      ).toEqual(['FLUSHALL', 'FLUSHDB']);
+      expect(databaseClientFactory.getOrCreateClient).toHaveBeenCalledWith(
+        mockCommonClientMetadata,
+      );
+      expect(dangerousCommandsProvider.getDangerousCommands).toHaveBeenCalled();
     });
   });
 

--- a/redisinsight/api/src/modules/database/database-info.service.ts
+++ b/redisinsight/api/src/modules/database/database-info.service.ts
@@ -8,6 +8,7 @@ import { RECOMMENDATION_NAMES } from 'src/constants';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { RedisClient } from 'src/modules/redis/client';
 import { DatabaseInfoProvider } from 'src/modules/database/providers/database-info.provider';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 import { DatabaseService } from './database.service';
 import { DatabaseOverviewKeyspace } from './constants/overview';
 
@@ -21,7 +22,26 @@ export class DatabaseInfoService {
     private readonly databaseInfoProvider: DatabaseInfoProvider,
     private readonly recommendationService: DatabaseRecommendationService,
     private readonly databaseService: DatabaseService,
+    private readonly dangerousCommandsProvider: DangerousCommandsProvider,
   ) {}
+
+  /**
+   * Get the list of "dangerous" commands for the connected Redis instance.
+   * Sourced from `ACL CAT dangerous`. Cached per connection.
+   */
+  public async getDangerousCommands(
+    clientMetadata: ClientMetadata,
+  ): Promise<string[]> {
+    this.logger.debug(
+      `Getting dangerous commands for: ${clientMetadata.databaseId}`,
+      clientMetadata,
+    );
+
+    const client: RedisClient =
+      await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+    return this.dangerousCommandsProvider.getDangerousCommands(client);
+  }
 
   /**
    * Get database general info

--- a/redisinsight/api/src/modules/database/database.module.ts
+++ b/redisinsight/api/src/modules/database/database.module.ts
@@ -18,6 +18,7 @@ import { DatabaseOverviewProvider } from 'src/modules/database/providers/databas
 import { StackDatabasesRepository } from 'src/modules/database/repositories/stack.databases.repository';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { DatabaseInfoProvider } from './providers/database-info.provider';
+import { DangerousCommandsProvider } from './providers/dangerous-commands.provider';
 import { ConnectionMiddleware } from './middleware/connection.middleware';
 
 const SERVER_CONFIG = config.get('server') as Config['server'];
@@ -42,6 +43,7 @@ export class DatabaseModule {
         DatabaseAnalytics,
         DatabaseFactory,
         DatabaseInfoService,
+        DangerousCommandsProvider,
         {
           provide: DatabaseOverviewProvider,
           useClass: databaseOverviewProvider,

--- a/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.spec.ts
+++ b/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.spec.ts
@@ -49,12 +49,43 @@ describe('DangerousCommandsProvider', () => {
       expect(result).toEqual([]);
     });
 
-    it('should return empty array when ACL is not supported', async () => {
+    it('should return empty array and cache it when ACL is not supported (unknown command)', async () => {
       client.call.mockRejectedValueOnce(new Error("ERR unknown command 'ACL'"));
 
-      const result = await service.getDangerousCommands(client);
+      const first = await service.getDangerousCommands(client);
+      const second = await service.getDangerousCommands(client);
 
-      expect(result).toEqual([]);
+      expect(first).toEqual([]);
+      expect(second).toEqual([]);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty array and cache it on NOPERM', async () => {
+      client.call.mockRejectedValueOnce(
+        new Error(
+          "NOPERM this user has no permissions to run the 'acl|cat' command",
+        ),
+      );
+
+      const first = await service.getDangerousCommands(client);
+      const second = await service.getDangerousCommands(client);
+
+      expect(first).toEqual([]);
+      expect(second).toEqual([]);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty array but NOT cache on transient errors', async () => {
+      client.call
+        .mockRejectedValueOnce(new Error('ECONNRESET socket hang up'))
+        .mockResolvedValueOnce(['flushall']);
+
+      const first = await service.getDangerousCommands(client);
+      const second = await service.getDangerousCommands(client);
+
+      expect(first).toEqual([]);
+      expect(second).toEqual(['FLUSHALL']);
+      expect(client.call).toHaveBeenCalledTimes(2);
     });
 
     it('should return empty array when reply is not an array', async () => {

--- a/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.spec.ts
+++ b/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.spec.ts
@@ -1,0 +1,109 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockStandaloneRedisClient } from 'src/__mocks__';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
+
+describe('DangerousCommandsProvider', () => {
+  const client = mockStandaloneRedisClient;
+  let service: DangerousCommandsProvider;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DangerousCommandsProvider],
+    }).compile();
+
+    service = module.get(DangerousCommandsProvider);
+  });
+
+  describe('getDangerousCommands', () => {
+    it('should return upper-cased dangerous commands from ACL CAT dangerous', async () => {
+      client.call.mockResolvedValueOnce([
+        'flushall',
+        'flushdb',
+        'keys',
+        'debug',
+      ]);
+
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual(['FLUSHALL', 'FLUSHDB', 'KEYS', 'DEBUG']);
+      expect(client.call).toHaveBeenCalledWith(['acl', 'cat', 'dangerous'], {
+        replyEncoding: 'utf8',
+      });
+    });
+
+    it('should deduplicate command names', async () => {
+      client.call.mockResolvedValueOnce(['flushall', 'FLUSHALL', 'keys']);
+
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual(['FLUSHALL', 'KEYS']);
+    });
+
+    it('should return empty array on empty reply', async () => {
+      client.call.mockResolvedValueOnce([]);
+
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when ACL is not supported', async () => {
+      client.call.mockRejectedValueOnce(new Error("ERR unknown command 'ACL'"));
+
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when reply is not an array', async () => {
+      client.call.mockResolvedValueOnce(null);
+
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should cache the result and not re-fetch on subsequent calls', async () => {
+      client.call.mockResolvedValueOnce(['flushall']);
+
+      const first = await service.getDangerousCommands(client);
+      const second = await service.getDangerousCommands(client);
+
+      expect(first).toEqual(['FLUSHALL']);
+      expect(second).toEqual(['FLUSHALL']);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should drop the cached entry so the next call re-fetches', async () => {
+      client.call
+        .mockResolvedValueOnce(['flushall'])
+        .mockResolvedValueOnce(['keys']);
+
+      await service.getDangerousCommands(client);
+      service.invalidate(client.clientMetadata.databaseId);
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual(['KEYS']);
+      expect(client.call).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handleInstanceDeletedEvent', () => {
+    it('should invalidate the cache for the deleted database', async () => {
+      client.call
+        .mockResolvedValueOnce(['flushall'])
+        .mockResolvedValueOnce(['keys']);
+
+      await service.getDangerousCommands(client);
+      service.handleInstanceDeletedEvent(client.clientMetadata.databaseId);
+      const result = await service.getDangerousCommands(client);
+
+      expect(result).toEqual(['KEYS']);
+      expect(client.call).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
+++ b/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { AppRedisInstanceEvents } from 'src/constants';
+import { RedisClient } from 'src/modules/redis/client';
+
+@Injectable()
+export class DangerousCommandsProvider {
+  private logger = new Logger('DangerousCommandsProvider');
+
+  private cache: Map<string, string[]> = new Map();
+
+  /**
+   * Get cached dangerous commands list for the connection, or fetch and cache it.
+   */
+  async getDangerousCommands(client: RedisClient): Promise<string[]> {
+    const cached = this.cache.get(client.clientMetadata.databaseId);
+    if (cached) {
+      return cached;
+    }
+
+    const commands = await this.fetchDangerousCommands(client);
+    this.cache.set(client.clientMetadata.databaseId, commands);
+    return commands;
+  }
+
+  /**
+   * Invalidate the cached entry for a given database id.
+   * Should be called when the connection for this database is closed.
+   */
+  invalidate(databaseId: string): void {
+    this.cache.delete(databaseId);
+  }
+
+  @OnEvent(AppRedisInstanceEvents.Deleted)
+  handleInstanceDeletedEvent(databaseId: string): void {
+    this.invalidate(databaseId);
+  }
+
+  /**
+   * Run `ACL CAT dangerous` against the connected Redis instance.
+   * Returns an upper-cased, deduplicated list of command names.
+   * Returns an empty list if ACL is not supported (e.g. Redis < 6.0).
+   */
+  private async fetchDangerousCommands(client: RedisClient): Promise<string[]> {
+    try {
+      const reply = (await client.call(['acl', 'cat', 'dangerous'], {
+        replyEncoding: 'utf8',
+      })) as string[];
+
+      if (!Array.isArray(reply)) {
+        return [];
+      }
+
+      return Array.from(
+        new Set(
+          reply
+            .filter((cmd): cmd is string => typeof cmd === 'string')
+            .map((cmd) => cmd.toUpperCase()),
+        ),
+      );
+    } catch (e) {
+      this.logger.debug(
+        'ACL CAT dangerous is not available on this Redis instance',
+        e?.message,
+      );
+      return [];
+    }
+  }
+}

--- a/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
+++ b/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { AppRedisInstanceEvents } from 'src/constants';
+import { AppRedisInstanceEvents, RedisErrorCodes } from 'src/constants';
 import { RedisClient } from 'src/modules/redis/client';
 
 @Injectable()
@@ -11,8 +11,10 @@ export class DangerousCommandsProvider {
 
   /**
    * Get cached dangerous commands list for the connection, or fetch and cache it.
-   * An empty result (e.g. ACL unsupported or NOPERM) is cached too so we don't
-   * re-issue a command that will always fail for this database.
+   * Permanent failures (ACL unsupported or NOPERM) are also cached as [] so we
+   * don't re-issue a command that will always fail for this database. Transient
+   * failures (network, timeout, etc.) return [] but are NOT cached, so the next
+   * call will try again.
    */
   async getDangerousCommands(client: RedisClient): Promise<string[]> {
     const { databaseId } = client.clientMetadata;
@@ -20,9 +22,21 @@ export class DangerousCommandsProvider {
       return this.cache.get(databaseId)!;
     }
 
-    const commands = await this.fetchDangerousCommands(client);
-    this.cache.set(databaseId, commands);
-    return commands;
+    try {
+      const commands = await this.fetchDangerousCommands(client);
+      this.cache.set(databaseId, commands);
+      return commands;
+    } catch (e) {
+      if (this.isPermanentError(e)) {
+        this.cache.set(databaseId, []);
+        return [];
+      }
+      this.logger.debug(
+        'Transient error fetching dangerous commands; not caching',
+        e?.message,
+      );
+      return [];
+    }
   }
 
   /**
@@ -40,31 +54,37 @@ export class DangerousCommandsProvider {
   /**
    * Run `ACL CAT dangerous` against the connected Redis instance.
    * Returns an upper-cased, deduplicated list of command names.
-   * Returns an empty list if ACL is not supported (e.g. Redis < 6.0).
    */
   private async fetchDangerousCommands(client: RedisClient): Promise<string[]> {
-    try {
-      const reply = (await client.call(['acl', 'cat', 'dangerous'], {
-        replyEncoding: 'utf8',
-      })) as string[];
+    const reply = (await client.call(['acl', 'cat', 'dangerous'], {
+      replyEncoding: 'utf8',
+    })) as string[];
 
-      if (!Array.isArray(reply)) {
-        return [];
-      }
-
-      return Array.from(
-        new Set(
-          reply
-            .filter((cmd): cmd is string => typeof cmd === 'string')
-            .map((cmd) => cmd.toUpperCase()),
-        ),
-      );
-    } catch (e) {
-      this.logger.debug(
-        'ACL CAT dangerous is not available on this Redis instance',
-        e?.message,
-      );
+    if (!Array.isArray(reply)) {
       return [];
     }
+
+    return Array.from(
+      new Set(
+        reply
+          .filter((cmd): cmd is string => typeof cmd === 'string')
+          .map((cmd) => cmd.toUpperCase()),
+      ),
+    );
+  }
+
+  /**
+   * A permanent error is one that will keep failing until the database or its
+   * ACL config changes:
+   *  - NOPERM: the connected user lacks permission to run ACL CAT
+   *  - "unknown command": Redis < 6.0 (no ACL at all)
+   * Everything else (connection reset, timeout, etc.) is treated as transient.
+   */
+  private isPermanentError(e: unknown): boolean {
+    const message = (e as { message?: string })?.message ?? '';
+    return (
+      message.includes(RedisErrorCodes.NoPermission) ||
+      message.includes(RedisErrorCodes.UnknownCommand)
+    );
   }
 }

--- a/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
+++ b/redisinsight/api/src/modules/database/providers/dangerous-commands.provider.ts
@@ -11,21 +11,22 @@ export class DangerousCommandsProvider {
 
   /**
    * Get cached dangerous commands list for the connection, or fetch and cache it.
+   * An empty result (e.g. ACL unsupported or NOPERM) is cached too so we don't
+   * re-issue a command that will always fail for this database.
    */
   async getDangerousCommands(client: RedisClient): Promise<string[]> {
-    const cached = this.cache.get(client.clientMetadata.databaseId);
-    if (cached) {
-      return cached;
+    const { databaseId } = client.clientMetadata;
+    if (this.cache.has(databaseId)) {
+      return this.cache.get(databaseId)!;
     }
 
     const commands = await this.fetchDangerousCommands(client);
-    this.cache.set(client.clientMetadata.databaseId, commands);
+    this.cache.set(databaseId, commands);
     return commands;
   }
 
   /**
-   * Invalidate the cached entry for a given database id.
-   * Should be called when the connection for this database is closed.
+   * Drop the cached entry for a given database id so the next call re-fetches.
    */
   invalidate(databaseId: string): void {
     this.cache.delete(databaseId);

--- a/redisinsight/api/test/api/database/GET-databases-id-dangerous-commands.test.ts
+++ b/redisinsight/api/test/api/database/GET-databases-id-dangerous-commands.test.ts
@@ -1,0 +1,37 @@
+import { describe, deps, before, expect, getMainCheckFn } from '../deps';
+import { Joi } from '../../helpers/test';
+const { localDb, request, server, constants } = deps;
+
+const endpoint = (id = constants.TEST_INSTANCE_ID) =>
+  request(server).get(`/${constants.API.DATABASES}/${id}/dangerous-commands`);
+
+const responseSchema = Joi.array().items(Joi.string()).required();
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+describe(`GET /databases/:id/dangerous-commands`, () => {
+  before(localDb.createDatabaseInstances);
+
+  [
+    {
+      name: 'Should return an array of dangerous command names (upper-case)',
+      responseSchema,
+      checkFn: ({ body }) => {
+        expect(Array.isArray(body)).to.eql(true);
+        body.forEach((cmd: string) => {
+          expect(cmd).to.eql(cmd.toUpperCase());
+        });
+      },
+    },
+    {
+      name: 'Should return NotFound error if instance id does not exist',
+      endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+      statusCode: 404,
+      responseBody: {
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Invalid database instance id.',
+      },
+    },
+  ].map(mainCheckFn);
+});


### PR DESCRIPTION
# What

New `GET /databases/:id/dangerous-commands` endpoint that returns the list of dangerous commands for the connected Redis instance, sourced from `ACL CAT dangerous`.

- Results are upper-cased and de-duplicated for FE consumption.
- Cached per database id; invalidated when the database instance is deleted (via `AppRedisInstanceEvents.Deleted`).
- Degrades to an empty list on Redis versions that do not support ACL — never throws.

Part of epic [RI-6594](https://redislabs.atlassian.net/browse/RI-6594) (Prod vs non-prod modes). Provides the authoritative dangerous-commands list that FE prod-mode guards will consume.

# Testing

- Unit tests for the provider (happy path, dedupe, empty reply, ACL unsupported, non-array reply, cache hit, invalidate, on-delete handler).
- Updated `database-info.service` spec to cover the new method.
- Integration test asserting the endpoint returns an array of upper-case strings and 404s for unknown ids.

Manual:
1. Start the API against a Redis 6.0+ instance, hit `GET /databases/{id}/dangerous-commands` — expect upper-cased command names.
2. Hit it against Redis < 6.0 — expect `200 []`.
3. Delete the database and call again on a new instance — expect a fresh fetch (no stale cache).

---

Closes RI-8179

[RI-6594]: https://redislabs.atlassian.net/browse/RI-6594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new database API endpoint that issues `ACL CAT dangerous` against Redis and caches results per database id; correctness depends on Redis error parsing and cache invalidation on instance deletion.
> 
> **Overview**
> Introduces a new `GET /databases/:id/dangerous-commands` endpoint that returns an upper-cased, de-duplicated list of dangerous Redis commands sourced from `ACL CAT dangerous`.
> 
> Implements a `DangerousCommandsProvider` with per-`databaseId` caching, cache invalidation on `AppRedisInstanceEvents.Deleted`, and error handling that caches permanent failures (ACL unsupported / `NOPERM`) as `[]` while treating other failures as transient.
> 
> Wires the provider through `DatabaseInfoService`/`DatabaseModule` and adds unit + integration tests covering fetch/normalization, caching/invalidation, and the new endpoint’s response/404 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ff01976983ffe107fa525f0aa1132f31f95279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->