### PR TITLE
Vector set review fixes (medium-priority)

### DIFF
--- a/redisinsight/api/src/modules/browser/keys/key-info/strategies/vector-set.key-info.strategy.ts
+++ b/redisinsight/api/src/modules/browser/keys/key-info/strategies/vector-set.key-info.strategy.ts
@@ -33,6 +33,16 @@ export class VectorSetKeyInfoStrategy extends KeyInfoStrategy {
       return result;
     }
 
+    // VINFO is documented as flat key/value pairs, so an odd length means
+    // Redis returned a malformed reply (or the protocol changed). Log a
+    // warning and drop the trailing unpaired entry rather than silently
+    // misaligning the loop or crashing on `undefined`.
+    if (vInfoResponse.length % 2 !== 0) {
+      this.logger.warn(
+        `VINFO response length ${vInfoResponse.length} is odd; dropping trailing unpaired entry.`,
+      );
+    }
+
     for (let i = 0; i < vInfoResponse.length - 1; i += 2) {
       const key = String(vInfoResponse[i]).toLowerCase();
       const value = vInfoResponse[i + 1];

--- a/redisinsight/api/src/modules/browser/vector-set/constants.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/constants.ts
@@ -11,3 +11,23 @@ export const VSIM_REPLY_STRIDE = 3;
  * to be retrieved per-element via VGETATTR after the search returns.
  */
 export const VSIM_REPLY_STRIDE_NO_ATTRIBS = 2;
+
+/**
+ * Literal Redis-protocol tokens used when building VADD / VSIM commands.
+ * Centralised here so the executable command builder, the preview formatter,
+ * and any future caller stay aligned on the exact wire-format spelling and
+ * cannot drift between Buffer / string mismatches or stray typos.
+ */
+export const VECTOR_SET_TOKENS = Object.freeze({
+  // Query-mode tokens for VADD / VSIM
+  ELE: 'ELE',
+  VALUES: 'VALUES',
+  FP32: 'FP32',
+  // VADD attribute clause
+  SETATTR: 'SETATTR',
+  // VSIM modifier clauses
+  COUNT: 'COUNT',
+  WITHSCORES: 'WITHSCORES',
+  WITHATTRIBS: 'WITHATTRIBS',
+  FILTER: 'FILTER',
+} as const);

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -464,15 +464,6 @@ export class VectorSetService {
   }
 
   /**
-   * Back-fill the `attributes` field on each match by issuing one VGETATTR
-   * per element in a single pipeline. Used as the fallback path for Redis
-   * 8.0.0–8.0.2 where VSIM rejects the WITHATTRIBS option.
-   *
-   * Mutates `matches` in place. Per-element errors are swallowed (logged at
-   * debug) so a single failing VGETATTR cannot drop the whole search reply;
-   * elements without attributes simply keep `attributes` undefined.
-   */
-  /**
    * Translate a thrown Redis error into the appropriate HTTP exception:
    * `WRONGTYPE` becomes a 400 (the client targeted a non-vector-set key), and
    * everything else flows through `catchAclError` so NOPERM / unknown-command
@@ -486,6 +477,15 @@ export class VectorSetService {
     throw catchAclError(error);
   }
 
+  /**
+   * Back-fill the `attributes` field on each match by issuing one VGETATTR
+   * per element in a single pipeline. Used as the fallback path for Redis
+   * 8.0.0–8.0.2 where VSIM rejects the WITHATTRIBS option.
+   *
+   * Mutates `matches` in place. Per-element errors are swallowed (logged at
+   * debug) so a single failing VGETATTR cannot drop the whole search reply;
+   * elements without attributes simply keep `attributes` undefined.
+   */
   private async fetchAttributesForMatches(
     client: RedisClient,
     keyName: Buffer | string,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { catchAclError, catchMultiTransactionError } from 'src/utils';
 import { RedisErrorCodes } from 'src/constants';
+import { ReplyError } from 'src/models';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import {
   BrowserToolKeysCommands,
@@ -90,10 +91,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -130,10 +128,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -210,10 +205,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -264,10 +256,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -304,10 +293,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -353,10 +339,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -388,10 +371,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -444,10 +424,7 @@ export class VectorSetService {
         error,
         clientMetadata,
       );
-      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
-        throw new BadRequestException(error.message);
-      }
-      throw catchAclError(error);
+      this.throwWrongTypeOrAcl(error);
     }
   }
 
@@ -495,6 +472,20 @@ export class VectorSetService {
    * debug) so a single failing VGETATTR cannot drop the whole search reply;
    * elements without attributes simply keep `attributes` undefined.
    */
+  /**
+   * Translate a thrown Redis error into the appropriate HTTP exception:
+   * `WRONGTYPE` becomes a 400 (the client targeted a non-vector-set key), and
+   * everything else flows through `catchAclError` so NOPERM / unknown-command
+   * errors map to 403 / 500 as expected. Used by every public service method
+   * to keep the 8 copies of this catch logic in sync.
+   */
+  private throwWrongTypeOrAcl(error: ReplyError): never {
+    if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+      throw new BadRequestException(error.message);
+    }
+    throw catchAclError(error);
+  }
+
   private async fetchAttributesForMatches(
     client: RedisClient,
     keyName: Buffer | string,

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -310,7 +310,9 @@ export function parseVsimReply(
     // Redis returning null/undefined for VSIM is unusual — an empty array is
     // the documented "no matches" reply. Log at debug so the case is visible
     // when chasing why a search came back empty without crashing the parser.
-    logger?.debug('VSIM returned null/undefined reply; treating as no matches.');
+    logger?.debug(
+      'VSIM returned null/undefined reply; treating as no matches.',
+    );
     return [];
   }
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.utils.ts
@@ -8,6 +8,7 @@ import {
   SimilaritySearchDto,
 } from 'src/modules/browser/vector-set/dto';
 import {
+  VECTOR_SET_TOKENS,
   VSIM_REPLY_STRIDE,
   VSIM_REPLY_STRIDE_NO_ATTRIBS,
 } from 'src/modules/browser/vector-set/constants';
@@ -144,32 +145,44 @@ function writeVsimTokens<T>(
   ];
 
   if (query.mode === 'ELE') {
-    tokens.push(tokenWriter.literal('ELE'), tokenWriter.element(query.element));
+    tokens.push(
+      tokenWriter.literal(VECTOR_SET_TOKENS.ELE),
+      tokenWriter.element(query.element),
+    );
   } else if (query.mode === 'VALUES') {
     tokens.push(
-      tokenWriter.literal('VALUES'),
+      tokenWriter.literal(VECTOR_SET_TOKENS.VALUES),
       tokenWriter.number(query.values.length),
       ...query.values.map((n) => tokenWriter.vectorValue(n)),
     );
   } else {
-    tokens.push(tokenWriter.literal('FP32'), tokenWriter.fp32(query.bytes));
+    tokens.push(
+      tokenWriter.literal(VECTOR_SET_TOKENS.FP32),
+      tokenWriter.fp32(query.bytes),
+    );
   }
 
   if (dto.count !== undefined && Number.isFinite(dto.count)) {
-    tokens.push(tokenWriter.literal('COUNT'), tokenWriter.number(dto.count));
+    tokens.push(
+      tokenWriter.literal(VECTOR_SET_TOKENS.COUNT),
+      tokenWriter.number(dto.count),
+    );
   }
 
   // WITHSCORES is always appended so the response shape is stable; they are
   // intentionally not part of the DTO. WITHATTRIBS is conditional because
   // Redis 8.0.0–8.0.2 errors out on it; the service back-fills attributes
   // via VGETATTR in that case.
-  tokens.push(tokenWriter.literal('WITHSCORES'));
+  tokens.push(tokenWriter.literal(VECTOR_SET_TOKENS.WITHSCORES));
   if (withAttribs) {
-    tokens.push(tokenWriter.literal('WITHATTRIBS'));
+    tokens.push(tokenWriter.literal(VECTOR_SET_TOKENS.WITHATTRIBS));
   }
 
   if (dto.filter !== undefined && dto.filter !== '') {
-    tokens.push(tokenWriter.literal('FILTER'), tokenWriter.filter(dto.filter));
+    tokens.push(
+      tokenWriter.literal(VECTOR_SET_TOKENS.FILTER),
+      tokenWriter.filter(dto.filter),
+    );
   }
 
   return tokens;
@@ -207,10 +220,14 @@ export function buildVaddCommand(
   }
 
   if (hasVectorFp32) {
-    args.push('FP32', Buffer.from(element.vectorFp32, 'base64'), element.name);
+    args.push(
+      VECTOR_SET_TOKENS.FP32,
+      Buffer.from(element.vectorFp32, 'base64'),
+      element.name,
+    );
   } else if (hasVectorValues) {
     args.push(
-      'VALUES',
+      VECTOR_SET_TOKENS.VALUES,
       element.vectorValues.length,
       ...element.vectorValues.map(String),
       element.name,
@@ -222,7 +239,7 @@ export function buildVaddCommand(
   }
 
   if (element.attributes !== undefined) {
-    args.push('SETATTR', element.attributes);
+    args.push(VECTOR_SET_TOKENS.SETATTR, element.attributes);
   }
 
   return args as RedisClientCommand;
@@ -289,7 +306,15 @@ export function parseVsimReply(
   logger?: Logger,
   options: VsimWithAttribsOption = {},
 ): SearchVectorSetMatchDto[] {
-  if (!reply || reply.length === 0) {
+  if (reply === null || reply === undefined) {
+    // Redis returning null/undefined for VSIM is unusual — an empty array is
+    // the documented "no matches" reply. Log at debug so the case is visible
+    // when chasing why a search came back empty without crashing the parser.
+    logger?.debug('VSIM returned null/undefined reply; treating as no matches.');
+    return [];
+  }
+
+  if (reply.length === 0) {
     return [];
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.styles.ts
@@ -4,18 +4,18 @@ import { TextArea } from 'uiSrc/components/base/inputs'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 
 export const Body = styled(Col)`
-  gap: ${({ theme }) => theme.core?.space?.space400};
-  padding-top: ${({ theme }) => theme.core?.space?.space100};
+  gap: ${({ theme }) => theme.core.space.space400};
+  padding-top: ${({ theme }) => theme.core.space.space100};
 `
 
 export const VectorTextArea = styled(TextArea)`
   font-family: 'Source Code Pro', 'Inconsolata', monospace;
-  border: 1px solid ${({ theme }) => theme.semantic?.color?.border?.neutral500};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   scrollbar-width: thin;
-  padding: ${({ theme }) => theme.core?.space?.space025};
-  padding-right: ${({ theme }) => theme.core?.space?.space400};
+  padding: ${({ theme }) => theme.core.space.space025};
+  padding-right: ${({ theme }) => theme.core.space.space400};
   background-color: ${({ theme }) =>
-    theme.semantic?.color?.background?.neutral100};
+    theme.semantic.color.background.neutral100};
 `
 
 export const VectorWrapper = styled.div`
@@ -25,8 +25,8 @@ export const VectorWrapper = styled.div`
 
 export const VectorActions = styled(Col)`
   position: absolute;
-  top: ${({ theme }) => theme.core?.space?.space150};
-  right: ${({ theme }) => theme.core?.space?.space150};
+  top: ${({ theme }) => theme.core.space.space150};
+  right: ${({ theme }) => theme.core.space.space150};
   z-index: 1;
 `
 
@@ -37,7 +37,7 @@ export const EditorWrapper = styled.div<{ children: React.ReactNode }>`
 
 export const EditButton = styled(IconButton)`
   position: absolute;
-  top: ${({ theme }) => theme.core?.space?.space150};
-  right: ${({ theme }) => theme.core?.space?.space200};
+  top: ${({ theme }) => theme.core.space.space150};
+  right: ${({ theme }) => theme.core.space.space200};
   z-index: 1;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -13,13 +13,7 @@ import { useSimilaritySearch } from '../../hooks/useSimilaritySearch'
 
 import { CommandPreview } from '../command-preview'
 import { FilterSyntaxHelpPopover } from '../filter-syntax-help-popover'
-import {
-  CountInlineLabel,
-  FilterLabel,
-  FormContainer,
-  ModeButtonContent,
-  ModeInfoIcon,
-} from './SimilaritySearchForm.styles'
+import * as S from './SimilaritySearchForm.styles'
 import {
   ELEMENT_MODE_TOOLTIP,
   ELEMENT_PLACEHOLDER,
@@ -106,7 +100,7 @@ export const SimilaritySearchForm = ({
   }
 
   return (
-    <FormContainer data-testid={TEST_ID} gap="m" grow={false}>
+    <S.FormContainer data-testid={TEST_ID} gap="m" grow={false}>
       <Row align="center" gap="m">
         <FlexItem grow={false}>
           <ButtonGroup data-testid={`${TEST_ID}-mode-toggle`}>
@@ -115,34 +109,34 @@ export const SimilaritySearchForm = ({
               onClick={() => setMode(SimilaritySearchMode.Vector)}
               data-testid={`${TEST_ID}-mode-vector`}
             >
-              <ModeButtonContent>
+              <S.ModeButtonContent>
                 Vector
                 <RiTooltip content={VECTOR_MODE_TOOLTIP} position="top">
-                  <ModeInfoIcon
+                  <S.ModeInfoIcon
                     aria-label={VECTOR_MODE_TOOLTIP}
                     data-testid={`${TEST_ID}-mode-vector-info`}
                   >
                     <InfoIcon />
-                  </ModeInfoIcon>
+                  </S.ModeInfoIcon>
                 </RiTooltip>
-              </ModeButtonContent>
+              </S.ModeButtonContent>
             </ButtonGroup.Button>
             <ButtonGroup.Button
               isSelected={state.mode === SimilaritySearchMode.Element}
               onClick={() => setMode(SimilaritySearchMode.Element)}
               data-testid={`${TEST_ID}-mode-element`}
             >
-              <ModeButtonContent>
+              <S.ModeButtonContent>
                 Element
                 <RiTooltip content={ELEMENT_MODE_TOOLTIP} position="top">
-                  <ModeInfoIcon
+                  <S.ModeInfoIcon
                     aria-label={ELEMENT_MODE_TOOLTIP}
                     data-testid={`${TEST_ID}-mode-element-info`}
                   >
                     <InfoIcon />
-                  </ModeInfoIcon>
+                  </S.ModeInfoIcon>
                 </RiTooltip>
-              </ModeButtonContent>
+              </S.ModeButtonContent>
             </ButtonGroup.Button>
           </ButtonGroup>
         </FlexItem>
@@ -174,9 +168,9 @@ export const SimilaritySearchForm = ({
         </FlexItem>
         <FlexItem grow={false}>
           <Row align="center" gap="m">
-            <CountInlineLabel data-testid={`${TEST_ID}-count-label`}>
+            <S.CountInlineLabel data-testid={`${TEST_ID}-count-label`}>
               Result count
-            </CountInlineLabel>
+            </S.CountInlineLabel>
             <QuantityCounter
               value={state.count ?? SIMILARITY_SEARCH_COUNT_DEFAULT}
               onChange={(value: number | null) =>
@@ -195,10 +189,10 @@ export const SimilaritySearchForm = ({
         <FlexItem grow>
           <FormField>
             <Row align="center" gap="s">
-              <FilterLabel>
+              <S.FilterLabel>
                 Filter expression
                 <FilterSyntaxHelpPopover />
-              </FilterLabel>
+              </S.FilterLabel>
               <FlexItem grow>
                 <TextInput
                   placeholder={FILTER_PLACEHOLDER}
@@ -240,6 +234,6 @@ export const SimilaritySearchForm = ({
           </PrimaryButton>
         </FlexItem>
       </Row>
-    </FormContainer>
+    </S.FormContainer>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-key-subheader/VectorSetKeySubheader.tsx
@@ -25,7 +25,7 @@ const VectorSetKeySubheader = ({
     <S.Container>
       <AutoSizer disableHeight>
         {({ width = 0 }) => (
-          <div style={{ width }}>
+          <FlexItem style={{ width }}>
             <Row justify={showPreview ? 'between' : 'end'} align="center">
               {showPreview && (
                 <FlexItem grow={false}>
@@ -63,7 +63,7 @@ const VectorSetKeySubheader = ({
                 ) : null}
               </Row>
             </Row>
-          </div>
+          </FlexItem>
         )}
       </AutoSizer>
     </S.Container>

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -427,7 +427,7 @@ export function deleteVectorSetElements(
         dispatch(removeVectorSetElementsSuccess())
         dispatch(removeElementsFromList(elements))
         if (newTotalValue > 0) {
-          dispatch<any>(refreshKeyInfoAction(key))
+          dispatch(refreshKeyInfoAction(key))
           dispatch(
             addMessageNotification(
               successMessages.REMOVED_KEY_VALUE(
@@ -560,7 +560,7 @@ export function addVectorSetElements(
       if (isStatusSuccessful(status)) {
         onSuccessAction?.()
         dispatch(addElementsSuccess())
-        dispatch<any>(fetchKeyInfo(data.keyName))
+        dispatch(fetchKeyInfo(data.keyName))
       } else {
         onFailAction?.()
         dispatch(addElementsFailure(DEFAULT_ERROR_MESSAGE))


### PR DESCRIPTION
# What

Follow-up to the high-priority polish PR (#5951) — same review, medium-priority findings. Three backend and four frontend fixes:

**Backend**
- `VectorSetKeyInfoStrategy.parseVInfo` now warns when VINFO returns an odd-length response instead of silently dropping the trailing entry
- Centralised the VSIM/VADD protocol tokens (`ELE`, `VALUES`, `FP32`, `COUNT`, `WITHSCORES`, `WITHATTRIBS`, `FILTER`, `SETATTR`) into a frozen `VECTOR_SET_TOKENS` constants object; `parseVsimReply` now debug-logs null/undefined replies
- Extracted the duplicated WRONGTYPE/ACL catch block (repeated 8× across `VectorSetService`) into a shared `throwWrongTypeOrAcl` helper

**Frontend**
- Dropped two unnecessary `dispatch<any>(...)` casts in `vectorSet.ts` — `AppDispatch` is already thunk-aware
- `SimilaritySearchForm` now imports its local styled components via `import * as S` per the frontend rules
- `ElementDetails.styles.ts` no longer reaches theme tokens via optional chaining — the theme is guaranteed by the provider
- `VectorSetKeySubheader` uses `FlexItem` instead of a raw `<div style={{ width }}>` for the AutoSizer-measured width wrapper

**Deliberately deferred** to separate follow-ups: default→named export flip for lazy-loaded vector-search routes; `similaritySearchPreviewController` → `createAsyncThunk({ signal })`; cross-cluster `import * as S` re-export under `keys-browser/`.

# Testing

- `yarn --cwd redisinsight/api test src/modules/browser/vector-set` — 103/103 pass
- `yarn --cwd redisinsight/ui tscheck` — no new errors against `.tscheck.rec.json` in any touched file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor/polish: behavior is largely unchanged aside from added logging and more defensive handling of malformed/null Redis replies, plus minor UI/typing cleanups.
> 
> **Overview**
> Improves Vector Set robustness by adding defensive logging/handling for malformed Redis replies: `parseVInfo` now warns on odd-length `VINFO` responses, and `parseVsimReply` debug-logs null/undefined replies while treating them as no matches.
> 
> Centralizes Redis vector-set command tokens into a frozen `VECTOR_SET_TOKENS` used by both VADD/VSIM command building and preview formatting, and deduplicates repeated WRONGTYPE/ACL error translation in `VectorSetService` via a shared `throwWrongTypeOrAcl` helper.
> 
> Frontend follow-ups align with conventions and typing: switches `SimilaritySearchForm` to `import * as S`, removes optional chaining on guaranteed theme tokens, replaces a raw width wrapper `div` with `FlexItem`, and drops unnecessary `dispatch<any>` casts in `vectorSet` slice thunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab74e3546376532b9016bcc6934ee3afdf08e413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->