### PR TITLE
RI-8196 Enrich BE analytics events with isProduction

### DIFF
--- a/redisinsight/api/src/__mocks__/bulk-actions.ts
+++ b/redisinsight/api/src/__mocks__/bulk-actions.ts
@@ -28,6 +28,7 @@ export const mockBulkActionOverview = {
     errors: [],
     keys: [],
   },
+  confirmedThrough: null,
 };
 
 export const mockDefaultDataManifest = {

--- a/redisinsight/api/src/__mocks__/databases.ts
+++ b/redisinsight/api/src/__mocks__/databases.ts
@@ -325,6 +325,12 @@ export const mockDatabaseRepository = jest.fn(() => ({
   cleanupPreSetup: jest.fn().mockResolvedValue({ affected: 0 }),
 }));
 
+export const mockDangerousCommandsProvider = jest.fn(() => ({
+  getDangerousCommands: jest.fn().mockResolvedValue([]),
+  invalidate: jest.fn(),
+  handleInstanceDeletedEvent: jest.fn(),
+}));
+
 export const mockDatabaseService = jest.fn(() => ({
   get: jest.fn().mockResolvedValue(mockDatabase),
   create: jest.fn().mockResolvedValue(mockDatabase),

--- a/redisinsight/api/src/__mocks__/profiler.ts
+++ b/redisinsight/api/src/__mocks__/profiler.ts
@@ -55,6 +55,7 @@ export const mockProfilerAnalyticsService: MockType<ProfilerAnalyticsService> =
   {
     sendLogDeleted: jest.fn(),
     sendLogDownloaded: jest.fn(),
+    sendProfilerStartedEvent: jest.fn(),
     getEventsEmitters: jest
       .fn()
       .mockImplementation(() => mockProfilerAnalyticsEvents),

--- a/redisinsight/api/src/constants/telemetry-events.ts
+++ b/redisinsight/api/src/constants/telemetry-events.ts
@@ -84,6 +84,7 @@ export enum TelemetryEvents {
   // Profiler
   ProfilerLogDownloaded = 'PROFILER_LOG_DOWNLOADED',
   ProfilerLogDeleted = 'PROFILER_LOG_DELETED',
+  ProfilerStarted = 'PROFILER_STARTED',
 
   // Slowlog
   SlowlogSetLogSlowerThan = 'SLOWLOG_SET_LOG_SLOWER_THAN',

--- a/redisinsight/api/src/modules/bulk-actions/bulk-actions.analytics.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-actions.analytics.spec.ts
@@ -2,30 +2,50 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   mockBulkActionOverview,
+  mockDatabase,
+  mockDatabaseRepository,
+  MockType,
   mockRedisNoAuthError,
   mockSessionMetadata,
 } from 'src/__mocks__';
 import { TelemetryEvents } from 'src/constants';
 import { BulkActionsAnalytics } from 'src/modules/bulk-actions/bulk-actions.analytics';
+import {
+  BulkActionConfirmation,
+  BulkActionType,
+} from 'src/modules/bulk-actions/constants';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 
 describe('BulkActionsAnalytics', () => {
   let service: BulkActionsAnalytics;
   let sendEventSpy;
   let sendFailedEventSpy;
+  let databaseRepository: MockType<DatabaseRepository>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BulkActionsAnalytics, EventEmitter2],
+      providers: [
+        BulkActionsAnalytics,
+        EventEmitter2,
+        {
+          provide: DatabaseRepository,
+          useFactory: mockDatabaseRepository,
+        },
+      ],
     }).compile();
 
     service = await module.get(BulkActionsAnalytics);
+    databaseRepository = module.get(DatabaseRepository);
     sendEventSpy = jest.spyOn(service as any, 'sendEvent');
     sendFailedEventSpy = jest.spyOn(service as any, 'sendFailedEvent');
   });
 
   describe('sendActionStarted', () => {
-    it('should emit event when action started (without summary)', () => {
-      service.sendActionStarted(mockSessionMetadata, mockBulkActionOverview);
+    it('should emit event when action started (without summary)', async () => {
+      await service.sendActionStarted(
+        mockSessionMetadata,
+        mockBulkActionOverview,
+      );
 
       expect(sendEventSpy).toHaveBeenCalledWith(
         mockSessionMetadata,
@@ -44,11 +64,14 @@ describe('BulkActionsAnalytics', () => {
             total: mockBulkActionOverview.progress.total,
             totalRange: '0 - 5 000',
           },
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should emit event when action started without progress data and filter as "PATTERN"', () => {
-      service.sendActionStarted(mockSessionMetadata, {
+    it('should emit event when action started without progress data and filter as "PATTERN"', async () => {
+      await service.sendActionStarted(mockSessionMetadata, {
         ...mockBulkActionOverview,
         filter: { match: 'some query', type: null },
         progress: undefined,
@@ -66,11 +89,14 @@ describe('BulkActionsAnalytics', () => {
             type: mockBulkActionOverview.filter?.type,
           },
           progress: {},
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should emit event when action started without progress and filter', () => {
-      service.sendActionStarted(mockSessionMetadata, {
+    it('should emit event when action started without progress and filter', async () => {
+      await service.sendActionStarted(mockSessionMetadata, {
         ...mockBulkActionOverview,
         filter: undefined,
         progress: undefined,
@@ -87,18 +113,65 @@ describe('BulkActionsAnalytics', () => {
             match: 'PATTERN', // todo: is this expected behavior?
           },
           progress: {},
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should not emit event in case of an error and should not fail', () => {
-      service.sendActionStarted(mockSessionMetadata, undefined);
+    it('should emit isProduction=true when database is production', async () => {
+      databaseRepository.get.mockResolvedValueOnce({
+        ...mockDatabase,
+        isProduction: true,
+      });
+
+      await service.sendActionStarted(
+        mockSessionMetadata,
+        mockBulkActionOverview,
+      );
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.BulkActionsStarted,
+        expect.objectContaining({ isProduction: 'true' }),
+      );
+    });
+    it('should round-trip confirmedThrough from overview', async () => {
+      await service.sendActionStarted(mockSessionMetadata, {
+        ...mockBulkActionOverview,
+        confirmedThrough: BulkActionConfirmation.TypeToConfirm,
+      });
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.BulkActionsStarted,
+        expect.objectContaining({ confirmedThrough: 'type-to-confirm' }),
+      );
+    });
+    it('should emit dangerous=false for Upload bulk action', async () => {
+      await service.sendActionStarted(mockSessionMetadata, {
+        ...mockBulkActionOverview,
+        type: BulkActionType.Upload,
+      });
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.BulkActionsStarted,
+        expect.objectContaining({ dangerous: 'false' }),
+      );
+    });
+    it('should not emit event in case of an error and should not fail', async () => {
+      await service.sendActionStarted(mockSessionMetadata, undefined);
       expect(sendEventSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('sendActionStopped', () => {
-    it('should emit event when action paused/stopped', () => {
-      service.sendActionStopped(mockSessionMetadata, mockBulkActionOverview);
+    it('should emit event when action paused/stopped', async () => {
+      await service.sendActionStopped(
+        mockSessionMetadata,
+        mockBulkActionOverview,
+      );
 
       expect(sendEventSpy).toHaveBeenCalledWith(
         mockSessionMetadata,
@@ -125,11 +198,14 @@ describe('BulkActionsAnalytics', () => {
             failed: mockBulkActionOverview.summary.failed,
             failedRange: '0 - 5 000',
           },
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should emit event when action paused/stopped without progress, filter and summary', () => {
-      service.sendActionStopped(mockSessionMetadata, {
+    it('should emit event when action paused/stopped without progress, filter and summary', async () => {
+      await service.sendActionStopped(mockSessionMetadata, {
         ...mockBulkActionOverview,
         filter: undefined,
         progress: undefined,
@@ -148,18 +224,24 @@ describe('BulkActionsAnalytics', () => {
           },
           progress: {},
           summary: {},
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should not emit event in case of an error and should not fail', () => {
-      service.sendActionStopped(mockSessionMetadata, undefined);
+    it('should not emit event in case of an error and should not fail', async () => {
+      await service.sendActionStopped(mockSessionMetadata, undefined);
       expect(sendEventSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('sendActionSucceed', () => {
-    it('should emit event when action succeed (without progress)', () => {
-      service.sendActionSucceed(mockSessionMetadata, mockBulkActionOverview);
+    it('should emit event when action succeed (without progress)', async () => {
+      await service.sendActionSucceed(
+        mockSessionMetadata,
+        mockBulkActionOverview,
+      );
 
       expect(sendEventSpy).toHaveBeenCalledWith(
         mockSessionMetadata,
@@ -180,11 +262,14 @@ describe('BulkActionsAnalytics', () => {
             failed: mockBulkActionOverview.summary.failed,
             failedRange: '0 - 5 000',
           },
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should emit event when action succeed without filter and summary', () => {
-      service.sendActionSucceed(mockSessionMetadata, {
+    it('should emit event when action succeed without filter and summary', async () => {
+      await service.sendActionSucceed(mockSessionMetadata, {
         ...mockBulkActionOverview,
         filter: undefined,
         summary: undefined,
@@ -201,18 +286,21 @@ describe('BulkActionsAnalytics', () => {
             match: 'PATTERN', // todo: is this expected behavior?
           },
           summary: {},
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should not emit event in case of an error and should not fail', () => {
-      service.sendActionSucceed(mockSessionMetadata, undefined);
+    it('should not emit event in case of an error and should not fail', async () => {
+      await service.sendActionSucceed(mockSessionMetadata, undefined);
       expect(sendEventSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('sendActionFailed', () => {
-    it('should emit event when action failed (without progress)', () => {
-      service.sendActionFailed(
+    it('should emit event when action failed (without progress)', async () => {
+      await service.sendActionFailed(
         mockSessionMetadata,
         mockBulkActionOverview,
         mockRedisNoAuthError,
@@ -225,18 +313,21 @@ describe('BulkActionsAnalytics', () => {
           databaseId: mockBulkActionOverview.databaseId,
           action: mockBulkActionOverview.type,
           error: mockRedisNoAuthError,
+          isProduction: 'false',
+          dangerous: 'true',
+          confirmedThrough: null,
         },
       );
     });
-    it('should not emit event in case of an error and should not fail', () => {
-      service.sendActionFailed(mockSessionMetadata, undefined, undefined);
+    it('should not emit event in case of an error and should not fail', async () => {
+      await service.sendActionFailed(mockSessionMetadata, undefined, undefined);
       expect(sendFailedEventSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('sendImportSamplesUploaded', () => {
-    it('should emit event when action succeed (without progress)', () => {
-      service.sendImportSamplesUploaded(
+    it('should emit event when action succeed (without progress)', async () => {
+      await service.sendImportSamplesUploaded(
         mockSessionMetadata,
         mockBulkActionOverview,
       );
@@ -256,11 +347,12 @@ describe('BulkActionsAnalytics', () => {
             failed: mockBulkActionOverview.summary.failed,
             failedRange: '0 - 5 000',
           },
+          isProduction: 'false',
         },
       );
     });
-    it('should emit event when action succeed without filter and summary', () => {
-      service.sendImportSamplesUploaded(mockSessionMetadata, {
+    it('should emit event when action succeed without filter and summary', async () => {
+      await service.sendImportSamplesUploaded(mockSessionMetadata, {
         ...mockBulkActionOverview,
         filter: undefined,
         summary: undefined,
@@ -274,11 +366,12 @@ describe('BulkActionsAnalytics', () => {
           action: mockBulkActionOverview.type,
           duration: mockBulkActionOverview.duration,
           summary: {},
+          isProduction: 'false',
         },
       );
     });
-    it('should not emit event in case of an error and should not fail', () => {
-      service.sendImportSamplesUploaded(mockSessionMetadata, undefined);
+    it('should not emit event in case of an error and should not fail', async () => {
+      await service.sendImportSamplesUploaded(mockSessionMetadata, undefined);
       expect(sendEventSpy).not.toHaveBeenCalled();
     });
   });

--- a/redisinsight/api/src/modules/bulk-actions/bulk-actions.analytics.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-actions.analytics.ts
@@ -1,16 +1,56 @@
 import { HttpException, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TelemetryEvents } from 'src/constants';
 import { TelemetryBaseService } from 'src/modules/analytics/telemetry.base.service';
 import { getRangeForNumber, BULK_ACTIONS_BREAKPOINTS } from 'src/utils';
 import { IBulkActionOverview } from 'src/modules/bulk-actions/interfaces/bulk-action-overview.interface';
 import { SessionMetadata } from 'src/common/models';
+import {
+  BulkActionType,
+  BulkActionConfirmation,
+} from 'src/modules/bulk-actions/constants';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 
 @Injectable()
 export class BulkActionsAnalytics extends TelemetryBaseService {
-  sendActionStarted(
+  constructor(
+    protected eventEmitter: EventEmitter2,
+    private readonly databaseRepository: DatabaseRepository,
+  ) {
+    super(eventEmitter);
+  }
+
+  private async resolveIsProduction(
+    sessionMetadata: SessionMetadata,
+    databaseId: string,
+  ): Promise<'true' | 'false'> {
+    try {
+      const database = await this.databaseRepository.get(
+        sessionMetadata,
+        databaseId,
+      );
+      return database?.isProduction ? 'true' : 'false';
+    } catch (e) {
+      return 'false';
+    }
+  }
+
+  private isDangerousAction(type: BulkActionType): 'true' | 'false' {
+    return type === BulkActionType.Delete || type === BulkActionType.Unlink
+      ? 'true'
+      : 'false';
+  }
+
+  private resolveConfirmedThrough(
+    overview: IBulkActionOverview,
+  ): BulkActionConfirmation | null {
+    return overview.confirmedThrough ?? null;
+  }
+
+  async sendActionStarted(
     sessionMetadata: SessionMetadata,
     overview: IBulkActionOverview,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.BulkActionsStarted, {
         databaseId: overview.databaseId,
@@ -32,16 +72,22 @@ export class BulkActionsAnalytics extends TelemetryBaseService {
             BULK_ACTIONS_BREAKPOINTS,
           ),
         },
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          overview.databaseId,
+        ),
+        dangerous: this.isDangerousAction(overview.type),
+        confirmedThrough: this.resolveConfirmedThrough(overview),
       });
     } catch (e) {
       // continue regardless of error
     }
   }
 
-  sendActionStopped(
+  async sendActionStopped(
     sessionMetadata: SessionMetadata,
     overview: IBulkActionOverview,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.BulkActionsStopped, {
         databaseId: overview.databaseId,
@@ -80,16 +126,22 @@ export class BulkActionsAnalytics extends TelemetryBaseService {
             BULK_ACTIONS_BREAKPOINTS,
           ),
         },
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          overview.databaseId,
+        ),
+        dangerous: this.isDangerousAction(overview.type),
+        confirmedThrough: this.resolveConfirmedThrough(overview),
       });
     } catch (e) {
       // continue regardless of error
     }
   }
 
-  sendActionSucceed(
+  async sendActionSucceed(
     sessionMetadata: SessionMetadata,
     overview: IBulkActionOverview,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.BulkActionsSucceed, {
         databaseId: overview.databaseId,
@@ -116,32 +168,44 @@ export class BulkActionsAnalytics extends TelemetryBaseService {
             BULK_ACTIONS_BREAKPOINTS,
           ),
         },
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          overview.databaseId,
+        ),
+        dangerous: this.isDangerousAction(overview.type),
+        confirmedThrough: this.resolveConfirmedThrough(overview),
       });
     } catch (e) {
       // continue regardless of error
     }
   }
 
-  sendActionFailed(
+  async sendActionFailed(
     sessionMetadata: SessionMetadata,
     overview: IBulkActionOverview,
     error: HttpException | Error,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.BulkActionsFailed, {
         databaseId: overview.databaseId,
         action: overview.type,
         error,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          overview.databaseId,
+        ),
+        dangerous: this.isDangerousAction(overview.type),
+        confirmedThrough: this.resolveConfirmedThrough(overview),
       });
     } catch (e) {
       // continue regardless of error
     }
   }
 
-  sendImportSamplesUploaded(
+  async sendImportSamplesUploaded(
     sessionMetadata: SessionMetadata,
     overview: IBulkActionOverview,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.ImportSamplesUploaded, {
         databaseId: overview.databaseId,
@@ -164,6 +228,10 @@ export class BulkActionsAnalytics extends TelemetryBaseService {
             BULK_ACTIONS_BREAKPOINTS,
           ),
         },
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          overview.databaseId,
+        ),
       });
     } catch (e) {
       // continue regardless of error

--- a/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-import.service.spec.ts
@@ -89,6 +89,7 @@ const mockImportResult: IBulkActionOverview = {
   filter: null,
   status: BulkActionStatus.Completed,
   duration: 100,
+  confirmedThrough: null,
 };
 
 const mockEmptyImportResult: IBulkActionOverview = {
@@ -100,6 +101,7 @@ const mockEmptyImportResult: IBulkActionOverview = {
   filter: null,
   status: BulkActionStatus.Completed,
   duration: 0,
+  confirmedThrough: null,
 };
 
 const mockReadableStream = Readable.from(Buffer.from('SET foo bar'));

--- a/redisinsight/api/src/modules/bulk-actions/bulk-import.service.ts
+++ b/redisinsight/api/src/modules/bulk-actions/bulk-import.service.ts
@@ -111,6 +111,7 @@ export class BulkImportService {
       filter: null,
       status: BulkActionStatus.Completed,
       duration: 0,
+      confirmedThrough: null,
     };
 
     this.analytics.sendActionStarted(clientMetadata.sessionMetadata, result);

--- a/redisinsight/api/src/modules/bulk-actions/constants/index.ts
+++ b/redisinsight/api/src/modules/bulk-actions/constants/index.ts
@@ -10,6 +10,11 @@ export enum BulkActionType {
   Unlink = 'unlink',
 }
 
+export enum BulkActionConfirmation {
+  Standard = 'standard',
+  TypeToConfirm = 'type-to-confirm',
+}
+
 export enum BulkActionStatus {
   Initializing = 'initializing',
   Initialized = 'initialized',

--- a/redisinsight/api/src/modules/bulk-actions/dto/create-bulk-action.dto.ts
+++ b/redisinsight/api/src/modules/bulk-actions/dto/create-bulk-action.dto.ts
@@ -1,5 +1,8 @@
 import { BulkActionFilter } from 'src/modules/bulk-actions/models/bulk-action-filter';
-import { BulkActionType } from 'src/modules/bulk-actions/constants';
+import {
+  BulkActionConfirmation,
+  BulkActionType,
+} from 'src/modules/bulk-actions/constants';
 import {
   IsBoolean,
   IsEnum,
@@ -41,4 +44,12 @@ export class CreateBulkActionDto extends BulkActionIdDto {
   @IsBoolean()
   @Type(() => Boolean)
   generateReport?: boolean;
+
+  @IsOptional()
+  @IsEnum(BulkActionConfirmation, {
+    message: `confirmedThrough must be a valid enum value. Valid values: ${Object.values(
+      BulkActionConfirmation,
+    )}.`,
+  })
+  confirmedThrough?: BulkActionConfirmation;
 }

--- a/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-overview.interface.ts
+++ b/redisinsight/api/src/modules/bulk-actions/interfaces/bulk-action-overview.interface.ts
@@ -1,4 +1,5 @@
 import {
+  BulkActionConfirmation,
   BulkActionStatus,
   BulkActionType,
 } from 'src/modules/bulk-actions/constants';
@@ -17,4 +18,5 @@ export interface IBulkActionOverview {
   summary: IBulkActionSummaryOverview;
   downloadUrl?: string;
   error?: string;
+  confirmedThrough?: BulkActionConfirmation | null;
 }

--- a/redisinsight/api/src/modules/bulk-actions/models/bulk-action.ts
+++ b/redisinsight/api/src/modules/bulk-actions/models/bulk-action.ts
@@ -1,6 +1,7 @@
 import { debounce } from 'lodash';
 import { Response } from 'express';
 import {
+  BulkActionConfirmation,
   BulkActionStatus,
   BulkActionType,
 } from 'src/modules/bulk-actions/constants';
@@ -33,6 +34,8 @@ export class BulkAction implements IBulkAction {
 
   private readonly generateReport: boolean;
 
+  private readonly confirmedThrough: BulkActionConfirmation | null;
+
   private streamingResponse: Response | null = null;
 
   private streamReadyResolver: (() => void) | null = null;
@@ -45,12 +48,14 @@ export class BulkAction implements IBulkAction {
     private readonly socket: Socket,
     private readonly analytics: BulkActionsAnalytics,
     generateReport: boolean = false,
+    confirmedThrough: BulkActionConfirmation | null = null,
   ) {
     this.debounce = debounce(this.sendOverview.bind(this), 1000, {
       maxWait: 1000,
     });
     this.status = BulkActionStatus.Initialized;
     this.generateReport = generateReport;
+    this.confirmedThrough = confirmedThrough;
   }
 
   /**
@@ -251,6 +256,7 @@ export class BulkAction implements IBulkAction {
       filter: this.filter.getOverview(),
       progress,
       summary,
+      confirmedThrough: this.confirmedThrough,
     };
 
     if (this.generateReport) {

--- a/redisinsight/api/src/modules/bulk-actions/providers/bulk-actions.provider.ts
+++ b/redisinsight/api/src/modules/bulk-actions/providers/bulk-actions.provider.ts
@@ -50,6 +50,7 @@ export class BulkActionsProvider {
       socket,
       this.analytics,
       dto.generateReport,
+      dto.confirmedThrough ?? null,
     );
 
     this.bulkActions.set(dto.id, bulkAction);

--- a/redisinsight/api/src/modules/cli/services/cli-analytics/cli-analytics.service.spec.ts
+++ b/redisinsight/api/src/modules/cli/services/cli-analytics/cli-analytics.service.spec.ts
@@ -6,6 +6,7 @@ import {
   mockDatabase,
   MockType,
   mockSessionMetadata,
+  mockDatabaseRepository,
 } from 'src/__mocks__';
 import { CommandType, TelemetryEvents } from 'src/constants';
 import { ReplyError } from 'src/models';
@@ -15,6 +16,7 @@ import {
   ICliExecResultFromNode,
 } from 'src/modules/cli/dto/cli.dto';
 import { CommandsService } from 'src/modules/commands/commands.service';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 import { CliAnalyticsService } from './cli-analytics.service';
 
 const mockCommandsService = {
@@ -36,6 +38,7 @@ describe('CliAnalyticsService', () => {
   let sendEventMethod: jest.SpyInstance<CliAnalyticsService, unknown[]>;
   let sendFailedEventMethod: jest.SpyInstance<CliAnalyticsService, unknown[]>;
   let commandsService: MockType<CommandsService>;
+  let databaseRepository: MockType<DatabaseRepository>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -44,10 +47,16 @@ describe('CliAnalyticsService', () => {
           provide: CommandsService,
           useFactory: () => mockCommandsService,
         },
+        {
+          provide: DatabaseRepository,
+          useFactory: mockDatabaseRepository,
+        },
         EventEmitter2,
         CliAnalyticsService,
       ],
     }).compile();
+
+    databaseRepository = module.get(DatabaseRepository);
 
     service = module.get<CliAnalyticsService>(CliAnalyticsService);
     sendEventMethod = jest.spyOn<CliAnalyticsService, any>(
@@ -271,6 +280,8 @@ describe('CliAnalyticsService', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -282,7 +293,54 @@ describe('CliAnalyticsService', () => {
         TelemetryEvents.CliCommandExecuted,
         {
           databaseId,
+          isProduction: 'false',
+          dangerous: 'false',
         },
+      );
+    });
+    it('should emit isProduction=true when database is marked production', async () => {
+      databaseRepository.get.mockResolvedValueOnce({
+        ...mockDatabase,
+        isProduction: true,
+      });
+
+      await service.sendCommandExecutedEvent(
+        mockSessionMetadata,
+        databaseId,
+        mockAdditionalData,
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.CliCommandExecuted,
+        expect.objectContaining({ isProduction: 'true' }),
+      );
+    });
+    it('should pass dangerous flag through from additionalData', async () => {
+      await service.sendCommandExecutedEvent(mockSessionMetadata, databaseId, {
+        ...mockAdditionalData,
+        dangerous: true,
+      });
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.CliCommandExecuted,
+        expect.objectContaining({ dangerous: 'true' }),
+      );
+    });
+    it('should default isProduction to false when database lookup throws', async () => {
+      databaseRepository.get.mockRejectedValueOnce(new Error('boom'));
+
+      await service.sendCommandExecutedEvent(
+        mockSessionMetadata,
+        databaseId,
+        mockAdditionalData,
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.CliCommandExecuted,
+        expect.objectContaining({ isProduction: 'false' }),
       );
     });
   });
@@ -306,6 +364,8 @@ describe('CliAnalyticsService', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -323,6 +383,8 @@ describe('CliAnalyticsService', () => {
           databaseId,
           error: ReplyError.name,
           command: 'sadd',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -345,6 +407,8 @@ describe('CliAnalyticsService', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -415,6 +479,8 @@ describe('CliAnalyticsService', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -440,6 +506,8 @@ describe('CliAnalyticsService', () => {
           databaseId,
           error: redisReplyError.name,
           command: 'sadd',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -464,6 +532,8 @@ describe('CliAnalyticsService', () => {
         {
           databaseId,
           error: CommandParsingError.name,
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });

--- a/redisinsight/api/src/modules/cli/services/cli-analytics/cli-analytics.service.ts
+++ b/redisinsight/api/src/modules/cli/services/cli-analytics/cli-analytics.service.ts
@@ -9,14 +9,31 @@ import {
 import { CommandsService } from 'src/modules/commands/commands.service';
 import { CommandTelemetryBaseService } from 'src/modules/analytics/command.telemetry.base.service';
 import { SessionMetadata } from 'src/common/models';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 
 @Injectable()
 export class CliAnalyticsService extends CommandTelemetryBaseService {
   constructor(
     protected eventEmitter: EventEmitter2,
     protected readonly commandsService: CommandsService,
+    private readonly databaseRepository: DatabaseRepository,
   ) {
     super(eventEmitter, commandsService);
+  }
+
+  private async resolveIsProduction(
+    sessionMetadata: SessionMetadata,
+    databaseId: string,
+  ): Promise<'true' | 'false'> {
+    try {
+      const database = await this.databaseRepository.get(
+        sessionMetadata,
+        databaseId,
+      );
+      return database?.isProduction ? 'true' : 'false';
+    } catch (e) {
+      return 'false';
+    }
   }
 
   sendClientCreatedEvent(
@@ -101,10 +118,20 @@ export class CliAnalyticsService extends CommandTelemetryBaseService {
     additionalData: object = {},
   ): Promise<void> {
     try {
+      const { dangerous, ...rest } = additionalData as {
+        dangerous?: boolean;
+        command?: string;
+        [k: string]: any;
+      };
       this.sendEvent(sessionMetadata, TelemetryEvents.CliCommandExecuted, {
         databaseId,
-        ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-        ...additionalData,
+        ...(await this.getCommandAdditionalInfo(rest['command'])),
+        ...rest,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
+        dangerous: dangerous ? 'true' : 'false',
       });
     } catch (e) {
       // ignore error
@@ -118,12 +145,22 @@ export class CliAnalyticsService extends CommandTelemetryBaseService {
     additionalData: object = {},
   ): Promise<void> {
     try {
+      const { dangerous, ...rest } = additionalData as {
+        dangerous?: boolean;
+        command?: string;
+        [k: string]: any;
+      };
       this.sendEvent(sessionMetadata, TelemetryEvents.CliCommandErrorReceived, {
         databaseId,
         error: error?.name,
         command: error?.command?.name,
-        ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-        ...additionalData,
+        ...(await this.getCommandAdditionalInfo(rest['command'])),
+        ...rest,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
+        dangerous: dangerous ? 'true' : 'false',
       });
     } catch (e) {
       // continue regardless of error
@@ -138,14 +175,24 @@ export class CliAnalyticsService extends CommandTelemetryBaseService {
   ): Promise<void> {
     const { status, error } = result;
     try {
+      const { dangerous, ...rest } = additionalData as {
+        dangerous?: boolean;
+        command?: string;
+        [k: string]: any;
+      };
       if (status === CommandExecutionStatus.Success) {
         this.sendEvent(
           sessionMetadata,
           TelemetryEvents.CliClusterNodeCommandExecuted,
           {
             databaseId,
-            ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-            ...additionalData,
+            ...(await this.getCommandAdditionalInfo(rest['command'])),
+            ...rest,
+            isProduction: await this.resolveIsProduction(
+              sessionMetadata,
+              databaseId,
+            ),
+            dangerous: dangerous ? 'true' : 'false',
           },
         );
       }
@@ -157,8 +204,13 @@ export class CliAnalyticsService extends CommandTelemetryBaseService {
             databaseId,
             error: error.name,
             command: error?.command?.name,
-            ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-            ...additionalData,
+            ...(await this.getCommandAdditionalInfo(rest['command'])),
+            ...rest,
+            isProduction: await this.resolveIsProduction(
+              sessionMetadata,
+              databaseId,
+            ),
+            dangerous: dangerous ? 'true' : 'false',
           },
         );
       }

--- a/redisinsight/api/src/modules/cli/services/cli-business/cli-business.service.spec.ts
+++ b/redisinsight/api/src/modules/cli/services/cli-business/cli-business.service.spec.ts
@@ -17,6 +17,7 @@ import {
   mockRedisFtInfoReply,
   mockFtInfoAnalyticsData,
   mockSessionMetadata,
+  mockDangerousCommandsProvider,
 } from 'src/__mocks__';
 import {
   CommandExecutionStatus,
@@ -35,6 +36,7 @@ import { KeytarUnavailableException } from 'src/modules/encryption/exceptions';
 import { CommandsService } from 'src/modules/commands/commands.service';
 import { DatabaseRecommendationService } from 'src/modules/database-recommendation/database-recommendation.service';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 import { OutputFormatterManager } from './output-formatter/output-formatter-manager';
 import {
   CliOutputFormatterTypes,
@@ -88,6 +90,10 @@ describe('CliBusinessService', () => {
         {
           provide: DatabaseRecommendationService,
           useFactory: mockDatabaseRecommendationService,
+        },
+        {
+          provide: DangerousCommandsProvider,
+          useFactory: mockDangerousCommandsProvider,
         },
       ],
     }).compile();
@@ -285,6 +291,7 @@ describe('CliBusinessService', () => {
         {
           command: 'ft.info',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
       expect(analyticsService.sendIndexInfoEvent).toHaveBeenCalledWith(
@@ -315,6 +322,7 @@ describe('CliBusinessService', () => {
         {
           command: 'memory',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -343,6 +351,7 @@ describe('CliBusinessService', () => {
         {
           command: 'memory',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -369,6 +378,7 @@ describe('CliBusinessService', () => {
         {
           command: 'script',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -391,6 +401,7 @@ describe('CliBusinessService', () => {
         {
           command: unknownCommand,
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -418,6 +429,7 @@ describe('CliBusinessService', () => {
         {
           command: 'get',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -487,6 +499,7 @@ describe('CliBusinessService', () => {
         {
           command: 'info',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -534,6 +547,7 @@ describe('CliBusinessService', () => {
         {
           command: 'memory',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -562,6 +576,7 @@ describe('CliBusinessService', () => {
         {
           command: 'memory',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -588,6 +603,7 @@ describe('CliBusinessService', () => {
         {
           command: 'script',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -610,6 +626,7 @@ describe('CliBusinessService', () => {
         {
           command: unknownCommand,
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -637,6 +654,7 @@ describe('CliBusinessService', () => {
         {
           command: 'get',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });
@@ -706,6 +724,7 @@ describe('CliBusinessService', () => {
         {
           command: 'info',
           outputFormat: CliOutputFormatterTypes.Raw,
+          dangerous: false,
         },
       );
     });

--- a/redisinsight/api/src/modules/cli/services/cli-business/cli-business.service.ts
+++ b/redisinsight/api/src/modules/cli/services/cli-business/cli-business.service.ts
@@ -29,6 +29,7 @@ import { ClientNotFoundErrorException } from 'src/modules/redis/exceptions/clien
 import { DatabaseRecommendationService } from 'src/modules/database-recommendation/database-recommendation.service';
 import { RedisClient } from 'src/modules/redis/client';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 import { v4 as uuidv4 } from 'uuid';
 import { getAnalyticsDataFromIndexInfo } from 'src/utils';
 import { OutputFormatterManager } from './output-formatter/output-formatter-manager';
@@ -47,6 +48,7 @@ export class CliBusinessService {
     private recommendationService: DatabaseRecommendationService,
     private readonly commandsService: CommandsService,
     private databaseClientFactory: DatabaseClientFactory,
+    private readonly dangerousCommandsProvider: DangerousCommandsProvider,
   ) {
     this.outputFormatterManager = new OutputFormatterManager();
     this.outputFormatterManager.addStrategy(
@@ -188,9 +190,10 @@ export class CliBusinessService {
     const outputFormat = dto.outputFormat || CliOutputFormatterTypes.Raw;
     let command: string = unknownCommand;
     let args: string[] = [];
+    let client: RedisClient | undefined;
 
     try {
-      const client: RedisClient =
+      client =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
 
       const formatter = this.outputFormatterManager.getStrategy(outputFormat);
@@ -216,6 +219,7 @@ export class CliBusinessService {
         {
           command,
           outputFormat,
+          dangerous: await this.isDangerousCommand(client, command),
         },
       );
 
@@ -255,6 +259,7 @@ export class CliBusinessService {
           {
             command,
             outputFormat,
+            dangerous: await this.isDangerousCommand(client, command),
           },
         );
 
@@ -279,6 +284,22 @@ export class CliBusinessService {
       }
 
       return { response: error.message, status: CommandExecutionStatus.Fail };
+    }
+  }
+
+  private async isDangerousCommand(
+    client: RedisClient | undefined,
+    command: string,
+  ): Promise<boolean> {
+    if (!client || !command) {
+      return false;
+    }
+    try {
+      const dangerous =
+        await this.dangerousCommandsProvider.getDangerousCommands(client);
+      return dangerous.includes(command.toUpperCase());
+    } catch (e) {
+      return false;
     }
   }
 

--- a/redisinsight/api/src/modules/database/database.module.ts
+++ b/redisinsight/api/src/modules/database/database.module.ts
@@ -58,6 +58,7 @@ export class DatabaseModule {
         DatabaseService,
         DatabaseConnectionService,
         DatabaseClientFactory,
+        DangerousCommandsProvider,
         // todo: rethink everything below
         DatabaseFactory,
         DatabaseInfoService,

--- a/redisinsight/api/src/modules/profiler/profiler-analytics.service.spec.ts
+++ b/redisinsight/api/src/modules/profiler/profiler-analytics.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  mockDatabase,
+  mockDatabaseRepository,
+  MockType,
+  mockSessionMetadata,
+} from 'src/__mocks__';
+import { TelemetryEvents } from 'src/constants';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
+import { ProfilerAnalyticsService } from './profiler-analytics.service';
+
+const databaseId = mockDatabase.id;
+
+describe('ProfilerAnalyticsService', () => {
+  let service: ProfilerAnalyticsService;
+  let sendEventSpy: jest.SpyInstance;
+  let databaseRepository: MockType<DatabaseRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProfilerAnalyticsService,
+        EventEmitter2,
+        {
+          provide: DatabaseRepository,
+          useFactory: mockDatabaseRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProfilerAnalyticsService>(ProfilerAnalyticsService);
+    databaseRepository = module.get(DatabaseRepository);
+    sendEventSpy = jest.spyOn(service as any, 'sendEvent');
+  });
+
+  describe('sendProfilerStartedEvent', () => {
+    it('should emit ProfilerStarted event with databaseId and isProduction=false', async () => {
+      await service.sendProfilerStartedEvent(mockSessionMetadata, databaseId);
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.ProfilerStarted,
+        { databaseId, isProduction: 'false' },
+      );
+    });
+
+    it('should emit isProduction=true when database is production', async () => {
+      databaseRepository.get.mockResolvedValueOnce({
+        ...mockDatabase,
+        isProduction: true,
+      });
+
+      await service.sendProfilerStartedEvent(mockSessionMetadata, databaseId);
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.ProfilerStarted,
+        expect.objectContaining({ isProduction: 'true' }),
+      );
+    });
+
+    it('should default isProduction to false when lookup throws', async () => {
+      databaseRepository.get.mockRejectedValueOnce(new Error('boom'));
+
+      await service.sendProfilerStartedEvent(mockSessionMetadata, databaseId);
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.ProfilerStarted,
+        { databaseId, isProduction: 'false' },
+      );
+    });
+  });
+
+  describe('sendLogDownloaded', () => {
+    it('should emit ProfilerLogDownloaded with isProduction', async () => {
+      await service.sendLogDownloaded(mockSessionMetadata, databaseId, 4242);
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.ProfilerLogDownloaded,
+        { databaseId, fileSizeBytes: 4242, isProduction: 'false' },
+      );
+    });
+  });
+
+  describe('sendLogDeleted', () => {
+    it('should emit ProfilerLogDeleted with isProduction', async () => {
+      await service.sendLogDeleted(mockSessionMetadata, databaseId, 100);
+
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.ProfilerLogDeleted,
+        { databaseId, fileSizeBytes: 100, isProduction: 'false' },
+      );
+    });
+  });
+
+  describe('getEventsEmitters', () => {
+    it('should expose download and delete events on the map', () => {
+      const map = service.getEventsEmitters();
+      expect(map.has(TelemetryEvents.ProfilerLogDownloaded)).toBe(true);
+      expect(map.has(TelemetryEvents.ProfilerLogDeleted)).toBe(true);
+    });
+  });
+});

--- a/redisinsight/api/src/modules/profiler/profiler-analytics.service.ts
+++ b/redisinsight/api/src/modules/profiler/profiler-analytics.service.ts
@@ -5,6 +5,7 @@ import { TelemetryBaseService } from 'src/modules/analytics/telemetry.base.servi
 import { CommandExecutionStatus } from 'src/modules/cli/dto/cli.dto';
 import { RedisError, ReplyError } from 'src/models';
 import { SessionMetadata } from 'src/common/models';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 
 export interface IExecResult {
   response: any;
@@ -16,7 +17,10 @@ export interface IExecResult {
 export class ProfilerAnalyticsService extends TelemetryBaseService {
   private events: Map<TelemetryEvents, Function> = new Map();
 
-  constructor(protected eventEmitter: EventEmitter2) {
+  constructor(
+    protected eventEmitter: EventEmitter2,
+    private readonly databaseRepository: DatabaseRepository,
+  ) {
     super(eventEmitter);
     this.events.set(
       TelemetryEvents.ProfilerLogDownloaded,
@@ -28,30 +32,70 @@ export class ProfilerAnalyticsService extends TelemetryBaseService {
     );
   }
 
-  sendLogDeleted(
+  private async resolveIsProduction(
+    sessionMetadata: SessionMetadata,
+    databaseId: string,
+  ): Promise<'true' | 'false'> {
+    try {
+      const database = await this.databaseRepository.get(
+        sessionMetadata,
+        databaseId,
+      );
+      return database?.isProduction ? 'true' : 'false';
+    } catch (e) {
+      return 'false';
+    }
+  }
+
+  async sendLogDeleted(
     sessionMetadata: SessionMetadata,
     databaseId: string,
     fileSizeBytes: number,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.ProfilerLogDeleted, {
         databaseId,
         fileSizeBytes,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
       });
     } catch (e) {
       // continue regardless of error
     }
   }
 
-  sendLogDownloaded(
+  async sendLogDownloaded(
     sessionMetadata: SessionMetadata,
     databaseId: string,
     fileSizeBytes: number,
-  ): void {
+  ): Promise<void> {
     try {
       this.sendEvent(sessionMetadata, TelemetryEvents.ProfilerLogDownloaded, {
         databaseId,
         fileSizeBytes,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
+      });
+    } catch (e) {
+      // continue regardless of error
+    }
+  }
+
+  async sendProfilerStartedEvent(
+    sessionMetadata: SessionMetadata,
+    databaseId: string,
+  ): Promise<void> {
+    try {
+      this.sendEvent(sessionMetadata, TelemetryEvents.ProfilerStarted, {
+        databaseId,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
       });
     } catch (e) {
       // continue regardless of error

--- a/redisinsight/api/src/modules/profiler/profiler.service.ts
+++ b/redisinsight/api/src/modules/profiler/profiler.service.ts
@@ -6,6 +6,7 @@ import { MonitorSettings } from 'src/modules/profiler/models/monitor-settings';
 import { LogFileProvider } from 'src/modules/profiler/providers/log-file.provider';
 import { RedisObserverProvider } from 'src/modules/profiler/providers/redis-observer.provider';
 import { ProfilerClientProvider } from 'src/modules/profiler/providers/profiler-client.provider';
+import { ProfilerAnalyticsService } from 'src/modules/profiler/profiler-analytics.service';
 import { SessionMetadata } from 'src/common/models';
 
 @Injectable()
@@ -16,6 +17,7 @@ export class ProfilerService {
     private logFileProvider: LogFileProvider,
     private redisObserverProvider: RedisObserverProvider,
     private profilerClientProvider: ProfilerClientProvider,
+    private analyticsService: ProfilerAnalyticsService,
   ) {}
 
   /**
@@ -50,6 +52,8 @@ export class ProfilerService {
         instanceId,
       );
     await monitorObserver.subscribe(profilerClient);
+
+    this.analyticsService.sendProfilerStartedEvent(sessionMetadata, instanceId);
   }
 
   /**

--- a/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.spec.ts
+++ b/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.spec.ts
@@ -8,6 +8,7 @@ import {
   mockStandaloneRedisClient,
   mockWorkbenchAnalyticsService,
   mockWorkbenchClientMetadata,
+  mockDangerousCommandsProvider,
 } from 'src/__mocks__';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { unknownCommand } from 'src/constants';
@@ -26,6 +27,7 @@ import {
   FormatterTypes,
 } from 'src/common/transformers';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 import {
   CommandExecutionType,
   RunQueryMode,
@@ -67,6 +69,10 @@ describe('WorkbenchCommandsExecutor', () => {
         {
           provide: DatabaseClientFactory,
           useFactory: mockDatabaseClientFactory,
+        },
+        {
+          provide: DangerousCommandsProvider,
+          useFactory: mockDangerousCommandsProvider,
         },
       ],
     }).compile();
@@ -113,6 +119,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: 'ft.info',
             rawMode: true,
+            dangerous: false,
           },
         );
         expect(mockAnalyticsService.sendIndexInfoEvent).toHaveBeenCalledWith(
@@ -153,6 +160,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });
@@ -188,6 +196,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });
@@ -226,6 +235,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });
@@ -265,6 +275,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });
@@ -304,6 +315,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: true,
+            dangerous: false,
           },
         );
       });
@@ -339,6 +351,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: mockSetCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });
@@ -375,6 +388,7 @@ describe('WorkbenchCommandsExecutor', () => {
           {
             command: unknownCommand,
             rawMode: false,
+            dangerous: false,
           },
         );
       });

--- a/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.ts
+++ b/redisinsight/api/src/modules/workbench/providers/workbench-commands.executor.ts
@@ -23,6 +23,7 @@ import { RedisClient } from 'src/modules/redis/client';
 import { getAnalyticsDataFromIndexInfo } from 'src/utils';
 import { RunQueryMode } from 'src/modules/workbench/models/command-execution';
 import { WorkbenchAnalytics } from 'src/modules/workbench/workbench.analytics';
+import { DangerousCommandsProvider } from 'src/modules/database/providers/dangerous-commands.provider';
 
 @Injectable()
 export class WorkbenchCommandsExecutor {
@@ -30,7 +31,10 @@ export class WorkbenchCommandsExecutor {
 
   private formatterManager: FormatterManager;
 
-  constructor(private analyticsService: WorkbenchAnalytics) {
+  constructor(
+    private analyticsService: WorkbenchAnalytics,
+    private readonly dangerousCommandsProvider: DangerousCommandsProvider,
+  ) {
     this.formatterManager = new FormatterManager();
     this.formatterManager.addStrategy(
       FormatterTypes.UTF8,
@@ -81,7 +85,11 @@ export class WorkbenchCommandsExecutor {
         client.clientMetadata.databaseId,
         dto.type,
         result,
-        { command, rawMode: mode === RunQueryMode.Raw },
+        {
+          command,
+          rawMode: mode === RunQueryMode.Raw,
+          dangerous: await this.isDangerousCommand(client, command),
+        },
       );
 
       if (command.toLowerCase() === 'ft.info') {
@@ -106,7 +114,11 @@ export class WorkbenchCommandsExecutor {
         client.clientMetadata.databaseId,
         dto.type,
         { ...errorResult, error },
-        { command, rawMode: dto.mode === RunQueryMode.Raw },
+        {
+          command,
+          rawMode: dto.mode === RunQueryMode.Raw,
+          dangerous: await this.isDangerousCommand(client, command),
+        },
       );
 
       if (
@@ -125,6 +137,22 @@ export class WorkbenchCommandsExecutor {
       }
 
       return [errorResult];
+    }
+  }
+
+  private async isDangerousCommand(
+    client: RedisClient | undefined,
+    command: string,
+  ): Promise<boolean> {
+    if (!client || !command) {
+      return false;
+    }
+    try {
+      const dangerous =
+        await this.dangerousCommandsProvider.getDangerousCommands(client);
+      return dangerous.includes(command.toUpperCase());
+    } catch (e) {
+      return false;
     }
   }
 

--- a/redisinsight/api/src/modules/workbench/workbench.analytics.spec.ts
+++ b/redisinsight/api/src/modules/workbench/workbench.analytics.spec.ts
@@ -6,12 +6,14 @@ import {
   mockDatabase,
   MockType,
   mockSessionMetadata,
+  mockDatabaseRepository,
 } from 'src/__mocks__';
 import { CommandType, TelemetryEvents } from 'src/constants';
 import { ReplyError } from 'src/models';
 import { CommandExecutionStatus } from 'src/modules/cli/dto/cli.dto';
 import { CommandParsingError } from 'src/modules/cli/constants/errors';
 import { CommandsService } from 'src/modules/commands/commands.service';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 import { WorkbenchAnalytics } from './workbench.analytics';
 import { CommandExecutionType } from './models/command-execution';
 
@@ -30,6 +32,7 @@ describe('WorkbenchAnalytics', () => {
   let sendEventMethod: jest.SpyInstance<WorkbenchAnalytics, unknown[]>;
   let sendFailedEventMethod: jest.SpyInstance<WorkbenchAnalytics, unknown[]>;
   let commandsService: MockType<CommandsService>;
+  let databaseRepository: MockType<DatabaseRepository>;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -41,9 +44,15 @@ describe('WorkbenchAnalytics', () => {
           provide: CommandsService,
           useFactory: () => mockCommandsService,
         },
+        {
+          provide: DatabaseRepository,
+          useFactory: mockDatabaseRepository,
+        },
         WorkbenchAnalytics,
       ],
     }).compile();
+
+    databaseRepository = module.get(DatabaseRepository);
 
     service = module.get<WorkbenchAnalytics>(WorkbenchAnalytics);
     sendEventMethod = jest.spyOn<WorkbenchAnalytics, any>(service, 'sendEvent');
@@ -83,7 +92,7 @@ describe('WorkbenchAnalytics', () => {
 
   describe('sendIndexInfoEvent', () => {
     it('should emit index info event for Workbench commands', async () => {
-      service.sendIndexInfoEvent(
+      await service.sendIndexInfoEvent(
         mockSessionMetadata,
         instanceId,
         CommandExecutionType.Workbench,
@@ -98,11 +107,12 @@ describe('WorkbenchAnalytics', () => {
         {
           databaseId: instanceId,
           any: 'fields',
+          isProduction: 'false',
         },
       );
     });
     it('should emit index info event for Search commands', async () => {
-      service.sendIndexInfoEvent(
+      await service.sendIndexInfoEvent(
         mockSessionMetadata,
         instanceId,
         CommandExecutionType.Search,
@@ -117,11 +127,12 @@ describe('WorkbenchAnalytics', () => {
         {
           databaseId: instanceId,
           any: 'fields',
+          isProduction: 'false',
         },
       );
     });
     it('should not fail and should not emit when no data to send', async () => {
-      service.sendIndexInfoEvent(
+      await service.sendIndexInfoEvent(
         mockSessionMetadata,
         instanceId,
         CommandExecutionType.Workbench,
@@ -154,6 +165,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -179,6 +192,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -202,6 +217,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -224,6 +241,8 @@ describe('WorkbenchAnalytics', () => {
         {
           databaseId: instanceId,
           command: 'set',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -245,6 +264,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Module,
           moduleName: 'redisbloom',
           capability: 'bf',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -266,6 +287,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Module,
           moduleName: 'custommodule',
           capability: 'n/a',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -287,6 +310,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Module,
           moduleName: 'custom',
           capability: 'n/a',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -306,6 +331,8 @@ describe('WorkbenchAnalytics', () => {
         TelemetryEvents.WorkbenchCommandExecuted,
         {
           databaseId: instanceId,
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -333,6 +360,8 @@ describe('WorkbenchAnalytics', () => {
           moduleName: 'n/a',
           capability: 'string',
           data: 'Some data',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -355,6 +384,8 @@ describe('WorkbenchAnalytics', () => {
           databaseId: instanceId,
           error: ReplyError.name,
           command: 'sadd',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -378,6 +409,8 @@ describe('WorkbenchAnalytics', () => {
           databaseId: instanceId,
           error: CommandParsingError.name,
           command: undefined,
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -398,7 +431,11 @@ describe('WorkbenchAnalytics', () => {
         mockSessionMetadata,
         TelemetryEvents.WorkbenchCommandErrorReceived,
         error,
-        { databaseId: instanceId },
+        {
+          databaseId: instanceId,
+          isProduction: 'false',
+          dangerous: 'false',
+        },
       );
     });
     it('should emit SearchCommandExecuted event', async () => {
@@ -419,6 +456,8 @@ describe('WorkbenchAnalytics', () => {
           commandType: CommandType.Core,
           moduleName: 'n/a',
           capability: 'string',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
@@ -446,10 +485,69 @@ describe('WorkbenchAnalytics', () => {
           moduleName: 'n/a',
           capability: 'string',
           data: 'Some data',
+          isProduction: 'false',
+          dangerous: 'false',
         },
       );
     });
   });
+  describe('production mode and dangerous flag enrichment', () => {
+    it('should emit isProduction=true when database is marked production', async () => {
+      databaseRepository.get.mockResolvedValueOnce({
+        ...mockDatabase,
+        isProduction: true,
+      });
+
+      await service.sendCommandExecutedEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Workbench,
+        { response: 'OK', status: CommandExecutionStatus.Success },
+        { command: 'set' },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.WorkbenchCommandExecuted,
+        expect.objectContaining({ isProduction: 'true' }),
+      );
+    });
+
+    it('should pass dangerous through from additionalData', async () => {
+      await service.sendCommandExecutedEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Workbench,
+        { response: 'OK', status: CommandExecutionStatus.Success },
+        { command: 'flushdb', dangerous: true },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.WorkbenchCommandExecuted,
+        expect.objectContaining({ dangerous: 'true' }),
+      );
+    });
+
+    it('should default isProduction to false when lookup throws', async () => {
+      databaseRepository.get.mockRejectedValueOnce(new Error('boom'));
+
+      await service.sendCommandExecutedEvent(
+        mockSessionMetadata,
+        instanceId,
+        CommandExecutionType.Workbench,
+        { response: 'OK', status: CommandExecutionStatus.Success },
+        { command: 'set' },
+      );
+
+      expect(sendEventMethod).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        TelemetryEvents.WorkbenchCommandExecuted,
+        expect.objectContaining({ isProduction: 'false' }),
+      );
+    });
+  });
+
   describe('sendCommandDeletedEvent', () => {
     it('should emit WorkbenchCommandDeleted event', () => {
       service.sendCommandDeletedEvent(mockSessionMetadata, instanceId, {

--- a/redisinsight/api/src/modules/workbench/workbench.analytics.ts
+++ b/redisinsight/api/src/modules/workbench/workbench.analytics.ts
@@ -6,6 +6,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CommandsService } from 'src/modules/commands/commands.service';
 import { CommandTelemetryBaseService } from 'src/modules/analytics/command.telemetry.base.service';
 import { SessionMetadata } from 'src/common/models';
+import { DatabaseRepository } from 'src/modules/database/repositories/database.repository';
 import { CommandExecutionType } from './models/command-execution';
 
 export interface IExecResult {
@@ -19,16 +20,32 @@ export class WorkbenchAnalytics extends CommandTelemetryBaseService {
   constructor(
     protected eventEmitter: EventEmitter2,
     protected readonly commandsService: CommandsService,
+    private readonly databaseRepository: DatabaseRepository,
   ) {
     super(eventEmitter, commandsService);
   }
 
-  sendIndexInfoEvent(
+  private async resolveIsProduction(
+    sessionMetadata: SessionMetadata,
+    databaseId: string,
+  ): Promise<'true' | 'false'> {
+    try {
+      const database = await this.databaseRepository.get(
+        sessionMetadata,
+        databaseId,
+      );
+      return database?.isProduction ? 'true' : 'false';
+    } catch (e) {
+      return 'false';
+    }
+  }
+
+  async sendIndexInfoEvent(
     sessionMetadata: SessionMetadata,
     databaseId: string,
     commandExecutionType: CommandExecutionType,
     additionalData: object,
-  ): void {
+  ): Promise<void> {
     if (!additionalData) {
       return;
     }
@@ -42,6 +59,10 @@ export class WorkbenchAnalytics extends CommandTelemetryBaseService {
       this.sendEvent(sessionMetadata, event, {
         databaseId,
         ...additionalData,
+        isProduction: await this.resolveIsProduction(
+          sessionMetadata,
+          databaseId,
+        ),
       });
     } catch (e) {
       // ignore error
@@ -81,6 +102,11 @@ export class WorkbenchAnalytics extends CommandTelemetryBaseService {
   ): Promise<void> {
     const { status } = result;
     try {
+      const { dangerous, ...rest } = additionalData as {
+        dangerous?: boolean;
+        command?: string;
+        [k: string]: any;
+      };
       if (status === CommandExecutionStatus.Success) {
         const event =
           commandExecutionType === CommandExecutionType.Search
@@ -89,19 +115,25 @@ export class WorkbenchAnalytics extends CommandTelemetryBaseService {
 
         this.sendEvent(sessionMetadata, event, {
           databaseId,
-          ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-          ...additionalData,
+          ...(await this.getCommandAdditionalInfo(rest['command'])),
+          ...rest,
+          isProduction: await this.resolveIsProduction(
+            sessionMetadata,
+            databaseId,
+          ),
+          dangerous: dangerous ? 'true' : 'false',
         });
       }
       if (status === CommandExecutionStatus.Fail) {
-        this.sendCommandErrorEvent(
+        await this.sendCommandErrorEvent(
           sessionMetadata,
           databaseId,
           result.error,
           commandExecutionType,
           {
-            ...(await this.getCommandAdditionalInfo(additionalData['command'])),
-            ...additionalData,
+            ...(await this.getCommandAdditionalInfo(rest['command'])),
+            ...rest,
+            dangerous,
           },
         );
       }
@@ -121,30 +153,44 @@ export class WorkbenchAnalytics extends CommandTelemetryBaseService {
     });
   }
 
-  private sendCommandErrorEvent(
+  private async sendCommandErrorEvent(
     sessionMetadata: SessionMetadata,
     databaseId: string,
     error: any,
     commandExecutionType: CommandExecutionType,
     additionalData: object = {},
-  ): void {
+  ): Promise<void> {
     try {
       const event =
         commandExecutionType === CommandExecutionType.Search
           ? TelemetryEvents.SearchCommandErrorReceived
           : TelemetryEvents.WorkbenchCommandErrorReceived;
 
+      const { dangerous, ...rest } = additionalData as {
+        dangerous?: boolean;
+        [k: string]: any;
+      };
+      const isProduction = await this.resolveIsProduction(
+        sessionMetadata,
+        databaseId,
+      );
+      const dangerousStr: 'true' | 'false' = dangerous ? 'true' : 'false';
+
       if (error instanceof HttpException) {
         this.sendFailedEvent(sessionMetadata, event, error, {
           databaseId,
-          ...additionalData,
+          ...rest,
+          isProduction,
+          dangerous: dangerousStr,
         });
       } else {
         this.sendEvent(sessionMetadata, event, {
           databaseId,
           error: error.name,
           command: error?.command?.name,
-          ...additionalData,
+          ...rest,
+          isProduction,
+          dangerous: dangerousStr,
         });
       }
     } catch (e) {


### PR DESCRIPTION
# What

Enriches existing backend analytics events with the connection's production status so we can answer the PRD's analytics questions ("did users run dangerous commands on prod?", "did Profiler start on prod?", "did bulk-delete confirm on prod?") without adding parallel FE `PROD_CONFIRMATION_SHOWN` events. Part of epic [RI-6594](https://redislabs.atlassian.net/browse/RI-6594) — Prod vs non-prod modes. Ticket: [RI-8196](https://redislabs.atlassian.net/browse/RI-8196).

Builds on [RI-8177](https://redislabs.atlassian.net/browse/RI-8177) (the `isProduction` field, `'true' | 'false'` string convention from `database.analytics.ts`) and [RI-8179](https://redislabs.atlassian.net/browse/RI-8179) (`DangerousCommandsProvider`, an ACL-CAT-backed dangerous-command cache).

### Events enriched

| Module | Events | New fields |
| --- | --- | --- |
| CLI | `CLI_COMMAND_EXECUTED`, `CLI_COMMAND_ERROR_RECEIVED`, `CLI_CLUSTER_NODE_COMMAND_EXECUTED` | `isProduction`, `dangerous` |
| Workbench | `WORKBENCH_COMMAND_EXECUTED`, `WORKBENCH_COMMAND_ERROR_RECEIVED`, `SEARCH_*` variants, `WORKBENCH_INDEX_INFO_SUBMITTED` | `isProduction`, `dangerous` (index info: `isProduction` only) |
| Bulk actions | `BULK_ACTIONS_STARTED`, `BULK_ACTIONS_STOPPED`, `BULK_ACTIONS_SUCCEED`, `BULK_ACTIONS_FAILED` | `isProduction`, `dangerous` (true for Delete/Unlink), `confirmedThrough` |
| Profiler | `PROFILER_LOG_DOWNLOADED`, `PROFILER_LOG_DELETED`, **new** `PROFILER_STARTED` | `isProduction` |

### Implementation notes

- Each analytics service injects `DatabaseRepository` and uses a private `resolveIsProduction(...)` helper, wrapped in try/catch (defaults to `'false'` on lookup failure so analytics never blocks the request path).
- `dangerous` is computed in the **caller** (CLI/Workbench command executors) using `DangerousCommandsProvider.getDangerousCommands(client)` — the cache is per-database, so the cost is one ACL CAT round-trip per connection. Caller passes the boolean via `additionalData`; the analytics service stringifies it.
- For Bulk actions, `dangerous` is derived from `BulkActionType` (Delete/Unlink → `'true'`, Upload → `'false'`) since there's no command-level granularity.
- New optional `confirmedThrough: 'standard' | 'type-to-confirm'` field on `CreateBulkActionDto`, threaded through `BulkAction` → `IBulkActionOverview` → analytics. Defaults to `null` (for paths that don't go through a confirmation dialog, including all imports).
- `DangerousCommandsProvider` is now exported from `DatabaseModule`.
- New `PROFILER_STARTED` event fires from `ProfilerService.addListenerForInstance` after the listener attaches.

### Out of scope (deferred)

Browser write events (key rename / delete / TTL change / value mutations, hash/list/set/zset/stream writes). The ticket's #5 scope item assumes existing BE analytics to enrich, but the codebase has **none** for those services — they're FE-tracked today. Adding them is a net-new module-wide telemetry effort and exceeds the "enrich existing emits" framing. RI-8184 will need to keep its FE confirmation event or get a follow-up BE ticket.

# Testing

- **Unit tests**: 238 affected tests pass (`cli-analytics`, `cli-business`, `workbench.analytics`, `workbench-commands.executor`, `bulk-actions.analytics`, `bulk-import.service`, `bulk-action`, new `profiler-analytics.service.spec.ts`). Full API suite (3444 tests) green. New assertions cover:
  - `isProduction='true'` when the database is production-flagged
  - `dangerous` passthrough for command events and Delete vs Upload for bulk
  - `confirmedThrough` round-trips through the bulk-action DTO
  - `isProduction='false'` fallback when the repository lookup throws
- **Lint**: clean on all touched files.
- **Type check**: no new `src/` errors (pre-existing `test/` failures unchanged).
- **Manual smoke** (still to do before un-drafting): with a prod-flagged and a non-prod database connected, run `GET foo` and `FLUSHDB` from CLI/Workbench and confirm Segment payloads carry the correct `isProduction` and `dangerous`; trigger a bulk-delete with the FE confirmation dialog and confirm `confirmedThrough='type-to-confirm'`; open Profiler and confirm `PROFILER_STARTED` fires once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RI-6594]: https://redislabs.atlassian.net/browse/RI-6594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RI-8196]: https://redislabs.atlassian.net/browse/RI-8196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RI-8177]: https://redislabs.atlassian.net/browse/RI-8177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RI-8179]: https://redislabs.atlassian.net/browse/RI-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ