### PR TITLE
RI-8197: Command Helper - Vector Set commands support

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -283,25 +283,25 @@ export default {
       name: 'main',
       url:
         process.env.RI_COMMANDS_MAIN_URL ||
-        'https://raw.githubusercontent.com/redis/redis-doc/master/commands.json',
+        'https://raw.githubusercontent.com/redis/docs/main/data/commands_core.json',
     },
     {
       name: 'redisearch',
       url:
         process.env.RI_COMMANDS_REDISEARCH_URL ||
-        'https://raw.githubusercontent.com/RediSearch/RediSearch/master/commands.json',
+        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisearch.json',
     },
     {
       name: 'redisjson',
       url:
         process.env.RI_COMMANDS_REDIJSON_URL ||
-        'https://raw.githubusercontent.com/RedisJSON/RedisJSON/master/commands.json',
+        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisjson.json',
     },
     {
       name: 'redistimeseries',
       url:
         process.env.RI_COMMANDS_REDISTIMESERIES_URL ||
-        'https://raw.githubusercontent.com/RedisTimeSeries/RedisTimeSeries/master/commands.json',
+        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redistimeseries.json',
     },
     {
       name: 'redisgraph',
@@ -319,7 +319,7 @@ export default {
       name: 'redisbloom',
       url:
         process.env.RI_COMMANDS_REDISBLOOM_URL ||
-        'https://raw.githubusercontent.com/RedisBloom/RedisBloom/master/commands.json',
+        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisbloom.json',
     },
   ],
   connections: {

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -23,6 +23,12 @@ const proxyPath = trim(process.env.RI_PROXY_PATH, '/');
 
 const customPluginsUri = posix.join('/', proxyPath, 'plugins');
 const staticUri = posix.join('/', proxyPath, 'static');
+
+// Pinned commit on redis/docs. Bumped by .github/workflows/bump-commands-pin.yml.
+// Do not edit this line manually — the bump workflow matches it by regex.
+const REDIS_DOCS_COMMANDS_SHA = '3ecfac43f3bd7ae703554e939560a52b0ceac583';
+const redisDocsCommandsUrl = (file: string): string =>
+  `https://raw.githubusercontent.com/redis/docs/${REDIS_DOCS_COMMANDS_SHA}/data/${file}.json`;
 const tutorialsUri = posix.join('/', proxyPath, 'static', 'tutorials');
 const customTutorialsUri = posix.join(
   '/',
@@ -283,25 +289,25 @@ export default {
       name: 'main',
       url:
         process.env.RI_COMMANDS_MAIN_URL ||
-        'https://raw.githubusercontent.com/redis/docs/main/data/commands_core.json',
+        redisDocsCommandsUrl('commands_core'),
     },
     {
       name: 'redisearch',
       url:
         process.env.RI_COMMANDS_REDISEARCH_URL ||
-        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisearch.json',
+        redisDocsCommandsUrl('commands_redisearch'),
     },
     {
       name: 'redisjson',
       url:
         process.env.RI_COMMANDS_REDIJSON_URL ||
-        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisjson.json',
+        redisDocsCommandsUrl('commands_redisjson'),
     },
     {
       name: 'redistimeseries',
       url:
         process.env.RI_COMMANDS_REDISTIMESERIES_URL ||
-        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redistimeseries.json',
+        redisDocsCommandsUrl('commands_redistimeseries'),
     },
     {
       name: 'redisgraph',
@@ -319,7 +325,7 @@ export default {
       name: 'redisbloom',
       url:
         process.env.RI_COMMANDS_REDISBLOOM_URL ||
-        'https://raw.githubusercontent.com/redis/docs/main/data/commands_redisbloom.json',
+        redisDocsCommandsUrl('commands_redisbloom'),
     },
   ],
   connections: {

--- a/redisinsight/ui/src/components/group-badge/GroupBadge.styles.ts
+++ b/redisinsight/ui/src/components/group-badge/GroupBadge.styles.ts
@@ -35,9 +35,12 @@ const compressedStyle = css`
 `
 export const StyledGroupBadge = styled(RiBadge)<StyledGroupBadgeProps>`
   min-width: ${({ theme }) => theme.core.space.space150};
+  flex-shrink: 0;
+  white-space: nowrap;
   & > p {
     display: flex;
     align-items: center;
+    white-space: nowrap;
   }
   ${({ $color }) =>
     `

--- a/redisinsight/ui/src/constants/commands.ts
+++ b/redisinsight/ui/src/constants/commands.ts
@@ -102,6 +102,7 @@ export enum CommandGroup {
   TopK = 'topk',
   BloomFilter = 'bf',
   CuckooFilter = 'cf',
+  VectorSet = 'module',
 }
 
 export enum CommandPrefix {

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -49,6 +49,7 @@ export const GROUP_TYPES_DISPLAY = Object.freeze({
   [CommandGroup.TopK]: 'TopK',
   [CommandGroup.BloomFilter]: 'Bloom Filter',
   [CommandGroup.CuckooFilter]: 'Cuckoo Filter',
+  [CommandGroup.VectorSet]: 'Vector Set',
 })
 
 export type GroupTypesDisplay = keyof typeof GROUP_TYPES_DISPLAY
@@ -77,6 +78,7 @@ export const GROUP_TYPES_COLORS = Object.freeze({
   [CommandGroup.Transactions]: 'var(--groupTransactionsColor)',
   [CommandGroup.Server]: 'var(--groupServerColor)',
   [CommandGroup.HyperLogLog]: 'var(--groupHyperLolLogColor)',
+  [CommandGroup.VectorSet]: 'var(--typeVectorSetColor)',
 })
 
 export type GroupTypesColors = keyof typeof GROUP_TYPES_COLORS


### PR DESCRIPTION
## Summary

Adds Vector Set commands (VADD, VSIM, VCARD, VDIM, ...) to the Command Helper.

- Switches the commands data source from the unmaintained `redis/redis-doc` (and the per-module RedisJSON/RedisSearch/etc. repos) to the official `redis/docs` repo. Vector Set commands ship in `commands_core.json` there.
- Registers a `Vector Set` command group: adds `CommandGroup.VectorSet` (keyed to the upstream `module` group value), a display label, and a color so the Command Helper filter dropdown lists vector set commands under their own group.
- Fixes a styling bug where long type labels (e.g. \"Vector Set\") wrapped mid-word in the Command Helper info row by setting \`flex-shrink: 0\` and \`white-space: nowrap\` on \`GroupBadge\`.

<img width="1331" height="300" alt="image" src="https://github.com/user-attachments/assets/faefba31-3df1-409f-ae49-abd13a2427eb" />

## Test plan

- [ ] Open Command Helper, confirm \"Vector Set\" appears in the type filter dropdown
- [ ] Select \"Vector Set\" — all V-prefixed commands listed
- [ ] Click into a vector set command (e.g. VSIM) — badge shows \"VECTOR SET\" on a single line, args wrap to the next row when long
- [ ] Run \`yarn type-check\` — passes with no new errors


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the default command metadata sources to pinned `redis/docs` JSON endpoints, which can affect Command Helper command coverage/format if the upstream data changes or the pin is bumped. UI changes are minor but touch shared constants used for grouping and styling.
> 
> **Overview**
> **Command Helper now supports Vector Set commands** by introducing a new `CommandGroup.VectorSet` (mapped to upstream `module`) and wiring in its display label and color so it appears as a first-class group in filtering/UI.
> 
> **Command metadata fetching is updated**: default command JSON URLs for core/Search/JSON/TimeSeries/Bloom are switched from various legacy repos to a pinned commit in `redis/docs` via a centralized URL builder.
> 
> **Minor UI polish**: `GroupBadge` styling is adjusted (`flex-shrink: 0`, `white-space: nowrap`) to prevent long group labels like “Vector Set” from wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e912f17fe85fa04b601d90104f98e302c7ee4937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->