### PR TITLE
docs: require agents to verify branch naming before opening PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ All detailed development standards are maintained in `.ai/rules/`:
 
 ### ✅ Always Do
 
+- Ensure the current branch name follows `.ai/skills/branches/SKILL.md` before opening a PR; rename it if it doesn't
 - Write to `src/` and `tests/` directories
 - Run `yarn lint` and `yarn test` before commits
 - Follow naming conventions (camelCase, PascalCase, UPPER_SNAKE_CASE)


### PR DESCRIPTION
# What

Lift branch-naming guidance into the **Always Do** list in `AGENTS.md` so AI coding agents check the current branch against the conventions in `.ai/skills/branches/SKILL.md` at PR time.

The skill was already linked from the references section, but as a passive doc pointer agents treated it as "consult if asked" rather than "verify every PR." This matters for agentic flows that auto-create worktrees with non-conformant branch names — the enforce-branch-name-rules workflow rejects those PRs.

# Testing

- Read the new line at `AGENTS.md` and confirm it directs agents to rename the current branch to match `.ai/skills/branches/SKILL.md` before opening a PR.
- This PR itself is the dogfood: the branch was originally auto-generated and was renamed to `docs/enforce-branch-naming-in-agents-md` per the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor/agent workflow guidance without affecting runtime code or CI behavior.
> 
> **Overview**
> Adds a new **Always Do** checklist item in `AGENTS.md` requiring agents to verify the current branch name matches `.ai/skills/branches/SKILL.md` (and rename it if not) before opening a PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cab418fa6bef9cbc80b804cd79ccb01f5165a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->