### PR TITLE
fix(rpm): set SHA-256 file-digest algorithm for FIPS hosts

### DIFF
--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -137,6 +137,34 @@ jobs:
         if: steps.resolve-targets.outputs.should_build == 'true'
         run: node ./scripts/verify-native-modules-linux.js --arch=${{ matrix.arch }}
 
+      - name: Verify RPM file-digest algorithm (FIPS-safe)
+        if: steps.resolve-targets.outputs.should_build == 'true'
+        run: |
+          shopt -s nullglob
+          rpms=( ./release/Redis-Insight*.rpm )
+          if [ ${#rpms[@]} -eq 0 ]; then
+            echo "No RPMs built for arch ${{ matrix.arch }} — skipping digest check."
+            exit 0
+          fi
+          if ! command -v rpm >/dev/null 2>&1; then
+            sudo apt-get update -qy
+            sudo apt-get install -qy rpm
+          fi
+          failed=0
+          for rpm_file in "${rpms[@]}"; do
+            algo=$(rpm -qp --qf '%{FILEDIGESTALGO}\n' "$rpm_file")
+            case "$algo" in
+              8|10)
+                echo "OK: $rpm_file uses FILEDIGESTALGO=$algo"
+                ;;
+              *)
+                echo "FAIL: $rpm_file uses FILEDIGESTALGO=$algo (must be 8 SHA-256 or 10 SHA-512 for FIPS hosts)"
+                failed=1
+                ;;
+            esac
+          done
+          exit $failed
+
       - uses: actions/upload-artifact@v7
         name: Upload vendor for plugins
         if: steps.resolve-targets.outputs.should_build == 'true'

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -133,6 +133,9 @@
     "afterInstall": "scripts/deb-after-install.sh",
     "afterRemove": "scripts/deb-before-remove.sh"
   },
+  "rpm": {
+    "fpm": ["--rpm-digest", "sha256"]
+  },
   "snap": {
     "plugs": ["default", "password-manager-service"],
     "confinement": "strict",


### PR DESCRIPTION
## Summary

- Fix `dnf install` failing with `cpio: Digest mismatch` on FIPS-enabled RHEL 9 / Rocky 9 / Alma 9 hosts by setting fpm's `--rpm-digest sha256` on the Linux RPM build, producing `FILEDIGESTALGO=8` instead of the default `(none)`/md5.
- Add a CI guard in `pipeline-build-linux.yml` that fails the build if `FILEDIGESTALGO` is anything other than `8` (SHA-256) or `10` (SHA-512), so this can't silently regress.
- Scope is RPM-only; `.deb`, `.AppImage`, `.snap`, macOS, and Windows pipelines are untouched.

Fixes #5950

## Root cause

Released 3.4.2 RPM:
```
$ rpm -qp --qf '%{FILEDIGESTALGO}\n' Redis-Insight-linux-x86_64.rpm
(none)
```
fpm's default is `--rpm-digest md5`, and FIPS kernels disallow MD5 — `dnf install` rejects the package on every file. `--nogpgcheck` / `--nodigest` / `rpm -ivh` workarounds bypass verification and break SaltStack/Ansible flows that drive `dnf`, so they are not a real fix.

## Verification

Reproduced locally with fpm 1.17.0 (the version installed by `pipeline-build-linux.yml`):
```
default.rpm: FILEDIGESTALGO=(none)   <- bug repro
sha256.rpm:  FILEDIGESTALGO=8        <- with the fix

digest hex length:
default.rpm: 32 chars (md5)
sha256.rpm:  64 chars (sha256)
```

## Test plan

- [ ] CI: `Build linux pipeline` x64 + arm64 jobs run the new `Verify RPM file-digest algorithm (FIPS-safe)` step and report `OK: ./release/Redis-Insight*.rpm uses FILEDIGESTALGO=8` for every produced RPM.
- [ ] Download the produced x86_64 RPM and confirm: `rpm -qp --qf '%{FILEDIGESTALGO}\n' Redis-Insight-*.rpm` returns `8`.
- [ ] On a FIPS-enabled RHEL 9 / Rocky 9 / Alma 9 host (`cat /proc/sys/crypto/fips_enabled` → `1`), `sudo dnf install ./Redis-Insight-*.rpm` succeeds with no flags and `rpm -V redisinsight` reports no digest mismatch.
- [ ] (Optional) `ansible localhost -m dnf -a "name=./Redis-Insight-*.rpm state=present" --become` succeeds on the same FIPS host — this is the reporter's actual workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build/packaging configuration change limited to RPM output plus a new CI check that may fail builds if packaging regresses.
> 
> **Overview**
> Ensures Linux RPM artifacts are *FIPS-safe* by configuring electron-builder/fpm to generate RPMs with SHA-256 file digests (via `--rpm-digest sha256`).
> 
> Adds a Linux pipeline step that inspects produced RPMs’ `FILEDIGESTALGO` and fails the build unless it is `8` (SHA-256) or `10` (SHA-512), preventing silent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce170567b7836fefd1289435768e28d88ab834c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->