### PR TITLE
ci: retry image pulls before starting Redis test environment

### DIFF
--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -73,6 +73,18 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
+      - name: Pull Redis test environment images
+        run: |
+          for i in 1 2 3; do
+            if docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml pull; then
+              exit 0
+            fi
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Failed to pull Redis test environment images after 3 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -58,6 +58,18 @@ jobs:
         run: |
           docker image load -i ./release/docker/docker-linux-alpine.amd64.tar
 
+      - name: Pull Redis test environment images
+        run: |
+          for i in 1 2 3; do
+            if docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml pull; then
+              exit 0
+            fi
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Failed to pull Redis test environment images after 3 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -120,6 +120,18 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
+      - name: Pull Redis test environment images
+        run: |
+          for i in 1 2 3; do
+            if docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml pull; then
+              exit 0
+            fi
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Failed to pull Redis test environment images after 3 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \


### PR DESCRIPTION
## Summary

- Adds a `Pull Redis test environment images` step (3 retries with 15s backoff) before `Start Redis test environment` in all three nightly e2e workflows.
- After the pre-pull, the subsequent `docker compose up` uses already-cached layers and doesn't touch the network — so a single flaky `ghcr.io` / Docker Hub handshake no longer fails the whole job.

## Motivation

Nightly run [26069302725](https://github.com/redis/RedisInsight/actions/runs/26069302725/job/76648032330) failed at the `Start Redis test environment` step with:

```
ssh Error Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Error response from daemon: Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
##[error]Process completed with exit code 1.
```

`docker compose up` implicitly pulls the images declared in `tests/e2e/rte.docker-compose.yml` (`redis:5`, `redis:7.4-rc2`, `redis:8.0-M02`, `redislabs/redismod`, `redislabs/redisgears:edge`, `lscr.io/linuxserver/openssh-server:...`). With no retry around the pull, one bad handshake fails the whole nightly. Same `docker compose up` pattern is used in all three e2e workflows, so all three were equally exposed.

## Files changed

- `.github/workflows/tests-e2e-playwright-docker.yml`
- `.github/workflows/tests-e2e-playwright-chromium.yml`
- `.github/workflows/tests-e2e-playwright-electron.yml`

## Test plan

- [ ] Re-run nightly `E2E Playwright Tests (v2)` and confirm jobs still pass.
- [ ] Monitor the next 5–7 nightly runs — when a transient pull hiccup occurs, expect `Pull attempt 1 failed, retrying in 15s...` in logs and the job to still pass.
- [ ] (Negative test, manual) Temporarily point one compose service at a bad tag locally and verify the retry loop exits with the `::error::` annotation after 3 attempts.

## Out of scope

- The other nightly flake (`Install all libs and dependencies` cancellation in [26007687920](https://github.com/redis/RedisInsight/actions/runs/26007687920)) will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)