### PR TITLE
RI-8187 Workbench dangerous-command gating via type-to-confirm

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
@@ -113,6 +113,10 @@ jest.mock('uiSrc/slices/workbench/wb-tutorials', () => {
   }
 })
 
+const sendWbQueryActionMock = sendWbQueryAction as jest.Mock
+const useDatabaseEnvironmentMock = useDatabaseEnvironment as jest.Mock
+const connectedInstanceSelectorMock = connectedInstanceSelector as jest.Mock
+
 describe('WBViewWrapper', () => {
   beforeAll(() => {
     QueryWrapper.mockImplementation(QueryWrapperMock)
@@ -182,21 +186,19 @@ describe('WBViewWrapper', () => {
 
     beforeEach(() => {
       capturedOnSubmit = null
-      ;(sendWbQueryAction as jest.Mock).mockClear()
-      ;(connectedInstanceSelector as jest.Mock).mockImplementation(
-        () => instance,
-      )
+      sendWbQueryActionMock.mockClear()
+      connectedInstanceSelectorMock.mockImplementation(() => instance)
     })
 
     afterEach(() => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: 'unspecified',
         isDangerousCommand: () => false,
       })
     })
 
     it('does not show the modal and dispatches when no command is dangerous', () => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: () => false,
       })
@@ -210,11 +212,11 @@ describe('WBViewWrapper', () => {
         screen.queryByTestId('type-to-confirm-modal-title'),
       ).not.toBeInTheDocument()
       expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
-      expect((sendWbQueryAction as jest.Mock).mock.calls[0][0]).toBe('PING')
+      expect(sendWbQueryActionMock.mock.calls[0][0]).toBe('PING')
     })
 
     it('shows the modal and defers dispatch when a command is dangerous', () => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: (cmd: string) =>
           ['FLUSHALL', 'FLUSHDB'].includes(cmd.toUpperCase()),
@@ -237,7 +239,7 @@ describe('WBViewWrapper', () => {
     })
 
     it('gates a multi-line dangerous command (Monaco continuation)', () => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
@@ -262,10 +264,8 @@ describe('WBViewWrapper', () => {
         port: 6379,
         connectionType: ConnectionType.Standalone,
       })
-      ;(connectedInstanceSelector as jest.Mock).mockImplementation(
-        () => namelessInstance,
-      )
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      connectedInstanceSelectorMock.mockImplementation(() => namelessInstance)
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
@@ -281,7 +281,7 @@ describe('WBViewWrapper', () => {
     })
 
     it('dispatches the original batch after typing the database name and confirming', () => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
@@ -300,13 +300,11 @@ describe('WBViewWrapper', () => {
         screen.queryByTestId('type-to-confirm-modal-title'),
       ).not.toBeInTheDocument()
       expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
-      expect((sendWbQueryAction as jest.Mock).mock.calls[0][0]).toBe(
-        'PING\nFLUSHALL',
-      )
+      expect(sendWbQueryActionMock.mock.calls[0][0]).toBe('PING\nFLUSHALL')
     })
 
     it('does not dispatch when the modal is cancelled', () => {
-      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+      useDatabaseEnvironmentMock.mockReturnValue({
         environment: Environment.Production,
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
@@ -236,6 +236,25 @@ describe('WBViewWrapper', () => {
       expect(sendWbQueryAction).not.toHaveBeenCalled()
     })
 
+    it('gates a multi-line dangerous command (Monaco continuation)', () => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
+      })
+
+      render(<WBViewWrapper />)
+      // Monaco joins continuation lines (the leading whitespace on the next
+      // line is preserved), so the verb arrives with an embedded newline.
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL\n  ASYNC')
+      })
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-title'),
+      ).toBeInTheDocument()
+      expect(sendWbQueryAction).not.toHaveBeenCalled()
+    })
+
     it('falls back to host:port when the connected instance has no name', () => {
       const namelessInstance = DBInstanceFactory.build({
         name: undefined,

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
@@ -18,8 +18,13 @@ import {
   loadWBHistory,
   processWBCommand,
   sendWBCommandAction,
+  sendWbQueryAction,
   workbenchResultsSelector,
 } from 'uiSrc/slices/workbench/wb-results'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { Environment } from 'apiClient'
+import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory'
+import { ConnectionType } from 'uiSrc/slices/interfaces'
 
 import WBViewWrapper from './WBViewWrapper'
 
@@ -36,15 +41,20 @@ jest.mock('uiSrc/pages/workbench/components/query', () => ({
   default: jest.fn(),
 }))
 
-const QueryWrapperMock = (props: QueryProps) => (
-  <div
-    onKeyDown={(e: any) => props.onKeyDown?.(e, 'get')}
-    data-testid="query"
-    aria-label="query"
-    role="textbox"
-    tabIndex={0}
-  />
-)
+let capturedOnSubmit: QueryProps['onSubmit'] | null = null
+
+const QueryWrapperMock = (props: QueryProps) => {
+  capturedOnSubmit = props.onSubmit
+  return (
+    <div
+      onKeyDown={(e: any) => props.onKeyDown?.(e, 'get')}
+      data-testid="query"
+      aria-label="query"
+      role="textbox"
+      tabIndex={0}
+    />
+  )
+}
 
 jest.mock('uiSrc/services', () => ({
   ...jest.requireActual('uiSrc/services'),
@@ -71,12 +81,23 @@ jest.mock('uiSrc/slices/app/plugins', () => ({
 
 jest.mock('uiSrc/slices/workbench/wb-results', () => ({
   ...jest.requireActual('uiSrc/slices/workbench/wb-results'),
+  sendWbQueryAction: jest.fn(() => ({ type: '__test_sendWbQueryAction__' })),
+  sendWBCommandAction: jest.fn(() => ({
+    type: '__test_sendWBCommandAction__',
+  })),
   sendWBCommandClusterAction: jest.fn(),
   processUnsupportedCommand: jest.fn(),
   updateCliCommandHistory: jest.fn,
   workbenchResultsSelector: jest.fn().mockReturnValue({
     loading: false,
     items: [],
+  }),
+}))
+
+jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
+  useDatabaseEnvironment: jest.fn().mockReturnValue({
+    environment: 'unspecified',
+    isDangerousCommand: () => false,
   }),
 }))
 
@@ -151,6 +172,138 @@ describe('WBViewWrapper', () => {
     render(<WBViewWrapper />)
 
     expect(screen.queryByTestId('clear-history-btn')).not.toBeInTheDocument()
+  })
+
+  describe('dangerous-command gating', () => {
+    const instance = DBInstanceFactory.build({
+      name: 'prod-db',
+      connectionType: ConnectionType.Standalone,
+    })
+
+    beforeEach(() => {
+      capturedOnSubmit = null
+      ;(sendWbQueryAction as jest.Mock).mockClear()
+      ;(connectedInstanceSelector as jest.Mock).mockImplementation(
+        () => instance,
+      )
+    })
+
+    afterEach(() => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: 'unspecified',
+        isDangerousCommand: () => false,
+      })
+    })
+
+    it('does not show the modal and dispatches when no command is dangerous', () => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: () => false,
+      })
+
+      render(<WBViewWrapper />)
+      act(() => {
+        capturedOnSubmit?.('PING')
+      })
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+      expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
+      expect((sendWbQueryAction as jest.Mock).mock.calls[0][0]).toBe('PING')
+    })
+
+    it('shows the modal and defers dispatch when a command is dangerous', () => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) =>
+          ['FLUSHALL', 'FLUSHDB'].includes(cmd.toUpperCase()),
+      })
+
+      render(<WBViewWrapper />)
+      act(() => {
+        capturedOnSubmit?.('PING\nFLUSHALL\nFLUSHDB')
+      })
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-title'),
+      ).toBeInTheDocument()
+      const description = screen.getByTestId(
+        'type-to-confirm-modal-description',
+      )
+      expect(description).toHaveTextContent(instance.name!)
+      expect(description).toHaveTextContent('FLUSHALL, FLUSHDB')
+      expect(sendWbQueryAction).not.toHaveBeenCalled()
+    })
+
+    it('falls back to host:port when the connected instance has no name', () => {
+      const namelessInstance = DBInstanceFactory.build({
+        name: undefined,
+        host: 'h',
+        port: 6379,
+        connectionType: ConnectionType.Standalone,
+      })
+      ;(connectedInstanceSelector as jest.Mock).mockImplementation(
+        () => namelessInstance,
+      )
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
+      })
+
+      render(<WBViewWrapper />)
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL')
+      })
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-description'),
+      ).toHaveTextContent('h:6379')
+    })
+
+    it('dispatches the original batch after typing the database name and confirming', () => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
+      })
+
+      render(<WBViewWrapper />)
+      act(() => {
+        capturedOnSubmit?.('PING\nFLUSHALL')
+      })
+
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: instance.name },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+      expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
+      expect((sendWbQueryAction as jest.Mock).mock.calls[0][0]).toBe(
+        'PING\nFLUSHALL',
+      )
+    })
+
+    it('does not dispatch when the modal is cancelled', () => {
+      ;(useDatabaseEnvironment as jest.Mock).mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
+      })
+
+      render(<WBViewWrapper />)
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL')
+      })
+
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+      expect(sendWbQueryAction).not.toHaveBeenCalled()
+    })
   })
 
   it.skip('"onSubmit" for Cluster connection should call "sendWBCommandClusterAction"', async () => {

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -50,7 +50,17 @@ import {
   changeSidePanel,
 } from 'uiSrc/slices/panels/sidePanels'
 import { InsightsPanelTabs, SidePanels } from 'uiSrc/slices/interfaces/insights'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal'
+import { getCommandsForExecution } from 'uiSrc/utils/monaco/monacoUtils'
 import WBView from './WBView'
+
+interface PendingSubmit {
+  value: string
+  commandId?: Nullable<string>
+  executeParams: CodeButtonParams
+  dangerousCommands: string[]
+}
 
 interface IState {
   loading: boolean
@@ -91,8 +101,11 @@ const WBViewWrapper = () => {
   const [script, setScript] = useState(scriptContext)
   const [scriptEl, setScriptEl] =
     useState<Nullable<monacoEditor.editor.IStandaloneCodeEditor>>(null)
+  const [pendingSubmit, setPendingSubmit] =
+    useState<Nullable<PendingSubmit>>(null)
 
   const instance = useSelector(connectedInstanceSelector)
+  const { isDangerousCommand } = useDatabaseEnvironment()
   const { visualizations = [] } = useSelector(appPluginsSelector)
   state = {
     scriptEl,
@@ -235,13 +248,11 @@ const WBViewWrapper = () => {
     setScript('')
   }
 
-  const sourceValueSubmit = (
-    value: string = script,
-    commandId?: Nullable<string>,
-    executeParams: CodeButtonParams = { clearEditor: true },
+  const runSubmission = (
+    value: string,
+    commandId: Maybe<Nullable<string>>,
+    executeParams: CodeButtonParams,
   ) => {
-    if (state.loading || (!value && !script)) return
-
     const lines = getMonacoLines(value)
     const parsedParams: Maybe<CodeButtonParams> = getParsedParamsInQuery(value)
 
@@ -253,25 +264,85 @@ const WBViewWrapper = () => {
     }
   }
 
+  const sourceValueSubmit = (
+    value: string = script,
+    commandId?: Nullable<string>,
+    executeParams: CodeButtonParams = { clearEditor: true },
+  ) => {
+    if (state.loading || (!value && !script)) return
+
+    const effectiveValue = value || script
+    const commands = getCommandsForExecution(effectiveValue)
+    const dangerousCommands = commands.filter((cmd) =>
+      isDangerousCommand(cmd.split(' ')[0]),
+    )
+    if (dangerousCommands.length > 0) {
+      setPendingSubmit({
+        value: effectiveValue,
+        commandId,
+        executeParams,
+        dangerousCommands,
+      })
+      return
+    }
+
+    runSubmission(value, commandId, executeParams)
+  }
+
+  const handleConfirmPendingSubmit = () => {
+    if (!pendingSubmit) return
+    const submission = pendingSubmit
+    setPendingSubmit(null)
+    runSubmission(
+      submission.value,
+      submission.commandId,
+      submission.executeParams,
+    )
+  }
+
   return (
-    <WBView
-      items={items}
-      clearing={clearing}
-      processing={processing}
-      isResultsLoaded={isLoaded}
-      script={script}
-      setScript={setScript}
-      setScriptEl={setScriptEl}
-      scrollDivRef={scrollDivRef}
-      activeMode={activeRunQueryMode}
-      onSubmit={sourceValueSubmit}
-      onQueryOpen={handleQueryOpen}
-      onQueryDelete={handleQueryDelete}
-      onAllQueriesDelete={handleAllQueriesDelete}
-      onQueryChangeMode={handleChangeQueryRunMode}
-      resultsMode={resultsMode}
-      onChangeGroupMode={handleChangeGroupMode}
-    />
+    <>
+      <WBView
+        items={items}
+        clearing={clearing}
+        processing={processing}
+        isResultsLoaded={isLoaded}
+        script={script}
+        setScript={setScript}
+        setScriptEl={setScriptEl}
+        scrollDivRef={scrollDivRef}
+        activeMode={activeRunQueryMode}
+        onSubmit={sourceValueSubmit}
+        onQueryOpen={handleQueryOpen}
+        onQueryDelete={handleQueryDelete}
+        onAllQueriesDelete={handleAllQueriesDelete}
+        onQueryChangeMode={handleChangeQueryRunMode}
+        resultsMode={resultsMode}
+        onChangeGroupMode={handleChangeGroupMode}
+      />
+      {pendingSubmit && (
+        <TypeToConfirmModal
+          title="Run dangerous commands?"
+          confirmationText={
+            instance?.name || `${instance?.host}:${instance?.port}`
+          }
+          actionDescription={
+            <>
+              You&apos;re about to run{' '}
+              <strong>{pendingSubmit.dangerousCommands.join(', ')}</strong>{' '}
+              against the production database{' '}
+              <strong>
+                {instance?.name || `${instance?.host}:${instance?.port}`}
+              </strong>
+              .
+            </>
+          }
+          confirmButtonText="Run command"
+          onConfirm={handleConfirmPendingSubmit}
+          onCancel={() => setPendingSubmit(null)}
+        />
+      )}
+    </>
   )
 }
 

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -300,6 +300,9 @@ const WBViewWrapper = () => {
     )
   }
 
+  const confirmationText =
+    instance?.name || `${instance?.host}:${instance?.port}`
+
   return (
     <>
       <WBView
@@ -323,18 +326,13 @@ const WBViewWrapper = () => {
       {pendingSubmit && (
         <TypeToConfirmModal
           title="Run dangerous commands?"
-          confirmationText={
-            instance?.name || `${instance?.host}:${instance?.port}`
-          }
+          confirmationText={confirmationText}
           actionDescription={
             <>
               You&apos;re about to run{' '}
               <strong>{pendingSubmit.dangerousCommands.join(', ')}</strong>{' '}
               against the production database{' '}
-              <strong>
-                {instance?.name || `${instance?.host}:${instance?.port}`}
-              </strong>
-              .
+              <strong>{confirmationText}</strong>.
             </>
           }
           confirmButtonText="Run command"

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -274,7 +274,7 @@ const WBViewWrapper = () => {
     const effectiveValue = value || script
     const commands = getCommandsForExecution(effectiveValue)
     const dangerousCommands = commands.filter((cmd) =>
-      isDangerousCommand(cmd.split(' ')[0]),
+      isDangerousCommand(cmd.split(/\s+/)[0]),
     )
     if (dangerousCommands.length > 0) {
       setPendingSubmit({

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -286,7 +286,7 @@ const WBViewWrapper = () => {
       return
     }
 
-    runSubmission(value, commandId, executeParams)
+    runSubmission(effectiveValue, commandId, executeParams)
   }
 
   const handleConfirmPendingSubmit = () => {


### PR DESCRIPTION
# What

Gates dangerous Redis commands (`ACL CAT dangerous`) in the Workbench multi-command runner behind a `TypeToConfirmModal` on production-environment connections. The dangerous-commands list is already populated on connect by [#5962](https://github.com/redis/RedisInsight/pull/5962) (RI-8186) — this PR just consumes it via `useDatabaseEnvironment().isDangerousCommand`.

When any command in the submitted batch is dangerous, `WBViewWrapper.sourceValueSubmit` holds the batch and opens the modal. The user types the database name (or `host:port` fallback) to confirm; cancel aborts the batch; confirm dispatches the original `sendWbQueryAction` unchanged. Non-production passes through with zero behavior change because the hook short-circuits to `false`.

The modal body lists the dangerous commands found in the batch (comma-joined) so users see exactly what they're authorizing, e.g.:

> _"You're about to run **FLUSHALL, FLUSHDB** against the production database **prod-db**."_

<img width="650" height="456" alt="Screenshot 2026-05-22 at 12 42 11" src="https://github.com/user-attachments/assets/facc0161-a9f0-4801-b3c9-b130895a83fa" />
(copy is subject to change)

## Design notes

- **One modal per batch** (vs one-per-dangerous-command in the original ticket text). Simpler UX, listing the commands in the body keeps the user informed.
- **Modal lives in `WBViewWrapper`**, matching the sibling pattern in [#5962](https://github.com/redis/RedisInsight/pull/5962) (CLI gating in `CliBodyWrapper`) and [#5963](https://github.com/redis/RedisInsight/pull/5963) (bulk delete gating in `BulkDeleteFooter`). Each surface has different post-confirm wiring, so a shared component would add indirection without payoff.
- **No FE telemetry** — BE `WORKBENCH_COMMAND_EXECUTED` event enriched by RI-8196 ([#5930](https://github.com/redis/RedisInsight/pull/5930), merged) carries `environment` + `dangerous` flags.

## Dependencies / siblings

- Depends on: RI-8198 (hook + slice action), RI-8186 / [#5962](https://github.com/redis/RedisInsight/pull/5962) (on-connect dangerous-commands fetch)
- Sibling: [#5962](https://github.com/redis/RedisInsight/pull/5962) (CLI gating — same hook, same modal), [#5963](https://github.com/redis/RedisInsight/pull/5963) (bulk delete gating)

# Testing

- `node node_modules/.bin/jest redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx -c jest.config.cjs` — 11/11 pass (4 new gating tests + the host:port fallback case + existing).
- Broader workbench area: 170/172 pass (2 pre-existing skips).
- `yarn lint:ui` — clean.

### Manual smoke (`yarn dev:desktop`)

- Connect to a DB marked Production (requires `devProdMode` flag on). Open Workbench:
  - [ ] `PING` → runs immediately, no modal.
  - [ ] `FLUSHALL` → modal opens, names the command and the DB; cancel → not dispatched; confirm with DB name → runs.
  - [ ] `PING\nFLUSHDB\nSET x 1` → one modal listing `FLUSHDB`; cancel → no commands run; confirm → whole batch dispatched.
  - [ ] `FLUSHALL ASYNC` → still gated (verb extracted before dangerous-command check).
- [ ] Connect to a Development-marked database → dangerous commands run without modal.
- [ ] With `devProdMode` flag off → dangerous commands run without modal regardless of environment.

---

Closes #RI-8187


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Workbench query submission flow to defer execution behind a confirmation modal when potentially destructive commands are detected, which could block or alter multi-command execution behavior if parsing/gating is incorrect.
> 
> **Overview**
> Adds **dangerous-command gating** to the Workbench multi-command runner: `WBViewWrapper` now parses the submitted batch (`getCommandsForExecution`) and, if any command verb is flagged by `useDatabaseEnvironment().isDangerousCommand`, defers dispatch and shows a `TypeToConfirmModal` requiring the user to type the DB name (or `host:port`) to proceed.
> 
> On confirm, the original batch is dispatched unchanged; on cancel, nothing is sent. Updates `WBViewWrapper.spec.tsx` with new tests covering non-dangerous pass-through, modal gating for multi-command and Monaco continuation cases, confirm/cancel behavior, and the `host:port` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72757c097809373b6288b017c810f22c9eb79f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->