### PR TITLE
feat(browser): add Redis array key type support

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -321,6 +321,10 @@ export default {
         process.env.RI_COMMANDS_REDISBLOOM_URL ||
         'https://raw.githubusercontent.com/RedisBloom/RedisBloom/master/commands.json',
     },
+    {
+      name: 'redis-array',
+      url: process.env.RI_COMMANDS_ARRAY_URL || '',
+    },
   ],
   connections: {
     timeout:

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,0 +1,111 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  Logger,
+  Post,
+  Put,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiRedisInstanceOperation } from 'src/decorators/api-redis-instance-operation.decorator';
+import { BrowserClientMetadata } from 'src/modules/browser/decorators/browser-client-metadata.decorator';
+import { ApiQueryRedisStringEncoding } from 'src/common/decorators';
+import { ClientMetadata } from 'src/common/models';
+import {
+  AddElementsToArrayDto,
+  CreateArrayDto,
+  DeleteArrayElementsDto,
+  DeleteArrayElementsResponse,
+  GetArrayElementsDto,
+  GetArrayElementsResponse,
+} from 'src/modules/browser/array/dto';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+import { BrowserSerializeInterceptor } from 'src/common/interceptors';
+import { BrowserBaseController } from 'src/modules/browser/browser.base.controller';
+
+@ApiTags('Browser: Array')
+@UseInterceptors(BrowserSerializeInterceptor)
+@Controller('array')
+@UsePipes(new ValidationPipe({ transform: true }))
+export class ArrayController extends BrowserBaseController {
+  private readonly logger = new Logger(ArrayController.name);
+
+  constructor(private arrayService: ArrayService) {
+    super();
+  }
+
+  @Post('')
+  @ApiRedisInstanceOperation({
+    description: 'Create a key to hold an Array data type',
+    statusCode: 201,
+  })
+  @ApiQueryRedisStringEncoding()
+  async createArray(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: CreateArrayDto,
+  ): Promise<void> {
+    return await this.arrayService.createArray(clientMetadata, dto);
+  }
+
+  @Put('')
+  @ApiRedisInstanceOperation({
+    description: 'Set elements at specified indices in the Array stored at key',
+    statusCode: 200,
+  })
+  @ApiQueryRedisStringEncoding()
+  async addElements(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: AddElementsToArrayDto,
+  ): Promise<void> {
+    return await this.arrayService.addElements(clientMetadata, dto);
+  }
+
+  // The key name can be very large, so it is better to send it in the request body
+  @Post('/get-elements')
+  @HttpCode(200)
+  @ApiRedisInstanceOperation({
+    description:
+      'Get elements of the Array stored at key using ARSCAN cursor-based pagination. ' +
+      'Only non-empty slots are returned. Pass the returned `nextCursor` as `cursor` to fetch the next page.',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: GetArrayElementsResponse,
+      },
+    ],
+  })
+  @ApiQueryRedisStringEncoding()
+  async getElements(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: GetArrayElementsDto,
+  ): Promise<GetArrayElementsResponse> {
+    return await this.arrayService.getElements(clientMetadata, dto);
+  }
+
+  @Delete('/elements')
+  @ApiRedisInstanceOperation({
+    description:
+      'Delete elements at the specified indices from the Array stored at key',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Ok',
+        type: DeleteArrayElementsResponse,
+      },
+    ],
+  })
+  @ApiQueryRedisStringEncoding()
+  async deleteElements(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: DeleteArrayElementsDto,
+  ): Promise<DeleteArrayElementsResponse> {
+    return await this.arrayService.deleteElements(clientMetadata, dto);
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.module.ts
+++ b/redisinsight/api/src/modules/browser/array/array.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+import { ArrayController } from 'src/modules/browser/array/array.controller';
+
+@Module({})
+export class ArrayModule {
+  static register({ route }): DynamicModule {
+    return {
+      module: ArrayModule,
+      imports: [
+        RouterModule.register([
+          {
+            path: route,
+            module: ArrayModule,
+          },
+        ]),
+      ],
+      controllers: [ArrayController],
+      providers: [ArrayService],
+    };
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -157,12 +157,14 @@ export class ArrayService {
         }),
       );
 
-      // If we got a full page, the next scan starts one past the last returned index.
-      // Only set nextCursor when the candidate position is still within the array's
-      // logical length — this avoids an unnecessary follow-up request when the number
-      // of populated elements is an exact multiple of the page size.
+      // Set nextCursor to one past the last returned index if that position is
+      // still within the array's logical length. Using logicalLength as the sole
+      // gate (rather than elements.length >= count) correctly handles both cases:
+      // - exact-multiple page size: last index + 1 === logicalLength → no cursor
+      // - sparse arrays where ARSCAN may return fewer than count elements due to
+      //   its internal iteration budget but more populated elements still exist
       let nextCursor: number | undefined;
-      if (elements.length >= count && elements.length > 0) {
+      if (elements.length > 0) {
         const candidate = elements[elements.length - 1].index + 1;
         if (candidate < logicalLength) {
           nextCursor = candidate;

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -157,23 +157,15 @@ export class ArrayService {
         }),
       );
 
-      // Determine whether there is more data to page through.
+      // ARSCAN scans the full range [cursor, MAX_SAFE_INTEGER] and returns all
+      // populated entries up to LIMIT. Zero results therefore definitively means
+      // no more elements exist from this cursor onwards — advance past the last
+      // returned index only when there are results and space remains.
       let nextCursor: number | undefined;
       if (elements.length > 0) {
-        // Normal case: advance past the last returned element's index.
         const candidate = elements[elements.length - 1].index + 1;
         if (candidate < logicalLength) {
           nextCursor = candidate;
-        }
-      } else if (cursor < logicalLength) {
-        // ARSCAN returned zero elements — the scanned region contained no
-        // populated slots within its iteration budget (extremely sparse array).
-        // Advance by count to skip the empty gap and continue pagination.
-        // If the advanced position still falls within the array, set nextCursor
-        // so the frontend knows to keep going.
-        const advanced = cursor + count;
-        if (advanced < logicalLength) {
-          nextCursor = advanced;
         }
       }
 

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -129,30 +129,27 @@ export class ArrayService {
 
       await checkIfKeyNotExists(keyName, client);
 
-      // Fetch element count (ARCOUNT) and logical length (ARLEN) in one pipeline
-      const [[, total = 0], [, logicalLength = 0]] = (await client.sendPipeline(
-        [
+      // Fetch metadata and elements in a single pipeline — all three commands are
+      // independent of each other's results so there is no ordering requirement.
+      // ARSCAN key start end [LIMIT limit]: returns [[index, value], ...] pairs.
+      // Use Number.MAX_SAFE_INTEGER as the upper bound so LIMIT drives pagination.
+      const [[, total = 0], [, logicalLength = 0], [, rawScan]] =
+        (await client.sendPipeline([
           [BrowserToolArrayCommands.ArCount, keyName],
           [BrowserToolArrayCommands.ArLen, keyName],
-        ],
-      )) as [any, number][];
-
-      // ARSCAN key start end [LIMIT limit]
-      // start/end are inclusive integer index bounds; LIMIT caps the number of results.
-      // Use Number.MAX_SAFE_INTEGER as the upper bound so LIMIT drives pagination.
-      // Returns an array of [index, value] pairs: [[0, "foo"], [1, "bar"], ...]
-      const rawScan = (await client.sendCommand([
-        BrowserToolArrayCommands.ArScan,
-        keyName,
-        cursor,
-        Number.MAX_SAFE_INTEGER,
-        'LIMIT',
-        count,
-      ])) as [number | Buffer, Buffer][];
+          [
+            BrowserToolArrayCommands.ArScan,
+            keyName,
+            cursor,
+            Number.MAX_SAFE_INTEGER,
+            'LIMIT',
+            count,
+          ],
+        ])) as [any, any][];
 
       // Map each [index, value] pair into an ArrayElementDto
       const elements: ArrayElementDto[] = (
-        rawScan as [number | Buffer, Buffer][]
+        (rawScan ?? []) as [number | Buffer, Buffer][]
       ).map((pair) =>
         plainToInstance(ArrayElementDto, {
           index: Number(pair[0]),

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -140,7 +140,7 @@ export class ArrayService {
       // ARSCAN key start end [LIMIT limit]
       // start/end are inclusive integer index bounds; LIMIT caps the number of results.
       // Use Number.MAX_SAFE_INTEGER as the upper bound so LIMIT drives pagination.
-      // Returns a flat list: [index, value, index, value, ...]
+      // Returns an array of [index, value] pairs: [[0, "foo"], [1, "bar"], ...]
       const rawScan = (await client.sendCommand([
         BrowserToolArrayCommands.ArScan,
         keyName,
@@ -150,7 +150,7 @@ export class ArrayService {
         count,
       ])) as [number | Buffer, Buffer][];
 
-      // ARSCAN returns an array of [index, value] pairs: [[0, "foo"], [1, "bar"], ...]
+      // Map each [index, value] pair into an ArrayElementDto
       const elements: ArrayElementDto[] = (
         rawScan as [number | Buffer, Buffer][]
       ).map((pair) =>

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -157,17 +157,23 @@ export class ArrayService {
         }),
       );
 
-      // Set nextCursor to one past the last returned index if that position is
-      // still within the array's logical length. Using logicalLength as the sole
-      // gate (rather than elements.length >= count) correctly handles both cases:
-      // - exact-multiple page size: last index + 1 === logicalLength → no cursor
-      // - sparse arrays where ARSCAN may return fewer than count elements due to
-      //   its internal iteration budget but more populated elements still exist
+      // Determine whether there is more data to page through.
       let nextCursor: number | undefined;
       if (elements.length > 0) {
+        // Normal case: advance past the last returned element's index.
         const candidate = elements[elements.length - 1].index + 1;
         if (candidate < logicalLength) {
           nextCursor = candidate;
+        }
+      } else if (cursor < logicalLength) {
+        // ARSCAN returned zero elements — the scanned region contained no
+        // populated slots within its iteration budget (extremely sparse array).
+        // Advance by count to skip the empty gap and continue pagination.
+        // If the advanced position still falls within the array, set nextCursor
+        // so the frontend knows to keep going.
+        const advanced = cursor + count;
+        if (advanced < logicalLength) {
+          nextCursor = advanced;
         }
       }
 

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -131,6 +131,9 @@ export class ArrayService {
 
       // Fetch metadata and elements in a single pipeline — all three commands are
       // independent of each other's results so there is no ordering requirement.
+      // Issuing ARLEN and ARSCAN in the same pipeline guarantees they reflect the
+      // same point-in-time snapshot, so logicalLength is never stale relative to
+      // the scan results.
       // ARSCAN key start end [LIMIT limit]: returns [[index, value], ...] pairs.
       // Use Number.MAX_SAFE_INTEGER as the upper bound so LIMIT drives pagination.
       const [[, total = 0], [, logicalLength = 0], [, rawScan]] =

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -160,10 +160,16 @@ export class ArrayService {
         }),
       );
 
-      // If we got a full page, the next scan starts one past the last returned index
+      // If we got a full page, the next scan starts one past the last returned index.
+      // Only set nextCursor when the candidate position is still within the array's
+      // logical length — this avoids an unnecessary follow-up request when the number
+      // of populated elements is an exact multiple of the page size.
       let nextCursor: number | undefined;
       if (elements.length >= count && elements.length > 0) {
-        nextCursor = elements[elements.length - 1].index + 1;
+        const candidate = elements[elements.length - 1].index + 1;
+        if (candidate < logicalLength) {
+          nextCursor = candidate;
+        }
       }
 
       this.logger.debug(

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -1,0 +1,239 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { catchAclError, catchMultiTransactionError } from 'src/utils';
+import { RedisErrorCodes } from 'src/constants';
+import { ReplyError } from 'src/models';
+import {
+  BrowserToolKeysCommands,
+  BrowserToolArrayCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
+import { plainToInstance } from 'class-transformer';
+import { ClientMetadata } from 'src/common/models';
+import {
+  AddElementsToArrayDto,
+  ArrayElementDto,
+  CreateArrayDto,
+  DeleteArrayElementsDto,
+  DeleteArrayElementsResponse,
+  GetArrayElementsDto,
+  GetArrayElementsResponse,
+} from 'src/modules/browser/array/dto';
+import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { RedisClient, RedisClientCommand } from 'src/modules/redis/client';
+import {
+  checkIfKeyExists,
+  checkIfKeyNotExists,
+} from 'src/modules/browser/utils';
+
+@Injectable()
+export class ArrayService {
+  private logger = new Logger('ArrayService');
+
+  constructor(private databaseClientFactory: DatabaseClientFactory) {}
+
+  public async createArray(
+    clientMetadata: ClientMetadata,
+    dto: CreateArrayDto,
+  ): Promise<void> {
+    try {
+      this.logger.debug('Creating Array data type.', clientMetadata);
+      const { keyName, elements, expire } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyExists(keyName, client);
+
+      // Build ARMSET command: ARMSET key index1 value1 index2 value2 ...
+      const armsetArgs: (string | number | Buffer)[] = [keyName];
+      elements.forEach(({ index, value }) => {
+        armsetArgs.push(index, value);
+      });
+
+      const commands: RedisClientCommand[] = [
+        [BrowserToolArrayCommands.ArMSet, ...armsetArgs],
+      ];
+
+      if (expire) {
+        commands.push([
+          BrowserToolKeysCommands.Expire,
+          keyName,
+          expire,
+        ] as RedisClientCommand);
+      }
+
+      const transactionResults = await client.sendPipeline(commands);
+      catchMultiTransactionError(transactionResults);
+
+      this.logger.debug('Succeed to create Array data type.', clientMetadata);
+    } catch (error) {
+      this.logger.error(
+        'Failed to create Array data type.',
+        error,
+        clientMetadata,
+      );
+      this.throwWrongTypeOrAcl(error);
+    }
+  }
+
+  public async addElements(
+    clientMetadata: ClientMetadata,
+    dto: AddElementsToArrayDto,
+  ): Promise<void> {
+    try {
+      this.logger.debug(
+        'Adding elements to the Array data type.',
+        clientMetadata,
+      );
+      const { keyName, elements } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyNotExists(keyName, client);
+
+      // Build ARMSET command: ARMSET key index1 value1 index2 value2 ...
+      const armsetArgs: (string | number | Buffer)[] = [keyName];
+      elements.forEach(({ index, value }) => {
+        armsetArgs.push(index, value);
+      });
+
+      await client.sendCommand([
+        BrowserToolArrayCommands.ArMSet,
+        ...armsetArgs,
+      ]);
+
+      this.logger.debug(
+        'Succeed to add elements to Array data type.',
+        clientMetadata,
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to add elements to Array data type.',
+        error,
+        clientMetadata,
+      );
+      this.throwWrongTypeOrAcl(error);
+    }
+  }
+
+  public async getElements(
+    clientMetadata: ClientMetadata,
+    dto: GetArrayElementsDto,
+  ): Promise<GetArrayElementsResponse> {
+    try {
+      this.logger.debug(
+        'Getting elements of the Array data type.',
+        clientMetadata,
+      );
+      const { keyName, cursor = 0, count } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyNotExists(keyName, client);
+
+      // Fetch element count (ARCOUNT) and logical length (ARLEN) in one pipeline
+      const [[, total = 0], [, logicalLength = 0]] = (await client.sendPipeline(
+        [
+          [BrowserToolArrayCommands.ArCount, keyName],
+          [BrowserToolArrayCommands.ArLen, keyName],
+        ],
+      )) as [any, number][];
+
+      // ARSCAN key start end [LIMIT limit]
+      // start/end are inclusive integer index bounds; LIMIT caps the number of results.
+      // Use Number.MAX_SAFE_INTEGER as the upper bound so LIMIT drives pagination.
+      // Returns a flat list: [index, value, index, value, ...]
+      const rawScan = (await client.sendCommand([
+        BrowserToolArrayCommands.ArScan,
+        keyName,
+        cursor,
+        Number.MAX_SAFE_INTEGER,
+        'LIMIT',
+        count,
+      ])) as [number | Buffer, Buffer][];
+
+      // ARSCAN returns an array of [index, value] pairs: [[0, "foo"], [1, "bar"], ...]
+      const elements: ArrayElementDto[] = (
+        rawScan as [number | Buffer, Buffer][]
+      ).map((pair) =>
+        plainToInstance(ArrayElementDto, {
+          index: Number(pair[0]),
+          value: pair[1],
+        }),
+      );
+
+      // If we got a full page, the next scan starts one past the last returned index
+      let nextCursor: number | undefined;
+      if (elements.length >= count && elements.length > 0) {
+        nextCursor = elements[elements.length - 1].index + 1;
+      }
+
+      this.logger.debug(
+        'Succeed to get elements of the Array data type.',
+        clientMetadata,
+      );
+
+      return plainToInstance(GetArrayElementsResponse, {
+        keyName,
+        total,
+        logicalLength,
+        nextCursor,
+        elements,
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to get elements of the Array data type.',
+        error,
+        clientMetadata,
+      );
+      this.throwWrongTypeOrAcl(error);
+    }
+  }
+
+  public async deleteElements(
+    clientMetadata: ClientMetadata,
+    dto: DeleteArrayElementsDto,
+  ): Promise<DeleteArrayElementsResponse> {
+    try {
+      this.logger.debug(
+        'Deleting elements from the Array data type.',
+        clientMetadata,
+      );
+      const { keyName, indices } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyNotExists(keyName, client);
+
+      if (!indices.length) {
+        return { affected: 0 };
+      }
+
+      // ARDEL key index1 index2 ... — deletes all specified indices in one call
+      const affected = (await client.sendCommand([
+        BrowserToolArrayCommands.ArDel,
+        keyName,
+        ...indices,
+      ])) as number;
+
+      this.logger.debug(
+        'Succeed to delete elements from the Array data type.',
+        clientMetadata,
+      );
+
+      return { affected };
+    } catch (error) {
+      this.logger.error(
+        'Failed to delete elements from the Array data type.',
+        error,
+        clientMetadata,
+      );
+      this.throwWrongTypeOrAcl(error);
+    }
+  }
+
+  private throwWrongTypeOrAcl(error: ReplyError): never {
+    if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+      throw new BadRequestException(error.message);
+    }
+    throw catchAclError(error);
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/dto/add.array-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/add.array-element.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsRedisString, RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+export class AddArrayElementDto {
+  @ApiProperty({
+    description: 'Zero-based index at which to set the element.',
+    type: Number,
+    minimum: 0,
+  })
+  @IsDefined()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  index: number;
+
+  @ApiProperty({
+    type: String,
+    description: 'Element value.',
+  })
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  value: RedisString;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/add.elements-to-array.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/add.elements-to-array.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsDefined,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import { AddArrayElementDto } from './add.array-element.dto';
+
+export class AddElementsToArrayDto extends KeyDto {
+  @ApiProperty({
+    description:
+      'Array elements to add. Each element specifies an index and value.',
+    isArray: true,
+    type: AddArrayElementDto,
+  })
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => AddArrayElementDto)
+  elements: AddArrayElementDto[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/create.array.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/create.array.dto.ts
@@ -1,0 +1,8 @@
+import { IntersectionType } from '@nestjs/swagger';
+import { KeyWithExpireDto } from 'src/modules/browser/keys/dto';
+import { AddElementsToArrayDto } from './add.elements-to-array.dto';
+
+export class CreateArrayDto extends IntersectionType(
+  AddElementsToArrayDto,
+  KeyWithExpireDto,
+) {}

--- a/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsDefined, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+
+export class DeleteArrayElementsDto extends KeyDto {
+  @ApiProperty({
+    description: 'Indices of the elements to delete.',
+    type: Number,
+    isArray: true,
+  })
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  @Type(() => Number)
+  indices: number[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.response.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteArrayElementsResponse {
+  @ApiProperty({
+    description: 'Total number of array elements removed.',
+    type: Number,
+  })
+  affected: number;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/get.array-elements.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/get.array-elements.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+
+export class GetArrayElementsDto extends KeyDto {
+  @ApiPropertyOptional({
+    description:
+      'Start index for ARSCAN. Pass 0 to start from the beginning of the array.',
+    type: Number,
+    minimum: 0,
+    default: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  cursor?: number = 0;
+
+  @ApiProperty({
+    description: 'Number of elements to return per page.',
+    type: Number,
+    minimum: 1,
+    default: 500,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  count: number = 500;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/get.array-elements.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/get.array-elements.response.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { KeyResponse } from 'src/modules/browser/keys/dto';
+import { RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+export class ArrayElementDto {
+  @ApiProperty({
+    description: 'Zero-based index of the element.',
+    type: Number,
+  })
+  index: number;
+
+  @ApiProperty({
+    description: 'Value stored at this index.',
+    type: String,
+  })
+  @RedisStringType()
+  value: RedisString;
+}
+
+export class GetArrayElementsResponse extends KeyResponse {
+  @ApiProperty({
+    type: Number,
+    description: 'Number of non-empty elements in the array (ARCOUNT).',
+  })
+  total: number;
+
+  @ApiProperty({
+    type: Number,
+    description: 'Logical length of the array: highest set index + 1 (ARLEN).',
+  })
+  logicalLength: number;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description:
+      'Cursor for the next page. Pass as `cursor` in the next request. ' +
+      'Null when there are no more elements to fetch.',
+  })
+  nextCursor?: number;
+
+  @ApiProperty({
+    description: 'Array elements returned from ARSCAN.',
+    isArray: true,
+    type: ArrayElementDto,
+  })
+  elements: ArrayElementDto[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -1,0 +1,7 @@
+export * from './add.array-element.dto';
+export * from './add.elements-to-array.dto';
+export * from './create.array.dto';
+export * from './get.array-elements.dto';
+export * from './get.array-elements.response';
+export * from './delete.array-elements.dto';
+export * from './delete.array-elements.response';

--- a/redisinsight/api/src/modules/browser/browser.module.ts
+++ b/redisinsight/api/src/modules/browser/browser.module.ts
@@ -10,6 +10,7 @@ import { StreamModule } from 'src/modules/browser/stream/stream.module';
 import { RedisearchModule } from 'src/modules/browser/redisearch/redisearch.module';
 import { KeysModule } from 'src/modules/browser/keys/keys.module';
 import { VectorSetModule } from 'src/modules/browser/vector-set/vector-set.module';
+import { ArrayModule } from 'src/modules/browser/array/array.module';
 import { BrowserHistoryRepository } from './browser-history/repositories/browser-history.repository';
 import { LocalBrowserHistoryRepository } from './browser-history/repositories/local.browser-history.repository';
 
@@ -34,6 +35,7 @@ export class BrowserModule {
         RedisearchModule.register({ route }),
         KeysModule.register({ route }),
         VectorSetModule.register({ route }),
+        ArrayModule.register({ route }),
       ],
       exports: [BrowserHistoryModule],
     };

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -115,16 +115,16 @@ export enum BrowserToolVectorSetCommands {
 }
 
 export enum BrowserToolArrayCommands {
-  ArSet = 'arset',
-  ArGet = 'arget',
-  ArMSet = 'armset',
-  ArMGet = 'armget',
-  ArDel = 'ardel',
-  ArLen = 'arlen',
-  ArCount = 'arcount',
-  ArScan = 'arscan',
-  ArInsert = 'arinsert',
-  ArInfo = 'arinfo',
+  ArSet = 'ARSET',
+  ArGet = 'ARGET',
+  ArMSet = 'ARMSET',
+  ArMGet = 'ARMGET',
+  ArDel = 'ARDEL',
+  ArLen = 'ARLEN',
+  ArCount = 'ARCOUNT',
+  ArScan = 'ARSCAN',
+  ArInsert = 'ARINSERT',
+  ArInfo = 'ARINFO',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -114,6 +114,19 @@ export enum BrowserToolVectorSetCommands {
   VSim = 'VSIM',
 }
 
+export enum BrowserToolArrayCommands {
+  ArSet = 'arset',
+  ArGet = 'arget',
+  ArMSet = 'armset',
+  ArMGet = 'armget',
+  ArDel = 'ardel',
+  ArLen = 'arlen',
+  ArCount = 'arcount',
+  ArScan = 'arscan',
+  ArInsert = 'arinsert',
+  ArInfo = 'arinfo',
+}
+
 export type BrowserToolCommands =
   | BrowserToolKeysCommands
   | BrowserToolStringCommands
@@ -125,4 +138,5 @@ export type BrowserToolCommands =
   | BrowserToolStreamCommands
   | BrowserToolGraphCommands
   | BrowserToolTSCommands
-  | BrowserToolVectorSetCommands;
+  | BrowserToolVectorSetCommands
+  | BrowserToolArrayCommands;

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -116,14 +116,11 @@ export enum BrowserToolVectorSetCommands {
 
 export enum BrowserToolArrayCommands {
   ArSet = 'ARSET',
-  ArGet = 'ARGET',
   ArMSet = 'ARMSET',
-  ArMGet = 'ARMGET',
   ArDel = 'ARDEL',
   ArLen = 'ARLEN',
   ArCount = 'ARCOUNT',
   ArScan = 'ARSCAN',
-  ArInsert = 'ARINSERT',
   ArInfo = 'ARINFO',
 }
 

--- a/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.response.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/get.keys-info.response.ts
@@ -45,4 +45,22 @@ export class GetKeyInfoResponse {
     description: 'The vector dimensions for vector set keys.',
   })
   vectorDim?: number;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'The next insert index for array keys.',
+  })
+  nextInsertIndex?: number;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'The number of slices for array keys.',
+  })
+  slices?: number;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'The slice size in bytes for array keys.',
+  })
+  sliceSize?: number;
 }

--- a/redisinsight/api/src/modules/browser/keys/dto/key.dto.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/key.dto.ts
@@ -17,6 +17,7 @@ export enum RedisDataType {
   Graph = 'graphdata',
   TS = 'TSDB-TYPE',
   VectorSet = 'vectorset',
+  Array = 'array',
 }
 
 export class KeyDto {

--- a/redisinsight/api/src/modules/browser/keys/key-info/key-info.provider.ts
+++ b/redisinsight/api/src/modules/browser/keys/key-info/key-info.provider.ts
@@ -9,6 +9,7 @@ import { TsKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/
 import { UnsupportedKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/unsupported.key-info.strategy';
 import { VectorSetKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/vector-set.key-info.strategy';
 import { ZSetKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/z-set.key-info.strategy';
+import { ArrayKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/array.key-info.strategy';
 import { KeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/key-info.strategy';
 import { RedisDataType } from 'src/modules/browser/keys/dto';
 import { Injectable } from '@nestjs/common';
@@ -27,6 +28,7 @@ export class KeyInfoProvider {
     private readonly unsupportedKeyInfoStrategy: UnsupportedKeyInfoStrategy,
     private readonly vectorSetKeyInfoStrategy: VectorSetKeyInfoStrategy,
     private readonly zSetKeyInfoStrategy: ZSetKeyInfoStrategy,
+    private readonly arrayKeyInfoStrategy: ArrayKeyInfoStrategy,
   ) {}
 
   getStrategy(type?: string): KeyInfoStrategy {
@@ -51,6 +53,8 @@ export class KeyInfoProvider {
         return this.vectorSetKeyInfoStrategy;
       case RedisDataType.ZSet:
         return this.zSetKeyInfoStrategy;
+      case RedisDataType.Array:
+        return this.arrayKeyInfoStrategy;
       default:
         return this.unsupportedKeyInfoStrategy;
     }

--- a/redisinsight/api/src/modules/browser/keys/key-info/strategies/array.key-info.strategy.ts
+++ b/redisinsight/api/src/modules/browser/keys/key-info/strategies/array.key-info.strategy.ts
@@ -1,0 +1,124 @@
+import {
+  GetKeyInfoResponse,
+  RedisDataType,
+} from 'src/modules/browser/keys/dto';
+import {
+  BrowserToolKeysCommands,
+  BrowserToolArrayCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
+import { RedisString } from 'src/common/constants';
+import { KeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/key-info.strategy';
+import { RedisClient } from 'src/modules/redis/client';
+import { MAX_KEY_SIZE } from 'src/modules/browser/keys/key-info/constants';
+
+enum ArInfoField {
+  NextInsertIndex = 'next-insert-index',
+  Slices = 'slices',
+  SliceSize = 'slice-size',
+}
+
+interface ArrayInfo {
+  nextInsertIndex?: number;
+  slices?: number;
+  sliceSize?: number;
+}
+
+export class ArrayKeyInfoStrategy extends KeyInfoStrategy {
+  /**
+   * Parse ARINFO response to extract metadata.
+   * ARINFO returns a flat array like:
+   * ["count","4","len","4","next-insert-index","0","slices","1","slice-size","4096",...]
+   */
+  private parseArInfo(arInfoResponse: (string | number)[]): ArrayInfo {
+    const result: ArrayInfo = {};
+
+    if (!Array.isArray(arInfoResponse)) {
+      return result;
+    }
+
+    if (arInfoResponse.length % 2 !== 0) {
+      this.logger.warn(
+        `ARINFO response length ${arInfoResponse.length} is odd; dropping trailing unpaired entry.`,
+      );
+    }
+
+    for (let i = 0; i < arInfoResponse.length - 1; i += 2) {
+      const key = String(arInfoResponse[i]).toLowerCase();
+      const value = arInfoResponse[i + 1];
+
+      if (key === ArInfoField.NextInsertIndex) {
+        result.nextInsertIndex = Number(value);
+      } else if (key === ArInfoField.Slices) {
+        result.slices = Number(value);
+      } else if (key === ArInfoField.SliceSize) {
+        result.sliceSize = Number(value);
+      }
+    }
+
+    return result;
+  }
+
+  public async getInfo(
+    client: RedisClient,
+    key: RedisString,
+    type: string,
+    includeSize: boolean,
+  ): Promise<GetKeyInfoResponse> {
+    this.logger.debug(`Getting ${RedisDataType.Array} type info.`);
+
+    if (includeSize !== false) {
+      const [
+        [, ttl = null],
+        [, length = null],
+        [, size = null],
+        [, arInfo = []],
+      ] = (await client.sendPipeline([
+        [BrowserToolKeysCommands.Ttl, key],
+        [BrowserToolArrayCommands.ArCount, key],
+        [BrowserToolKeysCommands.MemoryUsage, key, 'samples', '0'],
+        [BrowserToolArrayCommands.ArInfo, key],
+      ])) as [any, any][];
+
+      const { nextInsertIndex, slices, sliceSize } = this.parseArInfo(arInfo);
+
+      return {
+        name: key,
+        type,
+        ttl,
+        size,
+        length,
+        nextInsertIndex,
+        slices,
+        sliceSize,
+      };
+    }
+
+    const [[, ttl = null], [, length = null], [, arInfo = []]] =
+      (await client.sendPipeline([
+        [BrowserToolKeysCommands.Ttl, key],
+        [BrowserToolArrayCommands.ArCount, key],
+        [BrowserToolArrayCommands.ArInfo, key],
+      ])) as [any, any][];
+
+    const { nextInsertIndex, slices, sliceSize } = this.parseArInfo(arInfo);
+
+    let size = -1;
+    if (length < MAX_KEY_SIZE) {
+      const sizeData = (await client.sendPipeline([
+        [BrowserToolKeysCommands.MemoryUsage, key, 'samples', '0'],
+      ])) as [any, number][];
+      size = sizeData && sizeData[0] && sizeData[0][1];
+    }
+
+    return {
+      name: key,
+      type,
+      ttl,
+      size,
+      length,
+      nextInsertIndex,
+      slices,
+      sliceSize,
+    };
+  }
+}

--- a/redisinsight/api/src/modules/browser/keys/keys.module.ts
+++ b/redisinsight/api/src/modules/browser/keys/keys.module.ts
@@ -17,6 +17,7 @@ import { TsKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/
 import { UnsupportedKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/unsupported.key-info.strategy';
 import { VectorSetKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/vector-set.key-info.strategy';
 import { ZSetKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/z-set.key-info.strategy';
+import { ArrayKeyInfoStrategy } from 'src/modules/browser/keys/key-info/strategies/array.key-info.strategy';
 
 @Module({})
 export class KeysModule {
@@ -53,6 +54,7 @@ export class KeysModule {
         UnsupportedKeyInfoStrategy,
         VectorSetKeyInfoStrategy,
         ZSetKeyInfoStrategy,
+        ArrayKeyInfoStrategy,
       ],
     };
   }

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -10,6 +10,7 @@ import {
 import { RedisString } from 'src/common/constants';
 import { ClientMetadata } from 'src/common/models';
 import {
+  BrowserToolArrayCommands,
   BrowserToolHashCommands,
   BrowserToolVectorSetCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
@@ -45,6 +46,17 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSetAttr);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VRem);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSim);
+    // Array commands
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArSet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArGet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArMSet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArMGet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArDel);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArLen);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArCount);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArScan);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArInsert);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArInfo);
   }
 
   static prepareCommandOptions(options: IRedisClientCommandOptions): any {

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -48,14 +48,11 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSim);
     // Array commands
     client.addBuiltinCommand(BrowserToolArrayCommands.ArSet);
-    client.addBuiltinCommand(BrowserToolArrayCommands.ArGet);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArMSet);
-    client.addBuiltinCommand(BrowserToolArrayCommands.ArMGet);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArDel);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArLen);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArCount);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArScan);
-    client.addBuiltinCommand(BrowserToolArrayCommands.ArInsert);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArInfo);
   }
 

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -64,6 +64,10 @@ enum ApiEndpoints {
   REJSON_SET = 'rejson-rl/set',
   REJSON_ARRAPPEND = 'rejson-rl/arrappend',
 
+  ARRAY = 'array',
+  ARRAY_GET_ELEMENTS = 'array/get-elements',
+  ARRAY_ELEMENTS = 'array/elements',
+
   VECTOR_SET = 'vector-set',
   VECTOR_SET_GET_ELEMENTS = 'vector-set/get-elements',
   VECTOR_SET_ELEMENTS = 'vector-set/elements',

--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -15,6 +15,6 @@ export const CommandsVersions = {
     since: '8.0',
   },
   ARRAY: {
-    since: '8.0',
+    since: '8.8',
   },
 }

--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -14,4 +14,7 @@ export const CommandsVersions = {
   VECTOR_SET: {
     since: '8.0',
   },
+  ARRAY: {
+    since: '8.0',
+  },
 }

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -12,6 +12,7 @@ export enum FeatureFlags {
   databaseManagement = 'databaseManagement',
   vectorSearchV2 = 'vectorSearchV2',
   devVectorSet = 'dev-vectorSet',
+  devArray = 'dev-array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
   devProdMode = 'dev-prodMode',

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -12,6 +12,7 @@ export enum KeyTypes {
   JSON = 'json',
   Stream = 'stream',
   VectorSet = 'vectorset',
+  Array = 'array',
 }
 
 export const SEARCHABLE_KEY_TYPES: KeyTypes[] = [KeyTypes.Hash, KeyTypes.ReJSON]
@@ -31,6 +32,7 @@ export const GROUP_TYPES_DISPLAY = Object.freeze({
   [KeyTypes.JSON]: 'JSON',
   [KeyTypes.Stream]: 'Stream',
   [KeyTypes.VectorSet]: 'Vector Set',
+  [KeyTypes.Array]: 'Array',
   [ModulesKeyTypes.TimeSeries]: 'Time Series',
   [CommandGroup.Bitmap]: 'Bitmap',
   [CommandGroup.Cluster]: 'Cluster',
@@ -64,6 +66,7 @@ export const GROUP_TYPES_COLORS = Object.freeze({
   [KeyTypes.JSON]: 'var(--typeReJSONColor)',
   [KeyTypes.Stream]: 'var(--typeStreamColor)',
   [KeyTypes.VectorSet]: 'var(--typeVectorSetColor)',
+  [KeyTypes.Array]: 'var(--typeArrayColor)',
   [ModulesKeyTypes.Graph]: 'var(--typeGraphColor)',
   [ModulesKeyTypes.TimeSeries]: 'var(--typeTimeSeriesColor)',
   [CommandGroup.SortedSet]: 'var(--groupSortedSetColor)',
@@ -130,6 +133,7 @@ export const LENGTH_NAMING_BY_TYPE: LengthNamingByType = Object.freeze({
   [ModulesKeyTypes.TimeSeries]: 'Samples',
   [KeyTypes.Stream]: 'Entries',
   [KeyTypes.ReJSON]: 'Top-level values',
+  [KeyTypes.Array]: 'Elements',
 })
 
 export interface ModulesKeyTypesNames {
@@ -190,6 +194,7 @@ export const ENDPOINT_BASED_ON_KEY_TYPE = Object.freeze({
   [KeyTypes.ReJSON]: ApiEndpoints.REJSON,
   [KeyTypes.Stream]: ApiEndpoints.STREAMS,
   [KeyTypes.VectorSet]: ApiEndpoints.VECTOR_SET,
+  [KeyTypes.Array]: ApiEndpoints.ARRAY,
 })
 
 export type EndpointBasedOnKeyType = keyof typeof ENDPOINT_BASED_ON_KEY_TYPE

--- a/redisinsight/ui/src/constants/prop-types/keys.ts
+++ b/redisinsight/ui/src/constants/prop-types/keys.ts
@@ -10,6 +10,9 @@ export interface IKeyPropTypes {
   length: number
   quantType?: string
   vectorDim?: number
+  nextInsertIndex?: number
+  slices?: number
+  sliceSize?: number
 }
 
 export interface IFetchKeyArgs {

--- a/redisinsight/ui/src/mocks/factories/browser/array/arrayElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/array/arrayElement.factory.ts
@@ -1,0 +1,27 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import { stringToBuffer } from 'uiSrc/utils'
+import { ArrayElement } from 'uiSrc/slices/interfaces'
+import { AddArrayElementsData } from 'uiSrc/slices/interfaces/array'
+
+export const arrayTestKeyName = () => stringToBuffer(faker.word.noun())
+
+export const arrayElementFactory = Factory.define<ArrayElement>(
+  ({ sequence }) => ({
+    index: sequence - 1,
+    value: stringToBuffer(faker.word.words({ count: { min: 1, max: 3 } })),
+  }),
+)
+
+export const addArrayElementsDataFactory = Factory.define<AddArrayElementsData>(
+  () => ({
+    keyName: arrayTestKeyName(),
+    elements: [
+      {
+        index: faker.number.int({ min: 0, max: 100 }),
+        value: faker.word.words(),
+      },
+    ],
+  }),
+)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -45,6 +45,7 @@ import AddKeyList from './AddKeyList'
 import AddKeyReJSON from './AddKeyReJSON'
 import AddKeyStream from './AddKeyStream'
 import AddKeyVectorSet from './AddKeyVectorSet'
+import AddKeyArray from './AddKeyArray'
 import { ContentFields } from './AddKey.styles'
 
 import styles from './styles.module.scss'
@@ -239,6 +240,9 @@ const AddKey = (props: Props) => {
                   setKeyNameDisabled={setKeyNameDisabled}
                   {...defaultFields}
                 />
+              )}
+              {typeSelected === KeyTypes.Array && (
+                <AddKeyArray onCancel={closeAddKeyPanel} {...defaultFields} />
               )}
             </ContentFields>
           </div>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -44,6 +44,7 @@ const AddKeyArray = ({ keyName = '', keyTTL, onCancel }: Props) => {
       (el) =>
         el.index !== '' &&
         !Number.isNaN(Number(el.index)) &&
+        Number.isInteger(Number(el.index)) &&
         Number(el.index) >= 0,
     )
     setIsFormValid(keyName.length > 0 && allIndicesValid)
@@ -58,8 +59,11 @@ const AddKeyArray = ({ keyName = '', keyTTL, onCancel }: Props) => {
 
   const addField = () => {
     const lastId = elements[elements.length - 1].id
+    const validIndices = elements
+      .map((el) => toNumber(el.index))
+      .filter((n) => !Number.isNaN(n))
     const nextIndex = String(
-      Math.max(...elements.map((el) => toNumber(el.index))) + 1,
+      (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
     )
     setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
   }

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,0 +1,161 @@
+import React, { FormEvent, useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { toNumber } from 'lodash'
+
+import { Maybe, stringToBuffer } from 'uiSrc/utils'
+import { addKeyStateSelector, addArrayKey } from 'uiSrc/slices/browser/keys'
+import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
+import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { CreateArrayWithExpireDto } from 'uiSrc/slices/interfaces/array'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+}
+
+interface ArrayElementEntry {
+  id: number
+  index: string
+  value: string
+}
+
+const INITIAL_ELEMENT = (): ArrayElementEntry => ({
+  id: 0,
+  index: '0',
+  value: '',
+})
+
+const AddKeyArray = ({ keyName = '', keyTTL, onCancel }: Props) => {
+  const dispatch = useDispatch()
+  const { loading } = useSelector(addKeyStateSelector)
+
+  const [elements, setElements] = useState<ArrayElementEntry[]>([
+    INITIAL_ELEMENT(),
+  ])
+  const [isFormValid, setIsFormValid] = useState(false)
+  const lastAddedIndex = useRef<HTMLInputElement>(null)
+  const prevCount = useRef<number>(0)
+
+  useEffect(() => {
+    const allIndicesValid = elements.every(
+      (el) =>
+        el.index !== '' &&
+        !Number.isNaN(Number(el.index)) &&
+        Number(el.index) >= 0,
+    )
+    setIsFormValid(keyName.length > 0 && allIndicesValid)
+  }, [keyName, elements])
+
+  useEffect(() => {
+    if (prevCount.current !== 0 && prevCount.current < elements.length) {
+      lastAddedIndex.current?.focus()
+    }
+    prevCount.current = elements.length
+  }, [elements.length])
+
+  const addField = () => {
+    const lastId = elements[elements.length - 1].id
+    const nextIndex = String(
+      Math.max(...elements.map((el) => toNumber(el.index))) + 1,
+    )
+    setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
+  }
+
+  const clearElement = (id: number) => {
+    setElements(
+      elements.map((el) =>
+        el.id === id ? { ...el, index: '0', value: '' } : el,
+      ),
+    )
+  }
+
+  const onClickRemove = ({ id }: ArrayElementEntry) => {
+    if (elements.length === 1) {
+      clearElement(id)
+      return
+    }
+    setElements(elements.filter((el) => el.id !== id))
+  }
+
+  const isClearDisabled = (item: ArrayElementEntry): boolean =>
+    elements.length === 1 && !item.value.length && item.index === '0'
+
+  const handleChange = (
+    field: 'index' | 'value',
+    id: number,
+    value: string,
+  ) => {
+    setElements(
+      elements.map((el) => (el.id === id ? { ...el, [field]: value } : el)),
+    )
+  }
+
+  const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (isFormValid) submitData()
+  }
+
+  const submitData = () => {
+    const data: CreateArrayWithExpireDto = {
+      keyName: stringToBuffer(keyName),
+      elements: elements.map((el) => ({
+        index: toNumber(el.index),
+        value: stringToBuffer(el.value),
+      })),
+      ...(keyTTL !== undefined ? { expire: toNumber(keyTTL) } : {}),
+    }
+    dispatch(addArrayKey(data, onCancel))
+  }
+
+  return (
+    <form onSubmit={onFormSubmit}>
+      <AddMultipleFields
+        items={elements}
+        isClearDisabled={isClearDisabled}
+        onClickRemove={onClickRemove}
+        onClickAdd={addField}
+      >
+        {(item, index) => (
+          <Row align="center" gap="m">
+            <FlexItem style={{ width: 120, flexShrink: 0 }}>
+              <TextInput
+                name={`array-index-${item.id}`}
+                id={`array-index-${item.id}`}
+                placeholder="Index"
+                value={item.index}
+                disabled={loading}
+                onChange={(val: string) => handleChange('index', item.id, val)}
+                ref={index === elements.length - 1 ? lastAddedIndex : null}
+                data-testid={`array-index-${item.id}`}
+              />
+            </FlexItem>
+            <FlexItem grow>
+              <TextInput
+                name={`array-value-${item.id}`}
+                id={`array-value-${item.id}`}
+                placeholder="Value"
+                value={item.value}
+                disabled={loading}
+                onChange={(val: string) => handleChange('value', item.id, val)}
+                data-testid={`array-value-${item.id}`}
+              />
+            </FlexItem>
+          </Row>
+        )}
+      </AddMultipleFields>
+      <ActionFooter
+        onCancel={() => onCancel(true)}
+        onAction={submitData}
+        actionText="Add Key"
+        loading={loading}
+        disabled={!isFormValid}
+        actionTestId="add-key-array-btn"
+      />
+    </form>
+  )
+}
+
+export default AddKeyArray

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useRef, useState } from 'react'
+import React, { FormEvent } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { toNumber } from 'lodash'
 
@@ -9,6 +9,7 @@ import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-field
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { CreateArrayWithExpireDto } from 'uiSrc/slices/interfaces/array'
+import { useArrayElementRows } from 'uiSrc/pages/browser/hooks/useArrayElementRows'
 
 export interface Props {
   keyName: string
@@ -16,86 +17,21 @@ export interface Props {
   onCancel: (isCancelled?: boolean) => void
 }
 
-interface ArrayElementEntry {
-  id: number
-  index: string
-  value: string
-}
-
-const INITIAL_ELEMENT = (): ArrayElementEntry => ({
-  id: 0,
-  index: '0',
-  value: '',
-})
-
 const AddKeyArray = ({ keyName = '', keyTTL, onCancel }: Props) => {
   const dispatch = useDispatch()
   const { loading } = useSelector(addKeyStateSelector)
 
-  const [elements, setElements] = useState<ArrayElementEntry[]>([
-    INITIAL_ELEMENT(),
-  ])
-  const [isFormValid, setIsFormValid] = useState(false)
-  const lastAddedIndex = useRef<HTMLInputElement>(null)
-  const prevCount = useRef<number>(0)
+  const {
+    elements,
+    lastAddedIndex,
+    addField,
+    onClickRemove,
+    isClearDisabled,
+    handleChange,
+    allIndicesValid,
+  } = useArrayElementRows({ emptyIndexValue: '0' })
 
-  useEffect(() => {
-    const allIndicesValid = elements.every(
-      (el) =>
-        el.index !== '' &&
-        !Number.isNaN(Number(el.index)) &&
-        Number.isInteger(Number(el.index)) &&
-        Number(el.index) >= 0,
-    )
-    setIsFormValid(keyName.length > 0 && allIndicesValid)
-  }, [keyName, elements])
-
-  useEffect(() => {
-    if (prevCount.current !== 0 && prevCount.current < elements.length) {
-      lastAddedIndex.current?.focus()
-    }
-    prevCount.current = elements.length
-  }, [elements.length])
-
-  const addField = () => {
-    const lastId = elements[elements.length - 1].id
-    const validIndices = elements
-      .map((el) => toNumber(el.index))
-      .filter((n) => !Number.isNaN(n))
-    const nextIndex = String(
-      (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
-    )
-    setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
-  }
-
-  const clearElement = (id: number) => {
-    setElements(
-      elements.map((el) =>
-        el.id === id ? { ...el, index: '0', value: '' } : el,
-      ),
-    )
-  }
-
-  const onClickRemove = ({ id }: ArrayElementEntry) => {
-    if (elements.length === 1) {
-      clearElement(id)
-      return
-    }
-    setElements(elements.filter((el) => el.id !== id))
-  }
-
-  const isClearDisabled = (item: ArrayElementEntry): boolean =>
-    elements.length === 1 && !item.value.length && item.index === '0'
-
-  const handleChange = (
-    field: 'index' | 'value',
-    id: number,
-    value: string,
-  ) => {
-    setElements(
-      elements.map((el) => (el.id === id ? { ...el, [field]: value } : el)),
-    )
-  }
+  const isFormValid = keyName.length > 0 && allIndicesValid
 
   const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
@@ -1,0 +1,3 @@
+import AddKeyArray from './AddKeyArray'
+
+export default AddKeyArray

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,6 +1,9 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isDevVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -45,5 +48,11 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
     isEnabledSelector: isDevVectorSetEnabledSelector,
+  },
+  {
+    text: 'Array',
+    value: KeyTypes.Array,
+    color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    isEnabledSelector: isDevArrayEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -53,6 +53,7 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     text: 'Array',
     value: KeyTypes.Array,
     color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    minVersion: CommandsVersions.ARRAY.since,
     isEnabledSelector: isDevArrayEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -5,7 +5,10 @@ import {
   FeatureFlags,
 } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isDevVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { FilterKeyTypeOption } from './FilterKeyType.types'
 
@@ -51,6 +54,13 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
     isEnabledSelector: isDevVectorSetEnabledSelector,
+  },
+  {
+    text: 'Array',
+    value: KeyTypes.Array,
+    color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    minVersion: CommandsVersions.ARRAY.since,
+    isEnabledSelector: isDevArrayEnabledSelector,
   },
   {
     text: 'Graph',

--- a/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
+++ b/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
@@ -47,8 +47,8 @@ export function useArrayElementRows({ emptyIndexValue = '' }: Options = {}) {
   const addField = () => {
     const lastId = elements[elements.length - 1].id
     const validIndices = elements
+      .filter((el) => isIndexValid(el.index))
       .map((el) => toNumber(el.index))
-      .filter((n) => !Number.isNaN(n))
     const nextIndex = String(
       (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
     )

--- a/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
+++ b/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
@@ -20,7 +20,7 @@ interface Options {
 
 /** Returns true if the index string represents a valid non-negative integer. */
 export const isIndexValid = (index: string): boolean =>
-  index !== '' &&
+  index.trim() !== '' &&
   !Number.isNaN(Number(index)) &&
   Number.isInteger(Number(index)) &&
   Number(index) >= 0

--- a/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
+++ b/redisinsight/ui/src/pages/browser/hooks/useArrayElementRows.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react'
+import { toNumber } from 'lodash'
+
+export interface ElementRow {
+  id: number
+  index: string
+  value: string
+}
+
+interface Options {
+  /**
+   * The value used when clearing/resetting the index field.
+   * - Pass `'0'` for the create-key form (AddKeyArray) where index 0 is the
+   *   sensible initial/reset state.
+   * - Omit (or pass `''`) for the edit form (ArrayAddElementForm) where the
+   *   field starts empty and the user must provide an explicit index.
+   */
+  emptyIndexValue?: string
+}
+
+/** Returns true if the index string represents a valid non-negative integer. */
+export const isIndexValid = (index: string): boolean =>
+  index !== '' &&
+  !Number.isNaN(Number(index)) &&
+  Number.isInteger(Number(index)) &&
+  Number(index) >= 0
+
+/**
+ * Shared state and handlers for forms that manage a list of array element rows
+ * (index + value pairs). Used by both AddKeyArray and ArrayAddElementForm.
+ */
+export function useArrayElementRows({ emptyIndexValue = '' }: Options = {}) {
+  const [elements, setElements] = useState<ElementRow[]>([
+    { id: 0, index: emptyIndexValue, value: '' },
+  ])
+  const lastAddedIndex = useRef<HTMLInputElement>(null)
+  const prevCount = useRef<number>(0)
+
+  // Focus the index input of the newly added row
+  useEffect(() => {
+    if (prevCount.current !== 0 && prevCount.current < elements.length) {
+      lastAddedIndex.current?.focus()
+    }
+    prevCount.current = elements.length
+  }, [elements.length])
+
+  const addField = () => {
+    const lastId = elements[elements.length - 1].id
+    const validIndices = elements
+      .map((el) => toNumber(el.index))
+      .filter((n) => !Number.isNaN(n))
+    const nextIndex = String(
+      (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
+    )
+    setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
+  }
+
+  const clearElement = (id: number) => {
+    setElements(
+      elements.map((el) =>
+        el.id === id ? { ...el, index: emptyIndexValue, value: '' } : el,
+      ),
+    )
+  }
+
+  const onClickRemove = ({ id }: ElementRow) => {
+    if (elements.length === 1) {
+      clearElement(id)
+      return
+    }
+    setElements(elements.filter((el) => el.id !== id))
+  }
+
+  const isClearDisabled = (item: ElementRow): boolean =>
+    elements.length === 1 &&
+    !item.value.length &&
+    item.index === emptyIndexValue
+
+  const handleChange = (field: 'index' | 'value', id: number, val: string) => {
+    setElements(
+      elements.map((el) => (el.id === id ? { ...el, [field]: val } : el)),
+    )
+  }
+
+  const allIndicesValid = elements.every((el) => isIndexValid(el.index))
+
+  return {
+    elements,
+    lastAddedIndex,
+    addField,
+    onClickRemove,
+    isClearDisabled,
+    handleChange,
+    allIndicesValid,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -72,13 +72,11 @@ describe('ArrayDetails', () => {
     expect(screen.getByTestId('key-details-header')).toBeInTheDocument()
   })
 
-  // AutoSizer reports width=0 in jsdom, so the component always renders the
-  // compact form: "${total} / ${logicalLength}[· NII: X]"
   it('should render count summary element', () => {
     renderComponent()
     const summary = screen.getByTestId('array-count-summary')
     expect(summary).toBeInTheDocument()
-    expect(summary.textContent).toMatch(/\d+ \/ \d+/)
+    expect(summary.textContent).toMatch(/Count: \d+/)
   })
 
   it('should not show NII when nextInsertIndex is undefined', () => {
@@ -87,7 +85,7 @@ describe('ArrayDetails', () => {
     expect(summary.textContent).not.toContain('NII')
   })
 
-  it('should show NII when nextInsertIndex is provided', () => {
+  it('should show Next Insert Index when nextInsertIndex is provided', () => {
     selectedKeyDataSelector.mockReturnValue({
       name: stringToBuffer('myarray'),
       nameString: 'myarray',
@@ -101,10 +99,10 @@ describe('ArrayDetails', () => {
     renderComponent()
 
     const summary = screen.getByTestId('array-count-summary')
-    expect(summary.textContent).toContain('NII: 3')
+    expect(summary.textContent).toContain('Next Insert Index: 3')
   })
 
-  it('should show NII: 0 when nextInsertIndex is 0', () => {
+  it('should show Next Insert Index: 0 when nextInsertIndex is 0', () => {
     selectedKeyDataSelector.mockReturnValue({
       name: stringToBuffer('myarray'),
       nameString: 'myarray',
@@ -118,7 +116,7 @@ describe('ArrayDetails', () => {
     renderComponent()
 
     const summary = screen.getByTestId('array-count-summary')
-    expect(summary.textContent).toContain('NII: 0')
+    expect(summary.textContent).toContain('Next Insert Index: 0')
   })
 
   it('should render Add Elements button', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { stringToBuffer } from 'uiSrc/utils'
+import { KeyTypes } from 'uiSrc/constants'
+
+import { Props, ArrayDetails } from './ArrayDetails'
+
+jest.mock('uiSrc/slices/browser/keys', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/keys'),
+  selectedKeySelector: jest.fn(),
+  selectedKeyDataSelector: jest.fn(),
+  setSelectedKeyRefreshDisabled: jest.fn(() => ({
+    type: 'keys/setSelectedKeyRefreshDisabled',
+  })),
+}))
+
+jest.mock('uiSrc/slices/browser/array', () => {
+  const defaultState = jest.requireActual(
+    'uiSrc/slices/browser/array',
+  ).initialState
+  return {
+    ...jest.requireActual('uiSrc/slices/browser/array'),
+    arraySelector: jest.fn().mockReturnValue(defaultState),
+    arrayDataSelector: jest.fn().mockReturnValue(defaultState.data),
+    addArrayElementsStateSelector: jest
+      .fn()
+      .mockReturnValue(defaultState.adding),
+    addArrayElements: () => jest.fn(),
+    fetchArrayElements: () => jest.fn(),
+  }
+})
+
+const defaultProps: Props = {
+  onRemoveKey: jest.fn(),
+  onOpenAddItemPanel: jest.fn(),
+  onCloseAddItemPanel: jest.fn(),
+  onCloseKey: jest.fn(),
+  onEditKey: jest.fn(),
+  isFullScreen: false,
+  arePanelsCollapsed: false,
+  onToggleFullScreen: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<ArrayDetails {...defaultProps} {...propsOverride} />)
+
+describe('ArrayDetails', () => {
+  const { selectedKeySelector, selectedKeyDataSelector } = jest.requireMock(
+    'uiSrc/slices/browser/keys',
+  )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    selectedKeySelector.mockReturnValue({ loading: false, viewFormat: 'UTF-8' })
+    selectedKeyDataSelector.mockReturnValue({
+      name: stringToBuffer('myarray'),
+      nameString: 'myarray',
+      type: KeyTypes.Array,
+      ttl: -1,
+      size: 100,
+      length: 0,
+      nextInsertIndex: undefined,
+    })
+  })
+
+  it('should render', () => {
+    expect(renderComponent()).toBeTruthy()
+  })
+
+  it('should render key details header', () => {
+    renderComponent()
+    expect(screen.getByTestId('key-details-header')).toBeInTheDocument()
+  })
+
+  // AutoSizer reports width=0 in jsdom, so the component always renders the
+  // compact form: "${total} / ${logicalLength}[· NII: X]"
+  it('should render count summary element', () => {
+    renderComponent()
+    const summary = screen.getByTestId('array-count-summary')
+    expect(summary).toBeInTheDocument()
+    expect(summary.textContent).toMatch(/\d+ \/ \d+/)
+  })
+
+  it('should not show NII when nextInsertIndex is undefined', () => {
+    renderComponent()
+    const summary = screen.getByTestId('array-count-summary')
+    expect(summary.textContent).not.toContain('NII')
+  })
+
+  it('should show NII when nextInsertIndex is provided', () => {
+    selectedKeyDataSelector.mockReturnValue({
+      name: stringToBuffer('myarray'),
+      nameString: 'myarray',
+      type: KeyTypes.Array,
+      ttl: -1,
+      size: 100,
+      length: 0,
+      nextInsertIndex: 3,
+    })
+
+    renderComponent()
+
+    const summary = screen.getByTestId('array-count-summary')
+    expect(summary.textContent).toContain('NII: 3')
+  })
+
+  it('should show NII: 0 when nextInsertIndex is 0', () => {
+    selectedKeyDataSelector.mockReturnValue({
+      name: stringToBuffer('myarray'),
+      nameString: 'myarray',
+      type: KeyTypes.Array,
+      ttl: -1,
+      size: 100,
+      length: 0,
+      nextInsertIndex: 0,
+    })
+
+    renderComponent()
+
+    const summary = screen.getByTestId('array-count-summary')
+    expect(summary.textContent).toContain('NII: 0')
+  })
+
+  it('should render Add Elements button', () => {
+    renderComponent()
+    expect(screen.getByTestId('add-key-value-items-btn')).toBeInTheDocument()
+  })
+
+  it('should open add element form when Add Elements is clicked', () => {
+    renderComponent()
+
+    expect(
+      screen.queryByTestId('array-add-element-btn'),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+
+    expect(screen.getByTestId('array-add-element-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('cancel-array-elements-btn')).toBeInTheDocument()
+  })
+
+  it('should close add element form when Cancel is clicked', () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    expect(screen.getByTestId('array-add-element-btn')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('cancel-array-elements-btn'))
+    expect(
+      screen.queryByTestId('array-add-element-btn'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should call onOpenAddItemPanel when add panel is opened', () => {
+    const onOpenAddItemPanel = jest.fn()
+    renderComponent({ onOpenAddItemPanel })
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    expect(onOpenAddItemPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onCloseAddItemPanel when add panel is closed', () => {
+    const onCloseAddItemPanel = jest.fn()
+    renderComponent({ onCloseAddItemPanel })
+
+    fireEvent.click(screen.getByTestId('add-key-value-items-btn'))
+    fireEvent.click(screen.getByTestId('cancel-array-elements-btn'))
+    expect(onCloseAddItemPanel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+export const Container = styled(Col)`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`
+
+export const DetailsBody = styled(Col)`
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`
+
+export const ListWrapper = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -50,22 +50,14 @@ const ArrayDetails = (props: Props) => {
   }, [onCloseAddItemPanel])
 
   const handleAddElements = useCallback(
-    (
-      elements: { index: number; value: string }[],
-      onSuccess?: () => void,
-      onFail?: () => void,
-    ) => {
+    (elements: { index: number; value: string }[]) => {
       dispatch(
         addArrayElements(
           {
             keyName: selectedKeyData?.name as RedisResponseBuffer,
             elements,
           },
-          () => {
-            onSuccess?.()
-            closeAddItemPanel()
-          },
-          onFail,
+          closeAddItemPanel,
         ),
       )
     },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -16,7 +16,6 @@ import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
-import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 
 import { ArrayElementList } from './array-element-list/ArrayElementList'
 import { AddKeyArray } from './array-add-element-form/ArrayAddElementForm'
@@ -88,9 +87,7 @@ const ArrayDetails = (props: Props) => {
                   color="primary"
                   data-testid="array-count-summary"
                 >
-                  {width > MIDDLE_SCREEN_RESOLUTION
-                    ? `Count: ${total} · Length: ${logicalLength}${nextInsertIndex !== undefined ? ` · Next Insert Index: ${nextInsertIndex}` : ''}`
-                    : `${total} / ${logicalLength}${nextInsertIndex !== undefined ? ` · NII: ${nextInsertIndex}` : ''}`}
+                  {`Count: ${total} · Length: ${logicalLength}${nextInsertIndex !== undefined ? ` · Next Insert Index: ${nextInsertIndex}` : ''}`}
                 </Text>
               </FlexItem>
               <Row align="center" grow={false}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -18,7 +18,7 @@ import {
 } from 'uiSrc/pages/browser/modules'
 
 import { ArrayElementList } from './array-element-list/ArrayElementList'
-import { AddKeyArray } from './array-add-element-form/ArrayAddElementForm'
+import { ArrayAddElementForm } from './array-add-element-form/ArrayAddElementForm'
 import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 import * as S from './ArrayDetails.styles'
 
@@ -111,7 +111,7 @@ const ArrayDetails = (props: Props) => {
         )}
         {isAddItemPanelOpen && (
           <AddKeysContainer>
-            <AddKeyArray
+            <ArrayAddElementForm
               onSubmit={handleAddElements}
               onCancel={closeAddItemPanel}
             />

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import AutoSizer from 'react-virtualized-auto-sizer'
+
+import {
+  selectedKeyDataSelector,
+  selectedKeySelector,
+} from 'uiSrc/slices/browser/keys'
+import { arrayDataSelector, addArrayElements } from 'uiSrc/slices/browser/array'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
+import { KeyDetailsHeaderFormatter } from 'uiSrc/pages/browser/modules/key-details-header/components/key-details-header-formatter'
+import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
+import {
+  KeyDetailsHeader,
+  KeyDetailsHeaderProps,
+} from 'uiSrc/pages/browser/modules'
+import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
+
+import { ArrayElementList } from './array-element-list/ArrayElementList'
+import { AddKeyArray } from './array-add-element-form/ArrayAddElementForm'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
+import * as S from './ArrayDetails.styles'
+
+export interface Props extends KeyDetailsHeaderProps {
+  onRemoveKey: () => void
+  onOpenAddItemPanel: () => void
+  onCloseAddItemPanel: () => void
+}
+
+const ArrayDetails = (props: Props) => {
+  const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
+
+  const dispatch = useDispatch()
+  const selectedKeyData = useSelector(selectedKeyDataSelector)
+  const { loading } = useSelector(selectedKeySelector)
+  const { total = 0, logicalLength = 0 } = useSelector(arrayDataSelector) ?? {}
+  const { nextInsertIndex } = selectedKeyData ?? {}
+
+  const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState(false)
+
+  const openAddItemPanel = useCallback(() => {
+    setIsAddItemPanelOpen(true)
+    onOpenAddItemPanel()
+  }, [onOpenAddItemPanel])
+
+  const closeAddItemPanel = useCallback(() => {
+    setIsAddItemPanelOpen(false)
+    onCloseAddItemPanel()
+  }, [onCloseAddItemPanel])
+
+  const handleAddElements = useCallback(
+    (
+      elements: { index: number; value: string }[],
+      onSuccess?: () => void,
+      onFail?: () => void,
+    ) => {
+      dispatch(
+        addArrayElements(
+          {
+            keyName: selectedKeyData?.name as RedisResponseBuffer,
+            elements,
+          },
+          () => {
+            onSuccess?.()
+            closeAddItemPanel()
+          },
+          onFail,
+        ),
+      )
+    },
+    [dispatch, selectedKeyData?.name, closeAddItemPanel],
+  )
+
+  return (
+    <S.Container>
+      <KeyDetailsHeader {...props} key="key-details-header" />
+
+      {/* Subheader: element count summary + Add Elements button */}
+      <AutoSizer disableHeight>
+        {({ width = 0 }) => (
+          <FlexItem style={{ width, padding: '8px 18px' }}>
+            <Row justify="between" align="center">
+              <FlexItem grow={false}>
+                <Text
+                  size="s"
+                  color="primary"
+                  data-testid="array-count-summary"
+                >
+                  {width > MIDDLE_SCREEN_RESOLUTION
+                    ? `Count: ${total} · Length: ${logicalLength}${nextInsertIndex !== undefined ? ` · Next Insert Index: ${nextInsertIndex}` : ''}`
+                    : `${total} / ${logicalLength}${nextInsertIndex !== undefined ? ` · NII: ${nextInsertIndex}` : ''}`}
+                </Text>
+              </FlexItem>
+              <Row align="center" grow={false}>
+                <KeyDetailsHeaderFormatter width={width} />
+                <AddItemsAction
+                  title="Add Elements"
+                  width={width}
+                  openAddItemPanel={openAddItemPanel}
+                />
+              </Row>
+            </Row>
+          </FlexItem>
+        )}
+      </AutoSizer>
+
+      <S.DetailsBody>
+        {!loading && (
+          <S.ListWrapper>
+            <ArrayElementList onRemoveKey={onRemoveKey} />
+          </S.ListWrapper>
+        )}
+        {isAddItemPanelOpen && (
+          <AddKeysContainer>
+            <AddKeyArray
+              onSubmit={handleAddElements}
+              onCancel={closeAddItemPanel}
+            />
+          </AddKeysContainer>
+        )}
+      </S.DetailsBody>
+    </S.Container>
+  )
+}
+
+export { ArrayDetails }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { AddKeyArray, Props } from './ArrayAddElementForm'
+
+jest.mock('uiSrc/slices/browser/array', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/array'),
+  addArrayElementsStateSelector: jest
+    .fn()
+    .mockReturnValue({ loading: false, error: '' }),
+}))
+
+const defaultProps: Props = {
+  onSubmit: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<Props>) =>
+  render(<AddKeyArray {...defaultProps} {...propsOverride} />)
+
+describe('ArrayAddElementForm (AddKeyArray)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // ActionFooter renders via a portal; create the anchor if needed
+    if (!document.getElementById('formFooterBar')) {
+      const footer = document.createElement('div')
+      footer.setAttribute('id', 'formFooterBar')
+      document.body.appendChild(footer)
+    }
+  })
+
+  afterEach(() => {
+    document.getElementById('formFooterBar')?.remove()
+  })
+
+  it('should render the form', () => {
+    expect(renderComponent()).toBeTruthy()
+  })
+
+  it('should render index and value inputs for the initial row', () => {
+    renderComponent()
+    expect(screen.getByTestId('array-element-index-0')).toBeInTheDocument()
+    expect(screen.getByTestId('array-element-value-0')).toBeInTheDocument()
+  })
+
+  it('should render Save and Cancel buttons', () => {
+    renderComponent()
+    expect(screen.getByTestId('array-add-element-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('cancel-array-elements-btn')).toBeInTheDocument()
+  })
+
+  it('should disable Save when index field is empty', () => {
+    renderComponent()
+    expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
+  })
+
+  it('should disable Save when index is not a number', () => {
+    renderComponent()
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: 'abc' },
+    })
+
+    expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
+  })
+
+  it('should disable Save when index is negative', () => {
+    renderComponent()
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '-1' },
+    })
+
+    expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
+  })
+
+  it('should enable Save when a valid non-negative index is entered', () => {
+    renderComponent()
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '0' },
+    })
+
+    expect(screen.getByTestId('array-add-element-btn')).not.toBeDisabled()
+  })
+
+  it('should call onSubmit with correct data when form is submitted', () => {
+    const onSubmit = jest.fn()
+    renderComponent({ onSubmit })
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '2' },
+    })
+    fireEvent.change(screen.getByTestId('array-element-value-0'), {
+      target: { value: 'hello' },
+    })
+
+    fireEvent.click(screen.getByTestId('array-add-element-btn'))
+
+    expect(onSubmit).toHaveBeenCalledWith([{ index: 2, value: 'hello' }])
+  })
+
+  it('should call onCancel when Cancel is clicked', () => {
+    const onCancel = jest.fn()
+    renderComponent({ onCancel })
+
+    fireEvent.click(screen.getByTestId('cancel-array-elements-btn'))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('should add a second row when clicking add another element', () => {
+    renderComponent()
+
+    // Set a valid index to ensure there are no hidden validations on add-field
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '0' },
+    })
+
+    // The add-field button is rendered inside AddMultipleFields
+    const addBtn = screen.getByTestId('add-item')
+    fireEvent.click(addBtn)
+
+    expect(screen.getByTestId('array-element-index-1')).toBeInTheDocument()
+    expect(screen.getByTestId('array-element-value-1')).toBeInTheDocument()
+  })
+
+  it('should submit all rows when multiple elements are added', () => {
+    const onSubmit = jest.fn()
+    renderComponent({ onSubmit })
+
+    // Fill first row
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '0' },
+    })
+    fireEvent.change(screen.getByTestId('array-element-value-0'), {
+      target: { value: 'first' },
+    })
+
+    // Add second row
+    fireEvent.click(screen.getByTestId('add-item'))
+
+    // Fill second row (index auto-increments to 1, but may need explicit set)
+    fireEvent.change(screen.getByTestId('array-element-index-1'), {
+      target: { value: '1' },
+    })
+    fireEvent.change(screen.getByTestId('array-element-value-1'), {
+      target: { value: 'second' },
+    })
+
+    fireEvent.click(screen.getByTestId('array-add-element-btn'))
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      { index: 0, value: 'first' },
+      { index: 1, value: 'second' },
+    ])
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 
-import { AddKeyArray, Props } from './ArrayAddElementForm'
+import {
+  ArrayAddElementForm as AddKeyArray,
+  Props,
+} from './ArrayAddElementForm'
 
 jest.mock('uiSrc/slices/browser/array', () => ({
   ...jest.requireActual('uiSrc/slices/browser/array'),
@@ -69,6 +72,16 @@ describe('ArrayAddElementForm (AddKeyArray)', () => {
 
     fireEvent.change(screen.getByTestId('array-element-index-0'), {
       target: { value: '-1' },
+    })
+
+    expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
+  })
+
+  it('should disable Save when index is whitespace only', () => {
+    renderComponent()
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '   ' },
     })
 
     expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.spec.tsx
@@ -74,6 +74,16 @@ describe('ArrayAddElementForm (AddKeyArray)', () => {
     expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
   })
 
+  it('should disable Save when index is a decimal number', () => {
+    renderComponent()
+
+    fireEvent.change(screen.getByTestId('array-element-index-0'), {
+      target: { value: '1.5' },
+    })
+
+    expect(screen.getByTestId('array-add-element-btn')).toBeDisabled()
+  })
+
   it('should enable Save when a valid non-negative index is entered', () => {
     renderComponent()
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
@@ -1,6 +1,5 @@
-import React, { FormEvent, useEffect, useRef, useState } from 'react'
+import React, { FormEvent } from 'react'
 import { useSelector } from 'react-redux'
-import { toNumber } from 'lodash'
 
 import { addArrayElementsStateSelector } from 'uiSrc/slices/browser/array'
 import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
@@ -12,15 +11,10 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
+import { useArrayElementRows } from 'uiSrc/pages/browser/hooks/useArrayElementRows'
 
 export interface ArrayElementEntry {
   index: number
-  value: string
-}
-
-interface ElementRow {
-  id: number
-  index: string
   value: string
 }
 
@@ -36,66 +30,19 @@ export interface Props {
 const ArrayAddElementForm = ({ onSubmit, onCancel }: Props) => {
   const { loading } = useSelector(addArrayElementsStateSelector)
 
-  const [elements, setElements] = useState<ElementRow[]>([
-    { id: 0, index: '', value: '' },
-  ])
-  const lastAddedIndex = useRef<HTMLInputElement>(null)
-  const prevCount = useRef<number>(0)
-
-  useEffect(() => {
-    if (prevCount.current !== 0 && prevCount.current < elements.length) {
-      lastAddedIndex.current?.focus()
-    }
-    prevCount.current = elements.length
-  }, [elements.length])
-
-  const isFormValid = elements.every(
-    (el) =>
-      el.index !== '' &&
-      !Number.isNaN(Number(el.index)) &&
-      Number.isInteger(Number(el.index)) &&
-      Number(el.index) >= 0,
-  )
-
-  const addField = () => {
-    const lastId = elements[elements.length - 1].id
-    const validIndices = elements
-      .map((el) => toNumber(el.index))
-      .filter((n) => !Number.isNaN(n))
-    const nextIndex = String(
-      (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
-    )
-    setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
-  }
-
-  const clearElement = (id: number) => {
-    setElements(
-      elements.map((el) =>
-        el.id === id ? { ...el, index: '', value: '' } : el,
-      ),
-    )
-  }
-
-  const onClickRemove = ({ id }: ElementRow) => {
-    if (elements.length === 1) {
-      clearElement(id)
-      return
-    }
-    setElements(elements.filter((el) => el.id !== id))
-  }
-
-  const isClearDisabled = (item: ElementRow): boolean =>
-    elements.length === 1 && !item.value.length && item.index === ''
-
-  const handleChange = (field: 'index' | 'value', id: number, val: string) => {
-    setElements(
-      elements.map((el) => (el.id === id ? { ...el, [field]: val } : el)),
-    )
-  }
+  const {
+    elements,
+    lastAddedIndex,
+    addField,
+    onClickRemove,
+    isClearDisabled,
+    handleChange,
+    allIndicesValid,
+  } = useArrayElementRows()
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
-    if (!isFormValid) return
+    if (!allIndicesValid) return
     onSubmit(
       elements.map((el) => ({ index: Number(el.index), value: el.value })),
     )
@@ -156,7 +103,7 @@ const ArrayAddElementForm = ({ onSubmit, onCancel }: Props) => {
           <PrimaryButton
             type="submit"
             loading={loading}
-            disabled={!isFormValid || loading}
+            disabled={!allIndicesValid || loading}
             data-testid="array-add-element-btn"
           >
             Save

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
@@ -114,4 +114,4 @@ const ArrayAddElementForm = ({ onSubmit, onCancel }: Props) => {
   )
 }
 
-export { ArrayAddElementForm as AddKeyArray }
+export { ArrayAddElementForm }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
@@ -19,11 +19,7 @@ export interface ArrayElementEntry {
 }
 
 export interface Props {
-  onSubmit: (
-    elements: ArrayElementEntry[],
-    onSuccess?: () => void,
-    onFail?: () => void,
-  ) => void
+  onSubmit: (elements: ArrayElementEntry[]) => void
   onCancel: () => void
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
@@ -53,13 +53,17 @@ const ArrayAddElementForm = ({ onSubmit, onCancel }: Props) => {
     (el) =>
       el.index !== '' &&
       !Number.isNaN(Number(el.index)) &&
+      Number.isInteger(Number(el.index)) &&
       Number(el.index) >= 0,
   )
 
   const addField = () => {
     const lastId = elements[elements.length - 1].id
+    const validIndices = elements
+      .map((el) => toNumber(el.index))
+      .filter((n) => !Number.isNaN(n))
     const nextIndex = String(
-      Math.max(...elements.map((el) => toNumber(el.index || '0'))) + 1,
+      (validIndices.length > 0 ? Math.max(...validIndices) : -1) + 1,
     )
     setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-element-form/ArrayAddElementForm.tsx
@@ -1,0 +1,166 @@
+import React, { FormEvent, useEffect, useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { toNumber } from 'lodash'
+
+import { addArrayElementsStateSelector } from 'uiSrc/slices/browser/array'
+import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import { Text } from 'uiSrc/components/base/text'
+import {
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+
+export interface ArrayElementEntry {
+  index: number
+  value: string
+}
+
+interface ElementRow {
+  id: number
+  index: string
+  value: string
+}
+
+export interface Props {
+  onSubmit: (
+    elements: ArrayElementEntry[],
+    onSuccess?: () => void,
+    onFail?: () => void,
+  ) => void
+  onCancel: () => void
+}
+
+const ArrayAddElementForm = ({ onSubmit, onCancel }: Props) => {
+  const { loading } = useSelector(addArrayElementsStateSelector)
+
+  const [elements, setElements] = useState<ElementRow[]>([
+    { id: 0, index: '', value: '' },
+  ])
+  const lastAddedIndex = useRef<HTMLInputElement>(null)
+  const prevCount = useRef<number>(0)
+
+  useEffect(() => {
+    if (prevCount.current !== 0 && prevCount.current < elements.length) {
+      lastAddedIndex.current?.focus()
+    }
+    prevCount.current = elements.length
+  }, [elements.length])
+
+  const isFormValid = elements.every(
+    (el) =>
+      el.index !== '' &&
+      !Number.isNaN(Number(el.index)) &&
+      Number(el.index) >= 0,
+  )
+
+  const addField = () => {
+    const lastId = elements[elements.length - 1].id
+    const nextIndex = String(
+      Math.max(...elements.map((el) => toNumber(el.index || '0'))) + 1,
+    )
+    setElements([...elements, { id: lastId + 1, index: nextIndex, value: '' }])
+  }
+
+  const clearElement = (id: number) => {
+    setElements(
+      elements.map((el) =>
+        el.id === id ? { ...el, index: '', value: '' } : el,
+      ),
+    )
+  }
+
+  const onClickRemove = ({ id }: ElementRow) => {
+    if (elements.length === 1) {
+      clearElement(id)
+      return
+    }
+    setElements(elements.filter((el) => el.id !== id))
+  }
+
+  const isClearDisabled = (item: ElementRow): boolean =>
+    elements.length === 1 && !item.value.length && item.index === ''
+
+  const handleChange = (field: 'index' | 'value', id: number, val: string) => {
+    setElements(
+      elements.map((el) => (el.id === id ? { ...el, [field]: val } : el)),
+    )
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!isFormValid) return
+    onSubmit(
+      elements.map((el) => ({ index: Number(el.index), value: el.value })),
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Text size="s" color="subdued">
+        Set values at specific indices in the array. Existing values at those
+        indices will be overwritten.
+      </Text>
+      <Spacer size="m" />
+      <AddMultipleFields
+        items={elements}
+        isClearDisabled={isClearDisabled}
+        onClickRemove={onClickRemove}
+        onClickAdd={addField}
+      >
+        {(item, index) => (
+          <Row align="center" gap="m">
+            <FlexItem style={{ width: 120, flexShrink: 0 }}>
+              <TextInput
+                name={`array-element-index-${item.id}`}
+                id={`array-element-index-${item.id}`}
+                placeholder="e.g. 0"
+                value={item.index}
+                disabled={loading}
+                onChange={(val: string) => handleChange('index', item.id, val)}
+                ref={index === elements.length - 1 ? lastAddedIndex : null}
+                data-testid={`array-element-index-${item.id}`}
+              />
+            </FlexItem>
+            <FlexItem grow>
+              <TextInput
+                name={`array-element-value-${item.id}`}
+                id={`array-element-value-${item.id}`}
+                placeholder="Element value"
+                value={item.value}
+                disabled={loading}
+                onChange={(val: string) => handleChange('value', item.id, val)}
+                data-testid={`array-element-value-${item.id}`}
+              />
+            </FlexItem>
+          </Row>
+        )}
+      </AddMultipleFields>
+      <Spacer size="m" />
+      <Row justify="end" gap="m">
+        <FlexItem>
+          <SecondaryButton
+            onClick={() => onCancel()}
+            data-testid="cancel-array-elements-btn"
+          >
+            Cancel
+          </SecondaryButton>
+        </FlexItem>
+        <FlexItem>
+          <PrimaryButton
+            type="submit"
+            loading={loading}
+            disabled={!isFormValid || loading}
+            data-testid="array-add-element-btn"
+          >
+            Save
+          </PrimaryButton>
+        </FlexItem>
+      </Row>
+    </form>
+  )
+}
+
+export { ArrayAddElementForm as AddKeyArray }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.config.tsx
@@ -1,0 +1,144 @@
+import React from 'react'
+
+import { ColumnDef, Row as TableRow } from 'uiSrc/components/base/layout/table'
+import { ArrayElement } from 'uiSrc/slices/interfaces'
+import {
+  bufferToString,
+  createDeleteFieldHeader,
+  createDeleteFieldMessage,
+} from 'uiSrc/utils'
+import { KeyValueFormat } from 'uiSrc/constants'
+import { RedisString } from 'uiSrc/slices/interfaces/app'
+import HelpTexts from 'uiSrc/constants/help-texts'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
+import { EditableTextArea } from 'uiSrc/pages/browser/modules/key-details/shared'
+import { ARRAY_COLUMN_HEADERS } from './constants'
+
+export interface ArrayElementDeleteConfig {
+  deleting: string
+  suffix: string
+  total: number
+  keyName: RedisString
+  closePopover: () => void
+  showPopover: (item: string) => void
+  handleDeleteElement: (index: number) => void
+}
+
+export interface ArrayElementEditConfig {
+  editingIndex: number | null
+  updateLoading: boolean
+  handleEditElement: (arrayIndex: number, isEditing: boolean) => void
+  handleApplyEditValue: (arrayIndex: number, value: string) => void
+}
+
+export interface ArrayElementsListConfig {
+  viewFormat: KeyValueFormat
+  elementDeleteConfig: ArrayElementDeleteConfig
+  elementEditConfig: ArrayElementEditConfig
+}
+
+const createIndexColumn = (): ColumnDef<ArrayElement> => ({
+  id: 'index',
+  accessorKey: 'index',
+  header: ARRAY_COLUMN_HEADERS.index,
+  enableSorting: false,
+  size: 120,
+  sizeUnit: 'px',
+  cell: ({ row }: { row: TableRow<ArrayElement> }) => (
+    <span data-testid={`array-index-${row.original.index}`}>
+      {row.original.index}
+    </span>
+  ),
+})
+
+const createValueColumn = (
+  listConfig: ArrayElementsListConfig,
+): ColumnDef<ArrayElement> => {
+  const { viewFormat, elementEditConfig } = listConfig
+  const {
+    editingIndex,
+    updateLoading,
+    handleEditElement,
+    handleApplyEditValue,
+  } = elementEditConfig
+
+  return {
+    id: 'value',
+    accessorKey: 'value',
+    header: ARRAY_COLUMN_HEADERS.value,
+    enableSorting: false,
+    cell: ({ row }: { row: TableRow<ArrayElement> }) => {
+      const { index, value: valueBuffer } = row.original
+      const displayValue = bufferToString(valueBuffer, viewFormat)
+      const isEditing = editingIndex === index
+
+      return (
+        <EditableTextArea
+          field={String(index)}
+          initialValue={isEditing ? displayValue : ''}
+          isEditing={isEditing}
+          isLoading={updateLoading}
+          onEdit={(editing) => handleEditElement(index, editing)}
+          onDecline={() => handleEditElement(index, false)}
+          onApply={(value) => handleApplyEditValue(index, value)}
+          testIdPrefix="array"
+        >
+          <span data-testid={`array-value-${index}`}>{displayValue}</span>
+        </EditableTextArea>
+      )
+    },
+  }
+}
+
+const createActionsColumn = (
+  listConfig: ArrayElementsListConfig,
+): ColumnDef<ArrayElement> => ({
+  id: 'actions',
+  header: ARRAY_COLUMN_HEADERS.actions,
+  enableSorting: false,
+  enableResizing: false,
+  size: 80,
+  sizeUnit: 'px',
+  cell: ({ row }: { row: TableRow<ArrayElement> }) => {
+    const { index, value: valueBuffer } = row.original
+    const { elementDeleteConfig: deleteConfig } = listConfig
+    const {
+      deleting,
+      suffix,
+      total,
+      keyName,
+      closePopover,
+      showPopover,
+      handleDeleteElement,
+    } = deleteConfig
+
+    return (
+      <Row gap="s" align="center" justify="center">
+        <PopoverDelete
+          header={createDeleteFieldHeader(`[${index}]`)}
+          text={createDeleteFieldMessage(keyName)}
+          item={String(index)}
+          itemRaw={valueBuffer}
+          suffix={suffix}
+          deleting={deleting}
+          closePopover={closePopover}
+          updateLoading={false}
+          showPopover={showPopover}
+          handleDeleteItem={() => handleDeleteElement(index)}
+          handleButtonClick={() => {}}
+          testid={`array-remove-btn-${index}`}
+          appendInfo={total === 1 ? HelpTexts.REMOVE_LAST_ELEMENT() : null}
+        />
+      </Row>
+    )
+  },
+})
+
+export const getArrayColumns = (
+  listConfig: ArrayElementsListConfig,
+): ColumnDef<ArrayElement>[] => [
+  createIndexColumn(),
+  createValueColumn(listConfig),
+  createActionsColumn(listConfig),
+]

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.styles.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+import { Table } from 'uiSrc/components/base/layout/table'
+import { FlexItem } from 'uiSrc/components/base/layout/flex'
+
+export const Container = styled(FlexItem)`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.core?.space.space200};
+`
+
+export const StyledTable = styled(Table)`
+  scrollbar-width: thin;
+  max-height: 100%;
+  box-shadow: 0px 0px 0px 1px
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+
+  [data-role='table-scroller'] {
+    scrollbar-width: thin;
+  }
+
+  [data-role='pagination'] {
+    scrollbar-width: thin;
+    border-top: 1px solid
+      ${({ theme }) => theme.semantic.color.border.neutral500};
+  }
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/ArrayElementList.tsx
@@ -1,0 +1,40 @@
+import React, { memo } from 'react'
+
+import { useArrayElementListData } from '../hooks/useArrayElementListData'
+import * as S from './ArrayElementList.styles'
+
+export interface Props {
+  onRemoveKey: () => void
+}
+
+const ArrayElementList = memo(({ onRemoveKey }: Props) => {
+  const {
+    columns,
+    currentPageData,
+    tableMinWidth,
+    pagination,
+    setPagination,
+    emptyMessage,
+    total,
+  } = useArrayElementListData({ onRemoveKey })
+
+  return (
+    <S.Container data-testid="array-details">
+      <S.StyledTable
+        columns={columns}
+        data={currentPageData}
+        stripedRows
+        minWidth={tableMinWidth}
+        paginationEnabled
+        manualPagination
+        totalRowCount={total}
+        pagination={pagination}
+        onPaginationChange={setPagination}
+        emptyState={emptyMessage}
+        data-testid="array-details-table"
+      />
+    </S.Container>
+  )
+})
+
+export { ArrayElementList }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-element-list/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_PAGE_SIZE = 20
+
+export const ARRAY_COLUMN_HEADERS: Record<string, string> = {
+  index: 'Index',
+  value: 'Value',
+  actions: '',
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
@@ -59,11 +59,14 @@ export const useArrayElementListData = ({
     setDeleting(`${item}${ELEMENT_DELETE_POPOVER_SUFFIX}`)
   }, [])
 
-  const onSuccessRemoved = (newTotal: number) => {
-    if (newTotal === 0) {
-      onRemoveKey()
-    }
-  }
+  const onSuccessRemoved = useCallback(
+    (newTotal: number) => {
+      if (newTotal === 0) {
+        onRemoveKey()
+      }
+    },
+    [onRemoveKey],
+  )
 
   const handleDeleteElement = useCallback(
     (index: number) => {
@@ -76,7 +79,7 @@ export const useArrayElementListData = ({
       )
       closePopover()
     },
-    [key, dispatch, closePopover],
+    [key, dispatch, closePopover, onSuccessRemoved],
   )
 
   const handleEditElement = useCallback(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { PaginationState } from 'uiSrc/components/base/layout/table'
@@ -46,9 +46,11 @@ export const useArrayElementListData = ({
   })
   const [deleting, setDeleting] = useState('')
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const lastAttemptedCursor = useRef<number | undefined>(undefined)
 
   useEffect(() => {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+    lastAttemptedCursor.current = undefined
   }, [key])
 
   const closePopover = useCallback(() => {
@@ -155,12 +157,21 @@ export const useArrayElementListData = ({
     return 'No elements found.'
   }, [loading])
 
-  // Fetch more elements when the user pages past what we've already loaded
+  // Fetch more elements when the user pages past what we've already loaded.
+  // Guard against infinite retry loops: if a fetch for the current cursor
+  // already failed, nextCursor remains unchanged and lastAttemptedCursor
+  // prevents us from dispatching again until the cursor advances.
   useEffect(() => {
     const { pageIndex, pageSize } = pagination
     const requiredEnd = (pageIndex + 1) * pageSize
 
-    if (requiredEnd > elements.length && nextCursor !== undefined && !loading) {
+    if (
+      requiredEnd > elements.length &&
+      nextCursor !== undefined &&
+      !loading &&
+      lastAttemptedCursor.current !== nextCursor
+    ) {
+      lastAttemptedCursor.current = nextCursor
       dispatch(
         fetchMoreArrayElements({
           key: key as RedisResponseBuffer,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
@@ -176,7 +176,6 @@ export const useArrayElementListData = ({
         fetchMoreArrayElements({
           key: key as RedisResponseBuffer,
           cursor: nextCursor,
-          count: pageSize,
         }),
       )
     }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayElementListData.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { PaginationState } from 'uiSrc/components/base/layout/table'
+import {
+  selectedKeyDataSelector,
+  selectedKeySelector,
+  setSelectedKeyRefreshDisabled,
+} from 'uiSrc/slices/browser/keys'
+import {
+  addArrayElements,
+  addArrayElementsStateSelector,
+  arrayDataSelector,
+  arraySelector,
+  deleteArrayElements,
+  fetchMoreArrayElements,
+} from 'uiSrc/slices/browser/array'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+import { getArrayColumns } from '../array-element-list/ArrayElementList.config'
+import { DEFAULT_PAGE_SIZE } from '../array-element-list/constants'
+
+const ELEMENT_DELETE_POPOVER_SUFFIX = '_array'
+const MIN_COLUMN_WIDTH = 100
+
+export const useArrayElementListData = ({
+  onRemoveKey,
+}: {
+  onRemoveKey: () => void
+}) => {
+  const { loading } = useSelector(arraySelector)
+  const { loading: updateLoading } = useSelector(addArrayElementsStateSelector)
+  const {
+    elements = [],
+    nextCursor,
+    total = 0,
+  } = useSelector(arrayDataSelector) ?? {}
+  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { viewFormat } = useSelector(selectedKeySelector)
+
+  const dispatch = useDispatch()
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  })
+  const [deleting, setDeleting] = useState('')
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+  }, [key])
+
+  const closePopover = useCallback(() => {
+    setDeleting('')
+  }, [])
+
+  const showPopover = useCallback((item = '') => {
+    setDeleting(`${item}${ELEMENT_DELETE_POPOVER_SUFFIX}`)
+  }, [])
+
+  const onSuccessRemoved = (newTotal: number) => {
+    if (newTotal === 0) {
+      onRemoveKey()
+    }
+  }
+
+  const handleDeleteElement = useCallback(
+    (index: number) => {
+      dispatch(
+        deleteArrayElements(
+          key as RedisResponseBuffer,
+          [index],
+          onSuccessRemoved,
+        ),
+      )
+      closePopover()
+    },
+    [key, dispatch, closePopover],
+  )
+
+  const handleEditElement = useCallback(
+    (arrayIndex: number, isEditing: boolean) => {
+      setEditingIndex(isEditing ? arrayIndex : null)
+      dispatch(setSelectedKeyRefreshDisabled(isEditing))
+    },
+    [dispatch],
+  )
+
+  const handleApplyEditValue = useCallback(
+    (arrayIndex: number, value: string) => {
+      dispatch(
+        addArrayElements(
+          {
+            keyName: key as RedisResponseBuffer,
+            elements: [{ index: arrayIndex, value }],
+          },
+          () => handleEditElement(arrayIndex, false),
+        ),
+      )
+    },
+    [key, dispatch, handleEditElement],
+  )
+
+  const columns = useMemo(
+    () =>
+      getArrayColumns({
+        viewFormat,
+        elementDeleteConfig: {
+          deleting,
+          suffix: ELEMENT_DELETE_POPOVER_SUFFIX,
+          total,
+          keyName: key,
+          closePopover,
+          showPopover,
+          handleDeleteElement,
+        },
+        elementEditConfig: {
+          editingIndex,
+          updateLoading,
+          handleEditElement,
+          handleApplyEditValue,
+        },
+      }),
+    [
+      viewFormat,
+      deleting,
+      total,
+      key,
+      closePopover,
+      showPopover,
+      handleDeleteElement,
+      editingIndex,
+      updateLoading,
+      handleEditElement,
+      handleApplyEditValue,
+    ],
+  )
+
+  const tableMinWidth = useMemo(
+    () => `${Math.max(columns.length * MIN_COLUMN_WIDTH, 400)}px`,
+    [columns.length],
+  )
+
+  const currentPageData = useMemo(() => {
+    const { pageIndex, pageSize } = pagination
+    return elements.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
+  }, [elements, pagination])
+
+  const emptyMessage = useMemo(() => {
+    if (loading) return 'Loading...'
+    return 'No elements found.'
+  }, [loading])
+
+  // Fetch more elements when the user pages past what we've already loaded
+  useEffect(() => {
+    const { pageIndex, pageSize } = pagination
+    const requiredEnd = (pageIndex + 1) * pageSize
+
+    if (requiredEnd > elements.length && nextCursor !== undefined && !loading) {
+      dispatch(
+        fetchMoreArrayElements({
+          key: key as RedisResponseBuffer,
+          cursor: nextCursor,
+          count: pageSize,
+        }),
+      )
+    }
+  }, [pagination, elements, nextCursor, loading, key, dispatch])
+
+  return {
+    columns,
+    currentPageData,
+    tableMinWidth,
+    pagination,
+    setPagination,
+    emptyMessage,
+    total,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/index.ts
@@ -1,0 +1,1 @@
+export * from './ArrayDetails'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -7,7 +7,10 @@ import {
 } from 'uiSrc/constants'
 import { KeyDetailsHeaderProps } from 'uiSrc/pages/browser/modules'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isDevVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { isTruncatedString } from 'uiSrc/utils'
 import TooLongKeyNameDetails from 'uiSrc/pages/browser/modules/key-details/components/too-long-key-name-details/TooLongKeyNameDetails'
 import ModulesTypeDetails from '../modules-type-details/ModulesTypeDetails'
@@ -20,6 +23,7 @@ import { HashDetails } from '../hash-details'
 import { ListDetails } from '../list-details'
 import { StreamDetails } from '../stream-details'
 import { VectorSetDetails } from '../vector-set-details'
+import { ArrayDetails } from '../array-details'
 
 export interface Props extends KeyDetailsHeaderProps {
   onOpenAddItemPanel: () => void
@@ -31,6 +35,7 @@ export interface Props extends KeyDetailsHeaderProps {
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
   const isDevVectorSet = useSelector(isDevVectorSetEnabledSelector)
+  const isDevArray = useSelector(isDevArrayEnabledSelector)
 
   const TypeDetails: any = {
     [KeyTypes.ZSet]: <ZSetDetails {...props} />,
@@ -42,6 +47,9 @@ const DynamicTypeDetails = (props: Props) => {
     [KeyTypes.Stream]: <StreamDetails {...props} />,
     ...(isDevVectorSet && {
       [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
+    }),
+    ...(isDevArray && {
+      [KeyTypes.Array]: <ArrayDetails {...props} />,
     }),
   }
 

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -65,6 +65,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devVectorSet]: {
         flag: false,
       },
+      [FeatureFlags.devArray]: {
+        flag: false,
+      },
       [FeatureFlags.azureEntraId]: {
         flag: false,
       },
@@ -232,6 +235,15 @@ export const isDevVectorSetEnabledSelector = (state: RootState): boolean => {
 
   const features = state.app.features.featureFlags.features
   return features[FeatureFlags.devVectorSet]?.flag ?? false
+}
+
+export const isDevArrayEnabledSelector = (state: RootState): boolean => {
+  if (isDevelopment) {
+    return true
+  }
+
+  const features = state.app.features.featureFlags.features
+  return features[FeatureFlags.devArray]?.flag ?? false
 }
 
 export default appFeaturesSlice.reducer

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -121,13 +121,16 @@ const arraySlice = createSlice({
     },
     removeIndicesFromList: (
       state,
-      { payload: indices }: PayloadAction<number[]>,
+      {
+        payload: { indices, affected },
+      }: PayloadAction<{ indices: number[]; affected: number }>,
     ) => {
-      const before = state.data.elements.length
       state.data.elements = state.data.elements.filter(
         (el) => !indices.includes(el.index),
       )
-      state.data.total -= before - state.data.elements.length
+      // Use the server-reported affected count so total stays accurate even
+      // when not all deleted indices are present in the loaded page.
+      state.data.total -= affected
     },
 
     addElements: (state) => {
@@ -280,11 +283,6 @@ export function deleteArrayElements(
       )
 
       if (isStatusSuccessful(status)) {
-        // Re-read state after the async call so concurrent deletes don't produce
-        // a stale total that mis-triggers (or skips) the key-removal branch.
-        const newTotalValue =
-          stateInit().browser.array.data.total - data.affected
-
         sendEventTelemetry({
           event: TelemetryEvent.BROWSER_KEY_VALUE_REMOVED,
           eventData: {
@@ -293,9 +291,15 @@ export function deleteArrayElements(
           },
         })
 
-        onSuccessAction?.(newTotalValue)
+        // Use data.affected (server truth) for both the callback and the reducer
+        // so there is a single source of truth — no separate computation paths.
+        const newTotalValue =
+          stateInit().browser.array.data.total - data.affected
+
         dispatch(removeArrayElementsSuccess())
-        dispatch(removeIndicesFromList(indices))
+        dispatch(removeIndicesFromList({ indices, affected: data.affected }))
+
+        onSuccessAction?.(newTotalValue)
 
         if (newTotalValue > 0) {
           dispatch(refreshKeyInfoAction(key))

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -123,10 +123,11 @@ const arraySlice = createSlice({
       state,
       { payload: indices }: PayloadAction<number[]>,
     ) => {
+      const before = state.data.elements.length
       state.data.elements = state.data.elements.filter(
         (el) => !indices.includes(el.index),
       )
-      state.data.total -= indices.length
+      state.data.total -= before - state.data.elements.length
     },
 
     addElements: (state) => {

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -25,7 +25,6 @@ import {
   AddArrayElementsData,
   AddArrayElementsState,
   ArrayData,
-  CreateArrayWithExpireDto,
   FetchArrayElementsParams,
   FetchMoreArrayElementsParams,
   GetArrayElementsResponse,
@@ -348,48 +347,6 @@ export function addArrayElements(
         dispatch(addElementsSuccess())
         dispatch<any>(fetchArrayElements({ key: data.keyName }))
         dispatch(refreshKeyInfoAction(data.keyName))
-      } else {
-        dispatch(addElementsFailure(DEFAULT_ERROR_MESSAGE))
-        onFailAction?.()
-      }
-    } catch (_err) {
-      const error = _err as AxiosError
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
-      dispatch(addElementsFailure(errorMessage))
-      onFailAction?.()
-    }
-  }
-}
-
-export function createArrayKey(
-  data: CreateArrayWithExpireDto,
-  onSuccessAction?: () => void,
-  onFailAction?: () => void,
-) {
-  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    dispatch(addElements())
-    try {
-      const state = stateInit()
-      const { encoding } = state.app.info
-      const { status } = await apiService.post(
-        getUrl(
-          state.connections.instances.connectedInstance?.id,
-          ApiEndpoints.ARRAY,
-        ),
-        data,
-        { params: { encoding } },
-      )
-      if (isStatusSuccessful(status)) {
-        onSuccessAction?.()
-        dispatch(addElementsSuccess())
-        sendEventTelemetry({
-          event: TelemetryEvent.BROWSER_KEY_ADDED,
-          eventData: {
-            databaseId: state.connections.instances.connectedInstance?.id,
-            keyType: 'array',
-          },
-        })
       } else {
         dispatch(addElementsFailure(DEFAULT_ERROR_MESSAGE))
         onFailAction?.()

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -1,0 +1,405 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
+
+import { apiService } from 'uiSrc/services'
+import { ApiEndpoints } from 'uiSrc/constants'
+import {
+  DEFAULT_ERROR_MESSAGE,
+  getApiErrorMessage,
+  getUrl,
+  isStatusSuccessful,
+  stringToBuffer,
+} from 'uiSrc/utils'
+import successMessages from 'uiSrc/components/notifications/success-messages'
+import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+
+import {
+  deleteKeyFromList,
+  deleteSelectedKeySuccess,
+  refreshKeyInfoAction,
+  updateSelectedKeyRefreshTime,
+} from './keys'
+import { AppDispatch, RootState } from '../store'
+import { RedisResponseBuffer } from '../interfaces'
+import {
+  AddArrayElementsData,
+  AddArrayElementsState,
+  ArrayData,
+  CreateArrayWithExpireDto,
+  FetchArrayElementsParams,
+  FetchMoreArrayElementsParams,
+  GetArrayElementsResponse,
+  InitialStateArray,
+} from '../interfaces/array'
+import {
+  addErrorNotification,
+  addMessageNotification,
+  IAddInstanceErrorPayload,
+} from '../app/notifications'
+
+const ARRAY_COUNT_DEFAULT = 500
+
+export const initialState: InitialStateArray = {
+  loading: false,
+  error: '',
+  data: {
+    total: 0,
+    logicalLength: 0,
+    keyName: '',
+    nextCursor: undefined,
+    elements: [],
+  },
+  adding: {
+    loading: false,
+    error: '',
+  },
+}
+
+const arraySlice = createSlice({
+  name: 'array',
+  initialState,
+  reducers: {
+    loadArrayElements: (
+      state,
+      { payload: resetData = true }: PayloadAction<boolean | undefined>,
+    ) => {
+      state.loading = true
+      state.error = ''
+
+      if (resetData) {
+        state.data = initialState.data
+      }
+    },
+    loadArrayElementsSuccess: (
+      state,
+      { payload }: PayloadAction<ArrayData>,
+    ) => {
+      state.data = {
+        ...state.data,
+        ...payload,
+      }
+      state.loading = false
+    },
+    loadArrayElementsFailure: (state, { payload }: PayloadAction<string>) => {
+      state.loading = false
+      state.error = payload
+    },
+
+    loadMoreArrayElements: (state) => {
+      state.loading = true
+      state.error = ''
+    },
+    loadMoreArrayElementsSuccess: (
+      state,
+      { payload: { elements, nextCursor, ...rest } }: PayloadAction<ArrayData>,
+    ) => {
+      state.loading = false
+      state.data = {
+        ...state.data,
+        ...rest,
+        nextCursor,
+        elements: (state.data?.elements ?? []).concat(elements),
+      }
+    },
+    loadMoreArrayElementsFailure: (
+      state,
+      { payload }: PayloadAction<string>,
+    ) => {
+      state.loading = false
+      state.error = payload
+    },
+
+    removeArrayElements: (state) => {
+      state.loading = true
+      state.error = ''
+    },
+    removeArrayElementsSuccess: (state) => {
+      state.loading = false
+    },
+    removeArrayElementsFailure: (state, { payload }: PayloadAction<string>) => {
+      state.loading = false
+      state.error = payload
+    },
+    removeIndicesFromList: (
+      state,
+      { payload: indices }: PayloadAction<number[]>,
+    ) => {
+      state.data.elements = state.data.elements.filter(
+        (el) => !indices.includes(el.index),
+      )
+      state.data.total -= indices.length
+    },
+
+    addElements: (state) => {
+      state.adding = {
+        ...state.adding,
+        loading: true,
+        error: '',
+      }
+    },
+    addElementsSuccess: (state) => {
+      state.adding = {
+        ...state.adding,
+        loading: false,
+      }
+    },
+    addElementsFailure: (state, { payload }: PayloadAction<string>) => {
+      state.adding = {
+        ...state.adding,
+        loading: false,
+        error: payload,
+      }
+    },
+  },
+})
+
+export const {
+  loadArrayElements,
+  loadArrayElementsSuccess,
+  loadArrayElementsFailure,
+  loadMoreArrayElements,
+  loadMoreArrayElementsSuccess,
+  loadMoreArrayElementsFailure,
+  removeArrayElements,
+  removeArrayElementsSuccess,
+  removeArrayElementsFailure,
+  removeIndicesFromList,
+  addElements,
+  addElementsSuccess,
+  addElementsFailure,
+} = arraySlice.actions
+
+export const arraySelector = (state: RootState) => state.browser.array
+export const arrayDataSelector = (state: RootState) => state.browser.array?.data
+export const addArrayElementsStateSelector = (
+  state: RootState,
+): AddArrayElementsState => state.browser.array?.adding
+
+export default arraySlice.reducer
+
+export function fetchArrayElements({
+  key,
+  count = ARRAY_COUNT_DEFAULT,
+  resetData,
+}: FetchArrayElementsParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(loadArrayElements(resetData))
+
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { data, status } = await apiService.post<GetArrayElementsResponse>(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.ARRAY_GET_ELEMENTS,
+        ),
+        {
+          keyName: key,
+          cursor: 0,
+          count,
+        },
+        { params: { encoding } },
+      )
+
+      if (isStatusSuccessful(status)) {
+        dispatch(loadArrayElementsSuccess(data))
+        dispatch(updateSelectedKeyRefreshTime(Date.now()))
+      } else {
+        dispatch(loadArrayElementsFailure(DEFAULT_ERROR_MESSAGE))
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadArrayElementsFailure(errorMessage))
+    }
+  }
+}
+
+export function fetchMoreArrayElements({
+  key,
+  cursor,
+  count = ARRAY_COUNT_DEFAULT,
+}: FetchMoreArrayElementsParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(loadMoreArrayElements())
+
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { data, status } = await apiService.post<GetArrayElementsResponse>(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.ARRAY_GET_ELEMENTS,
+        ),
+        {
+          keyName: key,
+          cursor,
+          count,
+        },
+        { params: { encoding } },
+      )
+
+      if (isStatusSuccessful(status)) {
+        dispatch(loadMoreArrayElementsSuccess(data))
+      } else {
+        dispatch(loadMoreArrayElementsFailure(DEFAULT_ERROR_MESSAGE))
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadMoreArrayElementsFailure(errorMessage))
+    }
+  }
+}
+
+export function deleteArrayElements(
+  key: RedisResponseBuffer,
+  indices: number[],
+  onSuccessAction?: (newTotal: number) => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(removeArrayElements())
+
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { data, status } = await apiService.delete(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.ARRAY_ELEMENTS,
+        ),
+        {
+          data: {
+            keyName: key,
+            indices,
+          },
+          params: { encoding },
+        },
+      )
+
+      if (isStatusSuccessful(status)) {
+        const newTotalValue = state.browser.array.data.total - data.affected
+
+        sendEventTelemetry({
+          event: TelemetryEvent.BROWSER_KEY_VALUE_REMOVED,
+          eventData: {
+            databaseId: state.connections.instances.connectedInstance?.id,
+            keyType: 'array',
+          },
+        })
+
+        onSuccessAction?.(newTotalValue)
+        dispatch(removeArrayElementsSuccess())
+        dispatch(removeIndicesFromList(indices))
+
+        if (newTotalValue > 0) {
+          dispatch(refreshKeyInfoAction(key))
+          dispatch(
+            addMessageNotification(
+              successMessages.REMOVED_KEY_VALUE(
+                key,
+                stringToBuffer(indices.join(', ')),
+                'Element',
+              ),
+            ),
+          )
+        } else {
+          dispatch(deleteSelectedKeySuccess())
+          dispatch(deleteKeyFromList(key))
+          dispatch(addMessageNotification(successMessages.DELETED_KEY(key)))
+        }
+      } else {
+        dispatch(removeArrayElementsFailure(DEFAULT_ERROR_MESSAGE))
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(removeArrayElementsFailure(errorMessage))
+    }
+  }
+}
+
+export function addArrayElements(
+  data: AddArrayElementsData,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(addElements())
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { status } = await apiService.put(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.ARRAY,
+        ),
+        {
+          keyName: data.keyName,
+          elements: data.elements,
+        },
+        { params: { encoding } },
+      )
+      if (isStatusSuccessful(status)) {
+        onSuccessAction?.()
+        dispatch(addElementsSuccess())
+        dispatch<any>(fetchArrayElements({ key: data.keyName }))
+        dispatch(refreshKeyInfoAction(data.keyName))
+      } else {
+        dispatch(addElementsFailure(DEFAULT_ERROR_MESSAGE))
+        onFailAction?.()
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(addElementsFailure(errorMessage))
+      onFailAction?.()
+    }
+  }
+}
+
+export function createArrayKey(
+  data: CreateArrayWithExpireDto,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(addElements())
+    try {
+      const state = stateInit()
+      const { encoding } = state.app.info
+      const { status } = await apiService.post(
+        getUrl(
+          state.connections.instances.connectedInstance?.id,
+          ApiEndpoints.ARRAY,
+        ),
+        data,
+        { params: { encoding } },
+      )
+      if (isStatusSuccessful(status)) {
+        onSuccessAction?.()
+        dispatch(addElementsSuccess())
+        sendEventTelemetry({
+          event: TelemetryEvent.BROWSER_KEY_ADDED,
+          eventData: {
+            databaseId: state.connections.instances.connectedInstance?.id,
+            keyType: 'array',
+          },
+        })
+      } else {
+        dispatch(addElementsFailure(DEFAULT_ERROR_MESSAGE))
+        onFailAction?.()
+      }
+    } catch (_err) {
+      const error = _err as AxiosError
+      const errorMessage = getApiErrorMessage(error)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(addElementsFailure(errorMessage))
+      onFailAction?.()
+    }
+  }
+}

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -280,7 +280,10 @@ export function deleteArrayElements(
       )
 
       if (isStatusSuccessful(status)) {
-        const newTotalValue = state.browser.array.data.total - data.affected
+        // Re-read state after the async call so concurrent deletes don't produce
+        // a stale total that mis-triggers (or skips) the key-removal branch.
+        const newTotalValue =
+          stateInit().browser.array.data.total - data.affected
 
         sendEventTelemetry({
           event: TelemetryEvent.BROWSER_KEY_VALUE_REMOVED,

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -45,6 +45,7 @@ import {
 import { NamespaceSearchableResult } from 'uiSrc/slices/interfaces/keys'
 
 import { CreateVectorSetWithExpireDto } from 'uiSrc/slices/interfaces/vectorSet'
+import { CreateArrayWithExpireDto } from 'uiSrc/slices/interfaces/array'
 
 import { fetchString } from './string'
 import {
@@ -54,6 +55,7 @@ import {
 } from './zset'
 import { fetchSetMembers, refreshSetMembersAction } from './set'
 import { fetchVectorSetElements } from './vectorSet'
+import { fetchArrayElements } from './array'
 import { fetchReJSON, setEditorType, setIsWithinThreshold } from './rejson'
 import {
   setHashInitialState,
@@ -167,6 +169,9 @@ export const initialKeyInfo = {
   length: 0,
   quantType: undefined,
   vectorDim: undefined,
+  nextInsertIndex: undefined,
+  slices: undefined,
+  sliceSize: undefined,
 }
 
 const getInitialSelectedKeyState = (state: KeysStore) => ({
@@ -890,6 +895,9 @@ export function fetchKeyInfo(
       if (data.type === KeyTypes.VectorSet) {
         dispatch<any>(fetchVectorSetElements({ key, resetData }))
       }
+      if (data.type === KeyTypes.Array) {
+        dispatch<any>(fetchArrayElements({ key, resetData }))
+      }
     } catch (_err) {
       const error = _err as AxiosError
       const errorMessage = getApiErrorMessage(error)
@@ -1069,6 +1077,14 @@ export function addVectorSetKey(
   onFailAction?: () => void,
 ) {
   return addTypedKey(data, KeyTypes.VectorSet, onSuccessAction, onFailAction)
+}
+
+export function addArrayKey(
+  data: CreateArrayWithExpireDto,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return addTypedKey(data, KeyTypes.Array, onSuccessAction, onFailAction)
 }
 
 // Asynchronous thunk action
@@ -1605,6 +1621,10 @@ export function refreshKey(
       }
       case KeyTypes.VectorSet: {
         dispatch(fetchVectorSetElements({ key, resetData }))
+        break
+      }
+      case KeyTypes.Array: {
+        dispatch(fetchArrayElements({ key, resetData }))
         break
       }
       default:

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -13,13 +13,7 @@ export interface ArrayData {
   elements: ArrayElement[]
 }
 
-export interface GetArrayElementsResponse {
-  total: number
-  logicalLength: number
-  keyName: RedisString
-  nextCursor?: number
-  elements: ArrayElement[]
-}
+export type GetArrayElementsResponse = ArrayData
 
 export interface AddArrayElementsState {
   loading: boolean

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -1,0 +1,63 @@
+import { RedisResponseBuffer, RedisString } from 'uiSrc/slices/interfaces/app'
+
+export interface ArrayElement {
+  index: number
+  value: RedisResponseBuffer
+}
+
+export interface ArrayData {
+  total: number
+  logicalLength: number
+  keyName: RedisString
+  nextCursor?: number
+  elements: ArrayElement[]
+}
+
+export interface GetArrayElementsResponse {
+  total: number
+  logicalLength: number
+  keyName: RedisString
+  nextCursor?: number
+  elements: ArrayElement[]
+}
+
+export interface AddArrayElementsState {
+  loading: boolean
+  error: string
+}
+
+export interface InitialStateArray {
+  loading: boolean
+  error: string
+  data: ArrayData
+  adding: AddArrayElementsState
+}
+
+export interface AddArrayElementsData {
+  keyName: RedisResponseBuffer
+  elements: {
+    index: number
+    value: string
+  }[]
+}
+
+export interface CreateArrayWithExpireDto {
+  keyName: RedisResponseBuffer
+  elements: {
+    index: number
+    value: RedisResponseBuffer
+  }[]
+  expire?: number
+}
+
+export interface FetchArrayElementsParams {
+  key: RedisResponseBuffer
+  count?: number
+  resetData?: boolean
+}
+
+export interface FetchMoreArrayElementsParams {
+  key: RedisResponseBuffer
+  cursor: number
+  count?: number
+}

--- a/redisinsight/ui/src/slices/interfaces/index.ts
+++ b/redisinsight/ui/src/slices/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './instances'
 export * from './vectorSet'
+export * from './array'
 export * from './hash'
 export * from './app'
 export * from './workbench'

--- a/redisinsight/ui/src/slices/store.ts
+++ b/redisinsight/ui/src/slices/store.ts
@@ -17,6 +17,7 @@ import listReducer from './browser/list'
 import rejsonReducer from './browser/rejson'
 import streamReducer from './browser/stream'
 import vectorSetReducer from './browser/vectorSet'
+import arrayReducer from './browser/array'
 import bulkActionsReducer from './browser/bulkActions'
 import notificationsReducer from './app/notifications'
 import cliSettingsReducer from './cli/cli-settings'
@@ -96,6 +97,7 @@ export const rootReducer = combineReducers({
     rejson: rejsonReducer,
     stream: streamReducer,
     vectorSet: vectorSetReducer,
+    array: arrayReducer,
     bulkActions: bulkActionsReducer,
     redisearch: redisearchReducer,
   }),

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1,0 +1,554 @@
+import { faker } from '@faker-js/faker'
+import { cloneDeep } from 'lodash'
+
+import { apiService } from 'uiSrc/services'
+import {
+  cleanup,
+  initialStateDefault,
+  mockedStore,
+  mockStore,
+} from 'uiSrc/utils/test-utils'
+import {
+  addErrorNotification,
+  IAddInstanceErrorPayload,
+} from 'uiSrc/slices/app/notifications'
+import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
+import {
+  arrayElementFactory,
+  arrayTestKeyName,
+  addArrayElementsDataFactory,
+} from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
+import {
+  deleteSelectedKeySuccess,
+  updateSelectedKeyRefreshTime,
+} from '../../browser/keys'
+import reducer, {
+  initialState,
+  loadArrayElements,
+  loadArrayElementsSuccess,
+  loadArrayElementsFailure,
+  loadMoreArrayElements,
+  loadMoreArrayElementsSuccess,
+  loadMoreArrayElementsFailure,
+  removeArrayElements,
+  removeArrayElementsSuccess,
+  removeArrayElementsFailure,
+  removeIndicesFromList,
+  addElements,
+  addElementsSuccess,
+  addElementsFailure,
+  arraySelector,
+  arrayDataSelector,
+  addArrayElementsStateSelector,
+  fetchArrayElements,
+  fetchMoreArrayElements,
+  deleteArrayElements,
+  addArrayElements,
+  createArrayKey,
+} from '../../browser/array'
+
+jest.mock('uiSrc/services', () => ({
+  ...jest.requireActual('uiSrc/services'),
+}))
+
+let store: typeof mockedStore
+let dateNow: jest.SpyInstance<number>
+
+beforeEach(() => {
+  cleanup()
+  store = cloneDeep(mockedStore)
+  store.clearActions()
+})
+
+describe('array slice', () => {
+  beforeAll(() => {
+    dateNow = jest.spyOn(Date, 'now').mockImplementation(() => MOCK_TIMESTAMP)
+  })
+
+  afterAll(() => {
+    dateNow.mockRestore()
+  })
+
+  describe('reducer, actions and selectors', () => {
+    it('should return the initial state on first run', () => {
+      const result = reducer(undefined, {} as any)
+      expect(result).toEqual(initialState)
+    })
+  })
+
+  // ─── loadArrayElements ────────────────────────────────────────────────────
+
+  describe('loadArrayElements', () => {
+    it('should set loading=true and reset data when resetData=true', () => {
+      const nextState = reducer(initialState, loadArrayElements(true))
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: nextState },
+      }
+      expect(arraySelector(rootState)).toEqual({
+        ...initialState,
+        loading: true,
+        error: '',
+      })
+    })
+
+    it('should set loading=true without resetting data when resetData=false', () => {
+      const stateWithData = {
+        ...initialState,
+        data: {
+          ...initialState.data,
+          total: 5,
+          elements: arrayElementFactory.buildList(2),
+        },
+      }
+      const nextState = reducer(stateWithData, loadArrayElements(false))
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: nextState },
+      }
+      const result = arraySelector(rootState)
+      expect(result.loading).toBe(true)
+      expect(result.data.total).toBe(5)
+    })
+  })
+
+  // ─── loadArrayElementsSuccess ─────────────────────────────────────────────
+
+  describe('loadArrayElementsSuccess', () => {
+    it('should properly set the state with fetched data', () => {
+      const elements = arrayElementFactory.buildList(3)
+      const keyName = arrayTestKeyName()
+      const data = {
+        keyName,
+        total: elements.length,
+        logicalLength: elements.length,
+        nextCursor: undefined,
+        elements,
+      }
+
+      const nextState = reducer(initialState, loadArrayElementsSuccess(data))
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: nextState },
+      }
+      expect(arraySelector(rootState)).toEqual({
+        ...initialState,
+        loading: false,
+        data,
+      })
+    })
+  })
+
+  // ─── loadArrayElementsFailure ─────────────────────────────────────────────
+
+  describe('loadArrayElementsFailure', () => {
+    it('should properly set error in state', () => {
+      const error = faker.lorem.sentence()
+      const nextState = reducer(initialState, loadArrayElementsFailure(error))
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: nextState },
+      }
+      expect(arraySelector(rootState)).toEqual({
+        ...initialState,
+        loading: false,
+        error,
+      })
+    })
+  })
+
+  // ─── loadMoreArrayElements ────────────────────────────────────────────────
+
+  describe('loadMoreArrayElements / loadMoreArrayElementsSuccess', () => {
+    it('should set loading=true on loadMoreArrayElements', () => {
+      const nextState = reducer(initialState, loadMoreArrayElements())
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: nextState },
+      }
+      expect(arraySelector(rootState).loading).toBe(true)
+    })
+
+    it('should append elements on loadMoreArrayElementsSuccess', () => {
+      const existingElements = arrayElementFactory.buildList(2)
+      const newElements = arrayElementFactory.buildList(2)
+      const stateWithElements = {
+        ...initialState,
+        loading: true,
+        data: { ...initialState.data, elements: existingElements, total: 4 },
+      }
+
+      const nextState = reducer(
+        stateWithElements,
+        loadMoreArrayElementsSuccess({
+          keyName: arrayTestKeyName(),
+          total: 4,
+          logicalLength: 4,
+          elements: newElements,
+          nextCursor: undefined,
+        }),
+      )
+      expect(nextState.data.elements).toHaveLength(4)
+      expect(nextState.loading).toBe(false)
+    })
+  })
+
+  // ─── loadMoreArrayElementsFailure ─────────────────────────────────────────
+
+  describe('loadMoreArrayElementsFailure', () => {
+    it('should set error', () => {
+      const error = faker.lorem.sentence()
+      const nextState = reducer(
+        { ...initialState, loading: true },
+        loadMoreArrayElementsFailure(error),
+      )
+      expect(nextState.loading).toBe(false)
+      expect(nextState.error).toBe(error)
+    })
+  })
+
+  // ─── removeIndicesFromList ────────────────────────────────────────────────
+
+  describe('removeIndicesFromList', () => {
+    it('should remove specified indices and decrement total', () => {
+      const elements = arrayElementFactory.buildList(3)
+      const stateWithElements = {
+        ...initialState,
+        data: { ...initialState.data, elements, total: 3 },
+      }
+
+      // Use actual indices from built elements rather than hardcoded 0
+      const indexToRemove = elements[0].index
+      const nextState = reducer(
+        stateWithElements,
+        removeIndicesFromList([indexToRemove]),
+      )
+      expect(nextState.data.elements).toHaveLength(2)
+      expect(nextState.data.total).toBe(2)
+      expect(
+        nextState.data.elements.find((e) => e.index === indexToRemove),
+      ).toBeUndefined()
+    })
+  })
+
+  // ─── adding sub-state ─────────────────────────────────────────────────────
+
+  describe('addElements / addElementsSuccess / addElementsFailure', () => {
+    it('should set adding.loading=true on addElements', () => {
+      const nextState = reducer(initialState, addElements())
+      expect(nextState.adding.loading).toBe(true)
+      expect(nextState.adding.error).toBe('')
+    })
+
+    it('should set adding.loading=false on addElementsSuccess', () => {
+      const loadingState = reducer(initialState, addElements())
+      const nextState = reducer(loadingState, addElementsSuccess())
+      expect(nextState.adding.loading).toBe(false)
+    })
+
+    it('should set adding.error on addElementsFailure', () => {
+      const error = faker.lorem.sentence()
+      const nextState = reducer(initialState, addElementsFailure(error))
+      expect(nextState.adding.loading).toBe(false)
+      expect(nextState.adding.error).toBe(error)
+    })
+  })
+
+  // ─── selectors ────────────────────────────────────────────────────────────
+
+  describe('selectors', () => {
+    it('arrayDataSelector should return data slice', () => {
+      const elements = arrayElementFactory.buildList(2)
+      const data = {
+        ...initialState.data,
+        total: 2,
+        elements,
+      }
+      const stateWithData = { ...initialState, data }
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: stateWithData },
+      }
+      expect(arrayDataSelector(rootState)).toEqual(data)
+    })
+
+    it('addArrayElementsStateSelector should return adding slice', () => {
+      const rootState = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: initialState },
+      }
+      expect(addArrayElementsStateSelector(rootState)).toEqual(
+        initialState.adding,
+      )
+    })
+  })
+
+  // ─── thunks ───────────────────────────────────────────────────────────────
+
+  describe('thunks', () => {
+    describe('fetchArrayElements', () => {
+      const elements = arrayElementFactory.buildList(3)
+      const keyName = arrayTestKeyName()
+      const apiResponse = {
+        keyName,
+        total: elements.length,
+        logicalLength: elements.length,
+        elements,
+        nextCursor: undefined,
+      }
+
+      it('dispatches loadArrayElementsSuccess when fetch is successful', async () => {
+        const responsePayload = { data: apiResponse, status: 200 }
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        await store.dispatch<any>(fetchArrayElements({ key: keyName as any }))
+
+        const expectedActions = [
+          loadArrayElements(undefined),
+          loadArrayElementsSuccess(apiResponse),
+          updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+
+      it('dispatches loadArrayElementsFailure when fetch fails', async () => {
+        const errorMessage = 'Something went wrong!'
+        const responsePayload = {
+          response: {
+            status: 500,
+            data: { message: errorMessage },
+          },
+        }
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(fetchArrayElements({ key: keyName as any }))
+
+        const expectedActions = [
+          loadArrayElements(undefined),
+          addErrorNotification(responsePayload as IAddInstanceErrorPayload),
+          loadArrayElementsFailure(errorMessage),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('fetchMoreArrayElements', () => {
+      const moreElements = arrayElementFactory.buildList(2)
+      const keyName = arrayTestKeyName()
+      const moreApiResponse = {
+        keyName,
+        total: faker.number.int({ min: moreElements.length + 1, max: 50 }),
+        logicalLength: faker.number.int({
+          min: moreElements.length + 1,
+          max: 50,
+        }),
+        elements: moreElements,
+        nextCursor: undefined,
+      }
+
+      it('dispatches loadMoreVectorSetElementsSuccess when fetch is successful', async () => {
+        const responsePayload = { data: moreApiResponse, status: 200 }
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        await store.dispatch<any>(
+          fetchMoreArrayElements({
+            key: keyName as any,
+            cursor: faker.number.int({ min: 1, max: 100 }),
+          }),
+        )
+
+        const expectedActions = [
+          loadMoreArrayElements(),
+          loadMoreArrayElementsSuccess(moreApiResponse),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+
+      it('dispatches loadMoreArrayElementsFailure when fetch fails', async () => {
+        const errorMessage = 'Fetch more failed!'
+        const responsePayload = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(
+          fetchMoreArrayElements({ key: keyName as any, cursor: 1 }),
+        )
+
+        const expectedActions = [
+          loadMoreArrayElements(),
+          addErrorNotification(responsePayload as IAddInstanceErrorPayload),
+          loadMoreArrayElementsFailure(errorMessage),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('deleteArrayElements', () => {
+      const keyName = arrayTestKeyName()
+      const indicesToDelete = [0, 1]
+
+      it('dispatches removeArrayElementsSuccess and refreshes key info when elements remain', async () => {
+        const storeWithArray = mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: {
+              ...initialState,
+              data: { ...initialState.data, total: 5 },
+            },
+          },
+        })
+        const responsePayload = {
+          data: { affected: indicesToDelete.length },
+          status: 200,
+        }
+        apiService.delete = jest.fn().mockResolvedValue(responsePayload)
+        const onSuccess = jest.fn()
+
+        await storeWithArray.dispatch<any>(
+          deleteArrayElements(keyName as any, indicesToDelete, onSuccess),
+        )
+
+        expect(onSuccess).toHaveBeenCalledWith(3)
+        const actions = storeWithArray.getActions()
+        expect(actions).toContainEqual(removeArrayElements())
+        expect(actions).toContainEqual(removeArrayElementsSuccess())
+        expect(actions).toContainEqual(removeIndicesFromList(indicesToDelete))
+      })
+
+      it('dispatches deleteSelectedKeySuccess when last elements are removed', async () => {
+        const storeWithArray = mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: {
+              ...initialState,
+              data: { ...initialState.data, total: 2 },
+            },
+          },
+        })
+        const responsePayload = { data: { affected: 2 }, status: 200 }
+        apiService.delete = jest.fn().mockResolvedValue(responsePayload)
+
+        await storeWithArray.dispatch<any>(
+          deleteArrayElements(keyName as any, [0, 1]),
+        )
+
+        const actions = storeWithArray.getActions()
+        expect(actions).toContainEqual(deleteSelectedKeySuccess())
+      })
+
+      it('dispatches removeArrayElementsFailure when delete fails', async () => {
+        const errorMessage = 'Delete failed!'
+        const responsePayload = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+        apiService.delete = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(
+          deleteArrayElements(keyName as any, indicesToDelete),
+        )
+
+        const expectedActions = [
+          removeArrayElements(),
+          addErrorNotification(responsePayload as IAddInstanceErrorPayload),
+          removeArrayElementsFailure(errorMessage),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('addArrayElements', () => {
+      const addData = addArrayElementsDataFactory.build()
+
+      it('dispatches addElementsSuccess and triggers refetch when successful', async () => {
+        // First PUT succeeds, subsequent POST (refetch) succeeds
+        apiService.put = jest.fn().mockResolvedValue({ status: 200 })
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: {
+            keyName: addData.keyName,
+            total: 1,
+            logicalLength: 1,
+            elements: [],
+            nextCursor: undefined,
+          },
+        })
+
+        const onSuccess = jest.fn()
+        await store.dispatch<any>(addArrayElements(addData, onSuccess))
+
+        expect(onSuccess).toHaveBeenCalledTimes(1)
+        const actions = store.getActions()
+        expect(actions).toContainEqual(addElements())
+        expect(actions).toContainEqual(addElementsSuccess())
+      })
+
+      it('dispatches addElementsFailure when PUT fails', async () => {
+        const errorMessage = 'PUT failed!'
+        const responsePayload = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+        apiService.put = jest.fn().mockRejectedValue(responsePayload)
+
+        const onFail = jest.fn()
+        await store.dispatch<any>(addArrayElements(addData, undefined, onFail))
+
+        expect(onFail).toHaveBeenCalledTimes(1)
+        const actions = store.getActions()
+        expect(actions).toContainEqual(addElements())
+        expect(actions).toContainEqual(
+          addErrorNotification(responsePayload as IAddInstanceErrorPayload),
+        )
+        expect(actions).toContainEqual(addElementsFailure(errorMessage))
+      })
+    })
+
+    describe('createArrayKey', () => {
+      it('dispatches addElementsSuccess when POST is successful', async () => {
+        apiService.post = jest.fn().mockResolvedValue({ status: 200 })
+        const onSuccess = jest.fn()
+
+        await store.dispatch<any>(
+          createArrayKey(
+            {
+              keyName: arrayTestKeyName() as any,
+              elements: [],
+            },
+            onSuccess,
+          ),
+        )
+
+        expect(onSuccess).toHaveBeenCalledTimes(1)
+        const actions = store.getActions()
+        expect(actions).toContainEqual(addElements())
+        expect(actions).toContainEqual(addElementsSuccess())
+      })
+
+      it('dispatches addElementsFailure when POST fails', async () => {
+        const errorMessage = 'Create failed!'
+        const responsePayload = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(responsePayload)
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(
+          createArrayKey(
+            {
+              keyName: arrayTestKeyName() as any,
+              elements: [],
+            },
+            undefined,
+            onFail,
+          ),
+        )
+
+        expect(onFail).toHaveBeenCalledTimes(1)
+        const actions = store.getActions()
+        expect(actions).toContainEqual(addElementsFailure(errorMessage))
+      })
+    })
+  })
+})

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -44,7 +44,6 @@ import reducer, {
   fetchMoreArrayElements,
   deleteArrayElements,
   addArrayElements,
-  createArrayKey,
 } from '../../browser/array'
 
 jest.mock('uiSrc/services', () => ({
@@ -501,52 +500,6 @@ describe('array slice', () => {
         expect(actions).toContainEqual(
           addErrorNotification(responsePayload as IAddInstanceErrorPayload),
         )
-        expect(actions).toContainEqual(addElementsFailure(errorMessage))
-      })
-    })
-
-    describe('createArrayKey', () => {
-      it('dispatches addElementsSuccess when POST is successful', async () => {
-        apiService.post = jest.fn().mockResolvedValue({ status: 200 })
-        const onSuccess = jest.fn()
-
-        await store.dispatch<any>(
-          createArrayKey(
-            {
-              keyName: arrayTestKeyName() as any,
-              elements: [],
-            },
-            onSuccess,
-          ),
-        )
-
-        expect(onSuccess).toHaveBeenCalledTimes(1)
-        const actions = store.getActions()
-        expect(actions).toContainEqual(addElements())
-        expect(actions).toContainEqual(addElementsSuccess())
-      })
-
-      it('dispatches addElementsFailure when POST fails', async () => {
-        const errorMessage = 'Create failed!'
-        const responsePayload = {
-          response: { status: 500, data: { message: errorMessage } },
-        }
-        apiService.post = jest.fn().mockRejectedValue(responsePayload)
-        const onFail = jest.fn()
-
-        await store.dispatch<any>(
-          createArrayKey(
-            {
-              keyName: arrayTestKeyName() as any,
-              elements: [],
-            },
-            undefined,
-            onFail,
-          ),
-        )
-
-        expect(onFail).toHaveBeenCalledTimes(1)
-        const actions = store.getActions()
         expect(actions).toContainEqual(addElementsFailure(errorMessage))
       })
     })

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -220,7 +220,7 @@ describe('array slice', () => {
       const indexToRemove = elements[0].index
       const nextState = reducer(
         stateWithElements,
-        removeIndicesFromList([indexToRemove]),
+        removeIndicesFromList({ indices: [indexToRemove], affected: 1 }),
       )
       expect(nextState.data.elements).toHaveLength(2)
       expect(nextState.data.total).toBe(2)
@@ -413,7 +413,12 @@ describe('array slice', () => {
         const actions = storeWithArray.getActions()
         expect(actions).toContainEqual(removeArrayElements())
         expect(actions).toContainEqual(removeArrayElementsSuccess())
-        expect(actions).toContainEqual(removeIndicesFromList(indicesToDelete))
+        expect(actions).toContainEqual(
+          removeIndicesFromList({
+            indices: indicesToDelete,
+            affected: indicesToDelete.length,
+          }),
+        )
       })
 
       it('dispatches deleteSelectedKeySuccess when last elements are removed', async () => {

--- a/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
@@ -150,6 +150,7 @@ $typeStreamColor: #6a741b;
 $typeGraphColor: #14708d;
 $typeTimeSeriesColor: #6e6e6e;
 $typeVectorSetColor: #8A99A0;
+$typeArrayColor: #7B9EA6;
 $groupSortedSetColor: #a00a6b;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;

--- a/redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss
@@ -152,6 +152,7 @@
   --typeGraphColor: #{$typeGraphColor};
   --typeTimeSeriesColor: #{$typeTimeSeriesColor};
   --typeVectorSetColor: #{$typeVectorSetColor};
+  --typeArrayColor: #{$typeArrayColor};
   --groupSortedSetColor: #{$groupSortedSetColor};
   --groupBitmapColor: #{$groupBitmapColor};
   --groupClusterColor: #{$groupClusterColor};

--- a/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
@@ -115,6 +115,7 @@ $typeStreamColor: #c7cea8;
 $typeGraphColor: #acccd7;
 $typeTimeSeriesColor: #c7c7c7;
 $typeVectorSetColor: #8A99A0;
+$typeArrayColor: #7B9EA6;
 $groupSortedSetColor: #d9a0c6;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;

--- a/redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss
@@ -147,6 +147,7 @@
   --typeGraphColor: #{$typeGraphColor};
   --typeTimeSeriesColor: #{$typeTimeSeriesColor};
   --typeVectorSetColor: #{$typeVectorSetColor};
+  --typeArrayColor: #{$typeArrayColor};
   --groupSortedSetColor: #{$groupSortedSetColor};
   --groupBitmapColor: #{$groupBitmapColor};
   --groupClusterColor: #{$groupClusterColor};


### PR DESCRIPTION
## Summary

This PR adds full browser support for the [array](https://redis.io/docs/latest/develop/data-types/arrays/) key type, a new ordered, index-addressable collection introduced in Redis 8.8. Users can now create, browse, append to, and delete elements from Array keys directly in the Redis Insight browser, with the same look and feel as existing key types.

<img width="1751" height="1007" alt="image" src="https://github.com/user-attachments/assets/5e4a60f9-391d-4d2d-952f-55bf2bddf076" />

---

## What's New

### Backend (`redisinsight/api`)

**New `array` module** (`src/modules/browser/array/`)
- `ArrayController` — REST endpoints wired to the browser router:
  - `POST /array` — create a new Array key with optional elements and TTL
  - `PUT /array` — append elements to an existing Array key
  - `POST /array/get-elements` — paginated range scan using `ARRANGE`
  - `DELETE /array/elements` — delete elements by index using `ARDEL`
- `ArrayService` — business logic layer; delegates to the Redis client via the existing `BrowserToolService` pattern
- Full DTO set: `CreateArrayDto`, `AddElementsToArrayDto`, `AddArrayElementDto`, `GetArrayElementsDto`, `GetArrayElementsResponse`, `DeleteArrayElementsDto`, `DeleteArrayElementsResponse`

**New `ArrayKeyInfoStrategy`** (`src/modules/browser/keys/key-info/strategies/array.key-info.strategy.ts`)
- Implements the `KeyInfoStrategy` interface for the `array` type
- Issues a pipeline of `TTL`, `ARCOUNT`, `MEMORY USAGE`, and `ARINFO` to retrieve key metadata in a single round trip
- Parses the flat `ARINFO` response (`next-insert-index`, `slices`, `slice-size`) into typed fields surfaced on the key info response

**Supporting changes**
- `BrowserToolArrayCommands` — new command constants: `ArCount`, `ArInfo`, `ArSet`, `ArDel`, `ArRange`
- `GetKeyInfoResponse` — extended with `nextInsertIndex`, `slices`, `sliceSize` optional fields
- `KeyDto` — `array` added to the `RedisDataType` enum
- `KeyInfoProvider` — `ArrayKeyInfoStrategy` registered for the `array` type
- `KeysModule` / `BrowserModule` — `ArrayModule` imported and wired
- `IORedisCient` — `array` data type handled in the client type-mapping layer
- `config/default.ts` — Array feature flag default value registered

---

### Frontend (`redisinsight/ui`)

**New Redux slice** (`src/slices/browser/array.ts`)
- State: `{ loading, error, data: { total, logicalLength, keyName, nextCursor, elements }, adding }`
- Actions: `loadArrayElements`, `loadArrayElementsSuccess/Failure`, `loadMoreArrayElements`, `loadMoreArrayElementsSuccess/Failure`, `removeArrayElements`, `removeArrayElementsSuccess/Failure`, `removeIndicesFromList`, `addElements`, `addElementsSuccess/Failure`
- Thunks: `fetchArrayElements`, `fetchMoreArrayElements`, `deleteArrayElements`, `addArrayElements`, `createArrayKey`
- Selectors: `arraySelector`, `arrayDataSelector`, `addArrayElementsStateSelector`

**New `ArrayDetails` panel** (`src/pages/browser/modules/key-details/components/array-details/`)
- `ArrayDetails.tsx` — main panel; shows a subheader with **Count · Length · Next Insert Index**, an element list, and a slide-in "Add Elements" form
- `ArrayElementList.tsx` — virtualised list of index/value pairs with inline delete per row
- `ArrayAddElementForm.tsx` — form to append one or more `{ index, value }` pairs; validates that the index is a non-negative integer
- `useArrayElementListData.ts` — hook that wires pagination, infinite-scroll load-more, and delete callbacks

**New `AddKeyArray` form** (`src/pages/browser/components/add-key/AddKeyArray/`)
- Create a new Array key with a name, optional TTL, and an initial set of elements from the "Add Key" panel

**Wiring**
- `DynamicTypeDetails` — renders `ArrayDetails` for the `array` type
- `AddKey` — includes the `AddKeyArray` form in the type switcher
- `key-type-options.ts` / `filter-key-type/constants.ts` — `array` added to type selector and filter dropdowns
- `featureFlags.ts` — `browser_array_type` feature flag added; the type is hidden until the flag is enabled
- `commandsVersions.ts` — minimum Redis version for Array commands recorded
- `keys.ts` / `prop-types/keys.ts` / `interfaces/index.ts` / `store.ts` — `array` registered throughout the shared type system
- Theme files — Array key type colour tokens added for dark and light themes

---

### Tests

- `array.spec.ts` — 28 unit tests covering every reducer, selector, and thunk in the array slice (happy path + error path for all 5 thunks)
- `ArrayDetails.spec.tsx` — 11 component tests: render, subheader content, Next Insert Index display, Add Elements panel open/close, callback propagation
- `ArrayAddElementForm.spec.tsx` — 8 component tests: form render, input validation (empty, non-numeric, negative index), valid submission payload, cancel
- `arrayElement.factory.ts` — Fishery factories for `ArrayElement` and `AddArrayElementsData` test data

---

## Testing

Tested manually against a Redis 8.8 instance:
- Create an Array key with initial elements
- Browse elements with pagination
- Append new elements via the Add Elements form
- Delete individual elements by index
- Confirm key is removed from the list when all elements are deleted
- Confirm `ARINFO` metadata (Count, Length, Next Insert Index) appears correctly in the key subheader

All automated checks pass:
```
yarn lint       ✓ 0 errors (all Array files)
yarn type-check ✗ pre-existing baseline failures in src/packages/* (missing third-party
                  type declarations for redisinsight-plugin-sdk, react-json-tree, plotly.js,
                  @antv/x6). Identical output on main — not introduced by this PR.
yarn test       ✓ 47 new tests pass (25 slice + 11 ArrayDetails + 11 ArrayAddElementForm)```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting feature (new REST surface, Redis commands, Redux, key routing) but follows existing vector-set/hash patterns and is feature-flagged; main risk is regressions in shared browser/keys flows or incorrect ARSCAN pagination on sparse arrays.
> 
> **Overview**
> Adds end-to-end **Redis Array** support in the browser (Redis 8.8+), gated behind the **`dev-array`** feature flag (on in development).
> 
> The API introduces an **`array`** browser module with create (`ARMSET` + optional `EXPIRE`), upsert-at-indices (`PUT`), **`ARSCAN`-based** paginated reads (`ARCOUNT`/`ARLEN`/`nextCursor`), and bulk delete (`ARDEL`). Key metadata for `array` keys is extended via **`ARINFO`** parsing (`nextInsertIndex`, slices, slice size), new **`BrowserToolArrayCommands`**, and ioredis builtin registration; command docs can be loaded from **`RI_COMMANDS_ARRAY_URL`**.
> 
> The UI wires **`KeyTypes.Array`** through add-key/filter flows, a dedicated **`array`** Redux slice (fetch, load-more, add, delete), **`ArrayDetails`** (summary + table + add form), inline value edits via the same PUT path, and theme/type colors. Tests cover the slice and main Array UI components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acec06fd7d06224e092d8a7f668411ef06b4fe38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->