### PR TITLE
RI-8182 Add "Skip confirmations on non-production" settings toggle

### DIFF
--- a/redisinsight/ui/src/pages/settings/SettingsPage.tsx
+++ b/redisinsight/ui/src/pages/settings/SettingsPage.tsx
@@ -37,7 +37,10 @@ import {
   ThemeSettings,
   WorkbenchSettings,
 } from './components'
-import { DateTimeFormatter } from './components/general-settings'
+import {
+  DateTimeFormatter,
+  SkipConfirmations,
+} from './components/general-settings'
 import styles from './styles.module.scss'
 
 const SettingsPage = () => {
@@ -70,6 +73,7 @@ const SettingsPage = () => {
       <Divider />
       <Spacer />
       <DateTimeFormatter />
+      <SkipConfirmations />
     </>
   )
 

--- a/redisinsight/ui/src/pages/settings/components/general-settings/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/index.ts
@@ -1,5 +1,6 @@
 import DateTimeFormatter from './datetime-formatter/DateTimeFormatter'
+import SkipConfirmations from './skip-confirmations/SkipConfirmations'
 
-export { DateTimeFormatter }
+export { DateTimeFormatter, SkipConfirmations }
 
 export default DateTimeFormatter

--- a/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.spec.tsx
@@ -1,0 +1,90 @@
+import { cloneDeep } from 'lodash'
+import React from 'react'
+import { updateUserConfigSettingsAction } from 'uiSrc/slices/user/user-settings'
+import {
+  cleanup,
+  mockFeatureFlags,
+  mockedStore,
+  render,
+  screen,
+  userEvent,
+} from 'uiSrc/utils/test-utils'
+
+import SkipConfirmations from './SkipConfirmations'
+
+jest.mock('uiSrc/slices/user/user-settings', () => {
+  const original = jest.requireActual('uiSrc/slices/user/user-settings')
+  return {
+    ...original,
+    updateUserConfigSettingsAction: jest.fn(() => ({ type: 'TEST_ACTION' })),
+  }
+})
+
+let store: typeof mockedStore
+
+describe('SkipConfirmations', () => {
+  beforeEach(() => {
+    cleanup()
+    store = cloneDeep(mockedStore)
+    store.clearActions()
+    ;(updateUserConfigSettingsAction as jest.Mock).mockClear()
+    mockFeatureFlags({
+      'dev-prodMode': { flag: true },
+    })
+  })
+
+  it('should render with toggle off by default', () => {
+    render(<SkipConfirmations />, { store })
+
+    const toggle = screen.getByTestId(
+      'switch-skip-confirmations-non-production',
+    )
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).not.toBeChecked()
+  })
+
+  it('should reflect persisted on state from settings', () => {
+    const settings = store.getState().user.settings
+    const prevConfig = settings.config
+    // @ts-ignore-next-line
+    settings.config = {
+      ...prevConfig,
+      skipConfirmationsForNonProduction: true,
+    }
+
+    try {
+      render(<SkipConfirmations />, { store })
+
+      expect(
+        screen.getByTestId('switch-skip-confirmations-non-production'),
+      ).toBeChecked()
+    } finally {
+      // mockedStore.getState() shares state reference across cloneDeep — restore.
+      settings.config = prevConfig
+    }
+  })
+
+  it('should dispatch update action when toggled on', async () => {
+    render(<SkipConfirmations />, { store })
+
+    await userEvent.click(
+      screen.getByTestId('switch-skip-confirmations-non-production'),
+    )
+
+    expect(updateUserConfigSettingsAction).toHaveBeenCalledWith({
+      skipConfirmationsForNonProduction: true,
+    })
+  })
+
+  it('should not render when dev-prodMode feature flag is off', () => {
+    mockFeatureFlags({
+      'dev-prodMode': { flag: false },
+    })
+
+    render(<SkipConfirmations />, { store })
+
+    expect(
+      screen.queryByTestId('switch-skip-confirmations-non-production'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { FeatureFlags } from 'uiSrc/constants'
+import { FeatureFlagComponent } from 'uiSrc/components'
+import Divider from 'uiSrc/components/divider/Divider'
+import {
+  updateUserConfigSettingsAction,
+  userSettingsConfigSelector,
+} from 'uiSrc/slices/user/user-settings'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { SwitchInput } from 'uiSrc/components/base/inputs'
+import { Title } from 'uiSrc/components/base/text/Title'
+import { Text } from 'uiSrc/components/base/text'
+
+const SkipConfirmations = () => {
+  const { skipConfirmationsForNonProduction = false } =
+    useSelector(userSettingsConfigSelector) ?? {}
+
+  const dispatch = useDispatch()
+
+  const onToggle = (val: boolean) => {
+    dispatch(
+      updateUserConfigSettingsAction({
+        skipConfirmationsForNonProduction: val,
+      }),
+    )
+  }
+
+  return (
+    <FeatureFlagComponent name={FeatureFlags.devProdMode}>
+      <Divider />
+      <Spacer />
+      <Title size="M">Non-production databases</Title>
+      <Spacer size="m" />
+      <FormField>
+        <SwitchInput
+          checked={skipConfirmationsForNonProduction}
+          onCheckedChange={onToggle}
+          title="Skip confirmations on non-production"
+          data-testid="switch-skip-confirmations-non-production"
+        />
+      </FormField>
+      <Spacer size="s" />
+      <Text color="primary" size="s">
+        Skip additional confirmation dialogs when modifying data in
+        non-production databases.
+      </Text>
+    </FeatureFlagComponent>
+  )
+}
+
+export default SkipConfirmations

--- a/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/skip-confirmations/SkipConfirmations.tsx
@@ -43,8 +43,8 @@ const SkipConfirmations = () => {
       </FormField>
       <Spacer size="s" />
       <Text color="primary" size="s">
-        Skip additional confirmation dialogs when modifying data in
-        non-production databases.
+        Skip all confirmation dialogs when modifying data in non-production
+        databases.
       </Text>
     </FeatureFlagComponent>
   )


### PR DESCRIPTION
# What

Adds a new toggle in the General section of the Settings page that lets users skip additional confirmation dialogs when modifying data in non-production databases. Wired to the existing user-settings PATCH flow via the `skipConfirmationsForNonProduction` field. The entire row is gated behind the `dev-prodMode` feature flag.

The BE field on `UpdateSettingsDto` / `GetAppSettingsResponse` is already merged as part of the dependency ticket, so no BE or generated-client changes are required.

<img width="969" height="868" alt="Screenshot 2026-05-15 at 11 33 21" src="https://github.com/user-attachments/assets/b93d5c4b-915b-48b0-80ae-7576578fc3b7" />

# Testing

- Toggle is hidden when `dev-prodMode` flag is off; visible when on.
- Toggling persists via PATCH `/settings` and reloads correctly.
- Component spec covers: render, default off, persisted-on state, dispatch on toggle, flag-off no-render (4 tests, all green).

---

Closes #RI-8182

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reuses the existing user settings PATCH flow; behavior is gated behind the `dev-prodMode` feature flag and covered by a focused component test.
> 
> **Overview**
> Adds a new **General settings** toggle to let users set `skipConfirmationsForNonProduction`, allowing confirmation dialogs to be skipped when modifying data in non-production databases.
> 
> Introduces a feature-flagged `SkipConfirmations` component (render + persisted state + dispatch on toggle) and wires it into `SettingsPage`, along with a new spec verifying default/off, persisted/on, dispatch behavior, and flag-off non-render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d1bb8d8d1f0ccff6b573e566365d85cec91748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->