### PR TITLE
e2e: run Chromium Playwright workflow against production web build

### DIFF
--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -1,4 +1,4 @@
-name: E2E Playwright - Chromium (Dev)
+name: E2E Playwright - Chromium
 
 on:
   workflow_call:
@@ -17,7 +17,7 @@ env:
 
 jobs:
   e2e-chromium:
-    name: E2E Chromium (Local Dev)
+    name: E2E Chromium (Web Build)
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 60
@@ -54,15 +54,18 @@ jobs:
       - name: Build statics
         run: yarn build:statics
 
+      - name: Build UI (production web bundle)
+        run: yarn build:ui
+
       - name: Build API
         run: yarn --cwd redisinsight/api build
 
-      - name: Start application (dev mode)
+      - name: Start application (production mode)
+        env:
+          RI_SERVE_STATICS: 'true'
         run: |
-          yarn dev:api &
-          yarn dev:ui &
-          # Wait for the app to be ready
-          npx wait-on http://localhost:8080 http://localhost:5540/api/health --timeout 60000
+          yarn --cwd redisinsight/api start:prod &
+          npx wait-on http://localhost:5540/api/health --timeout 120000
 
       - name: Ensure host.docker.internal resolves on the host
         run: |
@@ -101,6 +104,8 @@ jobs:
         run: npx playwright test --project=chromium --project=chromium-serial
         env:
           CI: true
+          RI_CLIENT_URL: http://localhost:5540
+          RI_API_URL: http://localhost:5540
 
       - name: Upload test results
         if: always()
@@ -114,10 +119,7 @@ jobs:
 
       - name: Stop application
         if: always()
-        run: |
-          # Kill any node processes running the app
-          pkill -f "dist/src/main" || true
-          pkill -f "vite dev" || true
+        run: pkill -f "dist/src/main" || true
 
       - name: Stop Redis test environment
         if: always()


### PR DESCRIPTION
# What

Replace `vite dev` + `nest start --watch` in the Chromium Playwright workflow with a built UI bundle served by the API in production mode. Same topology as the existing Docker workflow (both UI and API on port 5540) but without packaging the docker image.

The dev-mode setup was paying Vite's on-demand compile cost on every page load across 4 parallel workers + a serial pass, pushing the job to ~55 min vs ~15 min for Electron/Docker which run against built bundles. Expected runtime: ~15–20 min.

# Testing

- Add the `e2e-tests` label to this PR to trigger the workflow.
- Watch the **E2E Playwright - Chromium** job runtime — should drop from ~55 min to ~15–20 min.
- Verify all chromium + chromium-serial tests still pass against the production build.

# Notes

- `RI_CLIENT_URL` and `RI_API_URL` are both set to `http://localhost:5540` for the test run (the API serves the UI bundle from `redisinsight/ui/dist` when `RI_SERVE_STATICS=true`).
- We lose the "tests run against the dev server" property — but dev-server regressions are immediately visible to any engineer running `yarn dev:*` locally, so the CI speedup is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are confined to CI workflow orchestration, but could cause false negatives/positives if production build/serve behavior differs from the previous dev-mode setup.
> 
> **Overview**
> Runs Chromium Playwright E2E against a **production web bundle** instead of `vite dev`/watch mode.
> 
> The workflow now builds the UI via `yarn build:ui`, starts the API in `start:prod` with `RI_SERVE_STATICS=true`, waits on `http://localhost:5540/api/health`, and points tests to the unified server by setting `RI_CLIENT_URL`/`RI_API_URL` to `http://localhost:5540`. Cleanup is simplified to only kill the production API process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4322b06a3074e9684c57307c5d50315447e331ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->