### PR TITLE
RI-8189 Disable tutorial Run + bulk-imports on production connections

### DIFF
--- a/redisinsight/ui/src/components/markdown/CodeButtonBlock/CodeButtonBlock.spec.tsx
+++ b/redisinsight/ui/src/components/markdown/CodeButtonBlock/CodeButtonBlock.spec.tsx
@@ -1,11 +1,21 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import reactRouterDom from 'react-router-dom'
-import { fireEvent, render, screen, act } from 'uiSrc/utils/test-utils'
+import {
+  fireEvent,
+  render,
+  screen,
+  act,
+  waitForRiTooltipVisible,
+} from 'uiSrc/utils/test-utils'
 import { Pages } from 'uiSrc/constants'
 import { setDBConfigStorageField } from 'uiSrc/services'
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
+
+const PRODUCTION_DISABLED_TOOLTIP =
+  'Button disabled for your production database to avoid accidental data modifications.'
 import CodeButtonBlock, { Props } from './CodeButtonBlock'
 
 const mockedProps = mock<Props>()
@@ -22,6 +32,18 @@ jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
   sendEventTelemetry: jest.fn(),
 }))
+
+jest.mock('uiSrc/components/hooks/useDatabaseMode', () => ({
+  ...jest.requireActual('uiSrc/components/hooks/useDatabaseMode'),
+  useDatabaseMode: jest.fn(),
+}))
+
+beforeEach(() => {
+  ;(useDatabaseMode as jest.Mock).mockReturnValue({
+    mode: 'unmarked',
+    isDangerousCommand: () => false,
+  })
+})
 
 describe('CodeButtonBlock', () => {
   it('should render', () => {
@@ -253,5 +275,80 @@ describe('CodeButtonBlock', () => {
     expect(
       screen.getByTestId('database-not-opened-popover'),
     ).toBeInTheDocument()
+  })
+
+  describe('production mode', () => {
+    it('should disable Run button and not call onApply when mode is production', () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+      const onApply = jest.fn()
+
+      render(
+        <CodeButtonBlock
+          {...instance(mockedProps)}
+          label={label}
+          onApply={onApply}
+          content={simpleContent}
+        />,
+      )
+
+      const runBtn = screen.getByTestId(`run-btn-${label}`)
+      expect(runBtn).toBeDisabled()
+
+      fireEvent.click(runBtn)
+      expect(onApply).not.toBeCalled()
+    })
+
+    it('should show the production tooltip copy on focus when mode is production', async () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+
+      render(
+        <CodeButtonBlock
+          {...instance(mockedProps)}
+          label={label}
+          onApply={jest.fn()}
+          content={simpleContent}
+        />,
+      )
+
+      await act(async () => {
+        fireEvent.focus(screen.getByTestId(`run-btn-${label}`).parentElement!)
+      })
+      await waitForRiTooltipVisible()
+
+      expect(
+        screen.getAllByText(PRODUCTION_DISABLED_TOOLTIP)[0],
+      ).toBeInTheDocument()
+    })
+
+    it('should keep Run button enabled when mode is unmarked', () => {
+      reactRouterDom.useParams = jest
+        .fn()
+        .mockReturnValue({ instanceId: 'instanceId' })
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'unmarked',
+        isDangerousCommand: () => false,
+      })
+      const onApply = jest.fn()
+
+      render(
+        <CodeButtonBlock
+          {...instance(mockedProps)}
+          label={label}
+          onApply={onApply}
+          content={simpleContent}
+        />,
+      )
+
+      const runBtn = screen.getByTestId(`run-btn-${label}`)
+      expect(runBtn).not.toBeDisabled()
+      fireEvent.click(runBtn)
+      expect(onApply).toBeCalled()
+    })
   })
 })

--- a/redisinsight/ui/src/components/markdown/CodeButtonBlock/CodeButtonBlock.tsx
+++ b/redisinsight/ui/src/components/markdown/CodeButtonBlock/CodeButtonBlock.tsx
@@ -37,6 +37,7 @@ import {
 } from 'uiSrc/components/base/icons'
 import { Title } from 'uiSrc/components/base/text/Title'
 import { AdditionalRedisModule } from 'apiClient'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
 
 import { RunConfirmationPopover } from './components'
 import styles from './styles.module.scss'
@@ -78,6 +79,8 @@ const CodeButtonBlock = (props: Props) => {
   const [isCopied, setIsCopied] = useState(false)
 
   const { instanceId } = useParams<{ instanceId: string }>()
+  const { mode } = useDatabaseMode()
+  const isProduction = mode === 'production'
 
   const isButtonHasConfirmation =
     params?.run_confirmation === BooleanParams.true
@@ -211,9 +214,11 @@ const CodeButtonBlock = (props: Props) => {
               button={
                 <RiTooltip
                   content={
-                    isPopoverOpen
-                      ? undefined
-                      : 'Open Workbench in the top navbar to see the command results.'
+                    isProduction
+                      ? 'Button disabled for your production database to avoid accidental data modifications.'
+                      : isPopoverOpen
+                        ? undefined
+                        : 'Open Workbench in the top navbar to see the command results.'
                   }
                   data-testid="run-btn-open-workbench-tooltip"
                 >
@@ -222,7 +227,7 @@ const CodeButtonBlock = (props: Props) => {
                     icon={isRan ? CheckBoldIcon : PlayIcon}
                     iconSide="right"
                     size="small"
-                    disabled={isLoading || isRan}
+                    disabled={isLoading || isRan || isProduction}
                     loading={isLoading}
                     className={cx(styles.actionBtn, styles.runBtn)}
                     {...rest}

--- a/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.spec.tsx
+++ b/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.spec.tsx
@@ -9,6 +9,7 @@ import {
   mockedStore,
   render,
   screen,
+  waitForRiTooltipVisible,
 } from 'uiSrc/utils/test-utils'
 import {
   customTutorialsBulkUploadSelector,
@@ -18,7 +19,11 @@ import {
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { checkResourse } from 'uiSrc/services/resourcesService'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
 import RedisUploadButton, { Props } from './RedisUploadButton'
+
+const PRODUCTION_DISABLED_TOOLTIP =
+  'Button disabled for your production database to avoid accidental data modifications.'
 
 jest.mock('uiSrc/slices/workbench/wb-custom-tutorials', () => ({
   ...jest.requireActual('uiSrc/slices/workbench/wb-custom-tutorials'),
@@ -37,11 +42,20 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
+jest.mock('uiSrc/components/hooks/useDatabaseMode', () => ({
+  ...jest.requireActual('uiSrc/components/hooks/useDatabaseMode'),
+  useDatabaseMode: jest.fn(),
+}))
+
 let store: typeof mockedStore
 beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
   store.clearActions()
+  ;(useDatabaseMode as jest.Mock).mockReturnValue({
+    mode: 'unmarked',
+    isDangerousCommand: () => false,
+  })
 })
 
 const props: Props = {
@@ -160,5 +174,59 @@ describe('RedisUploadButton', () => {
       },
     })
     ;(sendEventTelemetry as jest.Mock).mockRestore()
+  })
+
+  describe('production mode', () => {
+    it('should disable the bulk-import button when mode is production', () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+
+      render(<RedisUploadButton {...props} />)
+
+      const btn = screen.getByTestId('upload-data-bulk-btn')
+      expect(btn).toBeDisabled()
+    })
+
+    it('should not open popover or fire telemetry when clicked in production', () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+      const sendEventTelemetryMock = jest.fn()
+      ;(sendEventTelemetry as jest.Mock).mockImplementation(
+        sendEventTelemetryMock,
+      )
+
+      render(<RedisUploadButton {...props} />)
+
+      fireEvent.click(screen.getByTestId('upload-data-bulk-btn'))
+
+      expect(
+        screen.queryByTestId('upload-data-bulk-tooltip'),
+      ).not.toBeInTheDocument()
+      expect(sendEventTelemetryMock).not.toBeCalled()
+    })
+
+    it('should show the production tooltip copy on focus in production', async () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+
+      render(<RedisUploadButton {...props} />)
+
+      await act(async () => {
+        fireEvent.focus(
+          screen.getByTestId('upload-data-bulk-btn').parentElement!,
+        )
+      })
+      await waitForRiTooltipVisible()
+
+      expect(
+        screen.getAllByText(PRODUCTION_DISABLED_TOOLTIP)[0],
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.tsx
+++ b/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.tsx
@@ -28,9 +28,10 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { PlayFilledIcon, ContractsIcon } from 'uiSrc/components/base/icons'
 import { Text } from 'uiSrc/components/base/text'
-import { RiPopover } from 'uiSrc/components/base'
+import { RiPopover, RiTooltip } from 'uiSrc/components/base'
 import { Link } from 'uiSrc/components/base/link/Link'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -46,6 +47,8 @@ const RedisUploadButton = ({ label, path }: Props) => {
 
   const dispatch = useDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
+  const { mode } = useDatabaseMode()
+  const isProduction = mode === 'production'
 
   const urlToFile = getPathToResource(path)
 
@@ -118,18 +121,28 @@ const RedisUploadButton = ({ label, path }: Props) => {
         anchorClassName={styles.popoverAnchor}
         panelPaddingSize="none"
         button={
-          <SecondaryButton
-            loading={isLoading}
-            iconSide="right"
-            icon={ContractsIcon}
-            size="s"
-            className={styles.button}
-            onClick={openPopover}
-            color="secondary"
-            data-testid="upload-data-bulk-btn"
+          <RiTooltip
+            content={
+              isProduction
+                ? 'Button disabled for your production database to avoid accidental data modifications.'
+                : undefined
+            }
+            data-testid="upload-data-bulk-btn-tooltip"
           >
-            {truncateText(label, 86)}
-          </SecondaryButton>
+            <SecondaryButton
+              loading={isLoading}
+              disabled={isProduction}
+              iconSide="right"
+              icon={ContractsIcon}
+              size="s"
+              className={styles.button}
+              onClick={openPopover}
+              color="secondary"
+              data-testid="upload-data-bulk-btn"
+            >
+              {truncateText(label, 86)}
+            </SecondaryButton>
+          </RiTooltip>
         }
       >
         {instanceId ? (

--- a/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.spec.tsx
@@ -5,9 +5,11 @@ import {
   screen,
   fireEvent,
   waitForRiPopoverVisible,
+  waitForRiTooltipVisible,
   mockedStore,
   cleanup,
   waitForStack,
+  act,
 } from 'uiSrc/utils/test-utils'
 
 import {
@@ -18,7 +20,11 @@ import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { apiService } from 'uiSrc/services'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import successMessages from 'uiSrc/components/notifications/success-messages'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
 import LoadSampleData from './LoadSampleData'
+
+const PRODUCTION_DISABLED_TOOLTIP =
+  'Button disabled for your production database to avoid accidental data modifications.'
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
@@ -32,11 +38,20 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
+jest.mock('uiSrc/components/hooks/useDatabaseMode', () => ({
+  ...jest.requireActual('uiSrc/components/hooks/useDatabaseMode'),
+  useDatabaseMode: jest.fn(),
+}))
+
 let store: typeof mockedStore
 beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
   store.clearActions()
+  ;(useDatabaseMode as jest.Mock).mockReturnValue({
+    mode: 'unmarked',
+    isDangerousCommand: () => false,
+  })
 })
 
 describe('LoadSampleData', () => {
@@ -75,6 +90,45 @@ describe('LoadSampleData', () => {
     expect(sendEventTelemetry).toBeCalledWith({
       event: TelemetryEvent.IMPORT_SAMPLES_CLICKED,
       eventData: { databaseId: '1' },
+    })
+  })
+
+  describe('production mode', () => {
+    it('should disable the button and not open the popover in production', () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+
+      render(<LoadSampleData />)
+
+      const btn = screen.getByTestId('load-sample-data-btn')
+      expect(btn).toBeDisabled()
+
+      fireEvent.click(btn)
+      expect(
+        screen.queryByTestId('load-sample-data-btn-confirm'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should show the production tooltip copy on focus in production', async () => {
+      ;(useDatabaseMode as jest.Mock).mockReturnValue({
+        mode: 'production',
+        isDangerousCommand: () => false,
+      })
+
+      render(<LoadSampleData />)
+
+      await act(async () => {
+        fireEvent.focus(
+          screen.getByTestId('load-sample-data-btn').parentElement!,
+        )
+      })
+      await waitForRiTooltipVisible()
+
+      expect(
+        screen.getAllByText(PRODUCTION_DISABLED_TOOLTIP)[0],
+      ).toBeInTheDocument()
     })
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.tsx
+++ b/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.tsx
@@ -17,8 +17,9 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { PlayFilledIcon } from 'uiSrc/components/base/icons'
 import { Text } from 'uiSrc/components/base/text'
-import { RiPopover } from 'uiSrc/components/base'
+import { RiPopover, RiTooltip } from 'uiSrc/components/base'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -32,6 +33,8 @@ const LoadSampleData = (props: Props) => {
 
   const { id } = useSelector(connectedInstanceSelector)
   const { loading } = useSelector(bulkActionsSelector)
+  const { mode } = useDatabaseMode()
+  const isProduction = mode === 'production'
 
   const dispatch = useDispatch()
 
@@ -58,16 +61,25 @@ const LoadSampleData = (props: Props) => {
       panelPaddingSize="none"
       anchorClassName={cx(styles.buttonWrapper, anchorClassName)}
       button={
-        <SecondaryButton
-          filled
-          onClick={() => setIsConfirmationOpen(true)}
-          className={styles.loadDataBtn}
-          loading={loading}
-          disabled={loading}
-          data-testid="load-sample-data-btn"
+        <RiTooltip
+          content={
+            isProduction
+              ? 'Button disabled for your production database to avoid accidental data modifications.'
+              : undefined
+          }
+          data-testid="load-sample-data-btn-tooltip"
         >
-          Load sample data
-        </SecondaryButton>
+          <SecondaryButton
+            filled
+            onClick={() => setIsConfirmationOpen(true)}
+            className={styles.loadDataBtn}
+            loading={loading}
+            disabled={loading || isProduction}
+            data-testid="load-sample-data-btn"
+          >
+            Load sample data
+          </SecondaryButton>
+        </RiTooltip>
       }
     >
       <Row gap="m" responsive={false} style={{ padding: 15 }}>


### PR DESCRIPTION
# What

Wire `useDatabaseMode` into the three write-data surfaces tied to tutorials / sample data, so they are disabled with a tooltip when the connected database mode is `production`. All other modes (`fast`, `unmarked`, `disabled`) keep today's behaviour.

Gated surfaces:
- **CodeButtonBlock** — the `Run` button on tutorial code blocks.
- **RedisUploadButton** — the in-tutorial bulk-upload control rendered by the `redis-upload` markdown directive.
- **LoadSampleData** — the "Load sample data" button shown in the browser empty-state.

Tooltip copy (PRD-verbatim): _"Button disabled for your production database to avoid accidental data modifications."_

| Non-prod | Prod |
| --- | --- |
| <img width="507" height="394" alt="Screenshot 2026-05-18 at 17 48 48" src="https://github.com/user-attachments/assets/f378ad2e-f6a0-4e31-bacb-5c2e99251cd1" /> | <img width="664" height="499" alt="Screenshot 2026-05-18 at 17 47 44" src="https://github.com/user-attachments/assets/9927848d-b9db-42e0-bb2b-90a7d37b0157" /> |
| <img width="497" height="380" alt="Screenshot 2026-05-18 at 17 48 54" src="https://github.com/user-attachments/assets/fb77c0ca-83f4-44f1-9f41-8dd74f966ee4" /> | <img width="485" height="338" alt="Screenshot 2026-05-18 at 17 55 56" src="https://github.com/user-attachments/assets/584d70fb-8843-47f0-8236-8ba3fc1ebf68" /> |

# Testing

1. Toggle the `dev-prodMode` feature flag on.
2. Mark a connected database as production (RI-8180 toggle on the connection form).
3. Open a built-in tutorial → `Run` button is disabled with the prod tooltip on hover.
4. Open a tutorial that contains a `redis-upload` directive (e.g. a sample-data tutorial) → bulk-upload button is disabled with the prod tooltip; clicking does nothing and no telemetry fires.
5. In `/browser`, on an empty database (no keys) → "Load sample data" button is disabled with the prod tooltip.
6. Switch to a non-production connection (or toggle the flag off) → all three controls return to today's behaviour.

Unit tests: 30/30 passing.

---

Closes #RI-8189


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing execution paths by disabling tutorial run/bulk-import controls in `production` mode; risk is mainly regressions around incorrectly disabling actions or tooltip/telemetry behavior.
> 
> **Overview**
> Prevents write-affecting tutorial/sample-data actions on *production* connections by wiring `useDatabaseMode` into the tutorial `Run` button (`CodeButtonBlock`), the `redis-upload` bulk-import button (`RedisUploadButton`), and the browser empty-state *Load sample data* control (`LoadSampleData`).
> 
> In `production`, these buttons are now disabled and show a consistent tooltip message; clicks no longer open their confirmation popovers or trigger the associated actions/telemetry. Unit tests were extended to cover `production` vs non-prod behavior and tooltip visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e1460b75db6affec97896694e5444c8d263cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->