### PR TITLE
RI-8186 Gate dangerous CLI commands with type-to-confirm modal

### DIFF
--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
@@ -18,6 +18,8 @@ import { processCliClient } from 'uiSrc/slices/cli/cli-settings'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { processUnsupportedCommand } from 'uiSrc/utils/cliOutputActions'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory'
+import { ConnectionType } from 'uiSrc/slices/interfaces'
 
 import CliBodyWrapper from './CliBodyWrapper'
 
@@ -133,29 +135,35 @@ describe('CliBodyWrapper', () => {
   })
 
   describe('dangerous-command gating', () => {
-    const { getCommandRepeat } = jest.requireMock('uiSrc/utils')
+    const mockedConnectedInstanceSelector =
+      connectedInstanceSelector as jest.Mock
+    const mockedSendCliCommandAction = sendCliCommandAction as jest.Mock
+    const mockedUseDatabaseEnvironment = useDatabaseEnvironment as jest.Mock
+    const mockedGetCommandRepeat = jest.requireMock('uiSrc/utils')
+      .getCommandRepeat as jest.Mock
 
     beforeEach(() => {
-      ;(connectedInstanceSelector as jest.Mock).mockImplementation(() => ({
-        id: '123',
-        connectionType: 'STANDALONE',
-        db: 0,
-        host: 'h',
-        port: 6379,
+      const prodInstance = DBInstanceFactory.build({
         name: 'prod-db',
-      }))
-      ;(getCommandRepeat as jest.Mock).mockReturnValue(['FLUSHDB', 1])
+        connectionType: ConnectionType.Standalone,
+      })
+      mockedConnectedInstanceSelector.mockReturnValue(prodInstance)
+      mockedGetCommandRepeat.mockReturnValue(['FLUSHDB', 1])
     })
+
+    const setDangerousEnvironment = (isDangerous: boolean) => {
+      mockedUseDatabaseEnvironment.mockReturnValue({
+        environment: isDangerous ? 'production' : 'unspecified',
+        isDangerousCommand: () => isDangerous,
+      })
+    }
 
     it('does not dispatch the command and shows the modal when the command is dangerous', () => {
       const sendCliCommandActionMock = jest.fn()
-      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+      mockedSendCliCommandAction.mockImplementation(
         () => sendCliCommandActionMock,
       )
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
-        environment: 'production',
-        isDangerousCommand: () => true,
-      })
+      setDangerousEnvironment(true)
 
       render(<CliBodyWrapper />)
 
@@ -167,13 +175,10 @@ describe('CliBodyWrapper', () => {
 
     it('dispatches the command after the user confirms in the modal', () => {
       const sendCliCommandActionMock = jest.fn()
-      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+      mockedSendCliCommandAction.mockImplementation(
         () => sendCliCommandActionMock,
       )
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
-        environment: 'production',
-        isDangerousCommand: () => true,
-      })
+      setDangerousEnvironment(true)
 
       render(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
@@ -188,13 +193,10 @@ describe('CliBodyWrapper', () => {
 
     it('does not dispatch the command when the user cancels the modal', () => {
       const sendCliCommandActionMock = jest.fn()
-      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+      mockedSendCliCommandAction.mockImplementation(
         () => sendCliCommandActionMock,
       )
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
-        environment: 'production',
-        isDangerousCommand: () => true,
-      })
+      setDangerousEnvironment(true)
 
       render(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
@@ -206,13 +208,10 @@ describe('CliBodyWrapper', () => {
 
     it('passes commands through without modal when isDangerousCommand returns false', () => {
       const sendCliCommandActionMock = jest.fn()
-      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+      mockedSendCliCommandAction.mockImplementation(
         () => sendCliCommandActionMock,
       )
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
-        environment: 'unspecified',
-        isDangerousCommand: () => false,
-      })
+      setDangerousEnvironment(false)
 
       render(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
@@ -10,10 +10,14 @@ import {
   clearStoreActions,
 } from 'uiSrc/utils/test-utils'
 
-import { sendCliClusterCommandAction } from 'uiSrc/slices/cli/cli-output'
+import {
+  sendCliClusterCommandAction,
+  sendCliCommandAction,
+} from 'uiSrc/slices/cli/cli-output'
 import { processCliClient } from 'uiSrc/slices/cli/cli-settings'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { processUnsupportedCommand } from 'uiSrc/utils/cliOutputActions'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 
 import CliBodyWrapper from './CliBodyWrapper'
 
@@ -44,9 +48,23 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 jest.mock('uiSrc/slices/cli/cli-output', () => ({
   ...jest.requireActual('uiSrc/slices/cli/cli-output'),
   sendCliClusterCommandAction: jest.fn(),
+  sendCliCommandAction: jest.fn(),
   processUnsupportedCommand: jest.fn(),
   updateCliCommandHistory: jest.fn,
   concatToOutput: () => jest.fn(),
+}))
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  getCommandRepeat: jest.fn().mockReturnValue(['', 1]),
+  isRepeatCountCorrect: jest.fn().mockReturnValue(true),
+}))
+
+jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
+  useDatabaseEnvironment: jest.fn().mockReturnValue({
+    environment: 'unspecified',
+    isDangerousCommand: () => false,
+  }),
 }))
 
 jest.mock('uiSrc/utils/cliHelper', () => ({
@@ -112,6 +130,96 @@ describe('CliBodyWrapper', () => {
     })
 
     expect(processUnsupportedCommandMock).toBeCalled()
+  })
+
+  describe('dangerous-command gating', () => {
+    const { getCommandRepeat } = jest.requireMock('uiSrc/utils')
+
+    beforeEach(() => {
+      ;(connectedInstanceSelector as jest.Mock).mockImplementation(() => ({
+        id: '123',
+        connectionType: 'STANDALONE',
+        db: 0,
+        host: 'h',
+        port: 6379,
+        name: 'prod-db',
+      }))
+      ;(getCommandRepeat as jest.Mock).mockReturnValue(['FLUSHDB', 1])
+    })
+
+    it('does not dispatch the command and shows the modal when the command is dangerous', () => {
+      const sendCliCommandActionMock = jest.fn()
+      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: 'production',
+        isDangerousCommand: () => true,
+      })
+
+      render(<CliBodyWrapper />)
+
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      expect(sendCliCommandActionMock).not.toHaveBeenCalled()
+      expect(screen.getByTestId('type-to-confirm-modal-title')).toBeTruthy()
+    })
+
+    it('dispatches the command after the user confirms in the modal', () => {
+      const sendCliCommandActionMock = jest.fn()
+      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: 'production',
+        isDangerousCommand: () => true,
+      })
+
+      render(<CliBodyWrapper />)
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: 'prod-db' },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(sendCliCommandActionMock).toHaveBeenCalled()
+    })
+
+    it('does not dispatch the command when the user cancels the modal', () => {
+      const sendCliCommandActionMock = jest.fn()
+      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: 'production',
+        isDangerousCommand: () => true,
+      })
+
+      render(<CliBodyWrapper />)
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
+
+      expect(sendCliCommandActionMock).not.toHaveBeenCalled()
+    })
+
+    it('passes commands through without modal when isDangerousCommand returns false', () => {
+      const sendCliCommandActionMock = jest.fn()
+      ;(sendCliCommandAction as jest.Mock).mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: 'unspecified',
+        isDangerousCommand: () => false,
+      })
+
+      render(<CliBodyWrapper />)
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      expect(sendCliCommandActionMock).toHaveBeenCalled()
+      expect(screen.queryByTestId('type-to-confirm-modal-title')).toBeNull()
+    })
   })
 
   it('"onSubmit" for Cluster connection should call "sendCliClusterCommandAction"', () => {

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
@@ -44,12 +44,18 @@ import {
   processUnrepeatableNumber,
   processUnsupportedCommand,
 } from 'uiSrc/utils/cliOutputActions'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal/TypeToConfirmModal'
 import CliBody from './CliBody'
 
 import styles from './CliBody/styles.module.scss'
 
 const CliBodyWrapper = () => {
   const [command, setCommand] = useState('')
+  const [pendingCommand, setPendingCommand] = useState<{
+    commandLine: string
+    countRepeat: number
+  } | null>(null)
 
   const history = useHistory()
   const dispatch = useDispatch()
@@ -63,10 +69,11 @@ const CliBodyWrapper = () => {
     matchedCommand,
     cliClientUuid,
   } = useSelector(cliSettingsSelector)
-  const { connectionType, host, port, db } = useSelector(
+  const { connectionType, host, port, db, name } = useSelector(
     connectedInstanceSelector,
   )
   const { db: currentDbIndex } = useSelector(outputSelector)
+  const { isDangerousCommand } = useDatabaseEnvironment()
 
   useEffect(() => {
     if (!cliClientUuid) {
@@ -187,6 +194,11 @@ const CliBodyWrapper = () => {
       return
     }
 
+    if (isDangerousCommand(commandLine.split(' ')[0])) {
+      setPendingCommand({ commandLine, countRepeat })
+      return
+    }
+
     for (let i = 0; i < countRepeat; i++) {
       sendCommand(commandLine)
     }
@@ -219,6 +231,8 @@ const CliBodyWrapper = () => {
     setCommand('')
   }
 
+  const confirmationText = name || `${host}:${port}`
+
   return (
     <section ref={refHotkeys} className={styles.section}>
       <CliBody
@@ -228,6 +242,30 @@ const CliBodyWrapper = () => {
         setCommand={setCommand}
         onSubmit={handleSubmit}
       />
+      {pendingCommand && (
+        <TypeToConfirmModal
+          confirmationText={confirmationText}
+          title="Run dangerous command?"
+          actionDescription={
+            <>
+              You&apos;re about to run{' '}
+              <strong>{pendingCommand.commandLine}</strong> against the
+              production database <strong>{confirmationText}</strong>.
+            </>
+          }
+          confirmButtonText="Run command"
+          onConfirm={() => {
+            for (let i = 0; i < pendingCommand.countRepeat; i++) {
+              sendCommand(pendingCommand.commandLine)
+            }
+            setPendingCommand(null)
+          }}
+          onCancel={() => {
+            resetCommand()
+            setPendingCommand(null)
+          }}
+        />
+      )}
     </section>
   )
 }

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
@@ -194,7 +194,7 @@ const CliBodyWrapper = () => {
       return
     }
 
-    if (isDangerousCommand(commandLine.split(' ')[0])) {
+    if (isDangerousCommand(commandLine.trim().split(' ')[0])) {
       setPendingCommand({ commandLine, countRepeat })
       return
     }
@@ -261,6 +261,7 @@ const CliBodyWrapper = () => {
             setPendingCommand(null)
           }}
           onCancel={() => {
+            dispatch(concatToOutput(cliTexts.DANGEROUS_COMMAND_CANCELLED))
             resetCommand()
             setPendingCommand(null)
           }}

--- a/redisinsight/ui/src/components/messages/cli-output/cliOutput.tsx
+++ b/redisinsight/ui/src/components/messages/cli-output/cliOutput.tsx
@@ -167,6 +167,7 @@ export const cliTexts = {
     </ColorText>
   ),
   HELLO3_COMMAND_CLI: () => [cliTexts.HELLO3_COMMAND(), '\n'],
+  DANGEROUS_COMMAND_CANCELLED: 'Command cancelled.\n',
   CLI_ERROR_MESSAGE: (message: string) => [
     '\n',
     <ColorText color="danger" key={Date.now()}>

--- a/redisinsight/ui/src/components/messages/cli-output/cliOutput.tsx
+++ b/redisinsight/ui/src/components/messages/cli-output/cliOutput.tsx
@@ -167,7 +167,7 @@ export const cliTexts = {
     </ColorText>
   ),
   HELLO3_COMMAND_CLI: () => [cliTexts.HELLO3_COMMAND(), '\n'],
-  DANGEROUS_COMMAND_CANCELLED: 'Command cancelled.\n',
+  DANGEROUS_COMMAND_CANCELLED: ['Command cancelled.', '\n'],
   CLI_ERROR_MESSAGE: (message: string) => [
     '\n',
     <ColorText color="danger" key={Date.now()}>

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -743,6 +743,7 @@ export function fetchConnectedInstanceAction(
 
       if (data !== null) {
         dispatch(setConnectedInstanceSuccess(data))
+        dispatch(fetchConnectedInstanceDangerousCommandsAction(data.id))
         dispatch(setDefaultInstanceSuccess())
       }
       onSuccess?.()

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -60,6 +60,7 @@ import reducer, {
   checkDatabaseIndexAction,
   setConnectedInfoInstance,
   setConnectedInfoInstanceSuccess,
+  fetchConnectedInstanceAction,
   fetchConnectedInstanceInfoAction,
   testInstanceStandaloneAction,
   updateEditedInstance,
@@ -1550,6 +1551,38 @@ describe('instances slice', () => {
         const expectedActions = [setConnectedInfoInstance()]
 
         expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('fetchConnectedInstanceAction', () => {
+      it('dispatches setConnectedInstanceDangerousCommands after a successful connect', async () => {
+        // Arrange
+        const instanceData = instances[0]
+        const dangerousCommands = ['FLUSHDB', 'FLUSHALL']
+
+        apiService.get = jest.fn().mockImplementation((url: string) => {
+          if (url.endsWith('/dangerous-commands')) {
+            return Promise.resolve({ status: 200, data: dangerousCommands })
+          }
+          return Promise.resolve({ status: 200, data: instanceData })
+        })
+
+        // Act
+        await store.dispatch<any>(fetchConnectedInstanceAction(instanceData.id))
+        // Flush microtasks so the fire-and-forget dangerous-commands thunk resolves.
+        await Promise.resolve()
+        await Promise.resolve()
+
+        // Assert
+        expect(store.getActions()).toEqual(
+          expect.arrayContaining([
+            setDefaultInstance(),
+            setConnectedInstance(),
+            setConnectedInstanceSuccess(instanceData),
+            setDefaultInstanceSuccess(),
+            setConnectedInstanceDangerousCommands(dangerousCommands),
+          ]),
+        )
       })
     })
 


### PR DESCRIPTION
# What

Gates dangerous Redis commands (e.g. `FLUSHDB`, `FLUSHALL`, `DEBUG`) in the CLI behind a type-to-confirm modal on production-environment connections. Two pieces of wiring:

1. **On-connect fetch** — `fetchConnectedInstanceAction` now dispatches `fetchConnectedInstanceDangerousCommandsAction` right after `setConnectedInstanceSuccess`, populating the dangerous-commands list in Redux for both CLI and Workbench. Fire-and-forget; failure doesn't block the connection.
2. **CLI gating** — `CliBodyWrapper` checks `useDatabaseEnvironment().isDangerousCommand(cmd)` before dispatching. When true, the command is held in local state and the modal opens; the user types the database name to confirm. Cancel resets the input and dispatches nothing. The hook already short-circuits to `false` outside `Environment.Production` (and when the `devProdMode` flag is off), so no extra environment guard is needed at the call site.

No FE telemetry — per RI-8196 the BE-side `CLI_COMMAND_EXECUTED` event will carry `environment` + `dangerous` flags (separate PR #5930).

<img width="564" height="393" alt="Screenshot 2026-05-22 at 10 14 21" src="https://github.com/user-attachments/assets/0adec3d1-0b83-4c2a-a612-47c75ee4cffc" />
(copy is subject to change) 

# Testing

- [ ] `yarn test` passes for `CliBodyWrapper.spec.tsx` and `slices/tests/instances/instances.spec.ts`
- [ ] Connect to a database marked as Production (requires `devProdMode` flag on). Open the CLI.
  - [ ] `FLUSHDB` → modal opens with the DB name; cancel → command not dispatched; submit again → type the DB name → confirm → command runs
  - [ ] `PING` → runs immediately, no modal
- [ ] Connect to a Development-marked database → `FLUSHDB` runs without a modal
- [ ] With `devProdMode` flag off → `FLUSHDB` runs without a modal regardless of environment

---

References: #RI-8186

Depends on: #RI-8198 (hook + slice action), #RI-8179 (ACL CAT endpoint)
Sibling: #RI-8187 (Workbench gating — same hook, reuses the same on-connect fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI command submission flow and adds an extra on-connect fetch, which could impact command dispatch behavior and connection sequencing if the new gating or async fetch behaves unexpectedly.
> 
> **Overview**
> Adds *dangerous command* protection in the CLI: when `useDatabaseEnvironment().isDangerousCommand()` flags a command, `CliBodyWrapper` holds it and opens a `TypeToConfirmModal` requiring the user to type the database identifier before dispatching; cancel clears input and appends a new `cliTexts.DANGEROUS_COMMAND_CANCELLED` output.
> 
> Updates `fetchConnectedInstanceAction` to also trigger `fetchConnectedInstanceDangerousCommandsAction` after a successful connect (fire-and-forget) so the per-instance dangerous-commands list is populated in Redux, and extends unit tests to cover the new connect behavior and the CLI modal confirm/cancel paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf83016cc1b9a3f3c169f7ab4ac0fc3b0e6f001e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->