### PR TITLE
RI-8188 Gate Profiler start with confirmation on production databases

### DIFF
--- a/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
+++ b/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
@@ -6,12 +6,12 @@ import { IMonitorDataPayload } from 'uiSrc/slices/interfaces'
 
 import { RiTooltip } from 'uiSrc/components'
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
-import { PrimaryButton } from 'uiSrc/components/base/forms/buttons'
 import { ColorText, Text, Title } from 'uiSrc/components/base/text'
 import { SwitchInput } from 'uiSrc/components/base/inputs'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import MonitorLog from '../MonitorLog'
 import MonitorOutputList from '../MonitorOutputList'
+import ProfilerStartButton from '../ProfilerStartButton'
 
 import ProfilerImage from 'uiSrc/assets/img/profiler/magnifier.svg'
 
@@ -75,15 +75,9 @@ const Monitor = (props: Props) => {
         </Text>
 
         <div>
-          <RiTooltip content="Enable real-time profiling of your Redis database.">
-            <PrimaryButton
-              onClick={() => handleRunMonitor(saveLogValue)}
-              aria-label="start monitor"
-              data-testid="start-monitor"
-            >
-              Start Profiler
-            </PrimaryButton>
-          </RiTooltip>
+          <ProfilerStartButton
+            onStart={() => handleRunMonitor(saveLogValue)}
+          />
         </div>
 
         <div data-testid="save-log-container">

--- a/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
+++ b/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
@@ -47,7 +47,7 @@ const Monitor = (props: Props) => {
   } = props
   const [saveLogValue, setSaveLogValue] = useState(isSaveToFile)
 
-  const MonitorNotStarted = () => (
+  const renderMonitorNotStarted = () => (
     <Row
       align="center"
       style={{ margin: 48 }}
@@ -141,7 +141,7 @@ const Monitor = (props: Props) => {
           <MonitorError />
         ) : (
           <>
-            {!isStarted && <MonitorNotStarted />}
+            {!isStarted && renderMonitorNotStarted()}
             {!items?.length && isRunning && !isPaused && (
               <div
                 data-testid="monitor-started"

--- a/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
+++ b/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
@@ -4,22 +4,14 @@ import AutoSizer from 'react-virtualized-auto-sizer'
 
 import { IMonitorDataPayload } from 'uiSrc/slices/interfaces'
 
-import { RiTooltip } from 'uiSrc/components'
-import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
-import { ColorText, Text, Title } from 'uiSrc/components/base/text'
-import { SwitchInput } from 'uiSrc/components/base/inputs'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { ColorText } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import MonitorLog from '../MonitorLog'
 import MonitorOutputList from '../MonitorOutputList'
-import ProfilerStartButton from '../ProfilerStartButton'
-
-import ProfilerImage from 'uiSrc/assets/img/profiler/magnifier.svg'
+import MonitorNotStarted from '../MonitorNotStarted'
 
 import styles from './styles.module.scss'
-import { StyledImagePanel } from './Monitor.styles'
-import { Spacer } from 'uiSrc/components/base/layout'
-import { Banner } from 'uiSrc/components/base/display/banner'
-import { RiImage } from 'uiSrc/components/base/display'
 
 export interface Props {
   items: IMonitorDataPayload[]
@@ -46,62 +38,6 @@ const Monitor = (props: Props) => {
     handleRunMonitor = () => {},
   } = props
   const [saveLogValue, setSaveLogValue] = useState(isSaveToFile)
-
-  const renderMonitorNotStarted = () => (
-    <Row
-      align="center"
-      style={{ margin: 48 }}
-      gap="xxl"
-      data-testid="monitor-not-started"
-    >
-      <StyledImagePanel align="center">
-        <RiImage
-          src={ProfilerImage}
-          alt="Profiler"
-          style={{ userSelect: 'none', pointerEvents: 'none' }}
-        />
-        <Spacer size="l" />
-        <Text>
-          Get a deeper understanding of your database with real-time command,
-          key, and client statistics.
-        </Text>
-      </StyledImagePanel>
-
-      <Col gap="xl">
-        <Title size="M">Profiler</Title>
-        <Text>
-          Analyze every command sent to Redis in real time to debug issues and
-          optimize performance.
-        </Text>
-
-        <div>
-          <ProfilerStartButton onStart={() => handleRunMonitor(saveLogValue)} />
-        </div>
-
-        <div data-testid="save-log-container">
-          <RiTooltip
-            title="Allows you to download the generated log file after pausing the Profiler."
-            content="Profiler log is saved to a file on your local machine with no size limitation. The temporary log file will be automatically rewritten when the Profiler is reset."
-            data-testid="save-log-tooltip"
-          >
-            <SwitchInput
-              title="Save Log"
-              checked={saveLogValue}
-              onCheckedChange={setSaveLogValue}
-              data-testid="save-log-switch"
-            />
-          </RiTooltip>
-        </div>
-
-        <Banner
-          variant="attention"
-          showIcon
-          data-testid="monitor-warning-message"
-          message="Running Profiler will decrease throughput, avoid running it in production databases."
-        />
-      </Col>
-    </Row>
-  )
 
   const MonitorError = () => (
     <div className={styles.startContainer} data-testid="monitor-error">
@@ -141,7 +77,13 @@ const Monitor = (props: Props) => {
           <MonitorError />
         ) : (
           <>
-            {!isStarted && renderMonitorNotStarted()}
+            {!isStarted && (
+              <MonitorNotStarted
+                saveLogValue={saveLogValue}
+                setSaveLogValue={setSaveLogValue}
+                onStart={() => handleRunMonitor(saveLogValue)}
+              />
+            )}
             {!items?.length && isRunning && !isPaused && (
               <div
                 data-testid="monitor-started"

--- a/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
+++ b/redisinsight/ui/src/components/monitor/Monitor/Monitor.tsx
@@ -75,9 +75,7 @@ const Monitor = (props: Props) => {
         </Text>
 
         <div>
-          <ProfilerStartButton
-            onStart={() => handleRunMonitor(saveLogValue)}
-          />
+          <ProfilerStartButton onStart={() => handleRunMonitor(saveLogValue)} />
         </div>
 
         <div data-testid="save-log-container">

--- a/redisinsight/ui/src/components/monitor/MonitorNotStarted/MonitorNotStarted.spec.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorNotStarted/MonitorNotStarted.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import * as useDatabaseModeModule from 'uiSrc/components/hooks/useDatabaseMode'
+import MonitorNotStarted from './MonitorNotStarted'
+
+beforeEach(() => {
+  cleanup()
+  jest.spyOn(useDatabaseModeModule, 'useDatabaseMode').mockReturnValue({
+    mode: 'unmarked',
+    isDangerousCommand: () => false,
+  })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('MonitorNotStarted', () => {
+  it('should render the not-started container and warning banner', () => {
+    render(
+      <MonitorNotStarted
+        saveLogValue={false}
+        setSaveLogValue={jest.fn()}
+        onStart={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('monitor-not-started')).toBeInTheDocument()
+    expect(screen.getByTestId('monitor-warning-message')).toBeInTheDocument()
+    expect(screen.getByTestId('start-monitor')).toBeInTheDocument()
+  })
+
+  it('should call onStart when the Start button is clicked', () => {
+    const onStart = jest.fn()
+    render(
+      <MonitorNotStarted
+        saveLogValue={false}
+        setSaveLogValue={jest.fn()}
+        onStart={onStart}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('start-monitor'))
+
+    expect(onStart).toHaveBeenCalledTimes(1)
+  })
+})

--- a/redisinsight/ui/src/components/monitor/MonitorNotStarted/MonitorNotStarted.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorNotStarted/MonitorNotStarted.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Text, Title } from 'uiSrc/components/base/text'
+import { SwitchInput } from 'uiSrc/components/base/inputs'
+import { Spacer } from 'uiSrc/components/base/layout'
+import { Banner } from 'uiSrc/components/base/display/banner'
+import { RiImage } from 'uiSrc/components/base/display'
+import ProfilerImage from 'uiSrc/assets/img/profiler/magnifier.svg'
+
+import { StyledImagePanel } from '../Monitor/Monitor.styles'
+import ProfilerStartButton from '../ProfilerStartButton'
+
+export interface Props {
+  saveLogValue: boolean
+  setSaveLogValue: (v: boolean) => void
+  onStart: () => void
+}
+
+const MonitorNotStarted = ({
+  saveLogValue,
+  setSaveLogValue,
+  onStart,
+}: Props) => (
+  <Row
+    align="center"
+    style={{ margin: 48 }}
+    gap="xxl"
+    data-testid="monitor-not-started"
+  >
+    <StyledImagePanel align="center">
+      <RiImage
+        src={ProfilerImage}
+        alt="Profiler"
+        style={{ userSelect: 'none', pointerEvents: 'none' }}
+      />
+      <Spacer size="l" />
+      <Text>
+        Get a deeper understanding of your database with real-time command, key,
+        and client statistics.
+      </Text>
+    </StyledImagePanel>
+
+    <Col gap="xl">
+      <Title size="M">Profiler</Title>
+      <Text>
+        Analyze every command sent to Redis in real time to debug issues and
+        optimize performance.
+      </Text>
+
+      <div>
+        <ProfilerStartButton onStart={onStart} />
+      </div>
+
+      <div data-testid="save-log-container">
+        <RiTooltip
+          title="Allows you to download the generated log file after pausing the Profiler."
+          content="Profiler log is saved to a file on your local machine with no size limitation. The temporary log file will be automatically rewritten when the Profiler is reset."
+          data-testid="save-log-tooltip"
+        >
+          <SwitchInput
+            title="Save Log"
+            checked={saveLogValue}
+            onCheckedChange={setSaveLogValue}
+            data-testid="save-log-switch"
+          />
+        </RiTooltip>
+      </div>
+
+      <Banner
+        variant="attention"
+        showIcon
+        data-testid="monitor-warning-message"
+        message="Running Profiler will decrease throughput, avoid running it in production databases."
+      />
+    </Col>
+  </Row>
+)
+
+export default MonitorNotStarted

--- a/redisinsight/ui/src/components/monitor/MonitorNotStarted/index.ts
+++ b/redisinsight/ui/src/components/monitor/MonitorNotStarted/index.ts
@@ -1,0 +1,3 @@
+import MonitorNotStarted from './MonitorNotStarted'
+
+export default MonitorNotStarted

--- a/redisinsight/ui/src/components/monitor/ProfilerStartButton/ProfilerStartButton.spec.tsx
+++ b/redisinsight/ui/src/components/monitor/ProfilerStartButton/ProfilerStartButton.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import * as useDatabaseModeModule from 'uiSrc/components/hooks/useDatabaseMode'
+import ProfilerStartButton from './ProfilerStartButton'
+
+const mockUseDatabaseMode = (
+  mode: useDatabaseModeModule.UseDatabaseModeResult['mode'],
+) =>
+  jest.spyOn(useDatabaseModeModule, 'useDatabaseMode').mockReturnValue({
+    mode,
+    isDangerousCommand: () => false,
+  })
+
+beforeEach(() => {
+  cleanup()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('ProfilerStartButton', () => {
+  it('should render the Start Profiler button', () => {
+    mockUseDatabaseMode('unmarked')
+    render(<ProfilerStartButton onStart={jest.fn()} />)
+    expect(screen.getByTestId('start-monitor')).toBeInTheDocument()
+  })
+
+  it.each(['fast', 'unmarked', 'disabled'] as const)(
+    'should call onStart directly when mode is "%s"',
+    (mode) => {
+      mockUseDatabaseMode(mode)
+      const onStart = jest.fn()
+      render(<ProfilerStartButton onStart={onStart} />)
+
+      fireEvent.click(screen.getByTestId('start-monitor'))
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+      expect(screen.queryByTestId('confirm-popover')).not.toBeInTheDocument()
+    },
+  )
+
+  describe('in production mode', () => {
+    beforeEach(() => {
+      mockUseDatabaseMode('production')
+    })
+
+    it('should open the confirmation popover and not call onStart on first click', () => {
+      const onStart = jest.fn()
+      render(<ProfilerStartButton onStart={onStart} />)
+
+      fireEvent.click(screen.getByTestId('start-monitor'))
+
+      expect(onStart).not.toHaveBeenCalled()
+      expect(screen.getByTestId('confirm-popover')).toBeInTheDocument()
+    })
+
+    it('should call onStart when the user confirms', () => {
+      const onStart = jest.fn()
+      render(<ProfilerStartButton onStart={onStart} />)
+
+      fireEvent.click(screen.getByTestId('start-monitor'))
+      fireEvent.click(screen.getByTestId('profiler-start-confirm'))
+
+      expect(onStart).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call onStart and close the popover when the user cancels', () => {
+      const onStart = jest.fn()
+      render(<ProfilerStartButton onStart={onStart} />)
+
+      fireEvent.click(screen.getByTestId('start-monitor'))
+      fireEvent.click(screen.getByTestId('profiler-start-cancel'))
+
+      expect(onStart).not.toHaveBeenCalled()
+      expect(screen.queryByTestId('confirm-popover')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/redisinsight/ui/src/components/monitor/ProfilerStartButton/ProfilerStartButton.tsx
+++ b/redisinsight/ui/src/components/monitor/ProfilerStartButton/ProfilerStartButton.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import {
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+import ConfirmationPopover from 'uiSrc/components/confirmation-popover/ConfirmationPopover'
+import { useDatabaseMode } from 'uiSrc/components/hooks/useDatabaseMode'
+
+export interface Props {
+  onStart: () => void
+}
+
+const ProfilerStartButton = ({ onStart }: Props) => {
+  const { mode } = useDatabaseMode()
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const isProduction = mode === 'production'
+
+  const handleClick = () => {
+    if (isProduction) {
+      setIsConfirmOpen(true)
+      return
+    }
+    onStart()
+  }
+
+  const handleConfirm = () => {
+    setIsConfirmOpen(false)
+    onStart()
+  }
+
+  const button = (
+    <RiTooltip content="Enable real-time profiling of your Redis database.">
+      <PrimaryButton
+        onClick={handleClick}
+        aria-label="start monitor"
+        data-testid="start-monitor"
+      >
+        Start Profiler
+      </PrimaryButton>
+    </RiTooltip>
+  )
+
+  if (!isProduction) {
+    return button
+  }
+
+  return (
+    <ConfirmationPopover
+      isOpen={isConfirmOpen}
+      closePopover={() => setIsConfirmOpen(false)}
+      anchorPosition="rightCenter"
+      trigger={button}
+      title="Start Profiler"
+      message="You're connected to a production database. Profiler decreases throughput. Are you sure you want to run it now?"
+      confirmButton={
+        <Row gap="m" justify="end">
+          <SecondaryButton
+            size="s"
+            onClick={() => setIsConfirmOpen(false)}
+            data-testid="profiler-start-cancel"
+          >
+            Cancel
+          </SecondaryButton>
+          <PrimaryButton
+            size="s"
+            onClick={handleConfirm}
+            data-testid="profiler-start-confirm"
+          >
+            Run
+          </PrimaryButton>
+        </Row>
+      }
+    />
+  )
+}
+
+export default ProfilerStartButton

--- a/redisinsight/ui/src/components/monitor/ProfilerStartButton/index.ts
+++ b/redisinsight/ui/src/components/monitor/ProfilerStartButton/index.ts
@@ -1,0 +1,3 @@
+import ProfilerStartButton from './ProfilerStartButton'
+
+export default ProfilerStartButton


### PR DESCRIPTION
# What

Adds a Cancel/Run confirmation popover that intercepts the Profiler **Start** button when the connected database is marked as production (`useDatabaseMode().mode === 'production'`). Non-production and disabled modes start directly, preserving the existing behavior.

The Start button is extracted into a new `ProfilerStartButton` component that owns the popover state and the database-mode lookup, keeping `Monitor.tsx` as a minimal swap.

<img width="540" height="273" alt="Screenshot 2026-05-19 at 10 37 27" src="https://github.com/user-attachments/assets/fe5ae008-2f61-4837-89df-eb1aeafe9b12" />

# Testing

- Unit: `jest redisinsight/ui/src/components/monitor` (Monitor + new ProfilerStartButton specs).
- Manual smoke test with the `devProdMode` feature flag on:
  - Non-production database → clicking **Start Profiler** launches the profiler directly.
  - Database marked as production → clicking **Start Profiler** opens the Cancel/Run popover; **Cancel** closes without starting; **Run** starts the profiler.
  - Feature flag off → clicking **Start Profiler** launches the profiler directly.

---

Closes #RI-8188


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Profiler start flow by adding a production-only confirmation popover; risk is limited to UI/UX but could inadvertently block or alter start behavior depending on `useDatabaseMode` detection.
> 
> **Overview**
> Adds a **production-safety gate** to the Profiler start action: when `useDatabaseMode().mode === 'production'`, clicking **Start Profiler** now opens a Cancel/Run confirmation popover before invoking the start handler.
> 
> Refactors the “not started” Profiler intro UI out of `Monitor.tsx` into a dedicated `MonitorNotStarted` component and introduces `ProfilerStartButton` to encapsulate the start/confirm logic, with new Jest unit tests covering both non-production and production flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb459aa8557a397713e1148740385ad309763d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->