### PR TITLE
Add root tscheck and tscheck:force scripts + fix ts issue

### DIFF
--- a/.ai/skills/type-check-baselines/SKILL.md
+++ b/.ai/skills/type-check-baselines/SKILL.md
@@ -14,14 +14,20 @@ RedisInsight gates TypeScript errors per project via a one-way ratchet: current 
 
 ## Projects and commands
 
-| Project | tsconfig used | Baseline file | Compare | Refresh |
-| - | - | - | - | - |
-| UI | `redisinsight/ui/tsconfig.json` | `redisinsight/ui/.tscheck.rec.json` | `yarn --cwd redisinsight/ui type-check` | `yarn --cwd redisinsight/ui tscheck` |
-| API | `redisinsight/api/tsconfig.check.json` (strict, extends base) | `redisinsight/api/.tscheck.rec.json` | `yarn --cwd redisinsight/api type-check` | `yarn --cwd redisinsight/api tscheck` |
-| Desktop | `redisinsight/desktop/tsconfig.json` | `redisinsight/desktop/.tscheck.rec.json` | `yarn --cwd redisinsight/desktop type-check` | `yarn --cwd redisinsight/desktop tscheck` |
-| Configs | `configs/tsconfig.json` | — (must stay at 0 errors) | `yarn tsc --project configs/tsconfig.json --noEmit` | — |
+| Project | tsconfig used | Baseline file | Per-project compare |
+| - | - | - | - |
+| UI | `redisinsight/ui/tsconfig.json` | `redisinsight/ui/.tscheck.rec.json` | `yarn --cwd redisinsight/ui type-check` |
+| API | `redisinsight/api/tsconfig.check.json` (strict, extends base) | `redisinsight/api/.tscheck.rec.json` | `yarn --cwd redisinsight/api type-check` |
+| Desktop | `redisinsight/desktop/tsconfig.json` | `redisinsight/desktop/.tscheck.rec.json` | `yarn --cwd redisinsight/desktop type-check` |
+| Configs | `configs/tsconfig.json` | — (must stay at 0 errors) | `yarn tsc --project configs/tsconfig.json --noEmit` |
 
-`yarn type-check` (at repo root) runs all four. E2E Playwright is type-checked by a separate workflow (`tests-e2e-playwright-lint.yml`) — not part of `yarn type-check`. Force-overwrite for emergencies is `yarn --cwd redisinsight/<workspace> tscheck:force`.
+Run all checks together from the repo root:
+
+- `yarn type-check` — compare against baselines (all four projects). E2E Playwright is type-checked by a separate workflow (`tests-e2e-playwright-lint.yml`) — not part of this.
+- `yarn tscheck` — refresh baselines for ui/api/desktop after fixing errors. Projects whose error count didn't change produce no diff.
+- `yarn tscheck:force` — force-overwrite baselines for ui/api/desktop. Emergencies only.
+
+**Always run refresh commands through the root `yarn tscheck` / `yarn tscheck:force` wrappers.** The per-workspace refresh scripts (`yarn --cwd redisinsight/<ws> tscheck`) shell out to `tsc`, `tsx`, and `tsc-output-parser`, which are installed only in the **root** `node_modules/.bin/` — this repo is not a yarn workspace, so yarn won't add the root bin dir to PATH when invoked with `--cwd`. The root wrappers exist precisely to avoid that trap by running in the root yarn context first. If you must invoke the per-package script directly, prepend the root bin dir manually: `PATH="$PWD/node_modules/.bin:$PATH" yarn --cwd redisinsight/ui tscheck`.
 
 ## API has a dedicated check tsconfig
 
@@ -44,13 +50,13 @@ You introduced new errors. Fix them. Read the script output — it lists the fil
 
 ### CI says "baseline is outdated"
 
-You fixed errors (good). Refresh the baseline:
+You fixed errors (good). Refresh baselines from the repo root:
 
 ```sh
-yarn --cwd redisinsight/ui tscheck    # or api / desktop
+yarn tscheck
 ```
 
-Commit the updated `.tscheck.rec.json`.
+This runs the refresh for ui, api, and desktop; only the project whose count changed will produce a diff. Commit the updated `.tscheck.rec.json`.
 
 ### Adding a brand-new file with TS errors
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "test:cov:unit": "jest ./redisinsight/ui --group=-component --coverage -w 1",
     "test:cov:component": "jest ./redisinsight/ui --group=component --coverage -w 1",
     "type-check": "yarn --cwd redisinsight/ui type-check && yarn --cwd redisinsight/api type-check && yarn --cwd redisinsight/desktop type-check && tsc --project configs/tsconfig.json --noEmit",
+    "tscheck": "yarn --cwd redisinsight/ui tscheck && yarn --cwd redisinsight/api tscheck && yarn --cwd redisinsight/desktop tscheck",
+    "tscheck:force": "yarn --cwd redisinsight/ui tscheck:force && yarn --cwd redisinsight/api tscheck:force && yarn --cwd redisinsight/desktop tscheck:force",
     "sb": "storybook dev -p 6006",
     "build-sb": "storybook build"
   },

--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -634,7 +634,6 @@
   },
   "src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx": {
     "TS2339": 5,
-    "TS2345": 1,
     "TS2722": 1
   },
   "src/pages/home/components/manual-connection/ManualConnectionWrapper.tsx": {

--- a/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.spec.tsx
@@ -9,6 +9,7 @@ import ManualConnectionFrom, {
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { createInstanceStandaloneAction } from 'uiSrc/slices/instances/instances'
 import ManualConnectionWrapper, { Props } from './ManualConnectionWrapper'
+import { DbConnectionInfo } from '../../interfaces'
 
 const mockedProps = mock<Props>()
 
@@ -47,7 +48,7 @@ const mockManualConnectionFrom = (props: ManualConnectionFromProps) => (
     <button
       type="submit"
       data-testid="btn-submit"
-      onClick={() => props.onSubmit({})}
+      onClick={() => props.onSubmit({} as DbConnectionInfo)}
     >
       {props.submitButtonText}
     </button>
@@ -60,7 +61,7 @@ const mockManualConnectionFrom = (props: ManualConnectionFromProps) => (
           host: 'localhost',
           port: '6379',
           isProduction: true,
-        })
+        } as DbConnectionInfo)
       }
     >
       submit with isProduction


### PR DESCRIPTION
# What

Adds root-level `tscheck` and `tscheck:force` scripts that chain the per-workspace refresh scripts for ui/api/desktop, mirroring the existing root `type-check`. Updates the `type-check-baselines` skill to point at the new wrappers and document the PATH gotcha they sidestep.

The per-workspace scripts shell out to `tsc`, `tsx`, and `tsc-output-parser`, which exist only in the **root** `node_modules/.bin/`. This repo is not a yarn workspace, so `yarn --cwd redisinsight/<ws> tscheck` does not pick up the root bin dir on PATH and fails with `command not found` from a fresh shell. The root wrappers run in the root yarn context first, so child invocations inherit the correct PATH.

# Testing

```sh
yarn tscheck         # refresh all three baselines from repo root
yarn tscheck:force   # force-overwrite all three baselines
yarn type-check      # still green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds root-level script wrappers and documentation, plus a small test-only type assertion that reduces a recorded TS error count.
> 
> **Overview**
> Adds root `yarn tscheck` and `yarn tscheck:force` scripts that run the existing per-workspace baseline refresh commands for UI/API/Desktop, aligning with the existing root `type-check` workflow.
> 
> Updates the `type-check-baselines` skill doc to prefer the new root wrappers and explains the PATH issue they avoid when using `yarn --cwd`.
> 
> Fixes a TypeScript error in `ManualConnectionWrapper.spec.tsx` by typing the `onSubmit` payload as `DbConnectionInfo`, and updates the UI `.tscheck.rec.json` baseline to reflect the removed `TS2345` error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f35bf30cf7231f4250e894e0d81d2ecc2b8d841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->