### PR TITLE
RI-8162: load sample vector set

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -111,6 +111,7 @@ const AddKey = (props: Props) => {
   )
   const [keyName, setKeyName] = useState<string>('')
   const [keyTTL, setKeyTTL] = useState<Maybe<number>>(undefined)
+  const [keyNameDisabled, setKeyNameDisabled] = useState<boolean>(false)
 
   const onChangeType = (value: string) => {
     setTypeSelected(value)
@@ -188,6 +189,7 @@ const AddKey = (props: Props) => {
                 setKeyName={setKeyName}
                 keyTTL={keyTTL}
                 setKeyTTL={setKeyTTL}
+                keyNameDisabled={keyNameDisabled}
               />
 
               <Spacer size="xl" />

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -235,6 +235,8 @@ const AddKey = (props: Props) => {
               {typeSelected === KeyTypes.VectorSet && (
                 <AddKeyVectorSet
                   onCancel={closeAddKeyPanel}
+                  setKeyName={setKeyName}
+                  setKeyNameDisabled={setKeyNameDisabled}
                   {...defaultFields}
                 />
               )}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyCommonFields/AddKeyCommonFields.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyCommonFields/AddKeyCommonFields.tsx
@@ -21,6 +21,12 @@ export interface Props {
   setKeyName: React.Dispatch<React.SetStateAction<string>>
   keyTTL: Maybe<number>
   setKeyTTL: React.Dispatch<React.SetStateAction<Maybe<number>>>
+  /**
+   * When true, the key-name input is rendered as disabled in addition to the
+   * existing `loading` gate. Used by the vector-set "Load sample dataset"
+   * flow to lock the key name to the bundled `vec2word` value.
+   */
+  keyNameDisabled?: boolean
 }
 
 const AddKeyCommonFields = (props: Props) => {
@@ -33,6 +39,7 @@ const AddKeyCommonFields = (props: Props) => {
     setKeyName,
     keyTTL,
     setKeyTTL,
+    keyNameDisabled = false,
   } = props
 
   const handleTTLChange = (value: string) => {
@@ -91,7 +98,7 @@ const AddKeyCommonFields = (props: Props) => {
           value={keyName}
           placeholder={config.keyName.placeholder}
           onChange={setKeyName}
-          disabled={loading}
+          disabled={loading || keyNameDisabled}
           autoComplete="off"
           data-testid="key"
         />

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from 'uiSrc/utils/test-utils'
-import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import { addVectorSetKey, loadKeys } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
 import { FP32_VECTOR_FIXTURE_1_2_3 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { bulkActionOverviewFactory } from 'uiSrc/mocks/factories/browser/bulkActions/bulkActionOverview.factory'
@@ -17,6 +17,7 @@ import { Props } from './AddKeyVectorSet.types'
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
   addVectorSetKey: jest.fn(() => ({ type: 'keys/addVectorSetKey' })),
+  loadKeys: jest.fn(() => ({ type: 'keys/loadKeys' })),
 }))
 
 const mockLoad = jest.fn()
@@ -203,7 +204,7 @@ describe('AddKeyVectorSet', () => {
         }),
       )
 
-    it('on submit calls useLoadData.load with vec2word and closes the dialog on success', async () => {
+    it('on submit calls useLoadData.load with vec2word, refreshes the keys list, surfaces a success toast and closes the dialog', async () => {
       mockLoad.mockResolvedValue(bulkActionOverviewFactory.build())
       const onCancel = jest.fn()
       renderComponent({ onCancel })
@@ -216,6 +217,8 @@ describe('AddKeyVectorSet', () => {
       await waitFor(() =>
         expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
       )
+      expect(loadKeys).toHaveBeenCalled()
+      expectMessageDispatched('Sample dataset loaded')
       expect(onCancel).toHaveBeenCalled()
       expect(addVectorSetKey).not.toHaveBeenCalled()
     })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -230,9 +230,7 @@ describe('AddKeyVectorSet', () => {
         fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
       })
 
-      await waitFor(() =>
-        expectMessageDispatched('Sample dataset already loaded'),
-      )
+      await waitFor(() => expectMessageDispatched('Key already exists'))
       expect(mockLoad).not.toHaveBeenCalled()
       expect(onCancel).toHaveBeenCalled()
     })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
-import { act, fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
+import {
+  act,
+  fireEvent,
+  mockedStore,
+  render,
+  screen,
+  waitFor,
+} from 'uiSrc/utils/test-utils'
 import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
-import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { stringToBuffer } from 'uiSrc/utils'
 import { FP32_VECTOR_FIXTURE_1_2_3 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { bulkActionOverviewFactory } from 'uiSrc/mocks/factories/browser/bulkActions/bulkActionOverview.factory'
@@ -11,13 +17,6 @@ import { Props } from './AddKeyVectorSet.types'
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
   addVectorSetKey: jest.fn(() => ({ type: 'keys/addVectorSetKey' })),
-}))
-
-jest.mock('uiSrc/slices/app/notifications', () => ({
-  ...jest.requireActual('uiSrc/slices/app/notifications'),
-  addMessageNotification: jest.fn(() => ({
-    type: 'notifications/addMessageNotification',
-  })),
 }))
 
 const mockLoad = jest.fn()
@@ -51,6 +50,7 @@ describe('AddKeyVectorSet', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedStore.clearActions()
     // Default: vec2word does not exist, so submit proceeds to bulk-import.
     mockCheckVec2WordExists.mockResolvedValue(false)
     // ActionFooter renders via a portal to #formFooterBar
@@ -195,6 +195,14 @@ describe('AddKeyVectorSet', () => {
       expect(setKeyNameDisabled).toHaveBeenLastCalledWith(false)
     })
 
+    const expectMessageDispatched = (title: string) =>
+      expect(mockedStore.getActions()).toContainEqual(
+        expect.objectContaining({
+          type: 'notifications/addMessageNotification',
+          payload: expect.objectContaining({ title }),
+        }),
+      )
+
     it('on submit calls useLoadData.load with vec2word and closes the dialog on success', async () => {
       mockLoad.mockResolvedValue(bulkActionOverviewFactory.build())
       const onCancel = jest.fn()
@@ -209,7 +217,6 @@ describe('AddKeyVectorSet', () => {
         expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
       )
       expect(onCancel).toHaveBeenCalled()
-      expect(addMessageNotification).not.toHaveBeenCalled()
       expect(addVectorSetKey).not.toHaveBeenCalled()
     })
 
@@ -224,12 +231,7 @@ describe('AddKeyVectorSet', () => {
       })
 
       await waitFor(() =>
-        expect(addMessageNotification).toHaveBeenCalledWith(
-          expect.objectContaining({
-            title: 'Sample dataset already loaded',
-            variant: 'notice',
-          }),
-        ),
+        expectMessageDispatched('Sample dataset already loaded'),
       )
       expect(mockLoad).not.toHaveBeenCalled()
       expect(onCancel).toHaveBeenCalled()
@@ -245,11 +247,7 @@ describe('AddKeyVectorSet', () => {
         fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
       })
 
-      await waitFor(() =>
-        expect(addMessageNotification).toHaveBeenCalledWith(
-          expect.objectContaining({ title: 'Failed to create vector set' }),
-        ),
-      )
+      await waitFor(() => expectMessageDispatched('Failed to create vector set'))
       expect(onCancel).not.toHaveBeenCalled()
     })
   })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from 'uiSrc/utils/test-utils'
-import { addVectorSetKey, loadKeys } from 'uiSrc/slices/browser/keys'
+import { addKeyIntoList, addVectorSetKey } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
 import { FP32_VECTOR_FIXTURE_1_2_3 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
 import { bulkActionOverviewFactory } from 'uiSrc/mocks/factories/browser/bulkActions/bulkActionOverview.factory'
@@ -17,7 +17,7 @@ import { Props } from './AddKeyVectorSet.types'
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
   addVectorSetKey: jest.fn(() => ({ type: 'keys/addVectorSetKey' })),
-  loadKeys: jest.fn(() => ({ type: 'keys/loadKeys' })),
+  addKeyIntoList: jest.fn(() => ({ type: 'keys/addKeyIntoList' })),
 }))
 
 const mockLoad = jest.fn()
@@ -217,7 +217,9 @@ describe('AddKeyVectorSet', () => {
       await waitFor(() =>
         expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
       )
-      expect(loadKeys).toHaveBeenCalled()
+      expect(addKeyIntoList).toHaveBeenCalledWith(
+        expect.objectContaining({ key: stringToBuffer('vec2word') }),
+      )
       expectMessageDispatched('Sample vector set added')
       expect(onCancel).toHaveBeenCalled()
       expect(addVectorSetKey).not.toHaveBeenCalled()

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -1,14 +1,40 @@
 import React from 'react'
-import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { act, fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
 import { addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { stringToBuffer } from 'uiSrc/utils'
 import { FP32_VECTOR_FIXTURE_1_2_3 } from 'uiSrc/mocks/factories/browser/vectorSet/vectorSetElement.factory'
+import { bulkActionOverviewFactory } from 'uiSrc/mocks/factories/browser/bulkActions/bulkActionOverview.factory'
 import AddKeyVectorSet from './AddKeyVectorSet'
 import { Props } from './AddKeyVectorSet.types'
 
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
   addVectorSetKey: jest.fn(() => ({ type: 'keys/addVectorSetKey' })),
+}))
+
+jest.mock('uiSrc/slices/app/notifications', () => ({
+  ...jest.requireActual('uiSrc/slices/app/notifications'),
+  addMessageNotification: jest.fn(() => ({
+    type: 'notifications/addMessageNotification',
+  })),
+}))
+
+const mockLoad = jest.fn()
+jest.mock('uiSrc/services/hooks', () => ({
+  ...jest.requireActual('uiSrc/services/hooks'),
+  useLoadData: () => ({
+    load: mockLoad,
+    loading: false,
+    error: null,
+  }),
+}))
+
+const mockCheckVec2WordExists = jest.fn()
+jest.mock('./LoadSampleDataset', () => ({
+  __esModule: true,
+  ...jest.requireActual('./LoadSampleDataset'),
+  checkVec2WordExists: (...args: unknown[]) => mockCheckVec2WordExists(...args),
 }))
 
 const defaultProps: Props = {
@@ -25,6 +51,8 @@ describe('AddKeyVectorSet', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    // Default: vec2word does not exist, so submit proceeds to bulk-import.
+    mockCheckVec2WordExists.mockResolvedValue(false)
     // ActionFooter renders via a portal to #formFooterBar
     const footer = document.createElement('div')
     footer.setAttribute('id', 'formFooterBar')
@@ -137,5 +165,92 @@ describe('AddKeyVectorSet', () => {
 
     fireEvent.click(screen.getByText('Cancel'))
     expect(onCancel).toHaveBeenCalledWith(true)
+  })
+
+  describe('sample dataset mode', () => {
+    const selectSampleMode = () =>
+      fireEvent.click(screen.getByTestId('add-key-vector-set-populate-sample'))
+    const selectManualMode = () =>
+      fireEvent.click(screen.getByTestId('add-key-vector-set-populate-manual'))
+
+    it('swaps the form section and mirrors populate mode into the parent keyName + disabled flag', () => {
+      const setKeyName = jest.fn()
+      const setKeyNameDisabled = jest.fn()
+      renderComponent({ setKeyName, setKeyNameDisabled })
+
+      // Initial Manual render → input cleared and unlocked.
+      expect(setKeyName).toHaveBeenLastCalledWith('')
+      expect(setKeyNameDisabled).toHaveBeenLastCalledWith(false)
+
+      selectSampleMode()
+      expect(
+        screen.getByTestId('add-key-vector-set-load-sample-dataset'),
+      ).toBeInTheDocument()
+      expect(screen.queryByTestId('element-name')).not.toBeInTheDocument()
+      expect(setKeyName).toHaveBeenLastCalledWith('vec2word')
+      expect(setKeyNameDisabled).toHaveBeenLastCalledWith(true)
+
+      selectManualMode()
+      expect(setKeyName).toHaveBeenLastCalledWith('')
+      expect(setKeyNameDisabled).toHaveBeenLastCalledWith(false)
+    })
+
+    it('on submit calls useLoadData.load with vec2word and closes the dialog on success', async () => {
+      mockLoad.mockResolvedValue(bulkActionOverviewFactory.build())
+      const onCancel = jest.fn()
+      renderComponent({ onCancel })
+      selectSampleMode()
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+      })
+
+      await waitFor(() =>
+        expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
+      )
+      expect(onCancel).toHaveBeenCalled()
+      expect(addMessageNotification).not.toHaveBeenCalled()
+      expect(addVectorSetKey).not.toHaveBeenCalled()
+    })
+
+    it('dispatches an info toast and skips the bulk-import when vec2word already exists', async () => {
+      mockCheckVec2WordExists.mockResolvedValue(true)
+      const onCancel = jest.fn()
+      renderComponent({ onCancel })
+      selectSampleMode()
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+      })
+
+      await waitFor(() =>
+        expect(addMessageNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Sample dataset already loaded',
+            variant: 'notice',
+          }),
+        ),
+      )
+      expect(mockLoad).not.toHaveBeenCalled()
+      expect(onCancel).toHaveBeenCalled()
+    })
+
+    it('dispatches the failure toast and keeps the dialog open when load fails', async () => {
+      mockLoad.mockRejectedValue(new Error('boom'))
+      const onCancel = jest.fn()
+      renderComponent({ onCancel })
+      selectSampleMode()
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
+      })
+
+      await waitFor(() =>
+        expect(addMessageNotification).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Failed to create vector set' }),
+        ),
+      )
+      expect(onCancel).not.toHaveBeenCalled()
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -218,7 +218,7 @@ describe('AddKeyVectorSet', () => {
         expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
       )
       expect(loadKeys).toHaveBeenCalled()
-      expectMessageDispatched('Sample dataset loaded')
+      expectMessageDispatched('Sample vector set added')
       expect(onCancel).toHaveBeenCalled()
       expect(addVectorSetKey).not.toHaveBeenCalled()
     })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -240,6 +240,41 @@ describe('AddKeyVectorSet', () => {
       expect(onCancel).toHaveBeenCalled()
     })
 
+    it('ignores extra clicks while the preflight checkVec2WordExists call is still in flight', async () => {
+      // Pin the preflight as a deferred promise so we can simulate the
+      // "user clicked twice before the existence check resolved" window.
+      let resolveExists: (value: boolean) => void = () => {}
+      mockCheckVec2WordExists.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveExists = resolve
+          }),
+      )
+      mockLoad.mockResolvedValue(bulkActionOverviewFactory.build())
+      const onCancel = jest.fn()
+      renderComponent({ onCancel })
+      selectSampleMode()
+
+      const submitButton = screen.getByTestId('add-key-vector-set-btn')
+      await act(async () => {
+        fireEvent.click(submitButton)
+        fireEvent.click(submitButton)
+        fireEvent.click(submitButton)
+      })
+
+      expect(mockCheckVec2WordExists).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(submitButton).toBeDisabled())
+
+      await act(async () => {
+        resolveExists(false)
+      })
+
+      await waitFor(() =>
+        expect(mockLoad).toHaveBeenCalledWith(expect.anything(), 'vec2word'),
+      )
+      expect(mockLoad).toHaveBeenCalledTimes(1)
+    })
+
     it('dispatches the failure toast and keeps the dialog open when load fails', async () => {
       mockLoad.mockRejectedValue(new Error('boom'))
       const onCancel = jest.fn()

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.spec.tsx
@@ -245,7 +245,9 @@ describe('AddKeyVectorSet', () => {
         fireEvent.click(screen.getByTestId('add-key-vector-set-btn'))
       })
 
-      await waitFor(() => expectMessageDispatched('Failed to create vector set'))
+      await waitFor(() =>
+        expectMessageDispatched('Failed to create vector set'),
+      )
       expect(onCancel).not.toHaveBeenCalled()
     })
   })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.styles.ts
@@ -11,6 +11,7 @@ export const RadioCard = styled.label<
   React.LabelHTMLAttributes<HTMLLabelElement> & { $disabled?: boolean }
 >`
   display: flex;
+  flex-grow: 1;
   align-items: center;
   gap: ${({ theme }) => theme.core.space.space050};
   border: 1px solid ${({ theme }) => theme.semantic.color.border.secondary500};

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -162,7 +162,7 @@ const AddKeyVectorSet = ({
         <FormField label={POPULATE_LABEL}>
           <RiRadioGroupRoot
             value={populateMode}
-            onChange={(value) => setPopulateMode(value)}
+            onChange={(value: PopulateMode) => setPopulateMode(value)}
             data-testid="add-key-vector-set-populate"
           >
             <S.RadioCardList gap="m">

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useState } from 'react'
+import React, { FormEvent, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { toNumber } from 'lodash'
 
@@ -52,8 +52,18 @@ const AddKeyVectorSet = ({
   const { loading } = useSelector(addKeyStateSelector)
   const { id: instanceId } = useSelector(connectedInstanceSelector)
 
-  const [populateMode, setPopulateMode] = useState<string>(PopulateMode.Manual)
+  const [populateMode, setPopulateMode] = useState<PopulateMode>(
+    PopulateMode.Manual,
+  )
   const isSampleMode = populateMode === PopulateMode.Sample
+  // Local gate covering the *entire* sample-dataset submit flow — including
+  // the `checkVec2WordExists` preflight, which runs before `useLoadData`'s
+  // own `loading` flag flips. The state drives the button's `disabled` /
+  // `loading` props for rendering; the ref short-circuits synchronous
+  // double-clicks that fire before React flushes the state update.
+  const [isSubmittingSampleDataset, setIsSubmittingSampleDataset] =
+    useState(false)
+  const isSubmittingSampleDatasetRef = useRef(false)
 
   // Drive the parent-owned key-name input from the populate-mode toggle:
   // Sample → fixed `vec2word` (the bundled-file key), input locked; Manual →
@@ -74,8 +84,7 @@ const AddKeyVectorSet = ({
     }
   }, [isSampleMode, setKeyName, setKeyNameDisabled])
 
-  const { load: loadSampleDataset, loading: isLoadingSampleDataset } =
-    useLoadData()
+  const { load: loadSampleDataset } = useLoadData()
 
   const handleSubmit = (elements: SubmitElement[]) => {
     const data: CreateVectorSetWithExpireDto = {
@@ -91,10 +100,7 @@ const AddKeyVectorSet = ({
 
   const formApi = useVectorSetElementForm({ onSubmit: handleSubmit })
 
-  const [isKeyNameValid, setIsKeyNameValid] = useState<boolean>(false)
-  useEffect(() => {
-    setIsKeyNameValid(`${keyName}`.length > 0)
-  }, [keyName])
+  const isKeyNameValid = `${keyName}`.length > 0
 
   // Sample mode bypasses the manual-entry form fields entirely — the keyName
   // and per-element values are dictated by the bundled data file.
@@ -103,6 +109,9 @@ const AddKeyVectorSet = ({
     : isKeyNameValid && formApi.isFormValid
 
   const submitSampleDataset = async () => {
+    if (isSubmittingSampleDatasetRef.current) return
+    isSubmittingSampleDatasetRef.current = true
+    setIsSubmittingSampleDataset(true)
     try {
       // Mirror vector-search's "already exists" branch: if `vec2word` is
       // already in the database, skip the bulk-import and surface an info
@@ -126,6 +135,9 @@ const AddKeyVectorSet = ({
       onCancel()
     } catch {
       dispatch(addMessageNotification(loadSampleDatasetFailedNotification()))
+    } finally {
+      isSubmittingSampleDatasetRef.current = false
+      setIsSubmittingSampleDataset(false)
     }
   }
 
@@ -196,8 +208,8 @@ const AddKeyVectorSet = ({
         onCancel={() => onCancel(true)}
         onAction={onClickAction}
         actionText="Add Key"
-        loading={loading || isLoadingSampleDataset}
-        disabled={!isFormValid}
+        loading={loading || isSubmittingSampleDataset}
+        disabled={!isFormValid || isSubmittingSampleDataset}
         actionTestId="add-key-vector-set-btn"
       />
     </form>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -3,7 +3,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import { toNumber } from 'lodash'
 
 import { stringToBuffer } from 'uiSrc/utils'
-import { addKeyStateSelector, addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import {
+  addKeyStateSelector,
+  addVectorSetKey,
+  loadKeys,
+} from 'uiSrc/slices/browser/keys'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
@@ -30,6 +34,7 @@ import LoadSampleDataset, {
   checkVec2WordExists,
   keyAlreadyExistsNotification,
   loadSampleDatasetFailedNotification,
+  sampleDatasetLoadedNotification,
 } from './LoadSampleDataset'
 import { POPULATE_LABEL, POPULATE_OPTIONS, PopulateMode } from './constants'
 import { Props } from './AddKeyVectorSet.types'
@@ -107,6 +112,10 @@ const AddKeyVectorSet = ({
         return
       }
       await loadSampleDataset(instanceId, VEC2WORD_COLLECTION_NAME)
+      // Refresh the Browser keys list so the new key shows up immediately,
+      // then surface a green success toast.
+      dispatch(loadKeys())
+      dispatch(addMessageNotification(sampleDatasetLoadedNotification()))
       onCancel()
     } catch {
       dispatch(addMessageNotification(loadSampleDatasetFailedNotification()))

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -28,7 +28,7 @@ import { useVectorSetElementForm } from 'uiSrc/pages/browser/modules/key-details
 import LoadSampleDataset, {
   VEC2WORD_COLLECTION_NAME,
   checkVec2WordExists,
-  loadSampleDatasetAlreadyExistsNotification,
+  keyAlreadyExistsNotification,
   loadSampleDatasetFailedNotification,
 } from './LoadSampleDataset'
 import { POPULATE_LABEL, POPULATE_OPTIONS, PopulateMode } from './constants'
@@ -102,9 +102,7 @@ const AddKeyVectorSet = ({
       // already in the database, skip the bulk-import and surface an info
       // toast instead of silently re-running VADD on the existing key.
       if (await checkVec2WordExists(instanceId)) {
-        dispatch(
-          addMessageNotification(loadSampleDatasetAlreadyExistsNotification()),
-        )
+        dispatch(addMessageNotification(keyAlreadyExistsNotification()))
         onCancel()
         return
       }

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -4,10 +4,11 @@ import { toNumber } from 'lodash'
 
 import { stringToBuffer } from 'uiSrc/utils'
 import {
+  addKeyIntoList,
   addKeyStateSelector,
   addVectorSetKey,
-  loadKeys,
 } from 'uiSrc/slices/browser/keys'
+import { KeyTypes } from 'uiSrc/constants'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
@@ -112,9 +113,15 @@ const AddKeyVectorSet = ({
         return
       }
       await loadSampleDataset(instanceId, VEC2WORD_COLLECTION_NAME)
-      // Refresh the Browser keys list so the new key shows up immediately,
-      // then surface a green success toast.
-      dispatch(loadKeys())
+      // Splice the new key into the Browser keys list — same pattern as the
+      // manual addTypedKey flow — so it shows up immediately without
+      // triggering a full refetch (and the loading spinner that comes with it).
+      dispatch(
+        addKeyIntoList({
+          key: stringToBuffer(VEC2WORD_COLLECTION_NAME),
+          keyType: KeyTypes.VectorSet,
+        }),
+      )
       dispatch(addMessageNotification(sampleDatasetLoadedNotification()))
       onCancel()
     } catch {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -4,7 +4,10 @@ import { toNumber } from 'lodash'
 
 import { stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addVectorSetKey } from 'uiSrc/slices/browser/keys'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
+import { useLoadData } from 'uiSrc/services/hooks'
 import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
 import {
   RiRadioGroupItemIndicator,
@@ -14,6 +17,7 @@ import {
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { Col } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
 
 import {
   SubmitElement,
@@ -21,15 +25,51 @@ import {
 } from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form'
 import { useVectorSetElementForm } from 'uiSrc/pages/browser/modules/key-details/components/vector-set-details/hooks'
 
+import LoadSampleDataset, {
+  VEC2WORD_COLLECTION_NAME,
+  checkVec2WordExists,
+  loadSampleDatasetAlreadyExistsNotification,
+  loadSampleDatasetFailedNotification,
+} from './LoadSampleDataset'
 import { POPULATE_LABEL, POPULATE_OPTIONS, PopulateMode } from './constants'
 import { Props } from './AddKeyVectorSet.types'
 import * as S from './AddKeyVectorSet.styles'
 
-const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
+const AddKeyVectorSet = ({
+  keyName = '',
+  keyTTL,
+  onCancel,
+  setKeyName,
+  setKeyNameDisabled,
+}: Props) => {
   const dispatch = useDispatch()
   const { loading } = useSelector(addKeyStateSelector)
+  const { id: instanceId } = useSelector(connectedInstanceSelector)
 
   const [populateMode, setPopulateMode] = useState<string>(PopulateMode.Manual)
+  const isSampleMode = populateMode === PopulateMode.Sample
+
+  // Drive the parent-owned key-name input from the populate-mode toggle:
+  // Sample → fixed `vec2word` (the bundled-file key), input locked; Manual →
+  // clear and unlock so the user can pick their own.
+  //
+  // The cleanup branch fires on Sample → Manual toggle **and** on unmount
+  // (e.g. the user switches the key type away from Vector Set while Sample is
+  // active). In both cases we want to wipe the auto-populated `vec2word`
+  // value so it doesn't bleed into the next subform.
+  useEffect(() => {
+    setKeyName?.(isSampleMode ? VEC2WORD_COLLECTION_NAME : '')
+    setKeyNameDisabled?.(isSampleMode)
+    return () => {
+      if (isSampleMode) {
+        setKeyName?.('')
+        setKeyNameDisabled?.(false)
+      }
+    }
+  }, [isSampleMode, setKeyName, setKeyNameDisabled])
+
+  const { load: loadSampleDataset, loading: isLoadingSampleDataset } =
+    useLoadData()
 
   const handleSubmit = (elements: SubmitElement[]) => {
     const data: CreateVectorSetWithExpireDto = {
@@ -50,12 +90,43 @@ const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
     setIsKeyNameValid(`${keyName}`.length > 0)
   }, [keyName])
 
-  const isFormValid = isKeyNameValid && formApi.isFormValid
+  // Sample mode bypasses the manual-entry form fields entirely — the keyName
+  // and per-element values are dictated by the bundled data file.
+  const isFormValid = isSampleMode
+    ? true
+    : isKeyNameValid && formApi.isFormValid
+
+  const submitSampleDataset = async () => {
+    try {
+      // Mirror vector-search's "already exists" branch: if `vec2word` is
+      // already in the database, skip the bulk-import and surface an info
+      // toast instead of silently re-running VADD on the existing key.
+      if (await checkVec2WordExists(instanceId)) {
+        dispatch(
+          addMessageNotification(loadSampleDatasetAlreadyExistsNotification()),
+        )
+        onCancel()
+        return
+      }
+      await loadSampleDataset(instanceId, VEC2WORD_COLLECTION_NAME)
+      onCancel()
+    } catch {
+      dispatch(addMessageNotification(loadSampleDatasetFailedNotification()))
+    }
+  }
+
+  const onClickAction = () => {
+    if (isSampleMode) {
+      submitSampleDataset()
+    } else {
+      formApi.submitData()
+    }
+  }
 
   const onFormSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
     if (isFormValid) {
-      formApi.submitData()
+      onClickAction()
     }
   }
 
@@ -97,14 +168,21 @@ const AddKeyVectorSet = ({ keyName = '', keyTTL, onCancel }: Props) => {
           </RiRadioGroupRoot>
         </FormField>
 
-        <VectorSetElementFormFields {...formApi} loading={loading} />
+        {isSampleMode ? (
+          <>
+            <Spacer size="l" />
+            <LoadSampleDataset />
+          </>
+        ) : (
+          <VectorSetElementFormFields {...formApi} loading={loading} />
+        )}
       </Col>
 
       <ActionFooter
         onCancel={() => onCancel(true)}
-        onAction={formApi.submitData}
+        onAction={onClickAction}
         actionText="Add Key"
-        loading={loading}
+        loading={loading || isLoadingSampleDataset}
         disabled={!isFormValid}
         actionTestId="add-key-vector-set-btn"
       />

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.types.ts
@@ -5,6 +5,19 @@ export interface Props {
   keyName: string
   keyTTL: Maybe<number>
   onCancel: (isCancelled?: boolean) => void
+  /**
+   * Setter for the parent-owned `keyName` field. Used to auto-populate the
+   * common key-name input with the bundled dataset's fixed key when the user
+   * switches into "Load sample dataset" mode, and clear it again on switching
+   * back to manual entry.
+   */
+  setKeyName?: (value: string) => void
+  /**
+   * Setter for the parent-owned `keyName` input's `disabled` flag. Locked
+   * to `true` in sample-dataset mode (the key name is fixed by the bundled
+   * file) and `false` otherwise.
+   */
+  setKeyNameDisabled?: (disabled: boolean) => void
 }
 
 export interface PopulateOption {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+
+import LoadSampleDataset from './LoadSampleDataset'
+import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './constants'
+
+describe('LoadSampleDataset', () => {
+  it('renders all hardcoded preview rows and info pairs', () => {
+    render(<LoadSampleDataset />)
+
+    VEC2WORD_PREVIEW.forEach(({ word, vector }) => {
+      const row = screen.getByTestId(`load-sample-dataset-preview-${word}`)
+      expect(row).toHaveTextContent(word)
+      expect(row).toHaveTextContent(vector)
+    })
+
+    VEC2WORD_INFO.forEach(({ label, value }) => {
+      const testId = `load-sample-dataset-info-${label.toLowerCase().replace(/\s+/g, '-')}`
+      const row = screen.getByTestId(testId)
+      expect(row).toHaveTextContent(label)
+      expect(row).toHaveTextContent(value)
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from 'uiSrc/utils/test-utils'
 
 import LoadSampleDataset from './LoadSampleDataset'
-import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './constants'
+import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './data'
 
 describe('LoadSampleDataset', () => {
   it('renders all hardcoded preview rows and info pairs', () => {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.styles.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components'
+
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
+
+export const Layout = styled(Row)`
+  width: 100%;
+  padding: 0 15%;
+`
+
+export const PreviewColumn = styled(Col)`
+  width: 150px;
+  background: ${({ theme }) => theme.semantic.color.background.informative200};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.informative300};
+  border-radius: ${({ theme }) =>
+    theme.components.boxSelectionGroup.item.borderRadius};
+  padding: ${({ theme }) => theme.core.space.space150};
+`
+
+export const PreviewRowText = styled(Text)`
+  font-family: 'Source Code Pro', 'Inconsolata', monospace;
+`
+
+export const InfoRow = styled(Row)`
+  /* Fix the label column width so values line up as a flush-left column. */
+  & > *:first-child {
+    min-width: 70px;
+  }
+`

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 
-import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './constants'
+import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './data'
 import * as S from './LoadSampleDataset.styles'
 
 const LoadSampleDataset = () => (

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
+
+import { VEC2WORD_INFO, VEC2WORD_PREVIEW } from './constants'
+import * as S from './LoadSampleDataset.styles'
+
+const LoadSampleDataset = () => (
+  <S.Layout
+    gap="xl"
+    align="stretch"
+    justify="around"
+    data-testid="add-key-vector-set-load-sample-dataset"
+  >
+    <S.PreviewColumn gap="s" data-testid="load-sample-dataset-preview" grow>
+      {VEC2WORD_PREVIEW.map((row) => (
+        <Row
+          key={row.word}
+          gap="xs"
+          data-testid={`load-sample-dataset-preview-${row.word}`}
+          justify="between"
+          align="center"
+        >
+          <S.PreviewRowText size="s" color="informative600" variant="semiBold">
+            {row.word}
+          </S.PreviewRowText>
+          <S.PreviewRowText size="s" color="informative600" variant="semiBold">
+            {row.vector}
+          </S.PreviewRowText>
+        </Row>
+      ))}
+    </S.PreviewColumn>
+
+    <Col
+      gap="xs"
+      align="start"
+      data-testid="load-sample-dataset-info"
+      grow={false}
+    >
+      {VEC2WORD_INFO.map((row) => (
+        <S.InfoRow
+          key={row.label}
+          gap="m"
+          align="center"
+          data-testid={`load-sample-dataset-info-${row.label.toLowerCase().replace(/\s+/g, '-')}`}
+        >
+          <Text size="S" color="secondary">
+            {row.label}:
+          </Text>
+          <Text size="S" color="primary">
+            {row.value}
+          </Text>
+        </S.InfoRow>
+      ))}
+    </Col>
+  </S.Layout>
+)
+
+export default LoadSampleDataset

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/LoadSampleDataset.types.ts
@@ -1,0 +1,9 @@
+export interface Vec2WordPreviewRow {
+  word: string
+  vector: string
+}
+
+export interface Vec2WordInfoRow {
+  label: string
+  value: string
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/checkVec2WordExists.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/checkVec2WordExists.ts
@@ -1,0 +1,27 @@
+import { AxiosError } from 'axios'
+
+import { apiService } from 'uiSrc/services'
+import { ApiEndpoints } from 'uiSrc/constants'
+import { getUrl, stringToBuffer } from 'uiSrc/utils'
+
+import { VEC2WORD_COLLECTION_NAME } from './constants'
+
+/**
+ * Pre-flight check: does the `vec2word` key already exist in the connected
+ * database? Returns true on a successful KEY_INFO response, false on 404,
+ * and rethrows on any other error so the caller can surface a generic
+ * failure toast.
+ */
+export const checkVec2WordExists = async (
+  instanceId: string,
+): Promise<boolean> => {
+  try {
+    await apiService.post(getUrl(instanceId, ApiEndpoints.KEY_INFO), {
+      keyName: stringToBuffer(VEC2WORD_COLLECTION_NAME),
+    })
+    return true
+  } catch (err) {
+    if ((err as AxiosError)?.response?.status === 404) return false
+    throw err
+  }
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/checkVec2WordExists.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/checkVec2WordExists.ts
@@ -4,7 +4,7 @@ import { apiService } from 'uiSrc/services'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { getUrl, stringToBuffer } from 'uiSrc/utils'
 
-import { VEC2WORD_COLLECTION_NAME } from './constants'
+import { VEC2WORD_COLLECTION_NAME } from './data'
 
 /**
  * Pre-flight check: does the `vec2word` key already exist in the connected

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
@@ -1,0 +1,58 @@
+import { ToastVariant } from 'uiSrc/components/base/display/toast/RiToast'
+
+export const VEC2WORD_COLLECTION_NAME = 'vec2word'
+
+export interface Vec2WordPreviewRow {
+  word: string
+  vector: string
+  attributes: string
+}
+
+export const VEC2WORD_PREVIEW: Vec2WordPreviewRow[] = [
+  {
+    word: 'king',
+    vector: '[0.012, -0.045, 0.083, …]',
+    attributes: '{"pos":"noun"}',
+  },
+  {
+    word: 'queen',
+    vector: '[0.034, 0.067, -0.021, …]',
+    attributes: '{"pos":"noun"}',
+  },
+  {
+    word: 'apple',
+    vector: '[-0.011, 0.054, 0.092, …]',
+    attributes: '{"pos":"noun"}',
+  },
+]
+
+export interface Vec2WordInfoRow {
+  label: string
+  value: string
+}
+
+export const VEC2WORD_INFO: Vec2WordInfoRow[] = [
+  { label: 'Dataset', value: 'vec2word' },
+  { label: 'Size', value: '100' },
+  { label: 'Vector size', value: '300' },
+  { label: 'Embedding', value: 'GloVe' },
+]
+
+/** Toast shown when the bulk-import POST for `vec2word` fails. */
+export const loadSampleDatasetFailedNotification = () => ({
+  title: 'Failed to create vector set',
+  message: 'Please try again.',
+  variant: 'danger' as ToastVariant,
+})
+
+/**
+ * Toast shown when the user clicks "Add key" with sample-dataset mode but the
+ * target `vec2word` key already exists. Mirrors the vector-search
+ * `sampleDataAlreadyExists` notice variant.
+ */
+export const loadSampleDatasetAlreadyExistsNotification = () => ({
+  title: 'Sample dataset already loaded',
+  message: `A key named '${VEC2WORD_COLLECTION_NAME}' already exists in this database.`,
+  variant: 'notice' as ToastVariant,
+  showCloseButton: false,
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
@@ -46,12 +46,13 @@ export const loadSampleDatasetFailedNotification = () => ({
 })
 
 /**
- * Toast shown when the user clicks "Add key" with sample-dataset mode but the
- * target `vec2word` key already exists. Mirrors the vector-search
- * `sampleDataAlreadyExists` notice variant.
+ * Toast shown when the user clicks "Add key" in sample-dataset mode but the
+ * target key already exists. We can only verify the key is present — not
+ * that it actually holds the bundled sample dataset — so the copy intentionally
+ * stays generic.
  */
-export const loadSampleDatasetAlreadyExistsNotification = () => ({
-  title: 'Sample dataset already loaded',
+export const keyAlreadyExistsNotification = () => ({
+  title: 'Key already exists',
   message: `A key named '${VEC2WORD_COLLECTION_NAME}' already exists in this database.`,
   variant: 'notice' as ToastVariant,
   showCloseButton: false,

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
@@ -45,6 +45,13 @@ export const loadSampleDatasetFailedNotification = () => ({
   variant: 'danger' as ToastVariant,
 })
 
+/** Green success toast shown after the bulk-import POST for `vec2word` succeeds. */
+export const sampleDatasetLoadedNotification = () => ({
+  title: 'Sample dataset loaded',
+  message: `The '${VEC2WORD_COLLECTION_NAME}' vector set is ready to query.`,
+  showCloseButton: false,
+})
+
 /**
  * Toast shown when the user clicks "Add key" in sample-dataset mode but the
  * target key already exists. We can only verify the key is present — not

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/constants.ts
@@ -47,8 +47,8 @@ export const loadSampleDatasetFailedNotification = () => ({
 
 /** Green success toast shown after the bulk-import POST for `vec2word` succeeds. */
 export const sampleDatasetLoadedNotification = () => ({
-  title: 'Sample dataset loaded',
-  message: `The '${VEC2WORD_COLLECTION_NAME}' vector set is ready to query.`,
+  title: 'Sample vector set added',
+  message: `The '${VEC2WORD_COLLECTION_NAME}' sample vector set has been successfully added.`,
   showCloseButton: false,
 })
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/data.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/data.ts
@@ -1,0 +1,16 @@
+import { Vec2WordInfoRow, Vec2WordPreviewRow } from './LoadSampleDataset.types'
+
+export const VEC2WORD_COLLECTION_NAME = 'vec2word'
+
+export const VEC2WORD_PREVIEW: Vec2WordPreviewRow[] = [
+  { word: 'king', vector: '[0.012, -0.045, 0.083, …]' },
+  { word: 'queen', vector: '[0.034, 0.067, -0.021, …]' },
+  { word: 'apple', vector: '[-0.011, 0.054, 0.092, …]' },
+]
+
+export const VEC2WORD_INFO: Vec2WordInfoRow[] = [
+  { label: 'Dataset', value: VEC2WORD_COLLECTION_NAME },
+  { label: 'Size', value: '100' },
+  { label: 'Vector size', value: '300' },
+  { label: 'Embedding', value: 'GloVe' },
+]

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/index.ts
@@ -1,0 +1,3 @@
+export { default } from './LoadSampleDataset'
+export * from './constants'
+export * from './checkVec2WordExists'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/index.ts
@@ -1,3 +1,5 @@
 export { default } from './LoadSampleDataset'
-export * from './constants'
+export * from './data'
+export * from './notifications'
 export * from './checkVec2WordExists'
+export * from './LoadSampleDataset.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/notifications.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/LoadSampleDataset/notifications.ts
@@ -1,42 +1,6 @@
 import { ToastVariant } from 'uiSrc/components/base/display/toast/RiToast'
 
-export const VEC2WORD_COLLECTION_NAME = 'vec2word'
-
-export interface Vec2WordPreviewRow {
-  word: string
-  vector: string
-  attributes: string
-}
-
-export const VEC2WORD_PREVIEW: Vec2WordPreviewRow[] = [
-  {
-    word: 'king',
-    vector: '[0.012, -0.045, 0.083, …]',
-    attributes: '{"pos":"noun"}',
-  },
-  {
-    word: 'queen',
-    vector: '[0.034, 0.067, -0.021, …]',
-    attributes: '{"pos":"noun"}',
-  },
-  {
-    word: 'apple',
-    vector: '[-0.011, 0.054, 0.092, …]',
-    attributes: '{"pos":"noun"}',
-  },
-]
-
-export interface Vec2WordInfoRow {
-  label: string
-  value: string
-}
-
-export const VEC2WORD_INFO: Vec2WordInfoRow[] = [
-  { label: 'Dataset', value: 'vec2word' },
-  { label: 'Size', value: '100' },
-  { label: 'Vector size', value: '300' },
-  { label: 'Embedding', value: 'GloVe' },
-]
+import { VEC2WORD_COLLECTION_NAME } from './data'
 
 /** Toast shown when the bulk-import POST for `vec2word` fails. */
 export const loadSampleDatasetFailedNotification = () => ({

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/constants.ts
@@ -10,7 +10,6 @@ export const POPULATE_OPTIONS: PopulateOption[] = [
     value: PopulateMode.Sample,
     label: 'Load sample dataset',
     description: 'Explore vector sets with pre-loaded word embeddings',
-    disabled: true,
     id: 'populate-sample',
   },
   {

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -43,6 +43,9 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   connectedInstanceSelector: jest.fn().mockReturnValue({ id: '123' }),
 }))
 
+const connectedInstanceOverviewSelectorMock =
+  connectedInstanceOverviewSelector as jest.Mock
+
 beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
@@ -105,11 +108,9 @@ describe('FilterKeyType', () => {
   })
 
   it('should be disabled filter with database redis version < 6.0', () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '5.1',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '5.1',
+    }))
     render(<FilterKeyType />)
     const filterSelect = screen.getByTestId(filterSelectId)
 
@@ -117,11 +118,9 @@ describe('FilterKeyType', () => {
   })
 
   it('should be info box with database redis version < 6.0', () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '5.1',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '5.1',
+    }))
     render(<FilterKeyType />)
     expect(screen.getByTestId(unsupportedAnchorId)).toBeInTheDocument()
 
@@ -136,11 +135,9 @@ describe('FilterKeyType', () => {
     ;(sendEventTelemetry as jest.Mock).mockImplementation(
       () => sendEventTelemetryMock,
     )
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '5.1',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '5.1',
+    }))
 
     render(<FilterKeyType />)
 
@@ -199,11 +196,9 @@ describe('FilterKeyType', () => {
   })
 
   it('should show Vector Set when vector set feature flag is enabled and redis version >= 8.0', async () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '8.0.0',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '8.0.0',
+    }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
       `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
@@ -221,11 +216,9 @@ describe('FilterKeyType', () => {
   it('should hide Vector Set when vector set feature flag is disabled', () => {
     // Ensure the version gate is satisfied so the assertion truly
     // exercises the feature-flag path and not the version path.
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '8.0.0',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '8.0.0',
+    }))
     const { queryByText } = render(<FilterKeyType />)
 
     fireEvent.click(screen.getByTestId(filterSelectId))
@@ -234,11 +227,9 @@ describe('FilterKeyType', () => {
   })
 
   it('should hide Vector Set when redis version < 8.0 even if feature flag is enabled', async () => {
-    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
-      () => ({
-        version: '7.4.0',
-      }),
-    )
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '7.4.0',
+    }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
       `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

- Enable the **Load sample dataset** option on the Add Key → Vector Set form. Selecting it swaps the manual element-entry inputs for a hardcoded Preview + Info panel, auto-fills the key name with `vec2word`, and locks it.
- On submit, the existing `useLoadData` hook hits `POST /bulk-actions/import/vector-collection` with `{ collectionName: "vec2word" }` — same path bikes/movies use. Pre-flights with a `KEY_INFO` check so an already-loaded `vec2word` shows an info toast instead of re-running VADD.
- Adds an optional `keyNameDisabled` prop on `AddKeyCommonFields` so subforms can lock the parent-owned key-name input from the outside.

| Light | Dark |
| --- | --- | 
| <img width="643" height="623" alt="image" src="https://github.com/user-attachments/assets/3ea83525-c44f-467a-a325-bf4b13d896e9" /> | <img width="643" height="623" alt="image" src="https://github.com/user-attachments/assets/c6e278d4-acd2-4dd6-a16d-58a4dd63c6ef" /> |


# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

1. Open Add Key → Vector Set, pick **Load sample dataset** → key name auto-fills to `vec2word`, input locks, preview + info panel renders.
2. Click **Add Key** → key list refreshes with the new `vec2word` vector set; in `redis-cli`, `VCARD vec2word` → `100`, `VEMB vec2word king` → 300 floats.
3. Click **Add Key** again → info toast "Sample dataset already loaded" appears, no second import.
4. Switch back to **Create manually** → key name clears and unlocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new sample-dataset submission path that triggers API calls (KEY_INFO + bulk import) and mutates the keys list, so regressions could affect key creation UX and duplicate-submit handling, but changes are scoped to the Vector Set add form.
> 
> **Overview**
> **Vector Set add-key flow now supports loading a bundled sample dataset.** Selecting *Load sample dataset* swaps out the manual element-entry form for a preview/info panel, auto-sets the key name to `vec2word`, and disables editing of the key name.
> 
> On submit in sample mode, the UI performs a `KEY_INFO` preflight to detect an existing `vec2word`, then calls `useLoadData` (bulk import) when needed, injects the new key into the Browser list via `addKeyIntoList`, and shows success/failure/info toasts; it also adds a local submission gate to prevent double-clicks during the preflight.
> 
> Adds a `keyNameDisabled` prop to `AddKeyCommonFields` (wired through `AddKey.tsx`) so subforms can lock the shared key-name input. Includes new `LoadSampleDataset` component + tests, expanded `AddKeyVectorSet` tests, and small styling/test refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829f53bbc88c86b055176d01d268101f2ee63b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->