### PR TITLE
ci: skip docker-build on unrelated PR labels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       backend: ${{ steps.filter.outputs.backend }}
       desktop: ${{ steps.filter.outputs.desktop }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4.0.1
@@ -72,6 +73,10 @@ jobs:
               - 'redisinsight/api/**'
             desktop:
               - 'redisinsight/desktop/**'
+            docker:
+              - 'Dockerfile*'
+              - '.dockerignore'
+              - '*docker*.sh'
 
   # Check common conditions that trigger all test suites
   should-run-all-tests:
@@ -115,7 +120,8 @@ jobs:
     if: |
       needs.should-run-all-tests.outputs.result == 'true' ||
       needs.changes.outputs.frontend == 'true' ||
-      needs.changes.outputs.backend == 'true'
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.docker == 'true'
     uses: ./.github/workflows/docker-build.yml
 
   frontend-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,11 @@ jobs:
     secrets: inherit
 
   docker-build:
+    needs: [changes, should-run-all-tests]
+    if: |
+      needs.should-run-all-tests.outputs.result == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.backend == 'true'
     uses: ./.github/workflows/docker-build.yml
 
   frontend-tests:


### PR DESCRIPTION
# What

The `docker-build` job in `.github/workflows/tests.yml` had no `if:` gate, so it ran on every `pull_request: labeled` event — even unrelated labels like `bug` or `needs review` — wasting CI time.

Added a gate consistent with the other test jobs: run only when `should-run-all-tests` is true (workflow_dispatch, prerelease, `run-all-tests` label, etc.) or when frontend/backend files actually changed.

# Testing

- Add an unrelated label to this PR → `docker-build` should not run.
- Add the `run-all-tests` label → `docker-build` should run.
- Push a UI or API change on a `fe/...`, `be/...`, or `feature/...` branch → `docker-build` should run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just reduces unnecessary `docker-build` runs; main risk is accidentally skipping image builds when a Docker-impacting path isn’t covered by the filter.
> 
> **Overview**
> **Optimizes CI by skipping unnecessary Docker builds.** The `tests.yml` workflow now detects Docker-related changes via a new `docker` paths-filter output and adds an `if:` + `needs:` gate on `docker-build`.
> 
> `docker-build` runs only when `should-run-all-tests` is true or when frontend/backend code changes (or Docker files like `Dockerfile*`, `.dockerignore`, `*docker*.sh` change), avoiding runs triggered solely by unrelated PR labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b573f3a840ec66d454fb9ebbd62216f9c8af682b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->