### PR TITLE
Hide Similarity Result attribute columns by default

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
@@ -63,7 +63,7 @@ describe('useSimilarityResultColumns', () => {
     expect(result.current.columnsMap.size).toBe(0)
   })
 
-  it('keeps Element + Similarity anchored in shownColumns alongside visible attribute keys', () => {
+  it('keeps Element + Similarity anchored in shownColumns with attribute columns hidden by default', () => {
     const { result } = renderHook(() =>
       useSimilarityResultColumns([match('a', 0.9, '{"foo":1}')]),
     )
@@ -71,12 +71,13 @@ describe('useSimilarityResultColumns', () => {
     expect(result.current.shownColumns).toEqual([
       SimilarityResultsColumn.Name,
       SimilarityResultsColumn.Similarity,
-      attributeColumnId('foo'),
     ])
-    expect(result.current.columnVisibility).toEqual({})
+    expect(result.current.columnVisibility).toEqual({
+      [attributeColumnId('foo')]: false,
+    })
   })
 
-  it('hides columns when onShownColumnsChange omits them', () => {
+  it('shows columns when onShownColumnsChange includes them', () => {
     const { result } = renderHook(() =>
       useSimilarityResultColumns([match('a', 0.9, '{"foo":1,"bar":2}')]),
     )
@@ -117,7 +118,7 @@ describe('useSimilarityResultColumns', () => {
     expect(result.current.columnVisibility).toEqual({})
   })
 
-  it('preserves hidden state when new matches surface new attribute keys', () => {
+  it('preserves shown state when new matches surface new attribute keys', () => {
     const initial = [match('a', 0.9, '{"foo":1}')]
     const { result, rerender } = renderHook(
       (matches: VectorSetSimilarityMatch[]) =>
@@ -129,22 +130,21 @@ describe('useSimilarityResultColumns', () => {
       result.current.onShownColumnsChange([
         SimilarityResultsColumn.Name,
         SimilarityResultsColumn.Similarity,
+        attributeColumnId('foo'),
       ])
     })
-    expect(result.current.columnVisibility).toEqual({
-      [attributeColumnId('foo')]: false,
-    })
+    expect(result.current.columnVisibility).toEqual({})
 
-    // New search introduces a `bar` attribute → it should default to visible
-    // while the user's existing decision to hide `foo` is preserved.
+    // New search introduces a `bar` attribute → it should default to hidden
+    // while the user's existing decision to show `foo` is preserved.
     rerender([match('c', 0.7, '{"foo":1,"bar":2}')])
     expect(result.current.shownColumns).toEqual([
       SimilarityResultsColumn.Name,
       SimilarityResultsColumn.Similarity,
-      attributeColumnId('bar'),
+      attributeColumnId('foo'),
     ])
     expect(result.current.columnVisibility).toEqual({
-      [attributeColumnId('foo')]: false,
+      [attributeColumnId('bar')]: false,
     })
   })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.ts
@@ -37,8 +37,9 @@ export const attributeColumnId = (key: string): string =>
 /**
  * Column-visibility state for the similarity-search results table.
  *
- * Tracks *hidden* ids (not shown) so new attribute keys default to visible
- * while previously-hidden ones stay hidden across re-searches. Element +
+ * Tracks *explicitly shown* attribute ids so attribute columns default to
+ * hidden — the user opts them in via the Columns popover, and that decision
+ * is preserved when new searches surface new attribute keys. Element +
  * Similarity are always visible and excluded from `columnsMap`.
  */
 export const useSimilarityResultColumns = (
@@ -54,9 +55,9 @@ export const useSimilarityResultColumns = (
     [matches, parsedAttributesCache],
   )
 
-  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
-    () => new Set(),
-  )
+  const [shownAttributeColumns, setShownAttributeColumns] = useState<
+    Set<string>
+  >(() => new Set())
 
   const columns = useMemo(
     () => buildSimilarityResultsColumns(attributeKeys),
@@ -75,28 +76,32 @@ export const useSimilarityResultColumns = (
     () => [
       SimilarityResultsColumn.Name,
       SimilarityResultsColumn.Similarity,
-      ...Array.from(columnsMap.keys()).filter((id) => !hiddenColumns.has(id)),
+      ...Array.from(columnsMap.keys()).filter((id) =>
+        shownAttributeColumns.has(id),
+      ),
     ],
-    [columnsMap, hiddenColumns],
+    [columnsMap, shownAttributeColumns],
   )
 
   const onShownColumnsChange = useCallback(
     (next: string[]) => {
-      const nextShown = new Set(next)
-      const nextHidden = new Set<string>()
+      const nextSet = new Set(next)
+      const nextShownAttrs = new Set<string>()
       for (const id of columnsMap.keys()) {
-        if (!nextShown.has(id)) nextHidden.add(id)
+        if (nextSet.has(id)) nextShownAttrs.add(id)
       }
-      setHiddenColumns(nextHidden)
+      setShownAttributeColumns(nextShownAttrs)
     },
     [columnsMap],
   )
 
   const columnVisibility = useMemo<Record<string, boolean>>(() => {
     const out: Record<string, boolean> = {}
-    for (const id of hiddenColumns) out[id] = false
+    for (const id of columnsMap.keys()) {
+      if (!shownAttributeColumns.has(id)) out[id] = false
+    }
     return out
-  }, [hiddenColumns])
+  }, [columnsMap, shownAttributeColumns])
 
   return {
     columns,


### PR DESCRIPTION
## Summary
- Attribute columns in the VSIM (similarity-search) results table now start hidden.
- Users can opt columns in via the existing Columns popover; their selections persist across re-searches.
- New attribute keys surfaced by later searches also default to hidden.

<img width="661" height="634" alt="image" src="https://github.com/user-attachments/assets/72f65730-036a-45fe-9195-0295f9fc359e" />

## Test plan
- [ ] Run a VSIM on a vector set with attributes — only Element + Similarity columns are visible.
- [ ] Open the Columns popover and check an attribute — column appears.
- [ ] Re-run VSIM — previously-shown columns stay shown; any new attribute keys are hidden.
- [ ] `yarn test` passes for `vector-set-details/similarity-search-results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI column-visibility logic for vector-set similarity search; no auth, API, or data-path changes.
> 
> **Overview**
> **VSIM similarity results** now show only **Element** and **Similarity** by default; dynamic attribute columns are hidden until the user enables them in the **Columns** popover.
> 
> `useSimilarityResultColumns` switches from a **hidden-columns** set (attributes visible unless hidden) to **`shownAttributeColumns`** (attributes hidden unless explicitly selected). `columnVisibility` marks every attribute column not in that set as `false`. **Element** and **Similarity** stay always visible. On re-search, columns the user turned on stay on; **new** attribute keys still start hidden.
> 
> Specs were updated to match the opt-in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8924b437d745cc7efbec8609f225e121b704df4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->