### PR TITLE
fix(e2e): fix parallel-worker key interference and view-switch timing in key-list tests

### DIFF
--- a/tests/e2e-playwright/pages/browser/components/KeyList.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyList.ts
@@ -161,6 +161,7 @@ export class KeyList {
    */
   async switchToListView(): Promise<void> {
     await this.listViewButton.click();
+    await this.waitForKeysLoaded();
   }
 
   /**
@@ -168,6 +169,7 @@ export class KeyList {
    */
   async switchToTreeView(): Promise<void> {
     await this.treeViewButton.click();
+    await this.waitForKeysLoaded();
   }
 
   /**
@@ -389,10 +391,18 @@ export class KeyList {
 
   /**
    * Get the tree-view tooltip for a hovered folder.
+   * Retries the hover until the tooltip is visible — a React re-render between
+   * hover and tooltip open silently swallows the mouseenter event (Radix behaviour).
    */
   async namespaceTooltip(folderName: string): Promise<Locator> {
-    await this.hoverFolderNode(folderName);
-    return this.page.getByRole('tooltip').filter({ hasText: folderName });
+    const tooltip = this.page.getByRole('tooltip').filter({ hasText: folderName });
+    await expect
+      .poll(async () => {
+        await this.hoverFolderNode(folderName);
+        return tooltip.isVisible();
+      })
+      .toBe(true);
+    return tooltip;
   }
 
   /**

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-list-view.spec.ts
@@ -22,7 +22,7 @@ test.describe('Browser > Key List View', () => {
   const bulkKey1 = `${TEST_KEY_PREFIX}kl-bulk-a-${suffix}`;
   const bulkKey2 = `${TEST_KEY_PREFIX}kl-bulk-b-${suffix}`;
   const bulkPattern = `${TEST_KEY_PREFIX}kl-bulk-*-${suffix}`;
-  const allTestKeysPattern = `${TEST_KEY_PREFIX}*`;
+  const allTestKeysPattern = `${TEST_KEY_PREFIX}kl-*`;
 
   test.beforeAll(async ({ apiHelper }) => {
     const config = StandaloneConfigFactory.build({

--- a/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
+++ b/tests/e2e-playwright/tests/main/browser/key-list/key-tree-view.spec.ts
@@ -17,19 +17,19 @@ test.describe('Browser > Key Tree View', () => {
   const suffix = Date.now().toString(36);
 
   // Colon-delimited tree keys
-  const treeFolder = `${TEST_KEY_PREFIX}tree-${suffix}`;
+  const treeFolder = `${TEST_KEY_PREFIX}tv-tree-${suffix}`;
   const usersFolder = `${treeFolder}:users`;
   const userAliceKey = `${usersFolder}:alice`;
   const userBobKey = `${usersFolder}:bob`;
-  const flatLeafKey = `${TEST_KEY_PREFIX}leaf-${suffix}`;
+  const flatLeafKey = `${TEST_KEY_PREFIX}tv-leaf-${suffix}`;
 
   // Underscore-delimited tree keys (used by delimiter-change tests)
-  const underscoreTreeFolder = `${TEST_KEY_PREFIX}utree-${suffix}`;
+  const underscoreTreeFolder = `${TEST_KEY_PREFIX}tv-utree-${suffix}`;
   const underscoreUsersFolder = `${underscoreTreeFolder}_users`;
   const underscoreAliceKey = `${underscoreUsersFolder}_alice`;
   const underscoreBobKey = `${underscoreUsersFolder}_bob`;
 
-  const allTestKeysPattern = `${TEST_KEY_PREFIX}*`;
+  const allTestKeysPattern = `${TEST_KEY_PREFIX}tv-*`;
 
   test.beforeAll(async ({ apiHelper }) => {
     const config = StandaloneConfigFactory.build({
@@ -178,8 +178,8 @@ test.describe('Browser > Key Tree View', () => {
 
   test('should sort tree nodes ascending and descending', async ({ apiHelper, browserPage }) => {
     // Seed keys producing two top-level folders that sort in opposite orders for ASC/DESC
-    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}aaa-${suffix}:k1`, 'a');
-    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}zzz-${suffix}:k1`, 'z');
+    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}tv-aaa-${suffix}:k1`, 'a');
+    await apiHelper.createStringKey(database.id, `${TEST_KEY_PREFIX}tv-zzz-${suffix}:k1`, 'z');
 
     // Open the Browser page in Tree view
     await browserPage.goto(database.id);
@@ -189,8 +189,8 @@ test.describe('Browser > Key Tree View', () => {
     await expect
       .poll(async () => {
         const names = await browserPage.keyList.getVisibleTreeFolderNames();
-        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}aaa-${suffix}`));
-        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}zzz-${suffix}`));
+        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}tv-aaa-${suffix}`));
+        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}tv-zzz-${suffix}`));
         return aaaIndex !== -1 && zzzIndex !== -1 && aaaIndex < zzzIndex;
       })
       .toBe(true);
@@ -203,8 +203,8 @@ test.describe('Browser > Key Tree View', () => {
     await expect
       .poll(async () => {
         const names = await browserPage.keyList.getVisibleTreeFolderNames();
-        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}aaa-${suffix}`));
-        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}zzz-${suffix}`));
+        const aaaIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}tv-aaa-${suffix}`));
+        const zzzIndex = names.findIndex((name) => name.startsWith(`${TEST_KEY_PREFIX}tv-zzz-${suffix}`));
         return aaaIndex !== -1 && zzzIndex !== -1 && aaaIndex > zzzIndex;
       })
       .toBe(true);
@@ -220,8 +220,8 @@ test.describe('Browser > Key Tree View', () => {
     browserPage,
   }) => {
     // Seed mixed types so the type filter has something to narrow
-    const stringKey = `${TEST_KEY_PREFIX}filter-str-${suffix}`;
-    const hashKeyName = `${TEST_KEY_PREFIX}filter-hash-${suffix}`;
+    const stringKey = `${TEST_KEY_PREFIX}tv-filter-str-${suffix}`;
+    const hashKeyName = `${TEST_KEY_PREFIX}tv-filter-hash-${suffix}`;
     await apiHelper.createStringKey(database.id, stringKey, 'hello');
     await apiHelper.createHashKey(database.id, hashKeyName, [{ field: 'f1', value: 'v1' }]);
 
@@ -229,14 +229,14 @@ test.describe('Browser > Key Tree View', () => {
     await browserPage.goto(database.id);
     await browserPage.keyList.switchToListView();
     await browserPage.keyList.filterByType('Hash');
-    await browserPage.keyList.searchKeys(`${TEST_KEY_PREFIX}filter-*-${suffix}`);
+    await browserPage.keyList.searchKeys(`${TEST_KEY_PREFIX}tv-filter-*-${suffix}`);
 
     await expect(browserPage.keyList.getKeyRow(hashKeyName)).toBeVisible();
     await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();
 
     // Switch to Tree view; filters should persist
     await browserPage.keyList.switchToTreeView();
-    await expect(browserPage.keyList.searchInput).toHaveValue(`${TEST_KEY_PREFIX}filter-*-${suffix}`);
+    await expect(browserPage.keyList.searchInput).toHaveValue(`${TEST_KEY_PREFIX}tv-filter-*-${suffix}`);
     await expect(browserPage.keyList.resetFilterButton).toBeVisible();
     await expect(browserPage.keyList.getKeyRow(hashKeyName)).toBeVisible();
     await expect(browserPage.keyList.getKeyRow(stringKey)).not.toBeVisible();


### PR DESCRIPTION
## Summary

- **Cross-spec key deletion**: `key-list-view` and `key-tree-view` specs both use `StandaloneConfigFactory`, pointing to the same Redis instance. Their `afterEach` cleanup used the over-broad `test-*` pattern, so one worker's cleanup was deleting keys just seeded by the other parallel worker. Fixed by giving each spec a unique sub-prefix (`kl-` / `tv-`) and scoping the cleanup pattern to match only that spec's keys.
- **View-switch timing**: `switchToListView()` / `switchToTreeView()` returned immediately after clicking the toggle, while the triggered key scan is async. Assertions could race against an empty list. Both methods now call `waitForKeysLoaded()` after the click.
- **Flaky tooltip**: `namespaceTooltip` hovered once and returned — if a React re-render swallowed the `mouseenter` (known Radix behaviour), the tooltip never opened and `toBeVisible()` timed out. The method now retries the hover inside `expect.poll` until the tooltip is actually visible.

## Test plan

- [ ] Nightly E2E run passes without intermittent failures in `key-list-view` and `key-tree-view` specs
- [ ] `should group keys into folders` tooltip assertion no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright E2E helpers/spec data and only affect test stability (cleanup patterns and additional waits/retries).
> 
> **Overview**
> Reduces flakiness in key-list Playwright E2E runs by **scoping test key prefixes and cleanup patterns per spec** (e.g., `kl-*` vs `tv-*`) to avoid parallel-worker deletion of each other’s seeded keys.
> 
> Improves UI timing robustness by having `switchToListView()`/`switchToTreeView()` wait for the async key load (`waitForKeysLoaded()`), and makes `namespaceTooltip()` retry hover via `expect.poll()` until the tooltip is actually visible (handling React re-renders swallowing `mouseenter`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae99d9e3c638cb93fc9c6efdfcb92bc8879736a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->