### PR TITLE
RI-8185 Browser bulk delete via Type-to-confirm modal

### DIFF
--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -36,6 +36,7 @@ const BulkActionsConfig = () => {
     generateReport,
     filter,
     search,
+    confirmedThrough,
   } = useSelector(bulkActionsDeleteSelector)
   const { token } = useSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
@@ -132,6 +133,7 @@ const BulkActionsConfig = () => {
           match: search || '*',
         },
         generateReport,
+        ...(confirmedThrough ? { confirmedThrough } : {}),
       },
       onBulkDeleting,
     )

--- a/redisinsight/ui/src/constants/bulkActions.ts
+++ b/redisinsight/ui/src/constants/bulkActions.ts
@@ -12,14 +12,6 @@ export enum BulkActionsType {
   Unlink = 'unlink',
 }
 
-// Mirrors `BulkActionConfirmation` in
-// `redisinsight/api/src/modules/bulk-actions/constants/index.ts` (BE PR #5930,
-// merged). The BE enum is not re-exported via `apiClient` because bulk-actions
-// is exposed through a WebSocket gateway, and `dump-openapi.ts` only surfaces
-// REST DTOs. If a REST endpoint ever references `CreateBulkActionDto` (or the
-// OpenAPI dumper is extended to cover WS DTOs), switch all imports of
-// `BulkActionConfirmation` to `apiClient` and delete this definition. String
-// values must stay in sync with the BE enum.
 export enum BulkActionConfirmation {
   Standard = 'standard',
   TypeToConfirm = 'type-to-confirm',

--- a/redisinsight/ui/src/constants/bulkActions.ts
+++ b/redisinsight/ui/src/constants/bulkActions.ts
@@ -12,6 +12,16 @@ export enum BulkActionsType {
   Unlink = 'unlink',
 }
 
+// TODO(RI-8196): remove this enum once the BE PR merges
+// (https://github.com/redis/RedisInsight/pull/5930) and `BulkActionConfirmation`
+// becomes available from `apiClient`. At that point, switch all imports of
+// `BulkActionConfirmation` from `uiSrc/constants` to `apiClient` and delete
+// this definition. String values must stay in sync with the BE enum.
+export enum BulkActionConfirmation {
+  Standard = 'standard',
+  TypeToConfirm = 'type-to-confirm',
+}
+
 export enum BulkActionsStatus {
   Initializing = 'initializing',
   Initialized = 'initialized',

--- a/redisinsight/ui/src/constants/bulkActions.ts
+++ b/redisinsight/ui/src/constants/bulkActions.ts
@@ -12,11 +12,14 @@ export enum BulkActionsType {
   Unlink = 'unlink',
 }
 
-// TODO(RI-8196): remove this enum once the BE PR merges
-// (https://github.com/redis/RedisInsight/pull/5930) and `BulkActionConfirmation`
-// becomes available from `apiClient`. At that point, switch all imports of
-// `BulkActionConfirmation` from `uiSrc/constants` to `apiClient` and delete
-// this definition. String values must stay in sync with the BE enum.
+// Mirrors `BulkActionConfirmation` in
+// `redisinsight/api/src/modules/bulk-actions/constants/index.ts` (BE PR #5930,
+// merged). The BE enum is not re-exported via `apiClient` because bulk-actions
+// is exposed through a WebSocket gateway, and `dump-openapi.ts` only surfaces
+// REST DTOs. If a REST endpoint ever references `CreateBulkActionDto` (or the
+// OpenAPI dumper is extended to cover WS DTOs), switch all imports of
+// `BulkActionConfirmation` to `apiClient` and delete this definition. String
+// values must stay in sync with the BE enum.
 export enum BulkActionConfirmation {
   Standard = 'standard',
   TypeToConfirm = 'type-to-confirm',

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
@@ -35,10 +35,12 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   connectedInstanceSelector: jest.fn(),
 }))
 
+const connectedInstanceSelectorMock = connectedInstanceSelector as jest.Mock
+
 const mockConnectedInstance = (
   overrides: Partial<{ name: string; host: string; port: number }> = {},
 ) => {
-  ;(connectedInstanceSelector as jest.Mock).mockReturnValue({
+  connectedInstanceSelectorMock.mockReturnValue({
     id: 'instanceId',
     name: DB_NAME,
     host: DB_HOST,

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
@@ -1,20 +1,62 @@
 import React from 'react'
 import { mock } from 'ts-mockito'
-import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { Environment } from 'apiClient'
+import { cleanup, fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import * as useDatabaseEnvironmentModule from 'uiSrc/components/hooks/useDatabaseEnvironment'
 
 import BulkDeleteFooter, { Props } from './BulkDeleteFooter'
-import { setBulkDeleteGenerateReport } from 'uiSrc/slices/browser/bulkActions'
+import {
+  setBulkDeleteConfirmedThrough,
+  setBulkDeleteGenerateReport,
+  toggleBulkDeleteActionTriggered,
+} from 'uiSrc/slices/browser/bulkActions'
+import { BulkActionConfirmation } from 'uiSrc/constants'
 
 jest.mock('uiSrc/slices/browser/bulkActions', () => ({
   ...jest.requireActual('uiSrc/slices/browser/bulkActions'),
   setBulkDeleteGenerateReport: jest.fn().mockReturnValue({
     type: 'bulkActions/setBulkDeleteGenerateReport',
   }),
+  setBulkDeleteConfirmedThrough: jest.fn().mockReturnValue({
+    type: 'bulkActions/setBulkDeleteConfirmedThrough',
+  }),
+  toggleBulkDeleteActionTriggered: jest.fn().mockReturnValue({
+    type: 'bulkActions/toggleBulkDeleteActionTriggered',
+  }),
+}))
+
+const DB_NAME = 'prod-db'
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  connectedInstanceSelector: jest.fn().mockReturnValue({
+    id: 'instanceId',
+    name: DB_NAME,
+  }),
 }))
 
 const mockedProps = {
   ...mock<Props>(),
 }
+
+const mockEnvironment = (environment: Environment) => {
+  jest
+    .spyOn(useDatabaseEnvironmentModule, 'useDatabaseEnvironment')
+    .mockReturnValue({
+      environment,
+      isDangerousCommand: () => false,
+    })
+}
+
+beforeEach(() => {
+  cleanup()
+  jest.clearAllMocks()
+  mockEnvironment(Environment.Unspecified)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('BulkDeleteFooter', () => {
   it('should render', () => {
@@ -43,5 +85,101 @@ describe('BulkDeleteFooter', () => {
 
     // Checkbox default is false, clicking toggles to true
     expect(setBulkDeleteGenerateReport).toHaveBeenCalledWith(true)
+  })
+
+  describe('non-production environment', () => {
+    it.each([Environment.Unspecified, Environment.Development])(
+      'uses the existing popover flow when environment is %s',
+      (environment) => {
+        mockEnvironment(environment)
+        render(<BulkDeleteFooter {...mockedProps} />)
+
+        fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+
+        // Popover is rendered (apply button is its confirm slot), modal is not
+        expect(screen.getByTestId('bulk-action-apply-btn')).toBeInTheDocument()
+        expect(
+          screen.queryByTestId('type-to-confirm-modal-title'),
+        ).not.toBeInTheDocument()
+      },
+    )
+
+    it('dispatches the toggle without confirmedThrough on confirm', () => {
+      mockEnvironment(Environment.Development)
+      render(<BulkDeleteFooter {...mockedProps} />)
+
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+      fireEvent.click(screen.getByTestId('bulk-action-apply-btn'))
+
+      expect(toggleBulkDeleteActionTriggered).toHaveBeenCalled()
+      expect(setBulkDeleteConfirmedThrough).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('production environment', () => {
+    beforeEach(() => {
+      mockEnvironment(Environment.Production)
+    })
+
+    it('opens the TypeToConfirmModal instead of the popover', () => {
+      render(<BulkDeleteFooter {...mockedProps} />)
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-title'),
+      ).toBeInTheDocument()
+      // The popover confirm slot is not present in the prod branch
+      expect(
+        screen.queryByTestId('bulk-action-apply-btn'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('keeps the confirm button disabled until the DB name is typed exactly', () => {
+      render(<BulkDeleteFooter {...mockedProps} />)
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+
+      const confirmBtn = screen.getByTestId('type-to-confirm-modal-confirm-btn')
+      const input = screen.getByTestId('type-to-confirm-modal-input')
+
+      expect(confirmBtn).toBeDisabled()
+
+      fireEvent.change(input, { target: { value: 'wrong' } })
+      expect(confirmBtn).toBeDisabled()
+
+      fireEvent.change(input, { target: { value: DB_NAME } })
+      expect(confirmBtn).not.toBeDisabled()
+    })
+
+    it('dispatches confirmedThrough and the toggle when confirmed', () => {
+      render(<BulkDeleteFooter {...mockedProps} />)
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: DB_NAME },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(setBulkDeleteConfirmedThrough).toHaveBeenCalledWith(
+        BulkActionConfirmation.TypeToConfirm,
+      )
+      expect(toggleBulkDeleteActionTriggered).toHaveBeenCalled()
+    })
+
+    it('closes the modal without dispatching when cancelled', () => {
+      render(<BulkDeleteFooter {...mockedProps} />)
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+      expect(setBulkDeleteConfirmedThrough).not.toHaveBeenCalled()
+      expect(toggleBulkDeleteActionTriggered).not.toHaveBeenCalled()
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx
@@ -10,6 +10,7 @@ import {
   setBulkDeleteGenerateReport,
   toggleBulkDeleteActionTriggered,
 } from 'uiSrc/slices/browser/bulkActions'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { BulkActionConfirmation } from 'uiSrc/constants'
 
 jest.mock('uiSrc/slices/browser/bulkActions', () => ({
@@ -26,14 +27,25 @@ jest.mock('uiSrc/slices/browser/bulkActions', () => ({
 }))
 
 const DB_NAME = 'prod-db'
+const DB_HOST = '127.0.0.1'
+const DB_PORT = 6379
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
-  connectedInstanceSelector: jest.fn().mockReturnValue({
+  connectedInstanceSelector: jest.fn(),
+}))
+
+const mockConnectedInstance = (
+  overrides: Partial<{ name: string; host: string; port: number }> = {},
+) => {
+  ;(connectedInstanceSelector as jest.Mock).mockReturnValue({
     id: 'instanceId',
     name: DB_NAME,
-  }),
-}))
+    host: DB_HOST,
+    port: DB_PORT,
+    ...overrides,
+  })
+}
 
 const mockedProps = {
   ...mock<Props>(),
@@ -52,6 +64,7 @@ beforeEach(() => {
   cleanup()
   jest.clearAllMocks()
   mockEnvironment(Environment.Unspecified)
+  mockConnectedInstance()
 })
 
 afterEach(() => {
@@ -152,6 +165,21 @@ describe('BulkDeleteFooter', () => {
       expect(confirmBtn).toBeDisabled()
 
       fireEvent.change(input, { target: { value: DB_NAME } })
+      expect(confirmBtn).not.toBeDisabled()
+    })
+
+    it('falls back to host:port when the DB name is empty', () => {
+      mockConnectedInstance({ name: '' })
+      render(<BulkDeleteFooter {...mockedProps} />)
+      fireEvent.click(screen.getByTestId('bulk-action-warning-btn'))
+
+      const confirmBtn = screen.getByTestId('type-to-confirm-modal-confirm-btn')
+      const input = screen.getByTestId('type-to-confirm-modal-input')
+
+      // Empty input must NOT enable confirm — that would bypass the safety check.
+      expect(confirmBtn).toBeDisabled()
+
+      fireEvent.change(input, { target: { value: `${DB_HOST}:${DB_PORT}` } })
       expect(confirmBtn).not.toBeDisabled()
     })
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
@@ -1,21 +1,24 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
+import { Environment } from 'apiClient'
 
 import {
   bulkActionsDeleteOverviewSelector,
   setBulkDeleteStartAgain,
   toggleBulkDeleteActionTriggered,
   setBulkDeleteGenerateReport,
+  setBulkDeleteConfirmedThrough,
   bulkActionsDeleteSelector,
 } from 'uiSrc/slices/browser/bulkActions'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { keysDataSelector } from 'uiSrc/slices/browser/keys'
 import {
   getMatchType,
   sendEventTelemetry,
   TelemetryEvent,
 } from 'uiSrc/telemetry'
-import { BulkActionsType } from 'uiSrc/constants'
+import { BulkActionConfirmation, BulkActionsType } from 'uiSrc/constants'
 import { getRangeForNumber, BULK_THRESHOLD_BREAKPOINTS } from 'uiSrc/utils'
 
 import { DEFAULT_SEARCH_MATCH } from 'uiSrc/constants/api'
@@ -27,6 +30,8 @@ import {
 import { RefreshIcon } from 'uiSrc/components/base/icons'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { TypeToConfirmModal } from 'uiSrc/components/type-to-confirm-modal'
 import { isProcessedBulkAction } from '../../utils'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { ConfirmationPopover, RiTooltip } from 'uiSrc/components'
@@ -44,9 +49,13 @@ const BulkDeleteFooter = (props: Props) => {
   const { loading, generateReport, filter, search } = useSelector(
     bulkActionsDeleteSelector,
   )
+  const { name: databaseName = '' } = useSelector(connectedInstanceSelector)
   const { status } = useSelector(bulkActionsDeleteOverviewSelector) ?? {}
+  const { environment } = useDatabaseEnvironment()
+  const isProduction = environment === Environment.Production
 
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false)
+  const [isTypeToConfirmOpen, setIsTypeToConfirmOpen] = useState<boolean>(false)
 
   const dispatch = useDispatch()
 
@@ -55,9 +64,15 @@ const BulkDeleteFooter = (props: Props) => {
     dispatch(toggleBulkDeleteActionTriggered())
   }
 
-  const handleDeleteWarning = () => {
-    setIsPopoverOpen(true)
+  const handleTypeToConfirm = () => {
+    setIsTypeToConfirmOpen(false)
+    dispatch(
+      setBulkDeleteConfirmedThrough(BulkActionConfirmation.TypeToConfirm),
+    )
+    dispatch(toggleBulkDeleteActionTriggered())
+  }
 
+  const sendDeleteWarningTelemetry = () => {
     let matchValue = DEFAULT_SEARCH_MATCH
     if (search !== DEFAULT_SEARCH_MATCH && !!search) {
       matchValue = getMatchType(search)
@@ -80,6 +95,16 @@ const BulkDeleteFooter = (props: Props) => {
         action: BulkActionsType.Delete,
       },
     })
+  }
+
+  const handleDeleteWarning = () => {
+    setIsPopoverOpen(true)
+    sendDeleteWarningTelemetry()
+  }
+
+  const handleOpenTypeToConfirm = () => {
+    setIsTypeToConfirmOpen(true)
+    sendDeleteWarningTelemetry()
   }
 
   const handleStartNew = () => {
@@ -141,7 +166,7 @@ const BulkDeleteFooter = (props: Props) => {
           </SecondaryButton>
         )}
 
-        {!isProcessedBulkAction(status) && (
+        {!isProcessedBulkAction(status) && !isProduction && (
           <ConfirmationPopover
             anchorPosition="upCenter"
             ownFocus
@@ -182,6 +207,34 @@ const BulkDeleteFooter = (props: Props) => {
               </DestructiveButton>
             }
           />
+        )}
+        {!isProcessedBulkAction(status) && isProduction && (
+          <>
+            <PrimaryButton
+              loading={loading}
+              disabled={loading}
+              onClick={handleOpenTypeToConfirm}
+              data-testid="bulk-action-warning-btn"
+            >
+              Delete
+            </PrimaryButton>
+            {isTypeToConfirmOpen && (
+              <TypeToConfirmModal
+                title="Delete all matching keys"
+                confirmationText={databaseName}
+                confirmButtonText="Delete"
+                actionDescription={
+                  <>
+                    This will delete all keys matching the selected type and
+                    pattern. Bulk deletion may impact performance and cause
+                    memory spikes.
+                  </>
+                }
+                onConfirm={handleTypeToConfirm}
+                onCancel={() => setIsTypeToConfirmOpen(false)}
+              />
+            )}
+          </>
         )}
         {isProcessedBulkAction(status) && (
           <PrimaryButton

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
@@ -49,10 +49,13 @@ const BulkDeleteFooter = (props: Props) => {
   const { loading, generateReport, filter, search } = useSelector(
     bulkActionsDeleteSelector,
   )
-  const { name: databaseName = '' } = useSelector(connectedInstanceSelector)
+  const { name, host, port } = useSelector(connectedInstanceSelector)
   const { status } = useSelector(bulkActionsDeleteOverviewSelector) ?? {}
   const { environment } = useDatabaseEnvironment()
   const isProduction = environment === Environment.Production
+  // Fall back to host:port when name is empty so the modal never matches an
+  // empty input (which would bypass the type-to-confirm safety check).
+  const confirmationText = name || `${host}:${port}`
 
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false)
   const [isTypeToConfirmOpen, setIsTypeToConfirmOpen] = useState<boolean>(false)
@@ -221,7 +224,7 @@ const BulkDeleteFooter = (props: Props) => {
             {isTypeToConfirmOpen && (
               <TypeToConfirmModal
                 title="Delete all matching keys"
-                confirmationText={databaseName}
+                confirmationText={confirmationText}
                 confirmButtonText="Delete"
                 actionDescription={
                   <>

--- a/redisinsight/ui/src/slices/browser/bulkActions.ts
+++ b/redisinsight/ui/src/slices/browser/bulkActions.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import axios, { AxiosError } from 'axios'
 import {
   ApiEndpoints,
+  BulkActionConfirmation,
   BulkActionsType,
   KeyTypes,
   MAX_BULK_ACTION_ERRORS_LENGTH,
@@ -38,6 +39,7 @@ export const initialState: StateBulkActions = {
     filter: null,
     search: '',
     keyCount: null,
+    confirmedThrough: null,
   },
   bulkUpload: {
     loading: false,
@@ -88,6 +90,12 @@ const bulkActionsSlice = createSlice({
       { payload }: PayloadAction<boolean>,
     ) => {
       state.bulkDelete.generateReport = payload
+    },
+    setBulkDeleteConfirmedThrough: (
+      state,
+      { payload }: PayloadAction<Nullable<BulkActionConfirmation>>,
+    ) => {
+      state.bulkDelete.confirmedThrough = payload
     },
     setBulkDeleteFilter: (
       state,
@@ -180,6 +188,7 @@ export const {
   disconnectBulkDeleteAction,
   toggleBulkDeleteActionTriggered,
   setBulkDeleteGenerateReport,
+  setBulkDeleteConfirmedThrough,
   setBulkDeleteFilter,
   setBulkDeleteSearch,
   setBulkDeleteKeyCount,

--- a/redisinsight/ui/src/slices/interfaces/bulkActions.ts
+++ b/redisinsight/ui/src/slices/interfaces/bulkActions.ts
@@ -1,4 +1,5 @@
 import {
+  BulkActionConfirmation,
   BulkActionsStatus,
   BulkActionsType,
   KeyTypes,
@@ -52,6 +53,7 @@ export interface StateBulkActions {
     filter: Nullable<KeyTypes>
     search: string
     keyCount: Nullable<number>
+    confirmedThrough: Nullable<BulkActionConfirmation>
   }
   bulkUpload: {
     loading: boolean

--- a/redisinsight/ui/src/slices/tests/browser/bulkActions.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/bulkActions.spec.ts
@@ -1,6 +1,11 @@
 import { cloneDeep } from 'lodash'
 import { AxiosError } from 'axios'
-import { BulkActionsStatus, BulkActionsType, KeyTypes } from 'uiSrc/constants'
+import {
+  BulkActionConfirmation,
+  BulkActionsStatus,
+  BulkActionsType,
+  KeyTypes,
+} from 'uiSrc/constants'
 import reducer, {
   bulkActionsSelector,
   initialState,
@@ -17,6 +22,7 @@ import reducer, {
   setBulkDeleteStartAgain,
   setBulkUploadStartAgain,
   setBulkDeleteLoading,
+  setBulkDeleteConfirmedThrough,
   setBulkDeleteFilter,
   setBulkDeleteSearch,
   setBulkDeleteKeyCount,
@@ -265,6 +271,45 @@ describe('bulkActions slice', () => {
           browser: { bulkActions: nextState },
         })
         expect(bulkActionsSelector(rootState)).toEqual(state)
+      })
+    })
+
+    describe('setBulkDeleteConfirmedThrough', () => {
+      it('should set confirmedThrough', () => {
+        const state = {
+          ...initialState.bulkDelete,
+          confirmedThrough: BulkActionConfirmation.TypeToConfirm,
+        }
+
+        const nextState = reducer(
+          initialState,
+          setBulkDeleteConfirmedThrough(BulkActionConfirmation.TypeToConfirm),
+        )
+
+        const rootState = Object.assign(initialStateDefault, {
+          browser: { bulkActions: nextState },
+        })
+        expect(bulkActionsDeleteSelector(rootState)).toEqual(state)
+      })
+
+      it('should reset confirmedThrough to null', () => {
+        const currentState = {
+          ...initialState,
+          bulkDelete: {
+            ...initialState.bulkDelete,
+            confirmedThrough: BulkActionConfirmation.TypeToConfirm,
+          },
+        }
+
+        const nextState = reducer(
+          currentState,
+          setBulkDeleteConfirmedThrough(null),
+        )
+
+        const rootState = Object.assign(initialStateDefault, {
+          browser: { bulkActions: nextState },
+        })
+        expect(bulkActionsDeleteSelector(rootState).confirmedThrough).toBeNull()
       })
     })
 


### PR DESCRIPTION
# What

Wires Browser bulk key deletion through the existing `TypeToConfirmModal` when the connected database is classified as `Environment.Production` (via `useDatabaseEnvironment`). Non-production databases keep today's `ConfirmationPopover` flow.

The production path dispatches `confirmedThrough: 'type-to-confirm'`, which `BulkActionsConfig` threads into the `bulk-actions/create` socket payload so BE telemetry (RI-8196) can record the confirmation channel. The field is omitted from the wire when null, so non-production frames are byte-identical to today.

Part of epic [RI-6594](https://redislabs.atlassian.net/browse/RI-6594) — Prod vs non-prod modes.

<img width="679" height="504" alt="Screenshot 2026-05-22 at 10 22 22" src="https://github.com/user-attachments/assets/fa837448-1bf7-4f26-b087-65ed97620ba0" />
(copy is subject to change)

## Dependencies

- BE telemetry enrichment lives in [#5930](https://github.com/redis/RedisInsight/pull/5930) (RI-8196), still in review. The `BulkActionConfirmation` enum is temporarily defined in `redisinsight/ui/src/constants/bulkActions.ts` with a `TODO(RI-8196)` so this PR stays independent. Once #5930 merges and `apiClient` regenerates with `BulkActionConfirmation`, follow-up is: switch imports from `uiSrc/constants` to `apiClient` and delete the local enum. BE field is optional, so merge order doesn't matter.

# Testing

- `node node_modules/.bin/jest redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.spec.tsx -c jest.config.cjs` — 11/11 pass.
- `node node_modules/.bin/jest redisinsight/ui/src/slices/tests/browser/bulkActions.spec.ts -c jest.config.cjs` — 30/30 pass.
- Sibling specs in `bulk-actions-config` and `bulk-actions` — 49/49 pass.
- `yarn lint:ui` — clean.
- `yarn type-check` — clean.

### Manual smoke (`yarn dev:desktop`)

- Connect to a DB classified as Development → Browser → Bulk Actions → Delete → existing popover flow works end-to-end.
- Re-classify as Production → re-open Bulk Actions → Delete → modal appears, Confirm stays disabled until the DB name is typed exactly, then Delete dispatches identically to non-prod (overview updates, optional report download).
- In devtools WS frames, the prod `create` carries `confirmedThrough: "type-to-confirm"`; the non-prod frame does not.

---

Closes #RI-8185

[RI-6594]: https://redislabs.atlassian.net/browse/RI-6594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the confirmation UX for bulk key deletion in production and adds a new optional `confirmedThrough` field to the bulk-delete socket payload, which could affect delete initiation/telemetry if miswired.
> 
> **Overview**
> Bulk key deletion in Browser now uses `TypeToConfirmModal` when the connected database is classified as `Environment.Production`, while non-production keeps the existing `ConfirmationPopover` flow.
> 
> The delete flow records how the action was confirmed by adding `bulkDelete.confirmedThrough` to Redux state (new `BulkActionConfirmation` enum) and conditionally including `confirmedThrough` in the `bulk-actions/create` socket payload. Tests were expanded to cover production vs non-production confirmation behavior and the new slice action/state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5a8c6bb36c420dc2cade63c9e6a91d1d521a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->