### PR TITLE
RI-8184 Browser confirmations + display tweaks (key size column)

### DIFF
--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import { Environment } from 'apiClient'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import * as useDatabaseEnvironmentModule from 'uiSrc/components/hooks/useDatabaseEnvironment'
+
+import {
+  ProductionWriteConfirmationProvider,
+  ProductionWriteConfirmationRequest,
+  useProductionWriteConfirmation,
+} from '.'
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  connectedInstanceSelector: jest.fn().mockReturnValue({
+    name: 'prod-cache',
+    host: 'localhost',
+    port: 6379,
+  }),
+}))
+
+const mockedConnectedInstanceSelector = connectedInstanceSelector as jest.Mock
+
+const mockEnvironment = (environment: Environment) => {
+  jest
+    .spyOn(useDatabaseEnvironmentModule, 'useDatabaseEnvironment')
+    .mockReturnValue({
+      environment,
+      isDangerousCommand: () => false,
+    })
+}
+
+const typeInConfirmInput = (value: string) => {
+  fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+    target: { value },
+  })
+}
+
+interface TriggerProps {
+  onConfirm: jest.Mock
+  overrides?: Partial<ProductionWriteConfirmationRequest>
+}
+
+const Trigger = ({ onConfirm, overrides }: TriggerProps) => {
+  const { requestConfirmation } = useProductionWriteConfirmation()
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        requestConfirmation({
+          actionDescription: 'description',
+          onConfirm,
+          ...overrides,
+        })
+      }
+      data-testid="trigger"
+    >
+      trigger
+    </button>
+  )
+}
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(
+    <ProductionWriteConfirmationProvider>
+      {ui}
+    </ProductionWriteConfirmationProvider>,
+  )
+
+describe('ProductionWriteConfirmationProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedConnectedInstanceSelector.mockReturnValue({
+      name: 'prod-cache',
+      host: 'localhost',
+      port: 6379,
+    })
+    mockEnvironment(Environment.Unspecified)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('runs action immediately when environment is Unspecified', () => {
+    mockEnvironment(Environment.Unspecified)
+    const action = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-input'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('runs action immediately when environment is Development', () => {
+    mockEnvironment(Environment.Development)
+    const action = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-input'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('defers action and shows TypeToConfirm modal when environment is Production', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(action).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('type-to-confirm-modal-input'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toBeDisabled()
+  })
+
+  it('runs action only after user types DB name and confirms in production', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to host:port when DB name is empty', () => {
+    mockedConnectedInstanceSelector.mockReturnValue({
+      name: '',
+      host: 'localhost',
+      port: 6379,
+    })
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+    ).toBeDisabled()
+
+    typeInConfirmInput('localhost:6379')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels action and calls onCancel when user cancels in production', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+    const onCancel = jest.fn()
+
+    renderWithProvider(<Trigger onConfirm={action} overrides={{ onCancel }} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
+
+    expect(action).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs action immediately when hook is used outside the provider', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    // Render without the provider — fallback should run action immediately
+    render(<Trigger onConfirm={action} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-input'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
@@ -1,0 +1,78 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+import { useSelector } from 'react-redux'
+import { Environment } from 'apiClient'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import {
+  ProductionWriteConfirmationContextValue,
+  ProductionWriteConfirmationRequest,
+} from './ProductionWriteConfirmationProvider.types'
+
+const ProductionWriteConfirmationContext =
+  createContext<ProductionWriteConfirmationContextValue | null>(null)
+
+const fallbackValue: ProductionWriteConfirmationContextValue = {
+  requestConfirmation: ({ onConfirm }) => onConfirm(),
+}
+
+export const useProductionWriteConfirmation =
+  (): ProductionWriteConfirmationContextValue =>
+    useContext(ProductionWriteConfirmationContext) ?? fallbackValue
+
+interface Props {
+  children: React.ReactNode
+}
+
+export const ProductionWriteConfirmationProvider = ({ children }: Props) => {
+  const { environment } = useDatabaseEnvironment()
+  const { name, host, port } = useSelector(connectedInstanceSelector)
+  const [pending, setPending] =
+    useState<ProductionWriteConfirmationRequest | null>(null)
+
+  // Fall back to host:port when name is empty so the modal never matches
+  // an empty input (which would bypass the type-to-confirm safety check).
+  const confirmationText = name || `${host}:${port}`
+
+  const requestConfirmation = useCallback(
+    (confirmation: ProductionWriteConfirmationRequest) => {
+      if (environment === Environment.Production) {
+        setPending(confirmation)
+        return
+      }
+      confirmation.onConfirm()
+    },
+    [environment],
+  )
+
+  const value = useMemo(() => ({ requestConfirmation }), [requestConfirmation])
+
+  return (
+    <ProductionWriteConfirmationContext.Provider value={value}>
+      {children}
+      {pending && (
+        <TypeToConfirmModal
+          confirmationText={confirmationText}
+          title={pending.title}
+          actionDescription={pending.actionDescription}
+          confirmButtonText={pending.confirmButtonText}
+          cancelButtonText={pending.cancelButtonText}
+          onConfirm={() => {
+            pending.onConfirm()
+            setPending(null)
+          }}
+          onCancel={() => {
+            pending.onCancel?.()
+            setPending(null)
+          }}
+        />
+      )}
+    </ProductionWriteConfirmationContext.Provider>
+  )
+}

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export interface ProductionWriteConfirmationRequest {
+  title?: React.ReactNode
+  actionDescription: React.ReactNode
+  confirmButtonText?: string
+  cancelButtonText?: string
+  onConfirm: () => void
+  onCancel?: () => void
+}
+
+export interface ProductionWriteConfirmationContextValue {
+  requestConfirmation: (
+    confirmation: ProductionWriteConfirmationRequest,
+  ) => void
+}

--- a/redisinsight/ui/src/components/production-write-confirmation/index.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/index.ts
@@ -1,0 +1,8 @@
+export {
+  ProductionWriteConfirmationProvider,
+  useProductionWriteConfirmation,
+} from './ProductionWriteConfirmationProvider'
+export type {
+  ProductionWriteConfirmationContextValue,
+  ProductionWriteConfirmationRequest,
+} from './ProductionWriteConfirmationProvider.types'

--- a/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.spec.tsx
@@ -1,8 +1,26 @@
 import React from 'react'
+import { Environment } from 'apiClient'
 import { render, screen, fireEvent } from 'uiSrc/utils/test-utils'
 import { stringToBuffer } from 'uiSrc/utils'
 import { KeyTypes } from 'uiSrc/constants'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 import { DeleteKeyPopover } from './DeleteKeyPopover'
+
+jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
+  useDatabaseEnvironment: jest.fn().mockReturnValue({
+    environment: 'unspecified',
+    isDangerousCommand: () => false,
+  }),
+}))
+
+const mockedUseDatabaseEnvironment = useDatabaseEnvironment as jest.Mock
+
+const setEnvironment = (environment: Environment) => {
+  mockedUseDatabaseEnvironment.mockReturnValue({
+    environment,
+    isDangerousCommand: () => false,
+  })
+}
 
 describe('DeleteKeyPopover', () => {
   const mockProps = {
@@ -16,6 +34,7 @@ describe('DeleteKeyPopover', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    setEnvironment(Environment.Unspecified)
   })
 
   it('should render delete button with proper data-testid', () => {
@@ -87,6 +106,50 @@ describe('DeleteKeyPopover', () => {
     )
 
     expect(screen.getByTestId('submit-delete-key')).toBeDisabled()
+  })
+
+  describe('environment gating', () => {
+    it('bypasses popover and calls onDelete directly in Development', () => {
+      setEnvironment(Environment.Development)
+      render(<DeleteKeyPopover {...mockProps} />)
+
+      fireEvent.click(
+        screen.getByTestId(`delete-key-btn-${mockProps.nameString}`),
+      )
+
+      expect(mockProps.onDelete).toHaveBeenCalledWith(mockProps.name)
+      expect(mockProps.onOpenPopover).not.toHaveBeenCalled()
+    })
+
+    it('opens popover in Production (current behavior)', () => {
+      setEnvironment(Environment.Production)
+      render(<DeleteKeyPopover {...mockProps} />)
+
+      fireEvent.click(
+        screen.getByTestId(`delete-key-btn-${mockProps.nameString}`),
+      )
+
+      expect(mockProps.onOpenPopover).toHaveBeenCalledWith(
+        mockProps.rowId,
+        mockProps.type,
+      )
+      expect(mockProps.onDelete).not.toHaveBeenCalled()
+    })
+
+    it('opens popover in Unspecified (current behavior)', () => {
+      setEnvironment(Environment.Unspecified)
+      render(<DeleteKeyPopover {...mockProps} />)
+
+      fireEvent.click(
+        screen.getByTestId(`delete-key-btn-${mockProps.nameString}`),
+      )
+
+      expect(mockProps.onOpenPopover).toHaveBeenCalledWith(
+        mockProps.rowId,
+        mockProps.type,
+      )
+      expect(mockProps.onDelete).not.toHaveBeenCalled()
+    })
   })
 
   it('should format long names in the confirmation message', () => {

--- a/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/components/delete-key-popover/DeleteKeyPopover.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import cx from 'classnames'
+import { Environment } from 'apiClient'
 import { KeyTypes, ModulesKeyTypes } from 'uiSrc/constants'
 import { formatLongName } from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
@@ -10,6 +11,7 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { DeleteIcon } from 'uiSrc/components/base/icons'
 import ConfirmationPopover from 'uiSrc/components/confirmation-popover'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 
 export interface DeleteProps {
   nameString: string
@@ -32,8 +34,15 @@ export const DeleteKeyPopover = ({
   onDelete,
   onOpenPopover,
 }: DeleteProps) => {
+  const { environment } = useDatabaseEnvironment()
+  const bypassConfirmation = environment === Environment.Development
+
   const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.stopPropagation()
+    if (bypassConfirmation) {
+      onDelete(name)
+      return
+    }
     onOpenPopover(rowId, type)
   }
 

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-this-in-sfc */
-import React, { Ref, useRef, useState } from 'react'
+import React, { Ref, useEffect, useRef, useState } from 'react'
+import { Environment } from 'apiClient'
 import { useDispatch, useSelector } from 'react-redux'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { IconType, EqualIcon, FoldersIcon } from 'uiSrc/components/base/icons'
@@ -42,7 +43,12 @@ import { incrementOnboardStepAction } from 'uiSrc/slices/app/features'
 import { AutoRefresh, OnboardingTour } from 'uiSrc/components'
 import { RiPopover, RiTooltip } from 'uiSrc/components/base'
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
-import { BrowserColumns, KeyValueFormat, SortOrder } from 'uiSrc/constants'
+import {
+  BrowserColumns,
+  BrowserStorageItem,
+  KeyValueFormat,
+  SortOrder,
+} from 'uiSrc/constants'
 import { ISortedColumn } from 'uiSrc/components/virtual-table/interfaces'
 
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
@@ -52,6 +58,8 @@ import { ButtonGroup } from 'uiSrc/components/base/forms/button-group/ButtonGrou
 import { ToggleButton } from 'uiSrc/components/base/forms/buttons'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { Text } from 'uiSrc/components/base/text'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { localStorageService } from 'uiSrc/services'
 import styles from './styles.module.scss'
 import * as S from './KeysHeader.styles'
 
@@ -107,12 +115,32 @@ const KeysHeader = (props: Props) => {
   const { viewType, searchMode, isFiltered } = useSelector(keysSelector)
   const { shownColumns } = useSelector(appContextDbConfig)
   const { selectedIndex } = useSelector(redisearchSelector)
+  const { environment } = useDatabaseEnvironment()
 
   const [columnsConfigShown, setColumnsConfigShown] = useState(false)
 
   const rootDivRef: Ref<HTMLDivElement> = useRef(null)
+  const productionDefaultAppliedRef = useRef(false)
 
   const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (productionDefaultAppliedRef.current) return
+    if (environment !== Environment.Production || !instanceId) return
+
+    const storedConfig = localStorageService.get(
+      BrowserStorageItem.dbConfig + instanceId,
+    )
+    const hasUserConfigured = storedConfig?.shownColumns !== undefined
+    if (!hasUserConfigured) {
+      dispatch(
+        setBrowserShownColumns(
+          shownColumns.filter((col) => col !== BrowserColumns.Size),
+        ),
+      )
+    }
+    productionDefaultAppliedRef.current = true
+  }, [environment, instanceId])
 
   // TODO: Check if encoding can be reused from BE and FE
   const format = keyNameFormat as unknown as KeyValueFormat

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -127,14 +127,16 @@ const KeysHeader = (props: Props) => {
     if (environment !== Environment.Production || !instanceId) return
 
     // Hide the Size column by default on production connections that the
-    // user hasn't configured yet. Once setBrowserShownColumns dispatches,
-    // localStorage gets the user's preference and subsequent runs of this
-    // effect (e.g., switching to another DB) see hasUserConfigured=true
-    // and skip — no double-dispatch.
+    // user hasn't configured yet. setBrowserShownColumns persists under
+    // the `browserShownColumns` key (BrowserStorageItem.browserShownColumns)
+    // — must check the same key, not `shownColumns`, otherwise the effect
+    // would re-fire after a user explicitly toggles Size on and clobber
+    // their preference.
     const storedConfig = localStorageService.get(
       BrowserStorageItem.dbConfig + instanceId,
     )
-    const hasUserConfigured = storedConfig?.shownColumns !== undefined
+    const hasUserConfigured =
+      storedConfig?.[BrowserStorageItem.browserShownColumns] !== undefined
     if (!hasUserConfigured) {
       dispatch(
         setBrowserShownColumns(

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -120,14 +120,17 @@ const KeysHeader = (props: Props) => {
   const [columnsConfigShown, setColumnsConfigShown] = useState(false)
 
   const rootDivRef: Ref<HTMLDivElement> = useRef(null)
-  const productionDefaultAppliedRef = useRef(false)
 
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (productionDefaultAppliedRef.current) return
     if (environment !== Environment.Production || !instanceId) return
 
+    // Hide the Size column by default on production connections that the
+    // user hasn't configured yet. Once setBrowserShownColumns dispatches,
+    // localStorage gets the user's preference and subsequent runs of this
+    // effect (e.g., switching to another DB) see hasUserConfigured=true
+    // and skip — no double-dispatch.
     const storedConfig = localStorageService.get(
       BrowserStorageItem.dbConfig + instanceId,
     )
@@ -139,7 +142,7 @@ const KeysHeader = (props: Props) => {
         ),
       )
     }
-    productionDefaultAppliedRef.current = true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environment, instanceId])
 
   // TODO: Check if encoding can be reused from BE and FE

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.spec.tsx
@@ -60,6 +60,13 @@ jest.mock('uiSrc/services', () => ({
   }),
 }))
 
+jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
+  useDatabaseEnvironment: () => ({
+    environment: 'unspecified',
+    isDangerousCommand: () => false,
+  }),
+}))
+
 let store: typeof mockedStore
 beforeEach(() => {
   cleanup()

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 
+import { Environment } from 'apiClient'
 import {
   initialKeyInfo,
   keysSelector,
@@ -21,6 +22,7 @@ import {
   IconButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { ConfirmationPopover } from 'uiSrc/components'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 
 export interface Props {
   onDelete: (key: RedisResponseBuffer) => void
@@ -36,6 +38,8 @@ const KeyDetailsHeaderDelete = ({ onDelete }: Props) => {
   const { viewType } = useSelector(keysSelector)
 
   const [isPopoverDeleteOpen, setIsPopoverDeleteOpen] = useState(false)
+  const { environment } = useDatabaseEnvironment()
+  const bypassConfirmation = environment === Environment.Development
 
   const tooltipContent = formatLongName(keyProp || '')
 
@@ -44,6 +48,22 @@ const KeyDetailsHeaderDelete = ({ onDelete }: Props) => {
   }
 
   const showPopoverDelete = () => {
+    if (bypassConfirmation && keyBuffer) {
+      sendEventTelemetry({
+        event: getBasedOnViewTypeEvent(
+          viewType,
+          TelemetryEvent.BROWSER_KEY_DELETE_CLICKED,
+          TelemetryEvent.TREE_VIEW_KEY_DELETE_CLICKED,
+        ),
+        eventData: {
+          databaseId: instanceId,
+          source: 'keyValue',
+          keyType: type,
+        },
+      })
+      onDelete(keyBuffer)
+      return
+    }
     setIsPopoverDeleteOpen((isPopoverDeleteOpen) => !isPopoverDeleteOpen)
     sendEventTelemetry({
       event: getBasedOnViewTypeEvent(

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
@@ -48,23 +48,6 @@ const KeyDetailsHeaderDelete = ({ onDelete }: Props) => {
   }
 
   const showPopoverDelete = () => {
-    if (bypassConfirmation && keyBuffer) {
-      sendEventTelemetry({
-        event: getBasedOnViewTypeEvent(
-          viewType,
-          TelemetryEvent.BROWSER_KEY_DELETE_CLICKED,
-          TelemetryEvent.TREE_VIEW_KEY_DELETE_CLICKED,
-        ),
-        eventData: {
-          databaseId: instanceId,
-          source: 'keyValue',
-          keyType: type,
-        },
-      })
-      onDelete(keyBuffer)
-      return
-    }
-    setIsPopoverDeleteOpen((isPopoverDeleteOpen) => !isPopoverDeleteOpen)
     sendEventTelemetry({
       event: getBasedOnViewTypeEvent(
         viewType,
@@ -77,6 +60,11 @@ const KeyDetailsHeaderDelete = ({ onDelete }: Props) => {
         keyType: type,
       },
     })
+    if (bypassConfirmation && keyBuffer) {
+      onDelete(keyBuffer)
+      return
+    }
+    setIsPopoverDeleteOpen((isPopoverDeleteOpen) => !isPopoverDeleteOpen)
   }
 
   return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
@@ -27,6 +27,7 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiTooltip } from 'uiSrc/components'
 import { CopyButton } from 'uiSrc/components/copy-button'
 import { TextInput } from 'uiSrc/components/base/inputs'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 const StyledInputWrapper = styled(Row)`
@@ -63,6 +64,7 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
   const [keyIsEditing, setKeyIsEditing] = useState(false)
   const [keyIsHovering, setKeyIsHovering] = useState(false)
   const [keyIsEditable, setKeyIsEditable] = useState(true)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     setKey(keyProp)
@@ -100,7 +102,19 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
       !isEqualBuffers(keyBuffer, newKeyBuffer) &&
       !isNull(keyProp)
     ) {
-      onEditKey(keyBuffer, newKeyBuffer, () => setKey(keyProp))
+      requestConfirmation({
+        title: 'Rename key on production database?',
+        actionDescription: (
+          <>
+            You are about to rename <strong>{keyProp}</strong> to{' '}
+            <strong>{key}</strong> on a production database.
+          </>
+        ),
+        confirmButtonText: 'Rename',
+        onConfirm: () =>
+          onEditKey(keyBuffer, newKeyBuffer, () => setKey(keyProp)),
+        onCancel: () => setKey(keyProp),
+      })
     }
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.spec.tsx
@@ -1,14 +1,128 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
-import { render } from 'uiSrc/utils/test-utils'
+import { Environment } from 'apiClient'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { stringToBuffer } from 'uiSrc/utils'
+import {
+  initialKeyInfo,
+  selectedKeyDataSelector,
+} from 'uiSrc/slices/browser/keys'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import * as useDatabaseEnvironmentModule from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { Props, KeyDetailsHeaderTTL } from './KeyDetailsHeaderTTL'
 
 const mockedProps = mock<Props>()
 
+jest.mock('uiSrc/slices/browser/keys', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/keys'),
+  selectedKeyDataSelector: jest.fn(),
+}))
+
+jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
+  connectedInstanceSelector: jest.fn().mockReturnValue({
+    id: 'db-1',
+    name: 'prod-cache',
+    host: 'localhost',
+    port: 6379,
+  }),
+}))
+
+const mockedKeyDataSelector = selectedKeyDataSelector as jest.Mock
+const mockedConnectedInstanceSelector = connectedInstanceSelector as jest.Mock
+
+const mockEnvironment = (environment: Environment) => {
+  jest
+    .spyOn(useDatabaseEnvironmentModule, 'useDatabaseEnvironment')
+    .mockReturnValue({
+      environment,
+      isDangerousCommand: () => false,
+    })
+}
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(
+    <ProductionWriteConfirmationProvider>
+      {ui}
+    </ProductionWriteConfirmationProvider>,
+  )
+
 describe('KeyDetailsHeaderTTL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedKeyDataSelector.mockReturnValue({
+      ...initialKeyInfo,
+      name: stringToBuffer('my-key'),
+      nameString: 'my-key',
+      ttl: 100,
+    })
+    mockedConnectedInstanceSelector.mockReturnValue({
+      id: 'db-1',
+      name: 'prod-cache',
+      host: 'localhost',
+      port: 6379,
+    })
+    mockEnvironment(Environment.Unspecified)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('should render', () => {
     expect(
       render(<KeyDetailsHeaderTTL {...instance(mockedProps)} />),
     ).toBeTruthy()
+  })
+
+  describe('environment gating', () => {
+    const editTTL = () => {
+      const flex = screen.getByTestId('edit-ttl-btn')
+      fireEvent.click(flex)
+      const input = screen.getByTestId('edit-ttl-input')
+      fireEvent.change(input, { target: { value: '200' } })
+      fireEvent.click(screen.getByTestId('apply-btn'))
+    }
+
+    it('calls onEditTTL immediately when Unspecified', () => {
+      const onEditTTL = jest.fn()
+      mockEnvironment(Environment.Unspecified)
+      renderWithProvider(<KeyDetailsHeaderTTL onEditTTL={onEditTTL} />)
+      editTTL()
+      expect(onEditTTL).toHaveBeenCalledTimes(1)
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-input'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('calls onEditTTL immediately when Development', () => {
+      const onEditTTL = jest.fn()
+      mockEnvironment(Environment.Development)
+      renderWithProvider(<KeyDetailsHeaderTTL onEditTTL={onEditTTL} />)
+      editTTL()
+      expect(onEditTTL).toHaveBeenCalledTimes(1)
+    })
+
+    it('defers onEditTTL behind a type-to-confirm modal when Production', () => {
+      const onEditTTL = jest.fn()
+      mockEnvironment(Environment.Production)
+      renderWithProvider(<KeyDetailsHeaderTTL onEditTTL={onEditTTL} />)
+      editTTL()
+      expect(onEditTTL).not.toHaveBeenCalled()
+      expect(
+        screen.getByTestId('type-to-confirm-modal-input'),
+      ).toBeInTheDocument()
+      // Confirm is disabled until the user types the DB name
+      expect(
+        screen.getByTestId('type-to-confirm-modal-confirm-btn'),
+      ).toBeDisabled()
+
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: 'prod-cache' },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+      expect(onEditTTL).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
@@ -15,6 +15,7 @@ import { FlexItem, Grid } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { TextInput } from 'uiSrc/components/base/inputs'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -32,6 +33,7 @@ const KeyDetailsHeaderTTL = ({ onEditTTL }: Props) => {
   const [ttl, setTTL] = useState(`${ttlProp}`)
   const [ttlIsEditing, setTTLIsEditing] = useState(false)
   const [ttlIsHovering, setTTLIsHovering] = useState(false)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     setTTL(`${ttlProp}`)
@@ -60,7 +62,19 @@ const KeyDetailsHeaderTTL = ({ onEditTTL }: Props) => {
     setTTLIsHovering(false)
 
     if (`${ttlProp}` !== ttlValue && keyBuffer) {
-      onEditTTL(keyBuffer, +ttlValue)
+      requestConfirmation({
+        title: 'Change TTL on production database?',
+        actionDescription: (
+          <>
+            You are about to change the TTL of <strong>{keyProp}</strong> to{' '}
+            <strong>{ttlValue === '-1' ? 'No limit' : `${ttlValue} s`}</strong>{' '}
+            on a production database.
+          </>
+        ),
+        confirmButtonText: 'Change TTL',
+        onConfirm: () => onEditTTL(keyBuffer, +ttlValue),
+        onCancel: () => setTTL(`${ttlProp}`),
+      })
     }
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
@@ -21,6 +21,7 @@ import {
 } from 'uiSrc/telemetry'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { isTruncatedString, Nullable } from 'uiSrc/utils'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { NoKeySelected } from './components/no-key-selected'
 import { DynamicTypeDetails } from './components/dynamic-type-details'
 
@@ -131,12 +132,14 @@ const KeyDetails = (props: Props) => {
             onClosePanel={onCloseKey}
           />
         ) : (
-          <DynamicTypeDetails
-            {...props}
-            keyType={keyType}
-            onOpenAddItemPanel={onOpenAddItemPanel}
-            onCloseAddItemPanel={onCloseAddItemPanel}
-          />
+          <ProductionWriteConfirmationProvider>
+            <DynamicTypeDetails
+              {...props}
+              keyType={keyType}
+              onOpenAddItemPanel={onOpenAddItemPanel}
+              onCloseAddItemPanel={onCloseAddItemPanel}
+            />
+          </ProductionWriteConfirmationProvider>
         )}
       </div>
     </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.spec.tsx
@@ -1,7 +1,26 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
+import { Environment } from 'apiClient'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import * as useDatabaseEnvironmentModule from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import AddHashFields, { Props } from './AddHashFields'
+
+const mockEnvironment = (environment: Environment) => {
+  jest
+    .spyOn(useDatabaseEnvironmentModule, 'useDatabaseEnvironment')
+    .mockReturnValue({
+      environment,
+      isDangerousCommand: () => false,
+    })
+}
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(
+    <ProductionWriteConfirmationProvider>
+      {ui}
+    </ProductionWriteConfirmationProvider>,
+  )
 
 const HASH_FIELD = 'hash-field'
 const HASH_VALUE = 'hash-value'
@@ -9,6 +28,15 @@ const HASH_VALUE = 'hash-value'
 const mockedProps = mock<Props>()
 
 describe('AddHashFields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEnvironment(Environment.Unspecified)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('should render', () => {
     expect(render(<AddHashFields {...instance(mockedProps)} />)).toBeTruthy()
   })
@@ -50,5 +78,40 @@ describe('AddHashFields', () => {
 
     expect(fieldName).toHaveValue('')
     expect(fieldValue).toHaveValue('')
+  })
+
+  describe('environment gating', () => {
+    it('shows production confirmation when saving in Production', () => {
+      mockEnvironment(Environment.Production)
+      renderWithProvider(<AddHashFields {...instance(mockedProps)} />)
+
+      fireEvent.click(screen.getByTestId('save-fields-btn'))
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-input'),
+      ).toBeInTheDocument()
+    })
+
+    it('does not show confirmation in Development', () => {
+      mockEnvironment(Environment.Development)
+      renderWithProvider(<AddHashFields {...instance(mockedProps)} />)
+
+      fireEvent.click(screen.getByTestId('save-fields-btn'))
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-input'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not show confirmation in Unspecified', () => {
+      mockEnvironment(Environment.Unspecified)
+      renderWithProvider(<AddHashFields {...instance(mockedProps)} />)
+
+      fireEvent.click(screen.getByTestId('save-fields-btn'))
+
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-input'),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -32,6 +32,7 @@ import {
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { AddFieldsToHashDto, HashFieldDto } from 'apiClient'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -54,6 +55,7 @@ const AddHashFields = (props: Props) => {
   const { id: instanceId } = useSelector(connectedInstanceSelector)
 
   const lastAddedFieldName = useRef<HTMLInputElement>(null)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(
     () =>
@@ -156,6 +158,20 @@ const AddHashFields = (props: Props) => {
     dispatch(addHashFieldsAction(data, onSuccessAdded))
   }
 
+  const handleSubmit = () => {
+    requestConfirmation({
+      title: 'Add fields on production database?',
+      actionDescription: (
+        <>
+          You are about to add {fields.length} field
+          {fields.length === 1 ? '' : 's'} to a hash on a production database.
+        </>
+      ),
+      confirmButtonText: 'Add fields',
+      onConfirm: submitData,
+    })
+  }
+
   const isClearDisabled = (item: IHashFieldState): boolean =>
     fields.length === 1 &&
     !(item.fieldName.length || item.fieldValue.length || item.fieldTTL?.length)
@@ -245,7 +261,7 @@ const AddHashFields = (props: Props) => {
             <PrimaryButton
               disabled={loading}
               loading={loading}
-              onClick={submitData}
+              onClick={handleSubmit}
               data-testid="save-fields-btn"
             >
               Save

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -24,6 +24,7 @@ import {
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { ListElementDestination, PushElementToListDto } from 'apiClient'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -64,6 +65,7 @@ const AddListElements = (props: Props) => {
   const elementInput = useRef<HTMLInputElement>(null)
 
   const dispatch = useDispatch()
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     // ComponentDidMount
@@ -116,6 +118,20 @@ const AddListElements = (props: Props) => {
     dispatch(insertListElementsAction(data, onSuccessAdded))
   }
 
+  const handleSubmit = () => {
+    requestConfirmation({
+      title: 'Add elements on production database?',
+      actionDescription: (
+        <>
+          You are about to push {elements.length} element
+          {elements.length === 1 ? '' : 's'} to a list on a production database.
+        </>
+      ),
+      confirmButtonText: 'Add elements',
+      onConfirm: submitData,
+    })
+  }
+
   return (
     <Col gap="m">
       <EntryContent gap="m">
@@ -160,7 +176,10 @@ const AddListElements = (props: Props) => {
         </FlexItem>
         <FlexItem>
           <div>
-            <PrimaryButton onClick={submitData} data-testid="save-elements-btn">
+            <PrimaryButton
+              onClick={handleSubmit}
+              data-testid="save-elements-btn"
+            >
               Save
             </PrimaryButton>
           </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.spec.tsx
@@ -12,6 +12,7 @@ const COUNT_INPUT = 'count-input'
 const mockedProps = mock<Props>()
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
+  ...jest.requireActual('uiSrc/slices/instances/instances'),
   connectedInstanceOverviewSelector: jest.fn().mockReturnValue({
     version: '6.2.1',
   }),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
@@ -42,7 +42,12 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { RiPopover, RiTooltip } from 'uiSrc/components/base'
 import { TextInput } from 'uiSrc/components/base/inputs'
-import { DeleteListElementsDto, ListElementDestination } from 'apiClient'
+import {
+  DeleteListElementsDto,
+  Environment,
+  ListElementDestination,
+} from 'apiClient'
+import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 
 import {
   HEAD_DESTINATION,
@@ -90,6 +95,8 @@ const RemoveListElements = (props: Props) => {
   )
   const { id: instanceId } = useSelector(connectedInstanceSelector)
   const { viewType } = useSelector(keysSelector)
+  const { environment } = useDatabaseEnvironment()
+  const bypassConfirmation = environment === Environment.Development
 
   const countInput = useRef<HTMLInputElement>(null)
 
@@ -121,7 +128,6 @@ const RemoveListElements = (props: Props) => {
   }
 
   const showPopover = () => {
-    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)
     sendEventTelemetry({
       event: getBasedOnViewTypeEvent(
         viewType,
@@ -133,6 +139,11 @@ const RemoveListElements = (props: Props) => {
         keyType: KeyTypes.List,
       },
     })
+    if (bypassConfirmation) {
+      submitData()
+      return
+    }
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)
   }
 
   const closePopover = () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
@@ -18,6 +18,13 @@ jest.mock('uiSrc/slices/browser/rejson', () => ({
   fetchReJSON: jest.fn((key) => ({ type: 'FETCH_REJSON', payload: key })),
 }))
 
+jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
+  useDatabaseEnvironment: () => ({
+    environment: 'unspecified',
+    isDangerousCommand: () => false,
+  }),
+}))
+
 const mockedProps = mock<Props>()
 
 const mockUseSelector = useSelector as jest.Mock

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
@@ -13,6 +13,7 @@ import {
   Nullable,
 } from 'uiSrc/utils'
 import FieldMessage from 'uiSrc/components/field-message/FieldMessage'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import { JSONScalarProps } from '../interfaces'
 import {
@@ -46,6 +47,7 @@ const RejsonScalar = (props: JSONScalarProps) => {
   const [deleting, setDeleting] = useState<string>('')
 
   const dispatch = useDispatch()
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     setChangedValue(stringifyScalarValue(value))
@@ -62,16 +64,24 @@ const RejsonScalar = (props: JSONScalarProps) => {
       return
     }
 
-    dispatch<any>(
-      setReJSONDataAction(
-        selectedKey,
-        path,
-        String(value),
-        true,
-        undefined,
-        () => setEditing(false),
-      ),
-    )
+    requestConfirmation({
+      title: 'Edit value on production database?',
+      actionDescription:
+        'You are about to modify a JSON value on a production database.',
+      confirmButtonText: 'Save',
+      onConfirm: () => {
+        dispatch<any>(
+          setReJSONDataAction(
+            selectedKey,
+            path,
+            String(value),
+            true,
+            undefined,
+            () => setEditing(false),
+          ),
+        )
+      },
+    })
   }
 
   return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -30,6 +30,7 @@ import {
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -50,6 +51,7 @@ const AddSetMembers = (props: Props) => {
   const { viewType } = useSelector(keysSelector)
   const { id: instanceId } = useSelector(connectedInstanceSelector)
   const lastAddedMemberName = useRef<HTMLInputElement>(null)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     lastAddedMemberName.current?.focus()
@@ -131,6 +133,20 @@ const AddSetMembers = (props: Props) => {
     dispatch(addSetMembersAction(data, onSuccessAdded))
   }
 
+  const handleSubmit = () => {
+    requestConfirmation({
+      title: 'Add members on production database?',
+      actionDescription: (
+        <>
+          You are about to add {members.length} member
+          {members.length === 1 ? '' : 's'} to a set on a production database.
+        </>
+      ),
+      confirmButtonText: 'Add members',
+      onConfirm: submitData,
+    })
+  }
+
   const isClearDisabled = (item: ISetMemberState): boolean =>
     members.length === 1 && !item.name.length
 
@@ -180,7 +196,7 @@ const AddSetMembers = (props: Props) => {
           <PrimaryButton
             disabled={loading}
             loading={loading}
-            onClick={submitData}
+            onClick={handleSubmit}
             data-testid="save-members-btn"
           >
             Save

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
@@ -25,6 +25,7 @@ import {
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { AddStreamEntriesDto } from 'apiClient'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import StreamEntryFields from './StreamEntryFields/StreamEntryFields'
 import { Panel } from 'uiSrc/components/panel'
@@ -52,6 +53,7 @@ const AddStreamEntries = (props: Props) => {
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
   const dispatch = useDispatch()
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     const isValid = !entryIdError
@@ -132,6 +134,17 @@ const AddStreamEntries = (props: Props) => {
     }
   }
 
+  const handleSubmit = () => {
+    if (!isFormValid) return
+    requestConfirmation({
+      title: 'Add entry on production database?',
+      actionDescription:
+        'You are about to add a new entry to a stream on a production database.',
+      confirmButtonText: 'Add entry',
+      onConfirm: submitData,
+    })
+  }
+
   return (
     <Col gap="m">
       <EntryContent data-test-subj="add-stream-field-panel">
@@ -153,7 +166,7 @@ const AddStreamEntries = (props: Props) => {
         <PrimaryButton
           size="m"
           color="secondary"
-          onClick={submitData}
+          onClick={handleSubmit}
           disabled={!isFormValid}
           data-testid="save-elements-btn"
         >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -60,6 +60,7 @@ import { Text } from 'uiSrc/components/base/text'
 import { TextArea } from 'uiSrc/components/base/inputs'
 import { RiTooltip } from 'uiSrc/components'
 import { ProgressBarLoader } from 'uiSrc/components/base/display'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 const MIN_ROWS = 8
@@ -108,6 +109,7 @@ const StringDetailsValue = (props: Props) => {
   const containerRef: Ref<HTMLDivElement> = useRef(null)
 
   const dispatch = useDispatch()
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(
     () => () => {
@@ -193,12 +195,22 @@ const StringDetailsValue = (props: Props) => {
   }, [isEditItem])
 
   const onApplyChanges = () => {
-    const data = stringToSerializedBufferFormat(viewFormat, areaValue)
-    const onSuccess = () => {
-      setIsEdit(false)
-      setValue(formattingBuffer(data, viewFormat, { expanded: true })?.value)
-    }
-    dispatch(updateStringValueAction(key, data, onSuccess))
+    requestConfirmation({
+      title: 'Edit value on production database?',
+      actionDescription:
+        'You are about to modify a value on a production database.',
+      confirmButtonText: 'Save',
+      onConfirm: () => {
+        const data = stringToSerializedBufferFormat(viewFormat, areaValue)
+        const onSuccess = () => {
+          setIsEdit(false)
+          setValue(
+            formattingBuffer(data, viewFormat, { expanded: true })?.value,
+          )
+        }
+        dispatch(updateStringValueAction(key, data, onSuccess))
+      },
+    })
   }
 
   const onDeclineChanges = useCallback(() => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -26,6 +26,7 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -45,6 +46,7 @@ const AddZsetMembers = (props: Props) => {
     name: undefined,
   }
   const lastAddedMemberName = useRef<HTMLInputElement>(null)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(
     () =>
@@ -172,6 +174,21 @@ const AddZsetMembers = (props: Props) => {
     dispatch(fetchAddZSetMembers(data, closePanel))
   }
 
+  const handleSubmit = () => {
+    requestConfirmation({
+      title: 'Add members on production database?',
+      actionDescription: (
+        <>
+          You are about to add {members.length} member
+          {members.length === 1 ? '' : 's'} to a sorted set on a production
+          database.
+        </>
+      ),
+      confirmButtonText: 'Add members',
+      onConfirm: submitData,
+    })
+  }
+
   const isClearDisabled = (item: IZsetMemberState): boolean =>
     members.length === 1 && !(item.name.length || item.score.length)
 
@@ -243,7 +260,7 @@ const AddZsetMembers = (props: Props) => {
             <PrimaryButton
               disabled={loading || !isFormValid}
               loading={loading}
-              onClick={submitData}
+              onClick={handleSubmit}
               data-testid="save-members-btn"
             >
               Save

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.spec.tsx
@@ -55,7 +55,7 @@ describe('EditableInput', () => {
     })
     fireEvent.click(screen.getByTestId('apply-btn'))
 
-    expect(onApply).toBeCalledWith('value', expect.any(Object))
+    expect(onApply).toBeCalledWith('value')
   })
 
   it('should call on decline', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -103,9 +103,6 @@ const EditableInput = (props: Props) => {
             onEdit?.(false)
           }}
           onApply={(value) => {
-            // Drop the InlineItemEditor's MouseEvent — consumers don't read
-            // it, and capturing it across the deferred type-to-confirm
-            // closure would forward a stale reference.
             requestConfirmation({
               title: 'Edit value on production database?',
               actionDescription:

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -9,6 +9,7 @@ import { Props as InlineItemEditorProps } from 'uiSrc/components/inline-item-edi
 import { Text } from 'uiSrc/components/base/text'
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -45,6 +46,7 @@ const EditableInput = (props: Props) => {
   } = props
 
   const [isHovering, setIsHovering] = useState(false)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   if (!isEditing) {
     return (
@@ -101,8 +103,16 @@ const EditableInput = (props: Props) => {
             onEdit?.(false)
           }}
           onApply={(value, event) => {
-            onApply(value, event)
-            onEdit?.(false)
+            requestConfirmation({
+              title: 'Edit value on production database?',
+              actionDescription:
+                'You are about to modify a value on a production database.',
+              confirmButtonText: 'Save',
+              onConfirm: () => {
+                onApply(value, event)
+                onEdit?.(false)
+              },
+            })
           }}
           validation={validation}
           variant={variant}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -23,7 +23,7 @@ export interface Props {
   validation?: (value: string) => string
   editToolTipContent?: React.ReactNode
   onDecline: (event?: React.MouseEvent<HTMLElement>) => void
-  onApply: (value: string, event: React.MouseEvent) => void
+  onApply: (value: string, event?: React.MouseEvent) => void
   testIdPrefix?: string
   variant?: InlineItemEditorProps['variant']
 }
@@ -102,14 +102,17 @@ const EditableInput = (props: Props) => {
             onDecline(event)
             onEdit?.(false)
           }}
-          onApply={(value, event) => {
+          onApply={(value) => {
+            // Drop the InlineItemEditor's MouseEvent — consumers don't read
+            // it, and capturing it across the deferred type-to-confirm
+            // closure would forward a stale reference.
             requestConfirmation({
               title: 'Edit value on production database?',
               actionDescription:
                 'You are about to modify a value on a production database.',
               confirmButtonText: 'Save',
               onConfirm: () => {
-                onApply(value, event)
+                onApply(value)
                 onEdit?.(false)
               },
             })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -94,9 +94,6 @@ const EditablePopover = (props: Props) => {
         setIsPopoverOpen(false)
         onApply()
       },
-      // Also close the popover on cancel so we don't leave the
-      // (ownFocus) RiPopover open in a focus-trap limbo behind a
-      // dismissed modal.
       onCancel: () => setIsPopoverOpen(false),
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -94,6 +94,10 @@ const EditablePopover = (props: Props) => {
         setIsPopoverOpen(false)
         onApply()
       },
+      // Also close the popover on cancel so we don't leave the
+      // (ownFocus) RiPopover open in a focus-trap limbo behind a
+      // dismissed modal.
+      onCancel: () => setIsPopoverOpen(false),
     })
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -10,6 +10,7 @@ import {
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { Loader } from 'uiSrc/components/base/display'
 import { RiPopover } from 'uiSrc/components/base'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -53,6 +54,7 @@ const EditablePopover = (props: Props) => {
   const [isHovering, setIsHovering] = useState(false)
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(isOpen)
   const [isDelayed, setIsDelayed] = useState(false)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   const delayPopover = () => {
     if (!delay) return
@@ -83,8 +85,16 @@ const EditablePopover = (props: Props) => {
   }
 
   const handleApply = (): void => {
-    setIsPopoverOpen(false)
-    onApply()
+    requestConfirmation({
+      title: 'Edit value on production database?',
+      actionDescription:
+        'You are about to modify a value on a production database.',
+      confirmButtonText: 'Save',
+      onConfirm: () => {
+        setIsPopoverOpen(false)
+        onApply()
+      },
+    })
   }
 
   const handleDecline = () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.spec.tsx
@@ -55,7 +55,7 @@ describe('EditableTextArea', () => {
     })
     fireEvent.click(screen.getByTestId('apply-btn'))
 
-    expect(onApply).toBeCalledWith('value', expect.any(Object))
+    expect(onApply).toBeCalledWith('value')
   })
 
   it('should call on decline', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -30,7 +30,7 @@ export interface Props {
   onUpdateTextAreaHeight?: () => void
   onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void
   onDecline: (event?: React.MouseEvent<HTMLElement>) => void
-  onApply: (value: string, event: React.MouseEvent) => void
+  onApply: (value: string, event?: React.MouseEvent) => void
   testIdPrefix?: string
 }
 
@@ -153,14 +153,17 @@ const EditableTextArea = (props: Props) => {
                 setValue(initialValue)
                 onEdit(false)
               }}
-              onApply={(_, event) => {
+              onApply={() => {
+                // Drop the InlineItemEditor's MouseEvent — consumers don't
+                // read it, and capturing it across the deferred type-to-
+                // confirm closure would forward a stale reference.
                 requestConfirmation({
                   title: 'Edit value on production database?',
                   actionDescription:
                     'You are about to modify a value on a production database.',
                   confirmButtonText: 'Save',
                   onConfirm: () => {
-                    onApply(value, event)
+                    onApply(value)
                     setValue(initialValue)
                     onEdit(false)
                   },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -9,6 +9,7 @@ import { Text } from 'uiSrc/components/base/text'
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { TextArea } from 'uiSrc/components/base/inputs'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -59,6 +60,7 @@ const EditableTextArea = (props: Props) => {
   const [value, setValue] = useState('')
   const [isHovering, setIsHovering] = useState(false)
   const textAreaRef: Ref<HTMLTextAreaElement> = useRef(null)
+  const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {
     setValue(initialValue)
@@ -152,9 +154,17 @@ const EditableTextArea = (props: Props) => {
                 onEdit(false)
               }}
               onApply={(_, event) => {
-                onApply(value, event)
-                setValue(initialValue)
-                onEdit(false)
+                requestConfirmation({
+                  title: 'Edit value on production database?',
+                  actionDescription:
+                    'You are about to modify a value on a production database.',
+                  confirmButtonText: 'Save',
+                  onConfirm: () => {
+                    onApply(value, event)
+                    setValue(initialValue)
+                    onEdit(false)
+                  },
+                })
               }}
               approveText={approveText}
               approveByValidation={() => approveByValidation?.(value)}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -154,9 +154,6 @@ const EditableTextArea = (props: Props) => {
                 onEdit(false)
               }}
               onApply={() => {
-                // Drop the InlineItemEditor's MouseEvent — consumers don't
-                // read it, and capturing it across the deferred type-to-
-                // confirm closure would forward a stale reference.
                 requestConfirmation({
                   title: 'Edit value on production database?',
                   actionDescription:


### PR DESCRIPTION
# What

Implements RI-8184 (epic [RI-6594](https://redislabs.atlassian.net/browse/RI-6594) — Prod vs non-prod modes). Gates Browser write actions on the per-database `environment`:

- **Production** → require type-to-confirm against the DB name (matches the pattern from RI-8185/8186/8187).
- **Development** → bypass existing delete/remove popovers.
- **Unspecified** → today's behaviour, unchanged.

A `ProductionWriteConfirmationProvider` mounted in the key-details subtree owns the single shared modal; surfaces call `requestConfirmation({ ... })` from the `useProductionWriteConfirmation` hook.

Also: hide the **key size** column by default on production DBs (still toggleable via the existing column-visibility menu).

Per discussion, the "hide Load sample data" requirement is already covered upstream — the button is disabled with an explanatory tooltip in `LoadSampleData` itself, so we didn't add a second gate in `NoKeysFound`.

## Confirmation surfaces

All surfaces share the same `TypeToConfirmModal` (the user must type the DB name — or `host:port` when name is empty — to enable confirm).

<img width="656" height="430" alt="Screenshot 2026-05-27 at 16 51 07" src="https://github.com/user-attachments/assets/af828699-fe76-4fdf-a6fc-ace1fbcb4b75" />

| Surface | Title | Confirm button | Sample description |
|---|---|---|---|
| Rename key | Rename key on production database? | Rename | You are about to rename **users:42** to **users:42-archived** on a production database. |
| Change TTL | Change TTL on production database? | Change TTL | You are about to change the TTL of **users:42** to **3600 s** on a production database. |
| Edit value (string / JSON scalar / hash field / list element / zset score / stream group) | Edit value on production database? | Save | You are about to modify a value on a production database. |
| Add fields (hash) | Add fields on production database? | Add fields | You are about to add 3 fields to a hash on a production database. |
| Add elements (list) | Add elements on production database? | Add elements | You are about to push 2 elements to a list on a production database. |
| Add members (set) | Add members on production database? | Add members | You are about to add 1 member to a set on a production database. |
| Add members (zset) | Add members on production database? | Add members | You are about to add 2 members to a sorted set on a production database. |
| Add entry (stream) | Add entry on production database? | Add entry | You are about to add a new entry to a stream on a production database. |

## Other gated surfaces (existing popovers, dev-bypass only)

| Surface | Production | Development | Unspecified |
|---|---|---|---|
| Delete key (row + header) | existing `ConfirmationPopover` | bypass — delete immediately | existing popover |
| Remove list elements | existing `RiPopover` | bypass — remove immediately | existing popover |

# Testing

- [ ] Connect a database marked as **Production**; for each surface in the table above, trigger the write action and verify the type-to-confirm modal appears, the Confirm button is disabled until the DB name is typed, Confirm dispatches the write, and Cancel resets local state.
- [ ] On the same DB, verify the key list shows **TTL** column but not **Size** by default; enable Size via the column-visibility menu and confirm it persists across reloads.
- [ ] Connect a database marked as **Development**; verify delete key (row + header) and remove list elements execute immediately without showing the existing popover.
- [ ] Connect an **Unspecified** database; verify behaviour is unchanged from current `main` for every surface (no new modal, existing popovers still show).
- [ ] Open a DB where `name` is empty — confirm the modal prompts for `host:port` and matches that.

---

Closes #RI-8184

[RI-6594]: https://redislabs.atlassian.net/browse/RI-6594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many production write paths and delete bypass in Development; incorrect environment detection could skip confirmations or block legitimate edits.
> 
> **Overview**
> Introduces **`ProductionWriteConfirmationProvider`** and **`useProductionWriteConfirmation`**, which on **Production** defer browser writes behind a shared **type-to-confirm** modal (DB **name**, or **`host:port`** when name is empty); **Development** and **Unspecified** still run writes immediately. **`KeyDetails`** mounts the provider around key-detail UIs.
> 
> **Production-gated writes** now call `requestConfirmation` before applying: rename key, TTL, string/JSON/hash/list/set/zset/stream edits and “add” panels, plus shared **`EditableInput`**, **`EditableTextArea`**, and **`EditablePopover`**.
> 
> **Development-only shortcuts**: delete key (list row + header) and remove list elements **skip** their existing confirmation popovers and execute immediately; Production/Unspecified keep prior popover behavior.
> 
> **Keys header**: on Production, **hides the Size column by default** for connections without a saved `browserShownColumns` preference (user can still enable it via Columns).
> 
> Adds/extends unit tests for the provider, delete popover, TTL, and add-hash flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f204430c58c87630b03a99c15254889d5175c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->