### PR TITLE
ci: drop S3 test-report deploys and fix workflow token permissions

### DIFF
--- a/.github/workflows/clean-deployments.yml
+++ b/.github/workflows/clean-deployments.yml
@@ -6,6 +6,10 @@ jobs:
   clean:
     name: Clean deployments
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
     steps:
       - name: 🗑 Delete deployment (staging)
         uses: strumwolf/delete-deployment-environment@v4

--- a/.github/workflows/manual-build-enterprise.yml
+++ b/.github/workflows/manual-build-enterprise.yml
@@ -123,6 +123,10 @@ jobs:
     # secrets: inherit
     needs: [aws-upload]
     if: always()
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
 
   # Remove artifacts from github actions
   remove-artifacts:

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -121,6 +121,10 @@ jobs:
     # secrets: inherit
     needs: [aws-upload]
     if: always()
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
 
   # Remove artifacts from github actions
   remove-artifacts:

--- a/.github/workflows/tests-backend.yml
+++ b/.github/workflows/tests-backend.yml
@@ -51,20 +51,3 @@ jobs:
         with:
           name: ${{ env.REPORT_NAME }}
           path: redisinsight/api/report
-
-      - name: Get current date
-        id: date
-        if: always()
-        uses: ./.github/actions/get-current-date
-
-      - name: Deploy report
-        uses: ./.github/actions/deploy-test-reports
-        if: always()
-        with:
-          group: 'report'
-          path: '${{ vars.DEFAULT_TEST_REPORTS_URL }}/${{ steps.date.outputs.date }}/${{ github.run_id }}/${{ env.REPORT_NAME }}'
-          AWS_BUCKET_NAME_TEST: ${{ vars.AWS_BUCKET_NAME_TEST }}
-          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-          AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests-frontend.yml
+++ b/.github/workflows/tests-frontend.yml
@@ -45,20 +45,3 @@ jobs:
         with:
           name: ${{ env.REPORT_NAME }}
           path: report
-
-      - name: Get current date
-        id: date
-        if: always()
-        uses: ./.github/actions/get-current-date
-
-      - name: Deploy report
-        uses: ./.github/actions/deploy-test-reports
-        if: always()
-        with:
-          group: 'report'
-          path: '${{ vars.DEFAULT_TEST_REPORTS_URL }}/${{ steps.date.outputs.date }}/${{ github.run_id }}/${{ env.REPORT_NAME }}'
-          AWS_BUCKET_NAME_TEST: ${{ vars.AWS_BUCKET_NAME_TEST }}
-          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-          AWS_DISTRIBUTION_ID: ${{ secrets.AWS_DISTRIBUTION_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -253,6 +253,9 @@ jobs:
     name: Final coverage
     needs: run-tests
     if: always()
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,6 +218,10 @@ jobs:
   clean:
     uses: ./.github/workflows/clean-deployments.yml
     if: always()
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
     needs:
       [
         frontend-tests,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,6 +199,9 @@ jobs:
     if: needs.should-run.outputs.integration == 'true'
     uses: ./.github/workflows/tests-integration.yml
     secrets: inherit
+    permissions:
+      actions: write
+      contents: read
     with:
       short_rte_list: ${{ inputs.short_rte_list || true }}
       redis_client: ${{ inputs.redis_client || '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,6 +202,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      checks: write
     with:
       short_rte_list: ${{ inputs.short_rte_list || true }}
       redis_client: ${{ inputs.redis_client || '' }}


### PR DESCRIPTION
# What

Two CI cleanups bundled together:

- **Drop the "Deploy report" step** from the frontend and backend test workflows.
  The HTML coverage reports were being pushed to an S3 bucket (fronted by
  CloudFront) and linked from the run summary, but the reports are still
  available as workflow artifacts. The "Get current date" step that only
  fed this step was removed along with it.

- **Fix two workflow jobs that started returning 403** ("Resource not
  accessible by integration") after recent action major-version bumps:
  - `Final coverage` in `tests-integration.yml` — its Delete Artifact step
    now needs `actions: write` (after the `actions/github-script` v7→v9 bump).
  - `Delete deployments` in `clean-deployments.yml` — the
    `strumwolf/delete-deployment-environment` action now creates a deployment
    status before deletion, which needs `deployments: write`.

  In both cases, since the workflows are invoked via `workflow_call`, the
  required permissions are declared both on the called job *and* on each
  caller job, because a called workflow cannot elevate above the caller's
  granted scopes.

# Testing

- Re-run the affected workflows on this branch and confirm:
  - The `Final coverage` job's "Delete Artifact" step succeeds.
  - The `Clean deployments` job's three deployment-deletion steps succeed.
  - Test report artifacts (`report-fe`, `report-be`) are still uploaded
    even though S3 deploy is gone.
- Verify the workflow summary no longer contains the (now-dead) S3 report
  link for the frontend/backend test jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions YAML (no app/runtime code); main effect is fewer external deploy steps and broader but scoped token permissions for CI maintenance jobs.
> 
> **Overview**
> Removes **S3/CloudFront “Deploy report”** steps (and the date helper they depended on) from frontend and backend unit-test workflows; coverage HTML stays available via **workflow artifacts** only.
> 
> Adds explicit **`GITHUB_TOKEN` permissions** on reusable-workflow jobs so post–action-bump steps stop 403’ing: `actions: write` for integration **Final coverage** artifact deletion, and `actions`/`contents`/`deployments: write` for **clean deployments** (on the called workflow and every `workflow_call` caller, since callers cannot grant more than they declare). Integration test caller also gets **`checks: write`** for the test reporter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54fe7e0a4f13e4f260c9992e79b08b9fe02060c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->