### PR TITLE
Change hard coded similarity form search modes to enums

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.spec.ts
@@ -12,7 +12,10 @@ import {
 } from 'uiSrc/slices/browser/vectorSet'
 import { VectorSetSimilaritySearchResponse } from 'uiSrc/slices/interfaces'
 
-import { SimilaritySearchFormState } from '../../similarity-search-form'
+import {
+  SimilaritySearchFormState,
+  SimilaritySearchMode,
+} from '../../similarity-search-form'
 import { useSimilaritySearch } from './useSimilaritySearch'
 
 jest.mock('uiSrc/slices/browser/keys', () => ({
@@ -47,7 +50,7 @@ const mockedAbortSimilaritySearchPreview = jest.mocked(
 )
 
 const baseState = (): SimilaritySearchFormState => ({
-  mode: 'vector',
+  mode: SimilaritySearchMode.Vector,
   vectorInput: '',
   elementInput: '',
   count: 10,
@@ -129,7 +132,7 @@ describe('useSimilaritySearch', () => {
 
       const payload = result.current.buildSimilaritySearchPayload({
         ...baseState(),
-        mode: 'element',
+        mode: SimilaritySearchMode.Element,
         elementInput: 'book-1',
       })
 
@@ -206,7 +209,7 @@ describe('useSimilaritySearch', () => {
       expect(
         result.current.buildSimilaritySearchPayload({
           ...baseState(),
-          mode: 'element',
+          mode: SimilaritySearchMode.Element,
           elementInput: '   ',
         }),
       ).toBeNull()
@@ -454,7 +457,7 @@ describe('useSimilaritySearch', () => {
         act(() => {
           result.current.runSimilaritySearchPreview({
             ...baseState(),
-            mode: 'element',
+            mode: SimilaritySearchMode.Element,
             elementInput: 'book-1',
           })
           jest.advanceTimersByTime(300)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
@@ -15,7 +15,10 @@ import {
 import { VectorSetSimilaritySearchPayload } from 'uiSrc/slices/interfaces/vectorSet'
 import { stringToBuffer } from 'uiSrc/utils'
 
-import { SimilaritySearchFormState } from '../../similarity-search-form'
+import {
+  SimilaritySearchFormState,
+  SimilaritySearchMode,
+} from '../../similarity-search-form'
 import {
   bytesToBase64,
   validateVector,
@@ -89,7 +92,7 @@ export const useSimilaritySearch = (): UseSimilaritySearchResult => {
         keyName: selectedKeyData.name,
       }
 
-      if (state.mode === 'element') {
+      if (state.mode === SimilaritySearchMode.Element) {
         const element = state.elementInput.trim()
         if (!element) return null
         payload.elementName = stringToBuffer(element)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/index.ts
@@ -1,4 +1,7 @@
-export { SimilaritySearchForm } from './similarity-search-form'
+export {
+  SimilaritySearchForm,
+  SimilaritySearchMode,
+} from './similarity-search-form'
 export type {
   SimilaritySearchFormProps,
   SimilaritySearchFormState,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -61,7 +61,7 @@ export const SimilaritySearchForm = ({
     if (!prefillElement) return
     setState((prev) => ({
       ...prev,
-      mode: 'element',
+      mode: SimilaritySearchMode.Element,
       elementInput: prefillElement.value,
     }))
   }, [prefillElement?.nonce, prefillElement?.value])
@@ -111,8 +111,8 @@ export const SimilaritySearchForm = ({
         <FlexItem grow={false}>
           <ButtonGroup data-testid={`${TEST_ID}-mode-toggle`}>
             <ButtonGroup.Button
-              isSelected={state.mode === 'vector'}
-              onClick={() => setMode('vector')}
+              isSelected={state.mode === SimilaritySearchMode.Vector}
+              onClick={() => setMode(SimilaritySearchMode.Vector)}
               data-testid={`${TEST_ID}-mode-vector`}
             >
               <ModeButtonContent>
@@ -128,8 +128,8 @@ export const SimilaritySearchForm = ({
               </ModeButtonContent>
             </ButtonGroup.Button>
             <ButtonGroup.Button
-              isSelected={state.mode === 'element'}
-              onClick={() => setMode('element')}
+              isSelected={state.mode === SimilaritySearchMode.Element}
+              onClick={() => setMode(SimilaritySearchMode.Element)}
               data-testid={`${TEST_ID}-mode-element`}
             >
               <ModeButtonContent>
@@ -147,7 +147,7 @@ export const SimilaritySearchForm = ({
           </ButtonGroup>
         </FlexItem>
         <FlexItem grow>
-          {state.mode === 'vector' ? (
+          {state.mode === SimilaritySearchMode.Vector ? (
             <FormField>
               <TextInput
                 placeholder={VECTOR_PLACEHOLDER}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.types.ts
@@ -1,4 +1,7 @@
-export type SimilaritySearchMode = 'vector' | 'element'
+export enum SimilaritySearchMode {
+  Vector = 'vector',
+  Element = 'element',
+}
 
 export interface SimilaritySearchFormState {
   mode: SimilaritySearchMode

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.utils.spec.ts
@@ -1,10 +1,11 @@
 import { SIMILARITY_SEARCH_COUNT_DEFAULT } from './constants'
+import { SimilaritySearchMode } from './SimilaritySearchForm.types'
 import { initialFormState, isQueryReady } from './SimilaritySearchForm.utils'
 
 describe('initialFormState', () => {
   it('returns vector mode with empty inputs and the default count', () => {
     expect(initialFormState()).toEqual({
-      mode: 'vector',
+      mode: SimilaritySearchMode.Vector,
       vectorInput: '',
       elementInput: '',
       count: SIMILARITY_SEARCH_COUNT_DEFAULT,
@@ -22,7 +23,7 @@ describe('isQueryReady', () => {
     expect(
       isQueryReady({
         ...initialFormState(),
-        mode: 'element',
+        mode: SimilaritySearchMode.Element,
         elementInput: 'a',
       }),
     ).toBe(true)
@@ -32,7 +33,7 @@ describe('isQueryReady', () => {
     expect(
       isQueryReady({
         ...initialFormState(),
-        mode: 'element',
+        mode: SimilaritySearchMode.Element,
         elementInput: '',
       }),
     ).toBe(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.utils.ts
@@ -1,10 +1,13 @@
 import { validateVector } from '../../vector-set-element-form/utils'
 
 import { SIMILARITY_SEARCH_COUNT_DEFAULT } from './constants'
-import { SimilaritySearchFormState } from './SimilaritySearchForm.types'
+import {
+  SimilaritySearchFormState,
+  SimilaritySearchMode,
+} from './SimilaritySearchForm.types'
 
 export const initialFormState = (): SimilaritySearchFormState => ({
-  mode: 'vector',
+  mode: SimilaritySearchMode.Vector,
   vectorInput: '',
   elementInput: '',
   count: SIMILARITY_SEARCH_COUNT_DEFAULT,
@@ -21,7 +24,7 @@ export const isQueryReady = (
   state: SimilaritySearchFormState,
   vectorDim?: number,
 ): boolean => {
-  if (state.mode === 'element') {
+  if (state.mode === SimilaritySearchMode.Element) {
     return state.elementInput.trim().length > 0
   }
   const result = validateVector(state.vectorInput, vectorDim)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/index.ts
@@ -1,4 +1,5 @@
 export { SimilaritySearchForm } from './SimilaritySearchForm'
+export { SimilaritySearchMode } from './SimilaritySearchForm.types'
 export type {
   SimilaritySearchFormProps,
   SimilaritySearchFormState,


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

Small refactoring - use enum for 'element' | 'vector' search modes instead of hardcoded strings. 

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to UI form state and payload-building branches; main risk is mismatched enum exports/imports causing TypeScript or runtime mode checks to fail.
> 
> **Overview**
> Refactors vector set similarity search to use a shared `SimilaritySearchMode` enum instead of hard-coded `'vector' | 'element'` strings across the form, utilities, and `useSimilaritySearch` hook.
> 
> Updates public exports (`similarity-search-form/index.ts`) and adjusts related unit tests to reference the enum, keeping behavior the same while reducing stringly-typed mode handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecdc51c9a55b257440cb6f5f8a0592469854f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->