### PR TITLE
RI-8183 Add reusable TypeToConfirmModal component

### DIFF
--- a/redisinsight/ui/src/components/index.ts
+++ b/redisinsight/ui/src/components/index.ts
@@ -41,6 +41,7 @@ import {
 import { FormatedDate } from './formated-date'
 import { UploadWarning } from './upload-warning'
 import FormDialog from './form-dialog'
+import TypeToConfirmModal from './type-to-confirm-modal'
 
 export { FullScreen } from './full-screen'
 
@@ -88,4 +89,5 @@ export {
   FormatedDate,
   UploadWarning,
   FormDialog,
+  TypeToConfirmModal,
 }

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import TypeToConfirmModal, { Props } from './TypeToConfirmModal'
 
 const mockProps: Props = {
-  dbName: 'prod-cache-eu-west-1',
+  confirmationText: 'prod-cache-eu-west-1',
   actionDescription: 'This will run FLUSHDB against prod-cache-eu-west-1.',
   onConfirm: jest.fn(),
   onCancel: jest.fn(),
@@ -70,7 +70,7 @@ describe('TypeToConfirmModal', () => {
     ).toBeDisabled()
   })
 
-  it('confirm button should be disabled when typed value does not match dbName', () => {
+  it('confirm button should be disabled when typed value does not match confirmationText', () => {
     render(<TypeToConfirmModal {...mockProps} />)
 
     typeInConfirmInput('not-the-name')
@@ -80,7 +80,7 @@ describe('TypeToConfirmModal', () => {
     ).toBeDisabled()
   })
 
-  it('confirm button should be enabled when typed value exactly matches dbName', () => {
+  it('confirm button should be enabled when typed value exactly matches confirmationText', () => {
     render(<TypeToConfirmModal {...mockProps} />)
 
     typeInConfirmInput('prod-cache-eu-west-1')

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import TypeToConfirmModal, { Props } from './TypeToConfirmModal'
+
+const mockProps: Props = {
+  dbName: 'prod-cache-eu-west-1',
+  actionDescription: 'This will run FLUSHDB against prod-cache-eu-west-1.',
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+jest.mock('uiSrc/components/base/display', () => {
+  const actual = jest.requireActual('uiSrc/components/base/display')
+
+  return {
+    ...actual,
+    Modal: {
+      ...actual.Modal,
+      Content: {
+        ...actual.Modal.Content,
+        Header: {
+          ...actual.Modal.Content.Header,
+          Title: jest.fn().mockReturnValue(null),
+        },
+      },
+    },
+  }
+})
+
+const typeInConfirmInput = (value: string) => {
+  fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+    target: { value },
+  })
+}
+
+describe('TypeToConfirmModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render', () => {
+    expect(render(<TypeToConfirmModal {...mockProps} />)).toBeTruthy()
+  })
+
+  it('should render the action description', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-description'),
+    ).toHaveTextContent('This will run FLUSHDB against prod-cache-eu-west-1.')
+  })
+
+  it('should accept a ReactNode as actionDescription', () => {
+    render(
+      <TypeToConfirmModal
+        {...mockProps}
+        actionDescription={<span data-testid="custom-desc">custom desc</span>}
+      />,
+    )
+
+    expect(screen.getByTestId('custom-desc')).toBeInTheDocument()
+  })
+
+  it('confirm button should be disabled by default', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toBeDisabled()
+  })
+
+  it('confirm button should be disabled when typed value does not match dbName', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    typeInConfirmInput('not-the-name')
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toBeDisabled()
+  })
+
+  it('confirm button should be enabled when typed value exactly matches dbName', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    typeInConfirmInput('prod-cache-eu-west-1')
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).not.toBeDisabled()
+  })
+
+  it('match should be case-sensitive', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    typeInConfirmInput('PROD-CACHE-EU-WEST-1')
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toBeDisabled()
+  })
+
+  it('should not fire onConfirm when typed value does not match', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    typeInConfirmInput('mismatch')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(mockProps.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('should fire onConfirm when typed value matches and confirm is clicked', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    typeInConfirmInput('prod-cache-eu-west-1')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(mockProps.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fire onCancel when cancel button is clicked', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
+
+    expect(mockProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel button should be the default-focused action', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    expect(screen.getByTestId('type-to-confirm-modal-cancel-btn')).toHaveFocus()
+  })
+
+  it('should render custom button labels when provided', () => {
+    render(
+      <TypeToConfirmModal
+        {...mockProps}
+        confirmButtonText="Run FLUSHDB"
+        cancelButtonText="Back"
+      />,
+    )
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toHaveTextContent('Run FLUSHDB')
+    expect(
+      screen.getByTestId('type-to-confirm-modal-cancel-btn'),
+    ).toHaveTextContent('Back')
+  })
+})

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 
 import { Modal } from 'uiSrc/components/base/display'
 import { CancelIcon } from 'uiSrc/components/base/icons'
@@ -12,7 +12,7 @@ import { TextInput } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
 
 export interface Props {
-  dbName: string
+  confirmationText: string
   actionDescription: React.ReactNode
   onConfirm: () => void
   onCancel: () => void
@@ -22,7 +22,7 @@ export interface Props {
 }
 
 const TypeToConfirmModal = ({
-  dbName,
+  confirmationText,
   actionDescription,
   onConfirm,
   onCancel,
@@ -31,8 +31,7 @@ const TypeToConfirmModal = ({
   cancelButtonText = 'Cancel',
 }: Props) => {
   const [value, setValue] = useState('')
-
-  const isMatch = useMemo(() => value === dbName, [value, dbName])
+  const isMatch = value === confirmationText
 
   const handleConfirm = () => {
     if (!isMatch) return
@@ -63,7 +62,7 @@ const TypeToConfirmModal = ({
               <FormField
                 label={
                   <span>
-                    Type <strong>{dbName}</strong> to confirm
+                    Type <strong>{confirmationText}</strong> to confirm
                   </span>
                 }
               >

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo, useState } from 'react'
+
+import { Modal } from 'uiSrc/components/base/display'
+import { CancelIcon } from 'uiSrc/components/base/icons'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import {
+  DestructiveButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Text } from 'uiSrc/components/base/text'
+
+export interface Props {
+  dbName: string
+  actionDescription: React.ReactNode
+  onConfirm: () => void
+  onCancel: () => void
+  title?: React.ReactNode
+  confirmButtonText?: string
+  cancelButtonText?: string
+}
+
+const TypeToConfirmModal = ({
+  dbName,
+  actionDescription,
+  onConfirm,
+  onCancel,
+  title = 'Confirm action',
+  confirmButtonText = 'Confirm',
+  cancelButtonText = 'Cancel',
+}: Props) => {
+  const [value, setValue] = useState('')
+
+  const isMatch = useMemo(() => value === dbName, [value, dbName])
+
+  const handleConfirm = () => {
+    if (!isMatch) return
+    onConfirm()
+  }
+
+  return (
+    <Modal.Compose open>
+      <Modal.Content.Compose persistent onCancel={onCancel}>
+        <Modal.Content.Close
+          icon={CancelIcon}
+          onClick={onCancel}
+          data-testid="type-to-confirm-modal-close-btn"
+        />
+
+        <Modal.Content.Header.Compose>
+          <Modal.Content.Header.Title data-testid="type-to-confirm-modal-title">
+            {title}
+          </Modal.Content.Header.Title>
+        </Modal.Content.Header.Compose>
+
+        <Modal.Content.Body
+          content={
+            <Col gap="l">
+              <Text data-testid="type-to-confirm-modal-description">
+                {actionDescription}
+              </Text>
+              <FormField
+                label={
+                  <span>
+                    Type <strong>{dbName}</strong> to confirm
+                  </span>
+                }
+              >
+                <TextInput
+                  autoFocus={false}
+                  value={value}
+                  onChange={setValue}
+                  autoComplete="off"
+                  spellCheck={false}
+                  data-testid="type-to-confirm-modal-input"
+                />
+              </FormField>
+            </Col>
+          }
+        />
+
+        <Modal.Content.Footer.Compose>
+          <Modal.Content.Footer.Group>
+            <Row gap="m" justify="end">
+              <SecondaryButton
+                size="l"
+                autoFocus
+                onClick={onCancel}
+                data-testid="type-to-confirm-modal-cancel-btn"
+              >
+                {cancelButtonText}
+              </SecondaryButton>
+              <DestructiveButton
+                size="l"
+                onClick={handleConfirm}
+                disabled={!isMatch}
+                data-testid="type-to-confirm-modal-confirm-btn"
+              >
+                {confirmButtonText}
+              </DestructiveButton>
+            </Row>
+          </Modal.Content.Footer.Group>
+        </Modal.Content.Footer.Compose>
+      </Modal.Content.Compose>
+    </Modal.Compose>
+  )
+}
+
+export default TypeToConfirmModal

--- a/redisinsight/ui/src/components/type-to-confirm-modal/index.ts
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/index.ts
@@ -1,0 +1,6 @@
+import TypeToConfirmModal from './TypeToConfirmModal'
+
+export { TypeToConfirmModal }
+export type { Props as TypeToConfirmModalProps } from './TypeToConfirmModal'
+
+export default TypeToConfirmModal


### PR DESCRIPTION
# What

Adds a shared `TypeToConfirmModal` for gating destructive actions behind a case-sensitive type-to-confirm input. Renders an action description, a text input that must exactly match a provided `dbName`, a red Confirm button (disabled until match), and a Cancel button as the default-focused action.

This is the building block ticket — no consumers are wired in this PR. Bulk delete, CLI, and Workbench dangerous-command gates will adopt it in their own tickets. Design can be altered later.

<img width="766" height="467" alt="Screenshot 2026-05-15 at 12 54 19" src="https://github.com/user-attachments/assets/936901c8-b515-4278-8248-93dd2dfbf984" />
<img width="730" height="495" alt="Screenshot 2026-05-15 at 12 54 24" src="https://github.com/user-attachments/assets/fcaa200a-f425-40a9-96c5-2ea6e50f3ad7" />

# Testing

```bash
yarn --cwd redisinsight/ui test redisinsight/ui/src/components/type-to-confirm-modal
```

Verify:
- Confirm is disabled until the input value exactly matches `my-db` (case-sensitive).
- Clicking Cancel (which is focused on open) calls `onCancel`.
- Clicking Confirm after a match calls `onConfirm`.

---

Closes RI-8183

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new shared UI modal component and tests, with no changes to business logic or data flows; risk is limited to potential UX/accessibility regressions when adopted by future consumers.
> 
> **Overview**
> Introduces a reusable `TypeToConfirmModal` component that gates destructive actions behind a case-sensitive “type to confirm” input, with configurable title/description and confirm/cancel button labels.
> 
> Adds unit coverage for enabling/disabling confirm, case-sensitive matching, default focus on cancel, and confirm/cancel callbacks, and exports the new component via `components/index.ts` for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8398d7b251d36b3becaa662ba58cd35733284fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->