### PR TITLE
chore(ai): migrate AI rules to skills

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -7,18 +7,14 @@ This directory contains the **single source of truth** for AI-assisted developme
 This repository uses a centralized approach to AI development rules:
 
 - **`AGENTS.md`** (at repository root) - Entry point for AI agents with essential commands, testing instructions, and quick reference
-- **`.ai/rules/`** - Detailed development standards organized by topic
-- **`.ai/skills/`** - Agent skills (local and from npm packages)
+- **`.ai/skills/`** - Detailed development standards as skills, plus skills from npm packages
 - **`.ai/commands/`** - AI workflow commands and templates
 
-These rules are used by multiple AI coding assistants:
+These standards are consumed by:
 
-- **Cursor** (via symlinks: `.cursor/rules/` and `.cursor/commands/`)
-- **Augment** (via symlink: `.augment/`)
-- **Windsurf** (via symlink: `.windsurfrules`)
-- **GitHub Copilot** (via file: `.github/copilot-instructions.md`)
-- **Claude Code** (via `CLAUDE.md` plus `.claude/commands/` and `.claude/skills/` symlinks)
-- **Codex** (via `AGENTS.md` and `.agents/skills` symlink)
+- **Claude Code** (via `CLAUDE.md -> AGENTS.md` plus `.claude/commands/` and `.claude/skills/` symlinks)
+- **Codex** (via `AGENTS.md` and the `.agents/skills` symlink)
+- **GitHub Copilot** (via file: `.github/copilot-instructions.md`, optional)
 
 ## Structure
 
@@ -27,18 +23,19 @@ AGENTS.md                              # 🎯 AI agent entry point
 CLAUDE.md -> AGENTS.md                 # Claude Code entry point
 .ai/                                   # Single source of truth
 ├── README.md                          # This file (human-readable overview)
-├── rules/                             # Development standards (modular)
-│   ├── code-quality.md                # Linting, TypeScript standards
-│   ├── frontend.md                    # React, Redux, UI patterns
-│   ├── backend.md                     # NestJS, API patterns
-│   ├── testing.md                     # Testing standards
-│   ├── commits.md                     # Commit message guidelines
-│   └── pull-requests.md               # Pull request process
-├── skills/                            # Agent skills
-│   ├── branches/                      # Branch naming skill
-│   ├── commits/                       # Commit message skill
-│   ├── pull-requests/                 # Pull request skill
-|   └── feature-flags/SKILL.md         # Feature flag lifecycle
+├── skills/                            # Development standards and agent skills
+│   ├── code-quality/SKILL.md          # Linting, TypeScript standards, naming, imports
+│   ├── frontend/SKILL.md              # React, Redux, styled-components, UI patterns
+│   ├── backend/SKILL.md               # NestJS, API patterns, DI, error handling
+│   ├── testing/SKILL.md               # Jest/Testing Library standards, faker, helpers
+│   ├── e2e-testing/SKILL.md           # Playwright standards, page objects, fixtures
+│   ├── git-safety/SKILL.md            # Protected-branch guardrails
+│   ├── branches/SKILL.md              # Branch naming
+│   ├── commits/SKILL.md               # Commit messages (Conventional Commits)
+│   ├── pull-requests/SKILL.md         # Pull request process
+│   ├── feature-flags/SKILL.md         # Feature flag lifecycle
+│   ├── tsconfigs/SKILL.md             # TypeScript configuration
+│   ├── type-check-baselines/SKILL.md  # TS error baseline workflow
 │   └── redis-ui-components/ -> node_modules/@redis-ui/components/skills/redis-ui-components
 │       ├── SKILL.md                   # Component catalog and usage patterns
 │       └── references/                # Per-component API docs (Button, Select, etc.)
@@ -47,19 +44,16 @@ CLAUDE.md -> AGENTS.md                 # Claude Code entry point
     ├── commit-message.md              # Commit message generation
     └── pull-request-review.md         # PR review workflow
 
-# Symlinks (all AI tools read from .ai/)
-.cursor/
-  ├── rules/ -> ../.ai/rules/          # Cursor AI (rules)
-  ├── commands/ -> ../.ai/commands/    # Cursor AI (commands)
-  └── skills/ -> ../.ai/skills/        # Cursor AI (skills)
-.augment/ -> .ai/                      # Augment AI
-.windsurfrules -> .ai/                 # Windsurf AI
-.github/copilot-instructions.md        # GitHub Copilot
+# Symlinks
+.claude/
+  ├── commands/ -> ../.ai/commands/    # Claude Code (commands)
+  └── skills/ -> ../.ai/skills/        # Claude Code (skills)
 .agents/
-  └── skills -> ../.ai/skills          # Codex repo skills
+  └── skills -> ../.ai/skills          # Codex (skills)
+.github/copilot-instructions.md        # GitHub Copilot reference (if used)
 ```
 
-**Codex note**: Codex reads `AGENTS.md` for project instructions and discovers repo skills from `.agents/skills`. Do not symlink `.ai/rules/` into `.codex/rules/`: Codex `.rules` files are command execution policies, not Markdown development guidelines.
+**Codex note**: Codex reads `AGENTS.md` for project instructions and discovers repo skills from `.agents/skills`. Do not create `.codex/rules/`: Codex `.rules` files are command execution policies, not Markdown development guidelines.
 
 ## For AI Agents
 
@@ -71,20 +65,23 @@ CLAUDE.md -> AGENTS.md                 # Claude Code entry point
 - Git workflow guidelines
 - Boundaries and best practices
 
-**Then refer to**: `.ai/rules/` for detailed guidelines on specific topics.
+**Then refer to**: `.ai/skills/` for detailed guidelines on specific topics.
 
 ## For Human Developers
 
-This directory contains comprehensive development standards that are automatically used by AI coding assistants. The rules are organized into modular files for easy maintenance:
+This directory contains comprehensive development standards used by AI coding assistants. Each topic lives in its own skill folder:
 
-- **Code Quality Standards**: `.ai/rules/code-quality.md` - TypeScript standards, import organization, best practices
-- **Frontend Patterns**: `.ai/rules/frontend.md` - React, Redux, styled-components, UI component usage
-- **Backend Patterns**: `.ai/rules/backend.md` - NestJS, dependency injection, API patterns
-- **Testing Standards**: `.ai/rules/testing.md` - Testing patterns, faker usage, test helpers
-- **Branch Naming**: `.ai/skills/branches/SKILL.md` - Branch naming conventions
-- **Commit Messages**: `.ai/rules/commits.md` - Commit message guidelines (Conventional Commits)
-- **Pull Request Process**: `.ai/rules/pull-requests.md` - PR creation and review guidelines
+- **Code Quality**: `.ai/skills/code-quality/SKILL.md` - TypeScript standards, import organization, best practices
+- **Frontend**: `.ai/skills/frontend/SKILL.md` - React, Redux, styled-components, UI component usage
+- **Backend**: `.ai/skills/backend/SKILL.md` - NestJS, dependency injection, API patterns
+- **Testing**: `.ai/skills/testing/SKILL.md` - Jest/Testing Library patterns, faker, helpers
+- **E2E Testing**: `.ai/skills/e2e-testing/SKILL.md` - Playwright standards, page objects
+- **Git Safety**: `.ai/skills/git-safety/SKILL.md` - Protected-branch guardrails
+- **Branches**: `.ai/skills/branches/SKILL.md` - Branch naming conventions
+- **Commits**: `.ai/skills/commits/SKILL.md` - Commit message guidelines (Conventional Commits)
+- **Pull Requests**: `.ai/skills/pull-requests/SKILL.md` - PR creation and review guidelines
 - **Feature Flags**: `.ai/skills/feature-flags/SKILL.md` - Adding, promoting, and removing feature flags
+- **TS Error Baselines**: `.ai/skills/type-check-baselines/SKILL.md` - TypeScript error baseline workflow
 - **Redis UI Components**: `.ai/skills/redis-ui-components/` - Component API references, props, and usage examples (sourced from `@redis-ui/components` npm package via symlink)
 
 ## MCP (Model Context Protocol) Setup
@@ -143,11 +140,11 @@ The `mcp.json` file configures these services:
 
 ## Updating These Rules
 
-To update AI rules:
+To update AI standards:
 
-1. **Edit files in `.ai/` only** (never edit symlinked files directly)
-2. **Update `AGENTS.md`** if you change commands, testing instructions, or boundaries
-3. Changes automatically propagate to all AI tools via symlinks
+1. **Edit `SKILL.md` files under `.ai/skills/`** (never edit symlinked files directly)
+2. **Update `AGENTS.md`** if you change commands, testing instructions, or the always-on rules block
+3. Changes propagate to Claude Code automatically via the `.claude/` symlinks
 4. Commit changes to version control
 
 **Remember**: These rules exist to maintain code quality and consistency. Follow them, but also use good judgment.

--- a/.ai/commands/e2e-fix.md
+++ b/.ai/commands/e2e-fix.md
@@ -7,7 +7,7 @@ argument-hint: <test-pattern>
 
 Run E2E tests matching a pattern, analyze failures, and fix them.
 
-**Follow all standards in `.ai/rules/e2e-testing.md`**
+**Follow all standards in `.ai/skills/e2e-testing/SKILL.md`**
 
 ## Input
 

--- a/.ai/commands/e2e-generate.md
+++ b/.ai/commands/e2e-generate.md
@@ -7,7 +7,7 @@ argument-hint: <ticket-id or ticket-url>
 
 Use Playwright MCP to explore a page, discover testable functionality, and generate E2E tests based on a Jira ticket.
 
-**Follow all standards in `.ai/rules/e2e-testing.md`**
+**Follow all standards in `.ai/skills/e2e-testing/SKILL.md`**
 
 **Reference:** @tests/e2e-playwright/TEST_PLAN.md
 

--- a/.ai/commands/pr-plan.md
+++ b/.ai/commands/pr-plan.md
@@ -307,8 +307,8 @@ After saving the plan document:
 - **ALWAYS save the plan document** - use `write` tool to save to `docs/pr-plan-{ticket-id}-{brief-description}.md`
 - **Use main branch as baseline** - all analysis should be against current main
 - **Be specific and actionable** - every task should be clear and verifiable
-- **Consider PR stacking** - plan for small, reviewable PRs (see `.ai/rules/pull-requests.md`). plan breaking the implementation in a stack of PRs.
-- **Follow all project standards** - reference rules in `.ai/rules/`
+- **Consider PR stacking** - plan for small, reviewable PRs (see `.ai/skills/pull-requests/SKILL.md`). plan breaking the implementation in a stack of PRs.
+- **Follow all project standards** - reference skills in `.ai/skills/`
 - **Document assumptions** - if anything is unclear, document the assumption made
 - **Identify blockers early** - surface dependencies and knowledge gaps upfront
 

--- a/.ai/skills/backend/SKILL.md
+++ b/.ai/skills/backend/SKILL.md
@@ -1,8 +1,14 @@
 ---
-description: NestJS backend development patterns, module structure, services, controllers, DTOs, and error handling
-globs: redisinsight/api/**/*.ts
-alwaysApply: false
+name: backend
+description: >-
+  NestJS backend development patterns for the RedisInsight API:
+  module structure, services, controllers, DTOs, dependency injection,
+  and error handling. Use when editing any file under
+  redisinsight/api/**, writing or modifying NestJS modules,
+  controllers, services, DTOs, providers, or when the user mentions
+  the backend, API, or NestJS.
 ---
+
 
 # Backend Development (NestJS/API)
 

--- a/.ai/skills/code-quality/SKILL.md
+++ b/.ai/skills/code-quality/SKILL.md
@@ -1,6 +1,15 @@
 ---
-alwaysApply: true
+name: code-quality
+description: >-
+  Code-quality standards for RedisInsight: TypeScript strictness,
+  naming conventions (camelCase, PascalCase, UPPER_SNAKE_CASE),
+  linting rules, no `any` without reason, no `!important` in styles,
+  and constant extraction. Use when writing or refactoring any
+  TypeScript/JavaScript code in this repo, when ESLint or Prettier
+  issues come up, or when the user mentions code style, lint, naming
+  conventions, or general code quality.
 ---
+
 
 # Code Quality Standards
 

--- a/.ai/skills/e2e-testing/SKILL.md
+++ b/.ai/skills/e2e-testing/SKILL.md
@@ -1,8 +1,14 @@
 ---
-description: Playwright E2E testing standards, page object models, test structure, fixtures, and navigation patterns
-globs: tests/e2e-playwright/**/*.ts
-alwaysApply: false
+name: e2e-testing
+description: >-
+  Playwright end-to-end testing standards for RedisInsight: page
+  object models, test structure, fixtures, navigation patterns, and
+  flaky-test prevention. Use when editing files under
+  tests/e2e-playwright/**, writing Playwright tests, adding page
+  objects, or when the user mentions Playwright, E2E tests, page
+  objects, or end-to-end testing.
 ---
+
 
 # E2E Testing Standards (Playwright)
 

--- a/.ai/skills/frontend/SKILL.md
+++ b/.ai/skills/frontend/SKILL.md
@@ -1,8 +1,14 @@
 ---
-description: React frontend development patterns, Redux, styled-components, UI components, and hooks
-globs: redisinsight/ui/**/*.{ts,tsx}
-alwaysApply: false
+name: frontend
+description: >-
+  React/Redux frontend development patterns for RedisInsight UI:
+  component folder structure, styled-components, hooks, named exports,
+  barrel files, layout components, and theme usage. Use when editing
+  any file under redisinsight/ui/**, writing or modifying React
+  components, Redux slices, styled-components, custom hooks, or when
+  the user mentions UI, frontend, React, Redux, or styled-components.
 ---
+
 
 # Frontend Development (React/Redux)
 

--- a/.ai/skills/git-safety/SKILL.md
+++ b/.ai/skills/git-safety/SKILL.md
@@ -1,7 +1,15 @@
 ---
-description: Critical safety guardrails for protected branches - prevents direct commits, pushes, and force pushes to main, latest, and release branches
-alwaysApply: true
+name: git-safety
+description: >-
+  Critical safety guardrails for protected branches: never commit,
+  push, or force-push directly to main, latest, or release branches;
+  no destructive history rewrites without explicit user approval.
+  Use before any git operation that touches protected branches,
+  before force-push, reset --hard, history rewrite, or branch
+  deletion, or whenever the user asks about merging, pushing, or
+  release branches.
 ---
+
 
 # Git Safety Rules for AI Agents
 
@@ -54,4 +62,3 @@ If accidentally on a protected branch with uncommitted changes:
 - All changes must go through code review via Pull Requests
 - Direct pushes bypass CI/CD checks and team review
 - Mistakes on protected branches can affect the entire team and deployment pipeline
-

--- a/.ai/skills/testing/SKILL.md
+++ b/.ai/skills/testing/SKILL.md
@@ -1,8 +1,15 @@
 ---
-description: Jest and Testing Library standards, test patterns, faker usage, renderComponent helper, and mocking
-globs: "redisinsight/**/*.spec.{ts,tsx}"
-alwaysApply: false
+name: testing
+description: >-
+  Unit/integration testing standards for RedisInsight using Jest and
+  Testing Library: test structure, the `renderComponent` helper, faker
+  for test data, mocking patterns, and `waitFor` instead of fixed
+  time waits. Use when writing or modifying any `*.spec.ts` or
+  `*.spec.tsx` file, when adding component or slice tests, when
+  debugging flaky tests, or when the user mentions jest, testing
+  library, faker, or test patterns.
 ---
+
 
 # Testing Standards and Practices
 

--- a/.cursor/rules/backend.mdc
+++ b/.cursor/rules/backend.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/backend.md

--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/code-quality.md

--- a/.cursor/rules/e2e-testing.mdc
+++ b/.cursor/rules/e2e-testing.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/e2e-testing.md

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/frontend.md

--- a/.cursor/rules/git-safety.mdc
+++ b/.cursor/rules/git-safety.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/git-safety.md

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,1 +1,0 @@
-../../.ai/rules/testing.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,21 +5,20 @@
 This project uses a centralized AI rules structure:
 
 - **`AGENTS.md`** (repository root) - Entry point with commands, testing, and boundaries
-- **`.ai/rules/`** - Detailed development standards organized by topic
+- **`.ai/skills/`** - Detailed development standards as skill files (one folder per topic, each with a `SKILL.md`)
 - **`.ai/commands/`** - AI workflow commands and templates
-- **`.ai/skills/`** - Reusable agent skills shared by supported AI tools
 
-## 📂 Rules Structure
+## 📂 Skills Structure
 
-### Core Development Rules
+### Core Development Skills
 
-- **Code Quality**: `.ai/rules/code-quality.md`
+- **Code Quality**: `.ai/skills/code-quality/SKILL.md`
 
   - TypeScript best practices
   - Import organization
   - SonarJS complexity rules
 
-- **Frontend Development**: `.ai/rules/frontend.md`
+- **Frontend Development**: `.ai/skills/frontend/SKILL.md`
 
   - React 18 patterns and best practices
   - Redux Toolkit state management
@@ -28,7 +27,7 @@ This project uses a centralized AI rules structure:
   - Internal UI component wrappers (never import from @redis-ui directly)
   - Elastic UI deprecation (use Redis UI wrappers)
 
-- **Backend Development**: `.ai/rules/backend.md`
+- **Backend Development**: `.ai/skills/backend/SKILL.md`
 
   - NestJS module architecture
   - Service and controller patterns
@@ -36,20 +35,27 @@ This project uses a centralized AI rules structure:
   - Error handling
   - Redis integration patterns
 
-- **Testing Standards**: `.ai/rules/testing.md`
+- **Testing Standards**: `.ai/skills/testing/SKILL.md`
 
   - Jest and Testing Library patterns
   - Component testing with renderComponent helper
   - Faker for test data generation
   - No fixed timeouts (use waitFor)
   - Backend testing with NestJS
-  - E2E testing with Playwright
 
-- **Commit Messages**: `.ai/rules/commits.md`
+- **E2E Testing**: `.ai/skills/e2e-testing/SKILL.md`
+
+  - Playwright standards, page object models, fixtures
+
+- **Git Safety**: `.ai/skills/git-safety/SKILL.md`
+
+  - Protected-branch guardrails (no direct commits to main/latest/release)
+
+- **Commit Messages**: `.ai/skills/commits/SKILL.md`
 
   - Commit message format (Conventional Commits)
 
-- **Pull Requests**: `.ai/rules/pull-requests.md`
+- **Pull Requests**: `.ai/skills/pull-requests/SKILL.md`
   - PR process and review guidelines
   - Pre-commit checklist
 
@@ -81,4 +87,4 @@ This project uses a centralized AI rules structure:
 
 ---
 
-**Note**: This is a minimal reference file. GitHub Copilot cannot read the referenced files directly, but developers can access the full guidelines. Other AI tools (Cursor, Augment, Windsurf, Claude Code, Codex) access these rules via symlinks and can read `AGENTS.md` directly.
+**Note**: This is a minimal reference file. GitHub Copilot cannot read the referenced files directly, but developers can access the full guidelines. Claude Code and Codex read `AGENTS.md` directly; Claude Code additionally auto-discovers skills under `.ai/skills/` (Codex via the `.agents/skills` symlink).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,12 +92,35 @@ yarn test:api          # Backend tests
 
 **Fix any linting errors, type errors, or test failures before committing.**
 
-All detailed development standards are maintained in `.ai/rules/`:
+## Always-On Rules
 
-- **Code Quality**: `.ai/rules/code-quality.md` - Linting, TypeScript standards
-- **Frontend**: `.ai/rules/frontend.md` - React, Redux, UI patterns, styled-components
-- **Backend**: `.ai/rules/backend.md` - NestJS, API patterns, dependency injection
-- **Testing**: `.ai/rules/testing.md` - Testing standards, faker usage, test patterns
+These apply to every change in the repo. Skill files contain the full detail; the essentials are listed here so they're never missed.
+
+### Code quality (always)
+
+- Run `yarn lint` and `yarn type-check` before committing — both must pass.
+- TypeScript everywhere. Avoid `any`; use `unknown` if you must.
+- Naming: `PascalCase` components, `camelCase` functions/variables, `UPPER_SNAKE_CASE` constants, `is/has/should` prefix for booleans.
+- No `console.log` in production code (use `console.warn`/`error`).
+- Imports: external → built-ins → internal aliases (`uiSrc/*`, `apiClient`, `desktopSrc/*`) → relative → styles last. UI must not import from backend directly — use `apiClient`.
+- No magic numbers; extract duplicated strings to constants.
+
+### Git safety (always)
+
+- **Never commit, push, or force-push directly to `main`, `latest`, or `release/*`.** Always create a feature branch first.
+- Verify current branch with `git branch --show-current` before any push.
+- All changes go through pull requests.
+
+## Skills
+
+All detailed development standards are exposed as skills under `.ai/skills/`. Claude Code auto-discovers them; each skill triggers when its description matches the task.
+
+- **Code Quality**: `.ai/skills/code-quality/SKILL.md` - Linting, TypeScript standards, naming, import order
+- **Frontend**: `.ai/skills/frontend/SKILL.md` - React, Redux, UI patterns, styled-components
+- **Backend**: `.ai/skills/backend/SKILL.md` - NestJS, API patterns, dependency injection
+- **Testing**: `.ai/skills/testing/SKILL.md` - Jest/Testing Library standards, faker, test patterns
+- **E2E Testing**: `.ai/skills/e2e-testing/SKILL.md` - Playwright standards, page objects
+- **Git Safety**: `.ai/skills/git-safety/SKILL.md` - Protected-branch guardrails (detail)
 - **Branches**: `.ai/skills/branches/SKILL.md` - Branch naming conventions
 - **Commits**: `.ai/skills/commits/SKILL.md` - Commit message guidelines
 - **Pull Requests**: `.ai/skills/pull-requests/SKILL.md` - PR process and review guidelines

--- a/tests/e2e-playwright/README.md
+++ b/tests/e2e-playwright/README.md
@@ -7,7 +7,7 @@ Standalone Playwright E2E test suite for RedisInsight.
 | Document | Purpose |
 |----------|---------|
 | [`TEST_PLAN.md`](./TEST_PLAN.md) | Test coverage status and priorities |
-| [`.ai/rules/e2e-testing.md`](../../.ai/rules/e2e-testing.md) | Standards and patterns for writing tests |
+| [`.ai/skills/e2e-testing/SKILL.md`](../../.ai/skills/e2e-testing/SKILL.md) | Standards and patterns for writing tests |
 
 ### AI Commands
 

--- a/tests/e2e-playwright/TEST_PLAN.md
+++ b/tests/e2e-playwright/TEST_PLAN.md
@@ -2,7 +2,7 @@
 
 This document outlines the comprehensive E2E testing strategy for RedisInsight features.
 
-> **📋 Rules**: Before implementing tests, read [`.ai/rules/e2e-testing.md`](../../.ai/rules/e2e-testing.md) for coding standards, patterns, and best practices.
+> **📋 Rules**: Before implementing tests, read [`.ai/skills/e2e-testing/SKILL.md`](../../.ai/skills/e2e-testing/SKILL.md) for coding standards, patterns, and best practices.
 
 ## Overview
 


### PR DESCRIPTION
# What

Convert the six topic files in `.ai/rules/` into Claude Code skills under `.ai/skills/<name>/SKILL.md` so they auto-trigger via description-based matching. Lift the two `alwaysApply: true` rules (code-quality, git-safety) into the always-loaded `AGENTS.md` as concise summaries. Delete `.ai/rules/` and `.cursor/rules/` — the team uses Claude Code and Codex only, so the Cursor MDC rule format is dead weight.

**Why this change:** Cursor honors `globs` / `alwaysApply` frontmatter on `.ai/rules/*.md` and auto-attaches rules to relevant files. Claude Code does not — it only auto-loads `AGENTS.md`, and the rule files referenced there are just text from its perspective. Result: 443 lines of frontend conventions never entered context unless explicitly read. Skills (`.ai/skills/<name>/SKILL.md` with `name` + `description` frontmatter) are Claude Code's analog of Cursor's auto-attach, surfaced at session start and invoked when the description matches the task.

**New skills:**
- `frontend` — React/Redux UI patterns, styled-components, layout components
- `backend` — NestJS API patterns, DI, error handling
- `code-quality` — TypeScript standards, naming, import order
- `testing` — Jest/Testing Library patterns, faker, `renderComponent`
- `e2e-testing` — Playwright standards, page objects
- `git-safety` — protected-branch guardrails

Updated references in `.ai/README.md`, `.ai/commands/{pr-plan,e2e-fix,e2e-generate}.md`, `.github/copilot-instructions.md`, and `tests/e2e-playwright/{README,TEST_PLAN}.md` to point at the new paths.

# Testing

- Start a fresh Claude Code session in this repo — the available-skills list should include the six new skills with their descriptions.
- Ask Claude to add a React component under `redisinsight/ui/src/` — it should invoke the `frontend` skill before editing files.
- Ask Claude to add a NestJS endpoint — it should invoke the `backend` skill.
- `grep -r ".ai/rules" .` returns nothing (verified locally).
- No source code changed; `yarn lint` / `yarn type-check` unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/AI-assistant configuration reshuffle only, but mislinked paths or missing symlinks could reduce guideline auto-loading for agents.
> 
> **Overview**
> Moves the repo’s AI guidance from `.ai/rules/` markdown files to description-driven Claude Code skills under `.ai/skills/*/SKILL.md` (adding `name`/`description` frontmatter) and adds an **Always-On Rules** summary to `AGENTS.md`.
> 
> Updates command/docs references (including E2E docs and Copilot instructions) to point at the new skill paths, refreshes `.ai/README.md` structure/symlink guidance, and deletes the legacy `.cursor/rules/*.mdc` symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79ea0eb21928c3a3fda6236d16f6173ae5bec845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->