### PR TITLE
Show (nil) placeholder for missing vector set attributes

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -96,8 +96,9 @@ const buildAttributeColumn = (
     const attrs =
       parsedAttributesCache.get(row.original) ??
       parseAttributes(row.original.attributes)
-    const value = attrs[key]
-    const isMissing = !(key in attrs) || value === null || value === undefined
+    const hasOwn = Object.prototype.hasOwnProperty.call(attrs, key)
+    const value = hasOwn ? attrs[key] : undefined
+    const isMissing = !hasOwn || value === null || value === undefined
     return (
       <S.AttributeCell
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -96,11 +96,17 @@ const buildAttributeColumn = (
     const attrs =
       parsedAttributesCache.get(row.original) ??
       parseAttributes(row.original.attributes)
+    const value = attrs[key]
+    const isMissing = !(key in attrs) || value === null || value === undefined
     return (
       <S.AttributeCell
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}
       >
-        {renderAttributeValue(attrs[key])}
+        {isMissing ? (
+          <S.NilAttributeValue variant="italic">(nil)</S.NilAttributeValue>
+        ) : (
+          renderAttributeValue(value)
+        )}
       </S.AttributeCell>
     )
   },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -168,6 +168,26 @@ describe('SimilaritySearchResultsTable', () => {
       ).toHaveTextContent('(nil)')
     })
 
+    it('renders (nil) for keys colliding with Object.prototype', () => {
+      // `a` literally has an attribute named `toString`; `b` does not.
+      // Using `key in attrs` would resolve `toString` via the prototype
+      // chain for `b` and render `function toString() { ... }` instead of
+      // the (nil) placeholder.
+      const matches = [
+        buildMatch('a', 0.9, '{"toString":"hello"}'),
+        buildMatch('b', 0.8, '{}'),
+      ]
+
+      renderTable(matches)
+
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-0-toString'),
+      ).toHaveTextContent('hello')
+      expect(
+        screen.getByTestId('vector-set-similarity-attribute-cell-1-toString'),
+      ).toHaveTextContent('(nil)')
+    })
+
     it('hides columns whose visibility is explicitly false', () => {
       const matches = [buildMatch('a', 0.9, '{"city":"NYC","count":3}')]
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -162,10 +162,10 @@ describe('SimilaritySearchResultsTable', () => {
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-city'),
       ).toHaveTextContent('LA')
-      // b has no `count` attribute → empty cell
+      // b has no `count` attribute → (nil) placeholder
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-count'),
-      ).toHaveTextContent('')
+      ).toHaveTextContent('(nil)')
     })
 
     it('hides columns whose visibility is explicitly false', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.styles.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import { Table } from 'uiSrc/components/base/layout/table'
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
 
 export const Container = styled(FlexItem)`
   display: flex;
@@ -41,4 +42,8 @@ export const AttributeCell = styled.span<{
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`
+
+export const NilAttributeValue = styled(Text)`
+  color: ${({ theme }) => theme.semantic.color.text.neutral500};
 `


### PR DESCRIPTION
# What

In the vector set similarity search results table, render a muted `(nil)` placeholder in attribute cells when an element does not have a value for that attribute column, instead of leaving the cell blank.

| Light | Dark |
| --- | --- |
| <img width="668" height="675" alt="image" src="https://github.com/user-attachments/assets/a303a987-85f3-42bc-984a-ed4951ee3ea6" /> | <img width="668" height="675" alt="image" src="https://github.com/user-attachments/assets/9e35f4c7-1e27-4fda-9770-fee135791a0e" /> |

# Testing

1. Open a vector set with elements that have heterogeneous attributes (some elements have keys others don't).
2. Run a similarity search.
3. Verify that attribute columns show `(nil)` (in muted text) for elements that don't have the attribute, and the actual value otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters how missing attribute values render in the similarity results table; primary risk is minor display/regression around edge-case attribute keys.
> 
> **Overview**
> Vector set similarity search attribute cells now render a muted italic `(nil)` placeholder when an element is missing an attribute (or the value is `null`/`undefined`), instead of leaving the cell blank.
> 
> Attribute lookups were tightened to use `Object.prototype.hasOwnProperty.call` to avoid prototype-chain collisions (e.g., `toString`), with updated styling (`NilAttributeValue`) and expanded tests to cover both missing attributes and prototype-key edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39628fc0442016e1d47e67064ebb6af9339edb9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->