### PR TITLE
ci: drop setup-node yarn cache to fix flaky V8 crash

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -21,10 +21,6 @@ runs:
       uses: actions/setup-node@v4.0.4
       with:
         node-version: '22.22.0'
-        # disable cache for windows
-        # https://github.com/actions/setup-node/issues/975
-        cache: ${{ runner.os != 'Windows' && 'yarn' || '' }}
-        cache-dependency-path: ${{ runner.os != 'Windows' && '**/yarn.lock' || '' }}
 
     - name: Cache node_modules
       id: cache-node-modules


### PR DESCRIPTION
## Summary

`install-all-build-libs` was intermittently failing very early — before any install ran — with:

> ##[error]Could not get yarn cache folder path for /home/runner/.../redisearch

Examples:
- [Run 26007687920](https://github.com/redis/RedisInsight/actions/runs/26007687920/job/76442146820) — Build Linux / arm64, 2026-05-18 (also shows a V8 fatal-error stack: `V8_Fatal ... Deserializer::ReadObject`)
- [Run 25586644047](https://github.com/redis/RedisInsight/actions/runs/25586644047/job/75116466627) — Build Linux / arm64, 2026-05-09

### Root cause

`cache-dependency-path: '**/yarn.lock'` makes `actions/setup-node` discover 9 lockfiles and fire 9 parallel `yarn --version` + `yarn cache dir` subprocesses. On arm64 hosted runners, one of those Node 20 child processes occasionally crashes in V8 snapshot deserialization, returns empty, and setup-node fails the whole job. Narrowing the glob would only reduce the probability, not eliminate it.

### Fix

Remove setup-node's `cache:` / `cache-dependency-path:` inputs. setup-node no longer spawns `yarn cache dir` at all → the V8-crash path is gone.

This is safe because [.github/actions/install-all-build-libs/action.yml](https://github.com/redis/RedisInsight/blob/main/.github/actions/install-all-build-libs/action.yml) already has an `actions/cache@v4` step that caches `node_modules` directly, keyed on the three lockfiles we actually install from. When that cache hits, `yarn install` doesn't run and the yarn offline mirror is irrelevant. Only cost: cold installs (lockfile change or GitHub cache eviction) fetch from the npm registry instead of `~/.cache/yarn/v6` — roughly +60–120s on rare paths.

If cold-install times become a problem, a follow-up can add a manual `actions/cache@v4` step pinned to `~/.cache/yarn/v6` to restore the offline mirror without re-introducing `yarn cache dir` spawns.

## Test plan

- [ ] Build Linux / arm64 job passes on this branch
- [ ] In the setup-node step log, confirm no `yarn cache dir` lines appear
- [ ] `Cache node_modules` step still restores on a warm run (`Cache restored from key: node-modules-Linux-...`)
- [ ] Spot-check 2–3 reruns to confirm no new failure mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes `actions/setup-node` yarn caching to avoid intermittent runner failures; main impact is potentially slower cold installs when caches are missed.
> 
> **Overview**
> Removes `actions/setup-node`'s built-in Yarn caching configuration (`cache` / `cache-dependency-path`) from the `install-all-build-libs` composite action to prevent flaky early failures during cache-folder discovery.
> 
> Dependency caching now relies solely on the existing `actions/cache` step that restores `node_modules` for the root, `redisinsight`, and `redisinsight/api` workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aed78fa0887a065ff705d68bb8a45a64b75bcb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->