### PR TITLE
fix(ui): cast jest-mocked selectors in FilterKeyType.spec

### DIFF
--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -405,9 +405,6 @@
     "TS18048": 1,
     "TS2769": 1
   },
-  "src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx": {
-    "TS2339": 4
-  },
   "src/pages/browser/components/key-list/KeyList.spec.tsx": {
     "TS2322": 9,
     "TS2339": 3,

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -105,9 +105,11 @@ describe('FilterKeyType', () => {
   })
 
   it('should be disabled filter with database redis version < 6.0', () => {
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '5.1',
-    }))
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '5.1',
+      }),
+    )
     render(<FilterKeyType />)
     const filterSelect = screen.getByTestId(filterSelectId)
 
@@ -115,9 +117,11 @@ describe('FilterKeyType', () => {
   })
 
   it('should be info box with database redis version < 6.0', () => {
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '5.1',
-    }))
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '5.1',
+      }),
+    )
     render(<FilterKeyType />)
     expect(screen.getByTestId(unsupportedAnchorId)).toBeInTheDocument()
 
@@ -129,10 +133,14 @@ describe('FilterKeyType', () => {
   it('should send telemetry event with redis v < 6.0 after click on anchor', async () => {
     const sendEventTelemetryMock = jest.fn()
 
-    sendEventTelemetry.mockImplementation(() => sendEventTelemetryMock)
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '5.1',
-    }))
+    ;(sendEventTelemetry as jest.Mock).mockImplementation(
+      () => sendEventTelemetryMock,
+    )
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '5.1',
+      }),
+    )
 
     render(<FilterKeyType />)
 
@@ -191,9 +199,11 @@ describe('FilterKeyType', () => {
   })
 
   it('should show Vector Set when vector set feature flag is enabled and redis version >= 8.0', async () => {
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '8.0.0',
-    }))
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '8.0.0',
+      }),
+    )
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
       `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
@@ -211,9 +221,11 @@ describe('FilterKeyType', () => {
   it('should hide Vector Set when vector set feature flag is disabled', () => {
     // Ensure the version gate is satisfied so the assertion truly
     // exercises the feature-flag path and not the version path.
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '8.0.0',
-    }))
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '8.0.0',
+      }),
+    )
     const { queryByText } = render(<FilterKeyType />)
 
     fireEvent.click(screen.getByTestId(filterSelectId))
@@ -222,9 +234,11 @@ describe('FilterKeyType', () => {
   })
 
   it('should hide Vector Set when redis version < 8.0 even if feature flag is enabled', async () => {
-    connectedInstanceOverviewSelector.mockImplementationOnce(() => ({
-      version: '7.4.0',
-    }))
+    ;(connectedInstanceOverviewSelector as jest.Mock).mockImplementationOnce(
+      () => ({
+        version: '7.4.0',
+      }),
+    )
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
       `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,


### PR DESCRIPTION
# What

PR #5914 added three calls to `connectedInstanceOverviewSelector.mockImplementationOnce(...)` in `FilterKeyType.spec.tsx`. The selector's TS type is the real function, so calls to `.mockImplementationOnce` produce `TS2339` errors. The baseline file (`.tscheck.rec.json`) was not bumped along with the new errors, so any PR branching off the current `main` fails the `type-check / tsc baselines` workflow.

Cast all seven occurrences (four pre-existing + three new) to `jest.Mock`, plus the one `sendEventTelemetry.mockImplementation` call that had the same issue, and drop the now-zero `TS2339` entry for this spec from the baseline.

# Testing

- `yarn test redisinsight/ui/src/pages/browser/components/filter-key-type` → 14/14 pass.
- CI `type-check / tsc baselines` should go green.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust Jest mock typing and remove a now-resolved `TS2339` baseline entry, with no runtime code impact.
> 
> **Overview**
> Resolves TypeScript `TS2339` errors in `FilterKeyType.spec.tsx` by casting `connectedInstanceOverviewSelector` and `sendEventTelemetry` to `jest.Mock` before calling `mockImplementation(Once)`.
> 
> Updates `.tscheck.rec.json` to drop the `FilterKeyType.spec.tsx` `TS2339` baseline entry now that the spec no longer triggers those errors, unblocking the `type-check / tsc baselines` workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77957c808a731e8f04b9d9012f9a9b76eddc991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->