### PR TITLE
Use "Empty" label for missing vector set attributes

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -104,7 +104,7 @@ const buildAttributeColumn = (
         data-testid={`vector-set-similarity-attribute-cell-${row.index}-${key}`}
       >
         {isMissing ? (
-          <S.NilAttributeValue variant="italic">(nil)</S.NilAttributeValue>
+          <S.NilAttributeValue variant="italic">Empty</S.NilAttributeValue>
         ) : (
           renderAttributeValue(value)
         )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -162,17 +162,17 @@ describe('SimilaritySearchResultsTable', () => {
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-city'),
       ).toHaveTextContent('LA')
-      // b has no `count` attribute → (nil) placeholder
+      // b has no `count` attribute → Empty placeholder
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-count'),
-      ).toHaveTextContent('(nil)')
+      ).toHaveTextContent('Empty')
     })
 
-    it('renders (nil) for keys colliding with Object.prototype', () => {
+    it('renders Empty for keys colliding with Object.prototype', () => {
       // `a` literally has an attribute named `toString`; `b` does not.
       // Using `key in attrs` would resolve `toString` via the prototype
       // chain for `b` and render `function toString() { ... }` instead of
-      // the (nil) placeholder.
+      // the Empty placeholder.
       const matches = [
         buildMatch('a', 0.9, '{"toString":"hello"}'),
         buildMatch('b', 0.8, '{}'),
@@ -185,7 +185,7 @@ describe('SimilaritySearchResultsTable', () => {
       ).toHaveTextContent('hello')
       expect(
         screen.getByTestId('vector-set-similarity-attribute-cell-1-toString'),
-      ).toHaveTextContent('(nil)')
+      ).toHaveTextContent('Empty')
     })
 
     it('hides columns whose visibility is explicitly false', () => {


### PR DESCRIPTION
# What

Replace the `(nil)` placeholder in the vector set similarity search results table with `Empty`, to align with the existing convention used elsewhere in the browser/key-details surface (see `StringDetailsValue`, which renders an italic "Empty" label for empty string values).

Follow-up to #5946.

# Testing

1. Open a vector set with elements that have heterogeneous attributes.
2. Run a similarity search.
3. Verify that attribute columns show italic `Empty` for elements that don't have the attribute, and the actual value otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI copy change limited to the vector set similarity results table, with corresponding test expectation updates.
> 
> **Overview**
> Updates the vector set similarity search results table to show an italic **`Empty`** label (instead of `(nil)`) when an element is missing an attribute or the attribute value is `null`/`undefined`.
> 
> Adjusts the related table specs to assert the new placeholder text, including the regression case for attribute keys that collide with `Object.prototype` (e.g., `toString`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4405857cf0e93bf9f7bd9d605a0a4b83822f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->