### PR TITLE
hide all vector set for version < 8.0 and when ff is off 

### DIFF
--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -11,4 +11,7 @@ export const CommandsVersions = {
   HASH_TTL: {
     since: '7.3',
   },
+  VECTOR_SET: {
+    since: '8.0',
+  },
 }

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -21,6 +21,7 @@ import {
 import * as appFeaturesSlice from 'uiSrc/slices/app/features'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { setSocialDialogState } from 'uiSrc/slices/oauth/cloud'
+import { FeatureFlags } from 'uiSrc/constants'
 import AddKey from './AddKey'
 
 const handleAddKeyPanelMock = () => {}
@@ -36,6 +37,13 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
     version: '8.0.0',
   }),
 }))
+
+const mockVectorSetFlag = (enabled: boolean) =>
+  jest
+    .spyOn(appFeaturesSlice, 'appFeatureFlagsFeaturesSelector')
+    .mockReturnValue({
+      [FeatureFlags.devVectorSet]: { flag: enabled },
+    })
 
 let store: typeof mockedStore
 beforeEach(() => {
@@ -129,10 +137,11 @@ describe('AddKey', () => {
     ])
   })
 
-  it('should show Vector Set option when redis version >= 8.0', async () => {
+  it('should show Vector Set option when redis version >= 8.0 and vector set flag is enabled', async () => {
     ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
       version: '8.0.0',
     })
+    mockVectorSetFlag(true)
 
     render(
       <AddKey
@@ -149,6 +158,24 @@ describe('AddKey', () => {
     ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
       version: '7.4.0',
     })
+    mockVectorSetFlag(true)
+
+    render(
+      <AddKey
+        onAddKeyPanel={handleAddKeyPanelMock}
+        onClosePanel={handleCloseKeyMock}
+      />,
+    )
+
+    await userEvent.click(screen.getByTestId('select-key-type'))
+    expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()
+  })
+
+  it('should hide Vector Set option when vector set flag is disabled', async () => {
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
+      version: '8.0.0',
+    })
+    mockVectorSetFlag(false)
 
     render(
       <AddKey

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -45,11 +45,21 @@ const mockVectorSetFlag = (enabled: boolean) =>
       [FeatureFlags.devVectorSet]: { flag: enabled },
     })
 
+const mockRedisVersion = (version: string) =>
+  (connectedInstanceOverviewSelector as jest.Mock).mockReturnValue({ version })
+
 let store: typeof mockedStore
 beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
   store.clearActions()
+  // Reset selector mocks to the default version between tests so a stray
+  // override in one test doesn't bleed into the next.
+  mockRedisVersion('8.0.0')
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
 })
 
 describe('AddKey', () => {
@@ -138,9 +148,7 @@ describe('AddKey', () => {
   })
 
   it('should show Vector Set option when redis version >= 8.0 and vector set flag is enabled', async () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
-      version: '8.0.0',
-    })
+    mockRedisVersion('8.0.0')
     mockVectorSetFlag(true)
 
     render(
@@ -155,9 +163,7 @@ describe('AddKey', () => {
   })
 
   it('should hide Vector Set option when redis version < 8.0', async () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
-      version: '7.4.0',
-    })
+    mockRedisVersion('7.4.0')
     mockVectorSetFlag(true)
 
     render(
@@ -172,9 +178,7 @@ describe('AddKey', () => {
   })
 
   it('should hide Vector Set option when vector set flag is disabled', async () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
-      version: '8.0.0',
-    })
+    mockRedisVersion('8.0.0')
     mockVectorSetFlag(false)
 
     render(

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, set } from 'lodash'
 
 import {
   cleanup,
+  initialStateDefault,
   mockedStore,
+  mockStore,
   render,
   screen,
   userEvent,
@@ -38,12 +40,27 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   }),
 }))
 
-const mockVectorSetFlag = (enabled: boolean) =>
-  jest
-    .spyOn(appFeaturesSlice, 'appFeatureFlagsFeaturesSelector')
-    .mockReturnValue({
-      [FeatureFlags.devVectorSet]: { flag: enabled },
-    })
+/**
+ * Build a fresh store with the `devVectorSet` feature flag pre-seeded so the
+ * Vector Set option's `isEnabledSelector` (which reads the flag from the
+ * features slice) resolves correctly. We seed the store rather than spying
+ * on the selector because the option config holds an import-time reference
+ * to the selector, which jest spies on the module export cannot intercept.
+ */
+const renderWithVectorSetFlag = (enabled: boolean) => {
+  const storeState = set(
+    cloneDeep(initialStateDefault),
+    `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+    { flag: enabled },
+  )
+  return render(
+    <AddKey
+      onAddKeyPanel={handleAddKeyPanelMock}
+      onClosePanel={handleCloseKeyMock}
+    />,
+    { store: mockStore(storeState) },
+  )
+}
 
 const mockRedisVersion = (version: string) =>
   (connectedInstanceOverviewSelector as jest.Mock).mockReturnValue({ version })
@@ -149,14 +166,7 @@ describe('AddKey', () => {
 
   it('should show Vector Set option when redis version >= 8.0 and vector set flag is enabled', async () => {
     mockRedisVersion('8.0.0')
-    mockVectorSetFlag(true)
-
-    render(
-      <AddKey
-        onAddKeyPanel={handleAddKeyPanelMock}
-        onClosePanel={handleCloseKeyMock}
-      />,
-    )
+    renderWithVectorSetFlag(true)
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(await screen.findByText('Vector Set')).toBeInTheDocument()
@@ -164,14 +174,7 @@ describe('AddKey', () => {
 
   it('should hide Vector Set option when redis version < 8.0', async () => {
     mockRedisVersion('7.4.0')
-    mockVectorSetFlag(true)
-
-    render(
-      <AddKey
-        onAddKeyPanel={handleAddKeyPanelMock}
-        onClosePanel={handleCloseKeyMock}
-      />,
-    )
+    renderWithVectorSetFlag(true)
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()
@@ -179,14 +182,7 @@ describe('AddKey', () => {
 
   it('should hide Vector Set option when vector set flag is disabled', async () => {
     mockRedisVersion('8.0.0')
-    mockVectorSetFlag(false)
-
-    render(
-      <AddKey
-        onAddKeyPanel={handleAddKeyPanelMock}
-        onClosePanel={handleCloseKeyMock}
-      />,
-    )
+    renderWithVectorSetFlag(false)
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -9,7 +9,10 @@ import {
   userEvent,
 } from 'uiSrc/utils/test-utils'
 import { ADD_KEY_TYPE_OPTIONS } from 'uiSrc/pages/browser/components/add-key/constants/key-type-options'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import {
+  connectedInstanceOverviewSelector,
+  connectedInstanceSelector,
+} from 'uiSrc/slices/instances/instances'
 import {
   OAuthSocialAction,
   OAuthSocialSource,
@@ -28,6 +31,9 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   connectedInstanceSelector: jest.fn().mockReturnValue({
     id: '1',
     modules: [],
+  }),
+  connectedInstanceOverviewSelector: jest.fn().mockReturnValue({
+    version: '8.0.0',
   }),
 }))
 
@@ -121,6 +127,38 @@ describe('AddKey', () => {
       ...afterRenderActions,
       ...expectedActions,
     ])
+  })
+
+  it('should show Vector Set option when redis version >= 8.0', async () => {
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
+      version: '8.0.0',
+    })
+
+    render(
+      <AddKey
+        onAddKeyPanel={handleAddKeyPanelMock}
+        onClosePanel={handleCloseKeyMock}
+      />,
+    )
+
+    await userEvent.click(screen.getByTestId('select-key-type'))
+    expect(await screen.findByText('Vector Set')).toBeInTheDocument()
+  })
+
+  it('should hide Vector Set option when redis version < 8.0', async () => {
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockReturnValueOnce({
+      version: '7.4.0',
+    })
+
+    render(
+      <AddKey
+        onAddKeyPanel={handleAddKeyPanelMock}
+        onClosePanel={handleCloseKeyMock}
+      />,
+    )
+
+    await userEvent.click(screen.getByTestId('select-key-type'))
+    expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()
   })
 
   it('should not show text if db contains ReJSON module', async () => {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -10,13 +10,21 @@ import {
   resetAddKey,
   keysSelector,
 } from 'uiSrc/slices/browser/keys'
-import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import {
+  connectedInstanceOverviewSelector,
+  connectedInstanceSelector,
+} from 'uiSrc/slices/instances/instances'
 import {
   sendEventTelemetry,
   TelemetryEvent,
   getBasedOnViewTypeEvent,
 } from 'uiSrc/telemetry'
-import { isContainJSONModule, Maybe, stringToBuffer } from 'uiSrc/utils'
+import {
+  isContainJSONModule,
+  isVersionHigherOrEquals,
+  Maybe,
+  stringToBuffer,
+} from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
@@ -53,6 +61,7 @@ const AddKey = (props: Props) => {
   const { id: instanceId, modules = [] } = useSelector(
     connectedInstanceSelector,
   )
+  const { version } = useSelector(connectedInstanceOverviewSelector)
   const { viewType } = useSelector(keysSelector)
 
   useEffect(
@@ -64,7 +73,10 @@ const AddKey = (props: Props) => {
     [],
   )
 
-  const options = ADD_KEY_TYPE_OPTIONS.map((item) => {
+  const options = ADD_KEY_TYPE_OPTIONS.filter(
+    ({ minVersion }) =>
+      !minVersion || isVersionHigherOrEquals(version, minVersion),
+  ).map((item) => {
     const { value, color, text } = item
     return {
       value,

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -108,7 +108,9 @@ const AddKey = (props: Props) => {
       ),
     }
   })
-  const [typeSelected, setTypeSelected] = useState<string>(options[0].value)
+  const [typeSelected, setTypeSelected] = useState<string>(
+    options[0]?.value ?? KeyTypes.Hash,
+  )
   const [keyName, setKeyName] = useState<string>('')
   const [keyTTL, setKeyTTL] = useState<Maybe<number>>(undefined)
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -15,6 +15,10 @@ import {
   connectedInstanceSelector,
 } from 'uiSrc/slices/instances/instances'
 import {
+  appFeatureFlagsFeaturesSelector,
+  isDevelopment,
+} from 'uiSrc/slices/app/features'
+import {
   sendEventTelemetry,
   TelemetryEvent,
   getBasedOnViewTypeEvent,
@@ -62,6 +66,7 @@ const AddKey = (props: Props) => {
     connectedInstanceSelector,
   )
   const { version } = useSelector(connectedInstanceOverviewSelector)
+  const features = useSelector(appFeatureFlagsFeaturesSelector)
   const { viewType } = useSelector(keysSelector)
 
   useEffect(
@@ -74,8 +79,19 @@ const AddKey = (props: Props) => {
   )
 
   const options = ADD_KEY_TYPE_OPTIONS.filter(
-    ({ minVersion }) =>
-      !minVersion || isVersionHigherOrEquals(version, minVersion),
+    ({ minVersion, typeFeatureFlag }) => {
+      if (minVersion && !isVersionHigherOrEquals(version, minVersion)) {
+        return false
+      }
+      if (
+        typeFeatureFlag &&
+        !isDevelopment &&
+        !features[typeFeatureFlag]?.flag
+      ) {
+        return false
+      }
+      return true
+    },
   ).map((item) => {
     const { value, color, text } = item
     return {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import cx from 'classnames'
 import Divider from 'uiSrc/components/divider/Divider'
 import { KeyTypes } from 'uiSrc/constants'
@@ -14,10 +14,7 @@ import {
   connectedInstanceOverviewSelector,
   connectedInstanceSelector,
 } from 'uiSrc/slices/instances/instances'
-import {
-  appFeatureFlagsFeaturesSelector,
-  isDevelopment,
-} from 'uiSrc/slices/app/features'
+import { RootState } from 'uiSrc/slices/store'
 import {
   sendEventTelemetry,
   TelemetryEvent,
@@ -66,7 +63,17 @@ const AddKey = (props: Props) => {
     connectedInstanceSelector,
   )
   const { version } = useSelector(connectedInstanceOverviewSelector)
-  const features = useSelector(appFeatureFlagsFeaturesSelector)
+  // Resolve each option's optional `isEnabledSelector` against the store so
+  // the option config is the single source of truth for which key types are
+  // gated (e.g. behind dev/feature flags). `shallowEqual` keeps the filtered
+  // array stable across renders when membership doesn't change.
+  const enabledOptions = useSelector(
+    (state: RootState) =>
+      ADD_KEY_TYPE_OPTIONS.filter(
+        ({ isEnabledSelector }) => isEnabledSelector?.(state) ?? true,
+      ),
+    shallowEqual,
+  )
   const { viewType } = useSelector(keysSelector)
 
   useEffect(
@@ -78,36 +85,27 @@ const AddKey = (props: Props) => {
     [],
   )
 
-  const options = ADD_KEY_TYPE_OPTIONS.filter(
-    ({ minVersion, typeFeatureFlag }) => {
-      if (minVersion && !isVersionHigherOrEquals(version, minVersion)) {
-        return false
+  const options = enabledOptions
+    .filter(
+      ({ minVersion }) =>
+        !minVersion || isVersionHigherOrEquals(version, minVersion),
+    )
+    .map((item) => {
+      const { value, color, text } = item
+      return {
+        value,
+        inputDisplay: (
+          <HealthText
+            color={color}
+            style={{ lineHeight: 'inherit' }}
+            data-test-subj={value}
+            data-testid={value}
+          >
+            {text}
+          </HealthText>
+        ),
       }
-      if (
-        typeFeatureFlag &&
-        !isDevelopment &&
-        !features[typeFeatureFlag]?.flag
-      ) {
-        return false
-      }
-      return true
-    },
-  ).map((item) => {
-    const { value, color, text } = item
-    return {
-      value,
-      inputDisplay: (
-        <HealthText
-          color={color}
-          style={{ lineHeight: 'inherit' }}
-          data-test-subj={value}
-          data-testid={value}
-        >
-          {text}
-        </HealthText>
-      ),
-    }
-  })
+    })
   const [typeSelected, setTypeSelected] = useState<string>(
     options[0]?.value ?? KeyTypes.Hash,
   )

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.types.ts
@@ -1,0 +1,15 @@
+import { RootState } from 'uiSrc/slices/store'
+
+export type AddKeyTypeOption = {
+  text: string
+  value: string
+  color: string
+  minVersion?: string
+  /**
+   * Optional gate evaluated against the redux store. Lets the option encode
+   * its own enablement (e.g. dev-only types behind a feature flag) so the
+   * component renderer stays agnostic about which key types need extra
+   * checks. Returns `true` when omitted.
+   */
+  isEnabledSelector?: (state: RootState) => boolean
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,4 +1,5 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
+import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 
 export const ADD_KEY_TYPE_OPTIONS = [
   {
@@ -40,5 +41,6 @@ export const ADD_KEY_TYPE_OPTIONS = [
     text: 'Vector Set',
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
+    minVersion: CommandsVersions.VECTOR_SET.since,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,7 +1,9 @@
-import { FeatureFlags, GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
+import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
+import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import { AddKeyTypeOption } from '../AddKey.types'
 
-export const ADD_KEY_TYPE_OPTIONS = [
+export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
   {
     text: 'Hash',
     value: KeyTypes.Hash,
@@ -42,6 +44,6 @@ export const ADD_KEY_TYPE_OPTIONS = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    typeFeatureFlag: FeatureFlags.devVectorSet,
+    isEnabledSelector: isDevVectorSetEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,4 +1,4 @@
-import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
+import { FeatureFlags, GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 
 export const ADD_KEY_TYPE_OPTIONS = [
@@ -42,5 +42,6 @@ export const ADD_KEY_TYPE_OPTIONS = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
+    typeFeatureFlag: FeatureFlags.devVectorSet,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -190,7 +190,10 @@ describe('FilterKeyType', () => {
     expect(graphElement).not.toBeInTheDocument()
   })
 
-  it('should show Vector Set when vector set feature flag is enabled', async () => {
+  it('should show Vector Set when vector set feature flag is enabled and redis version >= 8.0', async () => {
+    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
+      version: '8.0.0',
+    }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
       `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
@@ -209,6 +212,24 @@ describe('FilterKeyType', () => {
     const { queryByText } = render(<FilterKeyType />)
 
     fireEvent.click(screen.getByTestId(filterSelectId))
+
+    expect(queryByText('Vector Set')).not.toBeInTheDocument()
+  })
+
+  it('should hide Vector Set when redis version < 8.0 even if feature flag is enabled', async () => {
+    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
+      version: '7.4.0',
+    }))
+    const initialStoreState = set(
+      cloneDeep(initialStateDefault),
+      `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+      { flag: true },
+    )
+    const { queryByText } = render(<FilterKeyType />, {
+      store: mockStore(initialStoreState),
+    })
+
+    await userEvent.click(screen.getByTestId(filterSelectId))
 
     expect(queryByText('Vector Set')).not.toBeInTheDocument()
   })

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -209,6 +209,11 @@ describe('FilterKeyType', () => {
   })
 
   it('should hide Vector Set when vector set feature flag is disabled', () => {
+    // Ensure the version gate is satisfied so the assertion truly
+    // exercises the feature-flag path and not the version path.
+    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
+      version: '8.0.0',
+    }))
     const { queryByText } = render(<FilterKeyType />)
 
     fireEvent.click(screen.getByTestId(filterSelectId))

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
@@ -80,7 +80,7 @@ const FilterKeyType = ({ modules }: Props) => {
     inputDisplay: JSX.Element
     dropdownDisplay: JSX.Element
   }[] = FILTER_KEY_TYPE_OPTIONS.filter(
-    ({ featureFlag, skipIfNoModule, typeFeatureFlag }) => {
+    ({ featureFlag, skipIfNoModule, typeFeatureFlag, minVersion }) => {
       if (
         typeFeatureFlag &&
         !isDevelopment &&
@@ -92,6 +92,9 @@ const FilterKeyType = ({ modules }: Props) => {
         skipIfNoModule &&
         !modules?.some(({ name }) => name === skipIfNoModule)
       ) {
+        return false
+      }
+      if (minVersion && !isVersionHigherOrEquals(version, minVersion)) {
         return false
       }
       return !featureFlag || features[featureFlag]?.flag

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import {
   SCAN_COUNT_DEFAULT,
@@ -22,11 +22,9 @@ import { FeatureNotAvailable } from 'uiSrc/components'
 import { FILTER_NOT_AVAILABLE_CONTENT } from 'uiSrc/components/messages'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { resetBrowserTree } from 'uiSrc/slices/app/context'
-import {
-  appFeatureFlagsFeaturesSelector,
-  isDevelopment,
-} from 'uiSrc/slices/app/features'
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { AdditionalRedisModule } from 'uiSrc/slices/interfaces'
+import { RootState } from 'uiSrc/slices/store'
 import { OutsideClickDetector } from 'uiSrc/components/base/utils'
 import { HealthText } from 'uiSrc/components/base/text/HealthText'
 import {
@@ -58,6 +56,17 @@ const FilterKeyType = ({ modules }: Props) => {
   const { version } = useSelector(connectedInstanceOverviewSelector)
   const { filter, viewType, searchMode } = useSelector(keysSelector)
   const features = useSelector(appFeatureFlagsFeaturesSelector)
+  // Resolve each option's optional `isEnabledSelector` against the store so
+  // the option config is the single source of truth for which key types are
+  // gated (e.g. behind dev/feature flags). `shallowEqual` keeps the filtered
+  // array stable across renders when membership doesn't change.
+  const enabledOptions = useSelector(
+    (state: RootState) =>
+      FILTER_KEY_TYPE_OPTIONS.filter(
+        ({ isEnabledSelector }) => isEnabledSelector?.(state) ?? true,
+      ),
+    shallowEqual,
+  )
 
   const { instanceId } = useParams<{ instanceId: string }>()
   const dispatch = useDispatch()
@@ -79,15 +88,8 @@ const FilterKeyType = ({ modules }: Props) => {
     value: string
     inputDisplay: JSX.Element
     dropdownDisplay: JSX.Element
-  }[] = FILTER_KEY_TYPE_OPTIONS.filter(
-    ({ featureFlag, skipIfNoModule, typeFeatureFlag, minVersion }) => {
-      if (
-        typeFeatureFlag &&
-        !isDevelopment &&
-        !features[typeFeatureFlag]?.flag
-      ) {
-        return false
-      }
+  }[] = enabledOptions
+    .filter(({ featureFlag, skipIfNoModule, minVersion }) => {
       if (
         skipIfNoModule &&
         !modules?.some(({ name }) => name === skipIfNoModule)
@@ -98,30 +100,30 @@ const FilterKeyType = ({ modules }: Props) => {
         return false
       }
       return !featureFlag || features[featureFlag]?.flag
-    },
-  ).map((item) => {
-    const { value, color, text } = item
-    return {
-      value,
-      inputDisplay: (
-        <HealthText
-          color={color}
-          data-test-subj={`filter-option-type-${value}`}
-        >
-          {text}
-        </HealthText>
-      ),
-      dropdownDisplay: (
-        <HealthText
-          color={color}
-          data-test-subj={`filter-option-type-${value}`}
-        >
-          {text}
-        </HealthText>
-      ),
-      'data-test-subj': `filter-option-type-${value}`,
-    }
-  })
+    })
+    .map((item) => {
+      const { value, color, text } = item
+      return {
+        value,
+        inputDisplay: (
+          <HealthText
+            color={color}
+            data-test-subj={`filter-option-type-${value}`}
+          >
+            {text}
+          </HealthText>
+        ),
+        dropdownDisplay: (
+          <HealthText
+            color={color}
+            data-test-subj={`filter-option-type-${value}`}
+          >
+            {text}
+          </HealthText>
+        ),
+        'data-test-subj': `filter-option-type-${value}`,
+      }
+    })
 
   options.unshift({
     value: ALL_KEY_TYPES_VALUE,

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.types.ts
@@ -1,0 +1,18 @@
+import { FeatureFlags } from 'uiSrc/constants'
+import { RootState } from 'uiSrc/slices/store'
+
+export type FilterKeyTypeOption = {
+  text: string
+  value: string
+  color: string
+  minVersion?: string
+  featureFlag?: FeatureFlags
+  skipIfNoModule?: string
+  /**
+   * Optional gate evaluated against the redux store. Lets the option encode
+   * its own enablement (e.g. dev-only types behind a feature flag) so the
+   * filter renderer stays agnostic about which key types need extra checks.
+   * Returns `true` when omitted.
+   */
+  isEnabledSelector?: (state: RootState) => boolean
+}

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -5,9 +5,11 @@ import {
   FeatureFlags,
 } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
+import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
+import { FilterKeyTypeOption } from './FilterKeyType.types'
 
-export const FILTER_KEY_TYPE_OPTIONS = [
+export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
   {
     text: 'Hash',
     value: KeyTypes.Hash,
@@ -47,8 +49,8 @@ export const FILTER_KEY_TYPE_OPTIONS = [
     text: 'Vector Set',
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
-    typeFeatureFlag: FeatureFlags.devVectorSet,
     minVersion: CommandsVersions.VECTOR_SET.since,
+    isEnabledSelector: isDevVectorSetEnabledSelector,
   },
   {
     text: 'Graph',

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -4,6 +4,7 @@ import {
   ModulesKeyTypes,
   FeatureFlags,
 } from 'uiSrc/constants'
+import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 
 export const FILTER_KEY_TYPE_OPTIONS = [
@@ -47,6 +48,7 @@ export const FILTER_KEY_TYPE_OPTIONS = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     typeFeatureFlag: FeatureFlags.devVectorSet,
+    minVersion: CommandsVersions.VECTOR_SET.since,
   },
   {
     text: 'Graph',


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Hide Vector Set key type from the Browser when it's not usable:
- On Redis < 8.0 (version doesn't support Vector Sets).
- When the `devVectorSet` feature flag is off.
Applies to both the key type filter dropdown and the New Key dropdown.

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. On Redis < 8.0: "Vector Set" is absent from the filter and New Key dropdowns.
2. On Redis >= 8.0 with `devVectorSet` off: still hidden.
3. On Redis >= 8.0 with `devVectorSet` on: visible in both dropdowns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating logic to hide/show a key type based on Redis version and a feature flag; low risk but could affect available dropdown options if the version/flag detection is wrong.
> 
> **Overview**
> Hides the **Vector Set** key type in the Browser unless *both* Redis is `>= 8.0` and the `devVectorSet` feature flag is enabled, applying to both the **New Key** type dropdown and the **key type filter** dropdown.
> 
> Refactors both dropdowns to derive option availability from option metadata (`minVersion` + optional `isEnabledSelector` evaluated against Redux state), adds typed option definitions, and extends tests to cover the new version/flag gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e3f3091ccc9d55281bfb7fbb5e19a85949000b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->