### PR TITLE
RI-8180 Add production toggle to add/edit connection form

### DIFF
--- a/redisinsight/ui/src/pages/home/components/form/ProductionToggle.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/ProductionToggle.tsx
@@ -1,0 +1,64 @@
+import React, { ChangeEvent } from 'react'
+import { FormikProps } from 'formik'
+
+import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
+import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { RiTooltip } from 'uiSrc/components'
+import { useGenerateId } from 'uiSrc/components/base/utils/hooks/generate-id'
+import { Text } from 'uiSrc/components/base/text/Text'
+
+export interface Props {
+  formik: FormikProps<DbConnectionInfo>
+}
+
+const ProductionToggleLabel = () => (
+  <Row align="center" gap="s">
+    <Text>Production</Text>
+    <RiTooltip
+      position="right"
+      content={
+        <Text>
+          When marked as production, Redis Insight adds an extra layer of
+          protection to prevent unintended changes. This includes additional
+          confirmation dialogs before modifying data and stronger friction
+          before running dangerous commands.
+        </Text>
+      }
+    >
+      <FlexItem>
+        <RiIcon type="InfoIcon" style={{ cursor: 'pointer' }} />
+      </FlexItem>
+    </RiTooltip>
+  </Row>
+)
+
+const ProductionToggle = (props: Props) => {
+  const { formik } = props
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    formik.handleChange(e)
+  }
+  const id = useGenerateId('', ' over isProduction')
+
+  return (
+    <Row gap="s">
+      <FlexItem>
+        <FormField>
+          <Checkbox
+            id={id}
+            name="isProduction"
+            label={<ProductionToggleLabel />}
+            checked={!!formik.values.isProduction}
+            onChange={handleChange}
+            data-testid="isProduction"
+          />
+        </FormField>
+      </FlexItem>
+    </Row>
+  )
+}
+
+export default ProductionToggle

--- a/redisinsight/ui/src/pages/home/components/form/index.ts
+++ b/redisinsight/ui/src/pages/home/components/form/index.ts
@@ -6,6 +6,7 @@ import TlsDetails from './TlsDetails'
 import DatabaseForm from './DatabaseForm'
 import SSHDetails from './SSHDetails'
 import ForceStandalone from './ForceStandalone'
+import ProductionToggle from './ProductionToggle'
 import KeyFormatSelector from './KeyFormatSelector'
 
 export {
@@ -18,5 +19,6 @@ export {
   SSHDetails,
   DbCompressor,
   ForceStandalone,
+  ProductionToggle,
   KeyFormatSelector,
 }

--- a/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx
@@ -7,6 +7,7 @@ import ManualConnectionFrom, {
   Props as ManualConnectionFromProps,
 } from 'uiSrc/pages/home/components/manual-connection/manual-connection-form/ManualConnectionForm'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { createInstanceStandaloneAction } from 'uiSrc/slices/instances/instances'
 import ManualConnectionWrapper, { Props } from './ManualConnectionWrapper'
 
 const mockedProps = mock<Props>()
@@ -20,6 +21,11 @@ jest.mock('./manual-connection-form/ManualConnectionForm', () => ({
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
   sendEventTelemetry: jest.fn(),
+}))
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  createInstanceStandaloneAction: jest.fn(() => ({ type: 'noop' })),
 }))
 
 const mockManualConnectionFrom = (props: ManualConnectionFromProps) => (
@@ -44,6 +50,20 @@ const mockManualConnectionFrom = (props: ManualConnectionFromProps) => (
       onClick={() => props.onSubmit({})}
     >
       {props.submitButtonText}
+    </button>
+    <button
+      type="button"
+      data-testid="btn-submit-prod"
+      onClick={() =>
+        props.onSubmit({
+          name: 'db',
+          host: 'localhost',
+          port: '6379',
+          isProduction: true,
+        })
+      }
+    >
+      submit with isProduction
     </button>
     <button
       type="button"
@@ -120,6 +140,19 @@ describe('ManualConnectionWrapper', () => {
     expect(sendEventTelemetry).toBeCalledWith({
       event: TelemetryEvent.CONFIG_DATABASES_MANUALLY_SUBMITTED,
     })
+  })
+
+  it('should pass isProduction through preparePayload to the create action', () => {
+    ;(createInstanceStandaloneAction as jest.Mock).mockClear()
+    render(<ManualConnectionWrapper {...instance(mockedProps)} />)
+    act(() => {
+      fireEvent.click(screen.getByTestId('btn-submit-prod'))
+    })
+
+    expect(createInstanceStandaloneAction).toHaveBeenCalledWith(
+      expect.objectContaining({ isProduction: true }),
+      expect.anything(),
+    )
   })
 
   it('should call proper telemetry event on Clone database', () => {

--- a/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.tsx
@@ -211,6 +211,7 @@ const ManualConnectionWrapper = (props: Props) => {
       tls,
       forceStandalone,
       keyNameFormat,
+      isProduction,
     } = values
 
     const database: any = {
@@ -227,6 +228,7 @@ const ManualConnectionWrapper = (props: Props) => {
       tls,
       forceStandalone,
       keyNameFormat,
+      isProduction,
     }
 
     // add tls & ssh for database (modifies database object)

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -13,6 +13,8 @@ import { appRedirectionSelector } from 'uiSrc/slices/app/url-handling'
 import { UrlHandlingActions } from 'uiSrc/slices/interfaces/urlHandling'
 import { ADD_NEW_CA_CERT, SshPassType } from 'uiSrc/pages/home/constants'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
+import { FeatureFlags } from 'uiSrc/constants/featureFlags'
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 
 import ManualConnectionForm, { Props } from './ManualConnectionForm'
 
@@ -42,6 +44,11 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 jest.mock('uiSrc/slices/app/url-handling', () => ({
   ...jest.requireActual('uiSrc/slices/app/url-handling'),
   appRedirectionSelector: jest.fn().mockReturnValue(() => ({ action: null })),
+}))
+
+jest.mock('uiSrc/slices/app/features', () => ({
+  ...jest.requireActual('uiSrc/slices/app/features'),
+  appFeatureFlagsFeaturesSelector: jest.fn().mockReturnValue({}),
 }))
 
 describe('InstanceForm', () => {
@@ -1403,5 +1410,94 @@ describe('InstanceForm', () => {
       })
     })
     expect(handleSubmit).toHaveBeenCalled()
+  })
+
+  describe('Production toggle', () => {
+    it('should not render the toggle when the devProdMode flag is off', () => {
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
+        [FeatureFlags.devProdMode]: { flag: false },
+      })
+
+      render(
+        <ManualConnectionForm
+          {...instance(mockedProps)}
+          isEditMode={false}
+          formFields={formFields}
+        />,
+      )
+
+      expect(screen.queryByTestId('isProduction')).not.toBeInTheDocument()
+    })
+
+    it('should render the toggle (off by default) when the devProdMode flag is on', () => {
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValue({
+        [FeatureFlags.devProdMode]: { flag: true },
+      })
+
+      render(
+        <ManualConnectionForm
+          {...instance(mockedProps)}
+          isEditMode={false}
+          formFields={formFields}
+        />,
+      )
+
+      const toggle = screen.getByTestId('isProduction')
+      expect(toggle).toBeInTheDocument()
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReset()
+    })
+
+    it('should pre-fill the toggle from the existing connection on edit', () => {
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValue({
+        [FeatureFlags.devProdMode]: { flag: true },
+      })
+
+      render(
+        <ManualConnectionForm
+          {...instance(mockedProps)}
+          isEditMode
+          formFields={{ ...formFields, isProduction: true }}
+        />,
+      )
+
+      const toggle = screen.getByTestId('isProduction')
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReset()
+    })
+
+    it('should submit isProduction in the payload when toggled on', async () => {
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValue({
+        [FeatureFlags.devProdMode]: { flag: true },
+      })
+      const handleSubmit = jest.fn()
+
+      render(
+        <div id="footerDatabaseForm">
+          <ManualConnectionForm
+            {...instance(mockedProps)}
+            isEditMode={false}
+            formFields={formFields}
+            onSubmit={handleSubmit}
+          />
+        </div>,
+      )
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('isProduction'))
+      })
+      await act(async () => {
+        fireEvent.keyDown(screen.getByTestId('form'), {
+          key: 'Enter',
+          code: 13,
+          charCode: 13,
+        })
+      })
+
+      expect(handleSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ isProduction: true }),
+      )
+      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReset()
+    })
   })
 })

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
@@ -7,10 +7,13 @@ import {
   SSHDetails,
   TlsDetails,
 } from 'uiSrc/pages/home/components/form'
+import ProductionToggle from 'uiSrc/pages/home/components/form/ProductionToggle'
 import Divider from 'uiSrc/components/divider/Divider'
 import { BuildType } from 'uiSrc/constants/env'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
 import { Spacer } from 'uiSrc/components/base/layout'
+import FeatureFlagComponent from 'uiSrc/components/feature-flag-component'
+import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import DecompressionAndFormatters from './DecompressionAndFormatters'
 import { ManualFormTab } from '../constants'
 
@@ -57,6 +60,14 @@ const AddConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
+          <FeatureFlagComponent name={FeatureFlags.devProdMode}>
+            <>
+              <Spacer size="m" />
+              <Divider />
+              <Spacer size="m" />
+              <ProductionToggle formik={formik} />
+            </>
+          </FeatureFlagComponent>
         </>
       )}
       {activeTab === ManualFormTab.Security && (

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -7,10 +7,13 @@ import {
   SSHDetails,
   TlsDetails,
 } from 'uiSrc/pages/home/components/form'
+import ProductionToggle from 'uiSrc/pages/home/components/form/ProductionToggle'
 import { Spacer } from 'uiSrc/components/base/layout'
 import Divider from 'uiSrc/components/divider/Divider'
 import { BuildType } from 'uiSrc/constants/env'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
+import FeatureFlagComponent from 'uiSrc/components/feature-flag-component'
+import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import DecompressionAndFormatters from './DecompressionAndFormatters'
 
 import { AZURE_READONLY_FIELDS, ManualFormTab } from '../constants'
@@ -72,6 +75,14 @@ const EditConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
+          <FeatureFlagComponent name={FeatureFlags.devProdMode}>
+            <>
+              <Spacer size="m" />
+              <Divider />
+              <Spacer size="m" />
+              <ProductionToggle formik={formik} />
+            </>
+          </FeatureFlagComponent>
           {isCloneMode && (
             <>
               <Spacer size="m" />

--- a/redisinsight/ui/src/slices/interfaces/instances.ts
+++ b/redisinsight/ui/src/slices/interfaces/instances.ts
@@ -56,6 +56,7 @@ export interface Instance extends Partial<DatabaseInstanceResponse> {
   visible?: boolean
   loading?: boolean
   isFreeDb?: boolean
+  isProduction?: boolean
   tags?: Tag[]
 }
 


### PR DESCRIPTION
# What

Adds an `isProduction` boolean toggle to the manual connection add/edit form, gated by the `dev-prodMode` feature flag. Defaults to off, pre-fills from the existing connection on edit, submits via the existing DTO so the BE persists it.

<img width="1087" height="484" alt="Screenshot 2026-05-15 at 13 22 32" src="https://github.com/user-attachments/assets/9e656119-2e4a-451f-bb91-e7200d518873" />


**No FE telemetry** — `RedisInstanceAdded` / `RedisInstanceEditedByUser` already carry `isProduction` (and `previousValues.isProduction` on edit) from [RI-8177](https://redislabs.atlassian.net/browse/RI-8177), which fully covers the PRD's tracking requirements.

# Testing

1. Enable `dev-prodMode` flag in `features-config.json`.
2. Open Add Database — the **Production** checkbox appears at the bottom of the General tab (under Force Standalone), tooltip matches PRD copy.
3. Toggle on, submit → DB persists `isProduction: true` (verify via GET `/databases/:id`).
4. Edit the same connection → toggle is pre-checked. Toggle off, submit → persists `isProduction: false`.
5. Disable the flag → toggle disappears in both Add and Edit forms.
6. Unit tests: `yarn jest redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx` (48/48 passing).

---

Closes #RI-8180

[RI-8177]: https://redislabs.atlassian.net/browse/RI-8177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI and payload extension gated behind `FeatureFlags.devProdMode`; main risk is accidental omission/mis-wiring of `isProduction` in create/edit flows.
> 
> **Overview**
> Adds a new `ProductionToggle` checkbox (with tooltip copy) to the **General** tab of manual add/edit connection forms, rendered only when `FeatureFlags.devProdMode` is enabled.
> 
> Threads `isProduction` from Formik values into `ManualConnectionWrapper.preparePayload()` so create/update actions receive and persist it, and extends the `Instance` interface with an optional `isProduction` field.
> 
> Updates unit tests to cover flag-gated rendering, prefill on edit, submission payload inclusion, and wrapper passing `isProduction` through to `createInstanceStandaloneAction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d705f0996b547791d71df520a6a56dfa8c75d37a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->