### PR TITLE
fix(deps): pin @types/react to 18.2.1 to unblock type-check

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -48,7 +48,7 @@ module.exports = {
     '\\.mjs$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(monaco-editor|react-monaco-editor|brotli-dec-wasm|until-async|rettime|uuid)/)',
+    'node_modules/(?!(monaco-editor|react-monaco-editor|brotli-dec-wasm|until-async|rettime|uuid|react-jsx-parser)/)',
   ],
   // TODO: add tests for plugins
   modulePathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -103,7 +103,9 @@
     "@elastic/eui/**/prismjs": "~1.30.0",
     "vite/esbuild": "^0.25.0",
     "react-router-dom/react-router/path-to-regexp": "^1.9.0",
-    "**/form-data": "^4.0.4"
+    "**/form-data": "^4.0.4",
+    "@types/react": "18.2.1",
+    "@types/react-dom": "18.2.1"
   },
   "devDependencies": {
     "@aivenio/tsc-output-parser": "2.1.1",

--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -240,8 +240,7 @@
   },
   "src/components/virtual-table/VirtualTable.tsx": {
     "TS2322": 2,
-    "TS2339": 1,
-    "TS2786": 5
+    "TS2339": 1
   },
   "src/constants/monaco/sqliteFunctions/monacoSQLiteFunctions.ts": {
     "TS2345": 1
@@ -738,9 +737,6 @@
   },
   "src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx": {
     "TS2322": 1
-  },
-  "src/pages/slow-log/SlowLogPage.tsx": {
-    "TS2786": 2
   },
   "src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx": {
     "TS2322": 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4042,17 +4042,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^18.0.0", "@types/react-dom@^18.0.5":
+"@types/react-dom@18.2.1", "@types/react-dom@^18.0.0", "@types/react-dom@^18.0.5", "@types/react-dom@^18.3.1":
   version "18.2.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.1.tgz#663b2612feb5f6431a70207430d7c04881b87f29"
   integrity sha512-8QZEV9+Kwy7tXFmjJrp3XUKQSs9LTnE0KnoUb0YCguWBiNW0Yfb2iBMYZ08WPg35IR6P3Z0s00B15SwZnO26+w==
   dependencies:
     "@types/react" "*"
-
-"@types/react-dom@^18.3.1":
-  version "18.3.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
-  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react-input-autosize@^2.2.0":
   version "2.2.1"
@@ -4118,31 +4113,14 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.20":
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.0.tgz#15cda145354accfc09a18d2f2305f9fc099ada21"
-  integrity sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==
+"@types/react@*", "@types/react@18.2.1", "@types/react@^17", "@types/react@^18.0.20", "@types/react@^18.3.12":
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.1.tgz#37f7d4be4a2b4f61d618e4ca12681acab9e58c20"
+  integrity sha512-KbNvY50AOVy1HBHbQc+iPK44HMaz6CRXuUFsu/L8yCP+nsuE1c1EQSdyaHhsPiI7gJQ3c3VRp+YuCL/5hzvcRw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
-
-"@types/react@^17":
-  version "17.0.58"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.58.tgz#c8bbc82114e5c29001548ebe8ed6c4ba4d3c9fb0"
-  integrity sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.3.12":
-  version "18.3.29"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.29.tgz#7f3b6e1515499d4fd199cc8fd4710114be36c1a2"
-  integrity sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.2.2"
 
 "@types/redux-mock-store@^1.0.2":
   version "1.0.3"
@@ -6383,11 +6361,6 @@ csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
-
-csstype@^3.2.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
-  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 csv-parser@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Summary

- Pin `@types/react` and `@types/react-dom` to `18.2.1` via `resolutions` to fix the `type-check / tsc baselines` CI job that started failing on every branch (including `main`) after the `react-jsx-parser` 1.29.0 → 2.4.1 Dependabot bump (#5953, commit 85f0b57e4).
- Refresh `redisinsight/ui/.tscheck.rec.json` to drop 7 obsolete `TS2786` entries that disappear once the duplicate `@types/react` is gone.

## Root cause

`react-jsx-parser@2.4.1` declares `@types/react@^18.3.12` and `@types/react-dom@^18.3.1` as transitive types. Yarn nested them under `node_modules/react-jsx-parser/node_modules/@types/react/…` alongside the project-wide `@types/react@18.2.1`. `@types/react@18.3` tightened `ReactNode` (added `bigint`) and changed children handling — when two structurally-incompatible copies are loaded together, every React component reachable from `react-jsx-parser`'s type graph (`Route`/`Redirect`, `Provider`, `ThemeProvider`, Storybook `Story`, …) stops being assignable as a JSX element. CI saw a flood of new `TS2786` errors → `scripts/ts-error-check.ts` threw `"There are more TS errors than previously recorded"`. Because the bad commit landed on `main`, every PR branch picked it up after rebase / `yarn install`.

Example failure: https://github.com/redis/RedisInsight/actions/runs/26219644395/job/77151028952

## Why this approach (vs. alternatives)

- **Revert the bump** — works, but Dependabot will re-open the PR weekly.
- **Bump our direct `@types/react` to 18.3.x** — the right long-term move, but `styled-components@5` (~800 styled components affected), `react-redux@7`, and `react-router-dom@5` types are all written against pre-18.3 React types and would break in ways that aren't fixable in source. That's a multi-PR migration, not an outage fix.
- **Refresh baselines to silence** — bakes a transient packaging issue into the debt counter; underlying duplicate `@types/react` would keep biting elsewhere (IDE go-to-def, library upgrades).

Pinning collapses the whole graph onto a single `18.2.1`, no source changes required. The 7 baseline entries removed are the `TS2786` errors in [VirtualTable.tsx](redisinsight/ui/src/components/virtual-table/VirtualTable.tsx) and [SlowLogPage.tsx](redisinsight/ui/src/pages/slow-log/SlowLogPage.tsx) that pre-dated this PR but now no longer occur.

## Follow-ups (separate PRs, not this one)

To eventually move off `@types/react@18.2.x`, these are the real blockers and each is its own initiative:

- `react-redux@7 → 8+` (types-first, moderate)
- `styled-components@5 → 6` (API rename/removals; codemod available)
- `react-router-dom@5 → 6` (significant migration — `<Switch>` → `<Routes>`, `component` → `element`, removed `useHistory`)

## Test plan

- [x] `yarn install` regenerates `yarn.lock`; `@types/react@^18.3.12` and `@types/react-dom@^18.3.1` entries are gone, all 18.x requesters collapse onto `18.2.1`
- [x] `yarn --cwd redisinsight/ui type-check` → `Great, no new errors!` (1825 baselined)
- [x] `yarn --cwd redisinsight/api type-check` → `Great, no new errors!` (4105 baselined)
- [x] `yarn --cwd redisinsight/desktop type-check` → `Great, no new errors!` (512 baselined)
- [x] `yarn tsc --project configs/tsconfig.json --noEmit` → pass
- [ ] CI `type-check / tsc baselines` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency resolution and test config tweaks intended to stabilize TypeScript checking; main risk is unexpected type or Jest transform side-effects from forced transitive versions.
> 
> **Overview**
> Unblocks failing TypeScript baseline checks by **forcing `@types/react` and `@types/react-dom` to `18.2.1` via `package.json` `resolutions`**, collapsing transitive React type versions introduced by dependency upgrades.
> 
> Updates lockfile accordingly and refreshes `redisinsight/ui/.tscheck.rec.json` to drop now-obsolete `TS2786` baseline entries. Also adjusts Jest config to ensure `react-jsx-parser` is transpiled by including it in `transformIgnorePatterns` exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8358817695f4404cb4a807cb322ff8156578c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->