### PR TITLE
docs: reference type-check and tscheck in AGENTS.md before-committing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,18 @@ yarn lint              # All code
 yarn lint:ui           # Frontend only
 yarn lint:api          # Backend only
 
-# Type checking
-yarn type-check:ui     # Frontend TypeScript
+# Type checking (compares against .tscheck.rec.json baselines for ui/api/desktop + configs)
+yarn type-check
+
+# Refresh baselines after intentionally adding or fixing TS errors (do not run casually)
+yarn tscheck
 
 # Tests
 yarn test              # Frontend tests
 yarn test:api          # Backend tests
 ```
+
+`yarn type-check` is the gate — CI fails if any (file × error-code) TS-error count increases. If you intentionally changed TS-error counts, run `yarn tscheck` to refresh the baselines and commit the updated `.tscheck.rec.json` files. See `.ai/skills/type-check-baselines/SKILL.md` for details (including the `yarn tscheck:force` escape hatch).
 
 **Fix any linting errors, type errors, or test failures before committing.**
 
@@ -97,6 +102,7 @@ All detailed development standards are maintained in `.ai/rules/`:
 - **Commits**: `.ai/skills/commits/SKILL.md` - Commit message guidelines
 - **Pull Requests**: `.ai/skills/pull-requests/SKILL.md` - PR process and review guidelines
 - **Feature Flags**: `.ai/skills/feature-flags/SKILL.md` - Adding, promoting, and removing feature flags
+- **TS Error Baselines**: `.ai/skills/type-check-baselines/SKILL.md` - Running and refreshing TypeScript error baselines
 - **Redis UI Components**: `.ai/skills/redis-ui-components/SKILL.md` - Component API references, props, and usage examples (from `@redis-ui/components` package)
 
 **Refer to these files for comprehensive guidelines on each topic.**


### PR DESCRIPTION
# What

Update `AGENTS.md` "Before Committing" section so agents run the right TypeScript checks:

- Remove obsolete `yarn type-check:ui` (no longer a script).
- Add `yarn type-check` (the gate — compares ui/api/desktop + configs against `.tscheck.rec.json` baselines) and `yarn tscheck` (baseline refresh).
- Add a short note explaining the gate vs. refresh distinction.
- Add the `type-check-baselines` skill to the `.ai/skills/` reference list.

# Testing

- Read [AGENTS.md](AGENTS.md) — both `yarn type-check` and `yarn tscheck` are in the "Before Committing" block; `type-check:ui` is gone.
- Doc-only change; no scripts touched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only update that changes recommended commands but does not touch build, CI, or runtime code; low risk beyond potential developer workflow confusion.
> 
> **Overview**
> Updates `AGENTS.md` before-commit instructions to replace the obsolete `yarn type-check:ui` with the baseline-gated `yarn type-check`, and adds `yarn tscheck` guidance for refreshing `.tscheck.rec.json` when TS error counts intentionally change.
> 
> Also documents the gate vs. refresh distinction and adds a reference to `.ai/skills/type-check-baselines/SKILL.md` in the standards list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543f54d88cd412a0fc3913d81d28297ee4a2b521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->