### PR TITLE
Handle withattribs for version < 8.0.3

### DIFF
--- a/redisinsight/api/.tscheck.rec.json
+++ b/redisinsight/api/.tscheck.rec.json
@@ -1228,7 +1228,7 @@
     "TS2345": 1
   },
   "src/modules/redis/client/redis.client.ts": {
-    "TS2322": 5,
+    "TS2322": 1,
     "TS7016": 1
   },
   "src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts": {

--- a/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/__tests__/vector-set.factory.ts
@@ -167,6 +167,12 @@ type VsimCommandOptions = {
   includeCount?: boolean;
   /** Append `FILTER <expr>` after `WITHSCORES`/`WITHATTRIBS`. */
   filter?: string;
+  /**
+   * Append `WITHATTRIBS`. Defaults to true. Set to false to mirror the
+   * Redis 8.0.0–8.0.2 fallback path where the option is omitted because
+   * the server errors out on it.
+   */
+  withAttribs?: boolean;
 };
 
 const appendCommonVsimSuffix = (
@@ -177,7 +183,10 @@ const appendCommonVsimSuffix = (
   if (options.includeCount !== false && count !== undefined) {
     args.push('COUNT', count);
   }
-  args.push('WITHSCORES', 'WITHATTRIBS');
+  args.push('WITHSCORES');
+  if (options.withAttribs !== false) {
+    args.push('WITHATTRIBS');
+  }
   if (options.filter !== undefined) {
     args.push('FILTER', options.filter);
   }

--- a/redisinsight/api/src/modules/browser/vector-set/constants.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/constants.ts
@@ -3,3 +3,11 @@
  * contains 3 entries per match in the order `(name, score, attributes|null)`.
  */
 export const VSIM_REPLY_STRIDE = 3;
+
+/**
+ * Stride of `VSIM ... WITHSCORES` replies (without WITHATTRIBS). The flat
+ * reply array contains 2 entries per match in the order `(name, score)`. Used
+ * on Redis 8.0.0–8.0.2 where WITHATTRIBS is not supported and attributes have
+ * to be retrieved per-element via VGETATTR after the search returns.
+ */
+export const VSIM_REPLY_STRIDE_NO_ATTRIBS = 2;

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
@@ -197,7 +197,7 @@ export class VectorSetController extends BrowserBaseController {
   @ApiRedisInstanceOperation({
     description:
       'Run a vector similarity search (VSIM) against the VectorSet stored at key. ' +
-      'WITHSCORES and WITHATTRIBS are always applied so each match carries a similarity score and the element attributes (when present).',
+      'WITHSCORES is always applied so each match carries a similarity score; element attributes are returned when present (resolved server-side either via WITHATTRIBS on Redis ≥ 8.0.3 or per-element VGETATTR on 8.0.0–8.0.2 where WITHATTRIBS is unsupported).',
     statusCode: 200,
     responses: [
       {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -788,6 +788,11 @@ describe('VectorSetService', () => {
     );
 
     beforeEach(() => {
+      // Default to "WITHATTRIBS supported" (Redis ≥ 8.0.3) so the canonical
+      // path is exercised here; the dedicated 8.0.0–8.0.2 fallback block
+      // below overrides this per-test.
+      client.isFeatureSupported = jest.fn().mockResolvedValue(true);
+
       when(client.sendCommand)
         .calledWith([
           BrowserToolKeysCommands.Exists,
@@ -1056,9 +1061,141 @@ describe('VectorSetService', () => {
         ),
       ).rejects.toThrow(ForbiddenException);
     });
+
+    describe('Redis 8.0.0–8.0.2 (WITHATTRIBS unsupported) fallback', () => {
+      beforeEach(() => {
+        client.isFeatureSupported = jest.fn().mockResolvedValue(false);
+      });
+
+      it('should check the VsimWithAttribs feature before issuing VSIM', async () => {
+        const expectedCommand = buildVsimByElementCommand(
+          mockSearchByElementDto,
+          { withAttribs: false },
+        );
+        when(client.sendCommand)
+          .calledWith(expectedCommand)
+          .mockResolvedValue([]);
+
+        await service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        );
+
+        expect(client.isFeatureSupported).toHaveBeenCalledWith(
+          RedisFeature.VsimWithAttribs,
+        );
+      });
+
+      it('should omit WITHATTRIBS from the VSIM command and back-fill attributes via VGETATTR pipeline', async () => {
+        const expectedCommand = buildVsimByElementCommand(
+          mockSearchByElementDto,
+          { withAttribs: false },
+        );
+        // Stride-2 reply (no attributes inline)
+        when(client.sendCommand)
+          .calledWith(expectedCommand)
+          .mockResolvedValue([
+            SEARCH_VSIM_MATCH_NAME_1,
+            '0.95',
+            SEARCH_VSIM_MATCH_NAME_2,
+            '0.81',
+          ]);
+
+        client.sendPipeline.mockResolvedValue([
+          [null, SEARCH_VSIM_MATCH_ATTRIBUTES_1],
+          [null, null],
+        ]);
+
+        const result = await service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        );
+
+        expect(client.sendCommand).toHaveBeenCalledWith(expectedCommand);
+        expect(client.sendPipeline).toHaveBeenCalledWith([
+          [
+            BrowserToolVectorSetCommands.VGetAttr,
+            mockSearchByElementDto.keyName,
+            SEARCH_VSIM_MATCH_NAME_1,
+          ],
+          [
+            BrowserToolVectorSetCommands.VGetAttr,
+            mockSearchByElementDto.keyName,
+            SEARCH_VSIM_MATCH_NAME_2,
+          ],
+        ]);
+        expect(result.elements).toEqual([
+          {
+            name: SEARCH_VSIM_MATCH_NAME_1,
+            score: 0.95,
+            attributes: SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+          },
+          { name: SEARCH_VSIM_MATCH_NAME_2, score: 0.81 },
+        ]);
+        expect('attributes' in result.elements[1]).toBe(false);
+      });
+
+      it('should not issue any VGETATTR pipeline when VSIM returns no matches', async () => {
+        const expectedCommand = buildVsimByElementCommand(
+          mockSearchByElementDto,
+          { withAttribs: false },
+        );
+        when(client.sendCommand)
+          .calledWith(expectedCommand)
+          .mockResolvedValue([]);
+
+        const result = await service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        );
+
+        expect(client.sendPipeline).not.toHaveBeenCalled();
+        expect(result.elements).toEqual([]);
+      });
+
+      it('should swallow per-element VGETATTR errors and leave attributes undefined for that match', async () => {
+        const expectedCommand = buildVsimByElementCommand(
+          mockSearchByElementDto,
+          { withAttribs: false },
+        );
+        when(client.sendCommand)
+          .calledWith(expectedCommand)
+          .mockResolvedValue([
+            SEARCH_VSIM_MATCH_NAME_1,
+            '0.95',
+            SEARCH_VSIM_MATCH_NAME_2,
+            '0.81',
+          ]);
+
+        const replyError: ReplyError = {
+          ...mockRedisNoPermError,
+          command: 'VGETATTR',
+        };
+        client.sendPipeline.mockResolvedValue([
+          [null, SEARCH_VSIM_MATCH_ATTRIBUTES_1],
+          [replyError, null],
+        ]);
+
+        const result = await service.similaritySearch(
+          mockBrowserClientMetadata,
+          mockSearchByElementDto,
+        );
+
+        expect(result.elements[0].attributes).toEqual(
+          SEARCH_VSIM_MATCH_ATTRIBUTES_1,
+        );
+        expect(result.elements[1].attributes).toBeUndefined();
+      });
+    });
   });
 
   describe('getSimilaritySearchPreview', () => {
+    beforeEach(() => {
+      // Default to "WITHATTRIBS supported" so the canonical preview shape is
+      // exercised; the dedicated fallback test below overrides this.
+      client.isFeatureSupported = jest.fn().mockResolvedValue(true);
+    });
+
     it('should render VSIM preview with ELE clause and quote element when needed', async () => {
       const dto = {
         keyName: Buffer.from('mykey'),
@@ -1165,6 +1302,24 @@ describe('VectorSetService', () => {
           count: 10,
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should omit WITHATTRIBS in the preview on Redis 8.0.0–8.0.2 (WITHATTRIBS unsupported)', async () => {
+      client.isFeatureSupported = jest.fn().mockResolvedValue(false);
+
+      const { preview } = await service.getSimilaritySearchPreview(
+        mockBrowserClientMetadata,
+        {
+          keyName: Buffer.from('mykey'),
+          elementName: Buffer.from('seed'),
+          count: 5,
+        },
+      );
+
+      expect(client.isFeatureSupported).toHaveBeenCalledWith(
+        RedisFeature.VsimWithAttribs,
+      );
+      expect(preview).toBe('VSIM mykey ELE seed COUNT 5 WITHSCORES');
     });
   });
 });

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -410,12 +410,24 @@ export class VectorSetService {
 
       await checkIfKeyNotExists(keyName, client);
 
-      const command = buildVsimCommand(dto);
+      // Redis 8.0.0–8.0.2 errors out when WITHATTRIBS is appended to VSIM, so
+      // on those versions we omit the option and back-fill attributes via
+      // per-element VGETATTR after the search returns. The response shape
+      // stays identical for FE consumers.
+      const withAttribs = await client.isFeatureSupported(
+        RedisFeature.VsimWithAttribs,
+      );
+
+      const command = buildVsimCommand(dto, { withAttribs });
       const reply = (await client.sendCommand(command)) as Array<
         string | Buffer | null
       >;
 
-      const elements = parseVsimReply(reply, this.logger);
+      const elements = parseVsimReply(reply, this.logger, { withAttribs });
+
+      if (!withAttribs && elements.length > 0) {
+        await this.fetchAttributesForMatches(client, keyName, elements);
+      }
 
       this.logger.debug(
         'Succeed to run similarity search on the VectorSet data type.',
@@ -449,7 +461,16 @@ export class VectorSetService {
         clientMetadata,
       );
 
-      const preview = formatVsimCommandPreview(dto);
+      // Mirror the version-aware branch in `similaritySearch` so the preview
+      // never advertises a WITHATTRIBS that the actual search would skip on
+      // Redis 8.0.0–8.0.2.
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      const withAttribs = await client.isFeatureSupported(
+        RedisFeature.VsimWithAttribs,
+      );
+
+      const preview = formatVsimCommandPreview(dto, { withAttribs });
 
       return plainToInstance(SearchVectorSetPreviewResponse, { preview });
     } catch (error) {
@@ -463,6 +484,43 @@ export class VectorSetService {
       }
       throw catchAclError(error);
     }
+  }
+
+  /**
+   * Back-fill the `attributes` field on each match by issuing one VGETATTR
+   * per element in a single pipeline. Used as the fallback path for Redis
+   * 8.0.0–8.0.2 where VSIM rejects the WITHATTRIBS option.
+   *
+   * Mutates `matches` in place. Per-element errors are swallowed (logged at
+   * debug) so a single failing VGETATTR cannot drop the whole search reply;
+   * elements without attributes simply keep `attributes` undefined.
+   */
+  private async fetchAttributesForMatches(
+    client: RedisClient,
+    keyName: Buffer | string,
+    matches: { name: string | Buffer; attributes?: string }[],
+  ): Promise<void> {
+    const commands: RedisClientCommand[] = matches.map((match) => [
+      BrowserToolVectorSetCommands.VGetAttr,
+      keyName,
+      match.name,
+    ]);
+
+    const results = await client.sendPipeline(commands);
+
+    results.forEach(([err, value], i) => {
+      if (err) {
+        this.logger.debug(
+          `VGETATTR failed for match ${matches[i].name?.toString()}; leaving attributes undefined.`,
+          err,
+        );
+        return;
+      }
+      if (value !== null && value !== undefined) {
+        matches[i].attributes =
+          typeof value === 'string' ? value : String(value);
+      }
+    });
   }
 
   private async fetchElementDetails(

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.spec.ts
@@ -210,6 +210,48 @@ describe('vector-set.utils', () => {
       expect(() => buildVsimCommand(dto)).toThrow(BadRequestException);
       expect(() => buildVsimCommand(dto)).toThrow(/exactly one/);
     });
+
+    it('should omit WITHATTRIBS when `withAttribs: false` is supplied (Redis 8.0.0–8.0.2 fallback)', () => {
+      const dto = similaritySearchDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: 5,
+      });
+
+      const command = buildVsimCommand(dto, {
+        withAttribs: false,
+      }) as unknown[];
+
+      expect(command).toEqual([
+        BrowserToolVectorSetCommands.VSim,
+        dto.keyName,
+        'ELE',
+        dto.elementName,
+        'COUNT',
+        5,
+        'WITHSCORES',
+      ]);
+      expect(command).not.toContain('WITHATTRIBS');
+    });
+
+    it('should still place FILTER after WITHSCORES when `withAttribs: false`', () => {
+      const dto = similaritySearchDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: 4,
+        filter: '.color == "red"',
+      });
+
+      const command = buildVsimCommand(dto, {
+        withAttribs: false,
+      }) as unknown[];
+
+      expect(command).not.toContain('WITHATTRIBS');
+      expect(command.indexOf('FILTER')).toBeGreaterThan(
+        command.indexOf('WITHSCORES'),
+      );
+      expect(command.slice(-2)).toEqual(['FILTER', '.color == "red"']);
+    });
   });
 
   describe('formatVsimCommandPreview', () => {
@@ -342,6 +384,18 @@ describe('vector-set.utils', () => {
       expect(() => formatVsimCommandPreview(dto)).toThrow(BadRequestException);
       expect(() => formatVsimCommandPreview(dto)).toThrow(/exactly one/);
     });
+
+    it('should omit WITHATTRIBS in preview when `withAttribs: false` is supplied', () => {
+      const dto = similaritySearchDtoFactory.build({
+        keyName: Buffer.from('vset:key'),
+        elementName: Buffer.from('seed'),
+        count: 5,
+      });
+
+      expect(formatVsimCommandPreview(dto, { withAttribs: false })).toBe(
+        'VSIM vset:key ELE seed COUNT 5 WITHSCORES',
+      );
+    });
   });
 
   describe('parseVsimReply', () => {
@@ -427,6 +481,41 @@ describe('vector-set.utils', () => {
       ];
 
       expect(() => parseVsimReply(reply)).not.toThrow();
+    });
+
+    it('should parse a (name, score) reply with stride 2 when `withAttribs: false`', () => {
+      const reply: Array<string | Buffer | null> = [
+        Buffer.from('m1'),
+        '0.95',
+        Buffer.from('m2'),
+        '0.81',
+      ];
+
+      const matches = parseVsimReply(reply, undefined, { withAttribs: false });
+
+      expect(matches).toEqual([
+        { name: Buffer.from('m1'), score: 0.95 },
+        { name: Buffer.from('m2'), score: 0.81 },
+      ]);
+      expect(matches[0].attributes).toBeUndefined();
+      expect(matches[1].attributes).toBeUndefined();
+    });
+
+    it('should drop a trailing partial tuple at stride 2 when `withAttribs: false`', () => {
+      const reply: Array<string | Buffer | null> = [
+        Buffer.from('m1'),
+        '0.9',
+        Buffer.from('m2'),
+      ];
+      const logger = { warn: jest.fn() } as unknown as Logger;
+
+      const matches = parseVsimReply(reply, logger, { withAttribs: false });
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].name).toEqual(Buffer.from('m1'));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('not a multiple of 2'),
+      );
     });
   });
 });

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -7,7 +7,21 @@ import {
   SearchVectorSetMatchDto,
   SimilaritySearchDto,
 } from 'src/modules/browser/vector-set/dto';
-import { VSIM_REPLY_STRIDE } from 'src/modules/browser/vector-set/constants';
+import {
+  VSIM_REPLY_STRIDE,
+  VSIM_REPLY_STRIDE_NO_ATTRIBS,
+} from 'src/modules/browser/vector-set/constants';
+
+/**
+ * Optional flag shared by the VSIM command builder, preview formatter, and
+ * reply parser. Defaults to `true` so callers that don't care about the
+ * Redis-version split keep the canonical `WITHSCORES WITHATTRIBS` shape.
+ *
+ * Set to `false` on Redis 8.0.0–8.0.2 where the `WITHATTRIBS` option is
+ * broken; in that mode the service back-fills attributes via per-element
+ * `VGETATTR` after the search returns.
+ */
+export type VsimWithAttribsOption = { withAttribs?: boolean };
 
 /**
  * Resolved query clause shared between the executable command builder and the
@@ -120,7 +134,10 @@ function writeVsimTokens<T>(
   dto: SimilaritySearchDto,
   query: ResolvedVsimQuery,
   tokenWriter: VsimTokenWriter<T>,
+  options: VsimWithAttribsOption = {},
 ): T[] {
+  const { withAttribs = true } = options;
+
   const tokens: T[] = [
     tokenWriter.literal(BrowserToolVectorSetCommands.VSim),
     tokenWriter.key(dto.keyName),
@@ -142,12 +159,14 @@ function writeVsimTokens<T>(
     tokens.push(tokenWriter.literal('COUNT'), tokenWriter.number(dto.count));
   }
 
-  // WITHSCORES and WITHATTRIBS are always appended so the response shape
-  // is stable; they are intentionally not part of the DTO.
-  tokens.push(
-    tokenWriter.literal('WITHSCORES'),
-    tokenWriter.literal('WITHATTRIBS'),
-  );
+  // WITHSCORES is always appended so the response shape is stable; they are
+  // intentionally not part of the DTO. WITHATTRIBS is conditional because
+  // Redis 8.0.0–8.0.2 errors out on it; the service back-fills attributes
+  // via VGETATTR in that case.
+  tokens.push(tokenWriter.literal('WITHSCORES'));
+  if (withAttribs) {
+    tokens.push(tokenWriter.literal('WITHATTRIBS'));
+  }
 
   if (dto.filter !== undefined && dto.filter !== '') {
     tokens.push(tokenWriter.literal('FILTER'), tokenWriter.filter(dto.filter));
@@ -209,18 +228,26 @@ export function buildVaddCommand(
   return args as RedisClientCommand;
 }
 
-export function buildVsimCommand(dto: SimilaritySearchDto): RedisClientCommand {
+export function buildVsimCommand(
+  dto: SimilaritySearchDto,
+  options: VsimWithAttribsOption = {},
+): RedisClientCommand {
   const query = resolveVsimQuery(dto);
 
-  return writeVsimTokens<string | number | Buffer>(dto, query, {
-    literal: (token) => token,
-    key: (key) => key as string | Buffer,
-    element: (element) => element as string | Buffer,
-    fp32: (bytes) => bytes,
-    number: (value) => value,
-    vectorValue: (value) => String(value),
-    filter: (filter) => filter,
-  }) as RedisClientCommand;
+  return writeVsimTokens<string | number | Buffer>(
+    dto,
+    query,
+    {
+      literal: (token) => token,
+      key: (key) => key as string | Buffer,
+      element: (element) => element as string | Buffer,
+      fp32: (bytes) => bytes,
+      number: (value) => value,
+      vectorValue: (value) => String(value),
+      filter: (filter) => filter,
+    },
+    options,
+  ) as RedisClientCommand;
 }
 
 /**
@@ -232,59 +259,75 @@ export function buildVsimCommand(dto: SimilaritySearchDto): RedisClientCommand {
  * supplied — the FE is expected to only call the preview endpoint once
  * the form has resolved to exactly one query mode.
  */
-export function formatVsimCommandPreview(dto: SimilaritySearchDto): string {
+export function formatVsimCommandPreview(
+  dto: SimilaritySearchDto,
+  options: VsimWithAttribsOption = {},
+): string {
   const query = resolveVsimQuery(dto);
 
-  return writeVsimTokens<string>(dto, query, {
-    literal: (token) => token,
-    key: (key) => quoteForCli(bufferOrStringToString(key)),
-    element: (element) => quoteForCli(bufferOrStringToString(element)),
-    // Render the FP32 bytes back as the canonical `\xHH\xHH...` escape
-    // string so the preview is copy-paste-safe into `redis-cli`. Wrapped in
-    // double quotes for the same reason.
-    fp32: (bytes) => `"${bytesToEscapeString(bytes)}"`,
-    number: (value) => String(value),
-    vectorValue: (value) => String(value),
-    filter: (filter) => quoteForCli(filter),
-  }).join(' ');
+  return writeVsimTokens<string>(
+    dto,
+    query,
+    {
+      literal: (token) => token,
+      key: (key) => quoteForCli(bufferOrStringToString(key)),
+      element: (element) => quoteForCli(bufferOrStringToString(element)),
+      // Render the FP32 bytes back as the canonical `\xHH\xHH...` escape
+      // string so the preview is copy-paste-safe into `redis-cli`. Wrapped in
+      // double quotes for the same reason.
+      fp32: (bytes) => `"${bytesToEscapeString(bytes)}"`,
+      number: (value) => String(value),
+      vectorValue: (value) => String(value),
+      filter: (filter) => quoteForCli(filter),
+    },
+    options,
+  ).join(' ');
 }
 
 export function parseVsimReply(
   reply: Array<string | Buffer | null> | null | undefined,
   logger?: Logger,
+  options: VsimWithAttribsOption = {},
 ): SearchVectorSetMatchDto[] {
   if (!reply || reply.length === 0) {
     return [];
   }
 
+  const { withAttribs = true } = options;
+  const stride = withAttribs ? VSIM_REPLY_STRIDE : VSIM_REPLY_STRIDE_NO_ATTRIBS;
+
   // Defensive: drop any trailing partial tuple. Redis is expected to always
-  // return a multiple of `VSIM_REPLY_STRIDE`, so this only protects against
-  // unexpected server-side bugs.
-  const remainder = reply.length % VSIM_REPLY_STRIDE;
+  // return a multiple of `stride`, so this only protects against unexpected
+  // server-side bugs.
+  const remainder = reply.length % stride;
   const usableLength =
     remainder === 0 ? reply.length : reply.length - remainder;
   if (remainder !== 0) {
     logger?.warn(
-      `VSIM reply length ${reply.length} is not a multiple of ${VSIM_REPLY_STRIDE}; dropping trailing partial tuple.`,
+      `VSIM reply length ${reply.length} is not a multiple of ${stride}; dropping trailing partial tuple.`,
     );
   }
 
   const matches: SearchVectorSetMatchDto[] = [];
-  for (let i = 0; i < usableLength; i += VSIM_REPLY_STRIDE) {
+  for (let i = 0; i < usableLength; i += stride) {
     const name = reply[i] as string | Buffer;
     const rawScore = reply[i + 1];
-    const rawAttributes = reply[i + 2];
 
     const score =
       typeof rawScore === 'number' ? rawScore : parseFloat(String(rawScore));
 
     const match: SearchVectorSetMatchDto = { name, score };
-    if (rawAttributes !== null && rawAttributes !== undefined) {
-      match.attributes =
-        typeof rawAttributes === 'string'
-          ? rawAttributes
-          : String(rawAttributes);
+
+    if (withAttribs) {
+      const rawAttributes = reply[i + 2];
+      if (rawAttributes !== null && rawAttributes !== undefined) {
+        match.attributes =
+          typeof rawAttributes === 'string'
+            ? rawAttributes
+            : String(rawAttributes);
+      }
     }
+
     matches.push(match);
   }
   return matches;

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -57,6 +57,7 @@ export enum RedisFeature {
   HashFieldsExpiration = 'HashFieldsExpiration',
   UnlinkCommand = 'UnlinkCommand',
   VRangeCommand = 'VRangeCommand',
+  VsimWithAttribs = 'VsimWithAttribs',
 }
 
 const CLIENT_DATABASE_FIELDS: (keyof Database)[] = ['providerDetails'];
@@ -195,6 +196,14 @@ export abstract class RedisClient extends EventEmitter2 {
           const redisVersion = await this.getRedisVersion();
           // VRANGE command was introduced in Redis 8.4
           return redisVersion && semverCompare('8.4', redisVersion) < 1;
+        } catch (e) {
+          return false;
+        }
+      case RedisFeature.VsimWithAttribs:
+        try {
+          const redisVersion = await this.getRedisVersion();
+          // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
+          return redisVersion && semverCompare('8.0.3', redisVersion) < 1;
         } catch (e) {
           return false;
         }

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -177,42 +177,34 @@ export abstract class RedisClient extends EventEmitter2 {
   public async isFeatureSupported(feature: RedisFeature): Promise<boolean> {
     switch (feature) {
       case RedisFeature.HashFieldsExpiration:
-        try {
-          const redisVersion = await this.getRedisVersion();
-          return redisVersion && semverCompare('7.3', redisVersion) < 1;
-        } catch (e) {
-          return false;
-        }
+        return this.isRedisVersionAtLeast('7.3');
       case RedisFeature.UnlinkCommand:
-        try {
-          const redisVersion = await this.getRedisVersion();
-          // UNLINK command was introduced in Redis 4.0.0
-          return redisVersion && semverCompare('4.0.0', redisVersion) < 1;
-        } catch (e) {
-          return false;
-        }
+        // UNLINK command was introduced in Redis 4.0.0
+        return this.isRedisVersionAtLeast('4.0.0');
       case RedisFeature.VRangeCommand:
-        try {
-          const redisVersion = await this.getRedisVersion();
-          // VRANGE command was introduced in Redis 8.4
-          return redisVersion && semverCompare('8.4', redisVersion) < 1;
-        } catch (e) {
-          return false;
-        }
+        // VRANGE command was introduced in Redis 8.4
+        return this.isRedisVersionAtLeast('8.4');
       case RedisFeature.VsimWithAttribs:
-        try {
-          const redisVersion = await this.getRedisVersion();
-          // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
-          return redisVersion && semverCompare('8.0.3', redisVersion) < 1;
-        } catch (e) {
-          return false;
-        }
+        // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
+        return this.isRedisVersionAtLeast('8.0.3');
       default:
         return false;
     }
   }
 
-  private async getRedisVersion(): Promise<string> {
+  private async isRedisVersionAtLeast(minVersion: string): Promise<boolean> {
+    try {
+      const redisVersion = await this.getRedisVersion();
+      if (!redisVersion) {
+        return false;
+      }
+      return semverCompare(minVersion, redisVersion) < 1;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  private async getRedisVersion(): Promise<string | undefined> {
     if (!this._redisVersion) {
       const infoData = await this.getInfo('server');
       this._redisVersion = infoData?.server?.redis_version;


### PR DESCRIPTION
# What

`VSIM ... WITHATTRIBS` is broken on Redis 8.0.0–8.0.2 (fixed in 8.0.3+). Added a `VsimWithAttribs` feature flag and made the `WITHATTRIBS` token optional in the VSIM command/preview/parse helpers.
On unsupported versions, the service omits `WITHATTRIBS` and back-fills attributes via a single `VGETATTR` pipeline (one entry per match). The controller, DTOs, request, and response shapes are unchanged.

# Testing

1. Connect to Redis 8.0.0–8.0.2 → run a similarity search on a vector set with attributes; verify results include `attributes` and the preview omits `WITHATTRIBS`.
2. Connect to Redis ≥ 8.0.3 → verify the canonical single-round-trip path still works and the preview shows `WITHATTRIBS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Redis-version-dependent behavior to the VectorSet similarity search path and introduces an additional `VGETATTR` pipeline fallback, which could impact correctness/performance on affected Redis versions if mishandled.
> 
> **Overview**
> **VectorSet similarity search is now Redis-version aware for `WITHATTRIBS`.** The service checks a new `RedisFeature.VsimWithAttribs` (fixed in Redis ≥ 8.0.3), conditionally omits `WITHATTRIBS` from the `VSIM` command/preview, and updates reply parsing to support both stride-3 (with attributes) and stride-2 (scores only) responses.
> 
> On Redis 8.0.0–8.0.2, the API keeps the response shape stable by back-filling per-match `attributes` using a single `VGETATTR` pipeline (swallowing per-element errors). Tests and factories are updated to cover both the canonical path and the fallback behavior, and Redis feature detection is refactored to use a shared version-check helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcae09a383c53823318e34ffa9653a35c605cc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->