### PR TITLE
RI-8200 Skip Type-to-confirm modal for command for session

### DIFF
--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
@@ -18,10 +18,18 @@ import { processCliClient } from 'uiSrc/slices/cli/cli-settings'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { processUnsupportedCommand } from 'uiSrc/utils/cliOutputActions'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 
 import CliBodyWrapper from './CliBodyWrapper'
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(
+    <ProductionWriteConfirmationProvider>
+      {ui}
+    </ProductionWriteConfirmationProvider>,
+  )
 
 let store: typeof mockedStore
 beforeEach(() => {
@@ -165,7 +173,7 @@ describe('CliBodyWrapper', () => {
       )
       setDangerousEnvironment(true)
 
-      render(<CliBodyWrapper />)
+      renderWithProvider(<CliBodyWrapper />)
 
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
 
@@ -180,7 +188,7 @@ describe('CliBodyWrapper', () => {
       )
       setDangerousEnvironment(true)
 
-      render(<CliBodyWrapper />)
+      renderWithProvider(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
 
       fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
@@ -198,12 +206,70 @@ describe('CliBodyWrapper', () => {
       )
       setDangerousEnvironment(true)
 
-      render(<CliBodyWrapper />)
+      renderWithProvider(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
 
       fireEvent.click(screen.getByTestId('type-to-confirm-modal-cancel-btn'))
 
       expect(sendCliCommandActionMock).not.toHaveBeenCalled()
+    })
+
+    it('skips the modal on subsequent runs of the same command after opt-in', () => {
+      const sendCliCommandActionMock = jest.fn()
+      mockedSendCliCommandAction.mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      setDangerousEnvironment(true)
+
+      renderWithProvider(<CliBodyWrapper />)
+
+      // First FLUSHDB — opt out for the session
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: 'prod-db' },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(sendCliCommandActionMock).toHaveBeenCalledTimes(1)
+
+      // Second FLUSHDB — should run without showing the modal
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      expect(sendCliCommandActionMock).toHaveBeenCalledTimes(2)
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('still prompts for a different dangerous command after opting out of one', () => {
+      const sendCliCommandActionMock = jest.fn()
+      mockedSendCliCommandAction.mockImplementation(
+        () => sendCliCommandActionMock,
+      )
+      setDangerousEnvironment(true)
+
+      renderWithProvider(<CliBodyWrapper />)
+
+      // Opt out for FLUSHDB
+      mockedGetCommandRepeat.mockReturnValue(['FLUSHDB', 1])
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: 'prod-db' },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(sendCliCommandActionMock).toHaveBeenCalledTimes(1)
+
+      // DEBUG SLEEP — different verb, must still prompt
+      mockedGetCommandRepeat.mockReturnValue(['DEBUG SLEEP 1', 1])
+      fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-title'),
+      ).toBeInTheDocument()
+      expect(sendCliCommandActionMock).toHaveBeenCalledTimes(1)
     })
 
     it('passes commands through without modal when isDangerousCommand returns false', () => {
@@ -213,7 +279,7 @@ describe('CliBodyWrapper', () => {
       )
       setDangerousEnvironment(false)
 
-      render(<CliBodyWrapper />)
+      renderWithProvider(<CliBodyWrapper />)
       fireEvent.keyDown(screen.getByTestId(cliCommandTestId), { key: 'Enter' })
 
       expect(sendCliCommandActionMock).toHaveBeenCalled()

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
@@ -45,7 +45,10 @@ import {
   processUnsupportedCommand,
 } from 'uiSrc/utils/cliOutputActions'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  toRedisConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import CliBody from './CliBody'
 
 import styles from './CliBody/styles.module.scss'
@@ -204,7 +207,7 @@ const CliBodyWrapper = () => {
           </>
         ),
         confirmButtonText: 'Run command',
-        commandId: `cmd:${verb}`,
+        commandId: toRedisConfirmationCommandId(verb),
         onConfirm: () => {
           for (let i = 0; i < countRepeat; i++) {
             sendCommand(commandLine)

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
@@ -45,17 +45,13 @@ import {
   processUnsupportedCommand,
 } from 'uiSrc/utils/cliOutputActions'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
-import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal/TypeToConfirmModal'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import CliBody from './CliBody'
 
 import styles from './CliBody/styles.module.scss'
 
 const CliBodyWrapper = () => {
   const [command, setCommand] = useState('')
-  const [pendingCommand, setPendingCommand] = useState<{
-    commandLine: string
-    countRepeat: number
-  } | null>(null)
 
   const history = useHistory()
   const dispatch = useDispatch()
@@ -74,6 +70,9 @@ const CliBodyWrapper = () => {
   )
   const { db: currentDbIndex } = useSelector(outputSelector)
   const { isDangerousCommand } = useDatabaseEnvironment()
+  const { requestConfirmation } = useProductionWriteConfirmation()
+
+  const confirmationText = name || `${host}:${port}`
 
   useEffect(() => {
     if (!cliClientUuid) {
@@ -194,8 +193,28 @@ const CliBodyWrapper = () => {
       return
     }
 
-    if (isDangerousCommand(commandLine.trim().split(' ')[0])) {
-      setPendingCommand({ commandLine, countRepeat })
+    const verb = commandLine.trim().split(/\s+/)[0]?.toUpperCase() ?? ''
+    if (isDangerousCommand(verb)) {
+      requestConfirmation({
+        title: 'Run dangerous command?',
+        actionDescription: (
+          <>
+            You&apos;re about to run <strong>{commandLine}</strong> against the
+            production database <strong>{confirmationText}</strong>.
+          </>
+        ),
+        confirmButtonText: 'Run command',
+        commandId: `cmd:${verb}`,
+        onConfirm: () => {
+          for (let i = 0; i < countRepeat; i++) {
+            sendCommand(commandLine)
+          }
+        },
+        onCancel: () => {
+          dispatch(concatToOutput(cliTexts.DANGEROUS_COMMAND_CANCELLED))
+          resetCommand()
+        },
+      })
       return
     }
 
@@ -231,8 +250,6 @@ const CliBodyWrapper = () => {
     setCommand('')
   }
 
-  const confirmationText = name || `${host}:${port}`
-
   return (
     <section ref={refHotkeys} className={styles.section}>
       <CliBody
@@ -242,31 +259,6 @@ const CliBodyWrapper = () => {
         setCommand={setCommand}
         onSubmit={handleSubmit}
       />
-      {pendingCommand && (
-        <TypeToConfirmModal
-          confirmationText={confirmationText}
-          title="Run dangerous command?"
-          actionDescription={
-            <>
-              You&apos;re about to run{' '}
-              <strong>{pendingCommand.commandLine}</strong> against the
-              production database <strong>{confirmationText}</strong>.
-            </>
-          }
-          confirmButtonText="Run command"
-          onConfirm={() => {
-            for (let i = 0; i < pendingCommand.countRepeat; i++) {
-              sendCommand(pendingCommand.commandLine)
-            }
-            setPendingCommand(null)
-          }}
-          onCancel={() => {
-            dispatch(concatToOutput(cliTexts.DANGEROUS_COMMAND_CANCELLED))
-            resetCommand()
-            setPendingCommand(null)
-          }}
-        />
-      )}
     </section>
   )
 }

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.constants.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.constants.ts
@@ -25,11 +25,4 @@ export enum BrowserConfirmationCommandId {
   ChangeTtl = 'browser:change-ttl',
 }
 
-const REDIS_CONFIRMATION_COMMAND_PREFIX = 'cmd:'
-
-/**
- * Build the commandId used by CLI and Workbench for a Redis verb (e.g.
- * `FLUSHDB`). Callers should pass an already-uppercased verb.
- */
-export const toRedisConfirmationCommandId = (verb: string): string =>
-  `${REDIS_CONFIRMATION_COMMAND_PREFIX}${verb}`
+export const REDIS_CONFIRMATION_COMMAND_PREFIX = 'cmd:'

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
@@ -3,6 +3,7 @@ import { Environment } from 'apiClient'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import * as useDatabaseEnvironmentModule from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory'
 
 import {
   ProductionWriteConfirmationProvider,
@@ -10,14 +11,11 @@ import {
   useProductionWriteConfirmation,
 } from '.'
 
+const defaultInstance = DBInstanceFactory.build({ name: 'prod-cache' })
+
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
-  connectedInstanceSelector: jest.fn().mockReturnValue({
-    id: 'instance-1',
-    name: 'prod-cache',
-    host: 'localhost',
-    port: 6379,
-  }),
+  connectedInstanceSelector: jest.fn(),
 }))
 
 const mockedConnectedInstanceSelector = connectedInstanceSelector as jest.Mock
@@ -71,12 +69,7 @@ const renderWithProvider = (ui: React.ReactElement) =>
 describe('ProductionWriteConfirmationProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedConnectedInstanceSelector.mockReturnValue({
-      id: 'instance-1',
-      name: 'prod-cache',
-      host: 'localhost',
-      port: 6379,
-    })
+    mockedConnectedInstanceSelector.mockReturnValue(defaultInstance)
     mockEnvironment(Environment.Unspecified)
   })
 
@@ -140,12 +133,8 @@ describe('ProductionWriteConfirmationProvider', () => {
   })
 
   it('falls back to host:port when DB name is empty', () => {
-    mockedConnectedInstanceSelector.mockReturnValue({
-      id: 'instance-1',
-      name: '',
-      host: 'localhost',
-      port: 6379,
-    })
+    const namelessInstance = DBInstanceFactory.build({ name: '' })
+    mockedConnectedInstanceSelector.mockReturnValue(namelessInstance)
     mockEnvironment(Environment.Production)
     const action = jest.fn()
 
@@ -156,7 +145,7 @@ describe('ProductionWriteConfirmationProvider', () => {
       screen.getByTestId('type-to-confirm-modal-confirm-btn'),
     ).toBeDisabled()
 
-    typeInConfirmInput('localhost:6379')
+    typeInConfirmInput(`${namelessInstance.host}:${namelessInstance.port}`)
     fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
 
     expect(action).toHaveBeenCalledTimes(1)
@@ -408,12 +397,9 @@ describe('ProductionWriteConfirmationProvider', () => {
     // previous KeyDetails subtree and re-mounts when a new key is opened
     // on the new database).
     unmount()
-    mockedConnectedInstanceSelector.mockReturnValue({
-      id: 'instance-2',
-      name: 'another-db',
-      host: 'localhost',
-      port: 6380,
-    })
+    mockedConnectedInstanceSelector.mockReturnValue(
+      DBInstanceFactory.build({ name: 'another-db' }),
+    )
 
     renderWithProvider(
       <Trigger onConfirm={action} overrides={{ commandId: 'edit-value' }} />,

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.spec.tsx
@@ -13,6 +13,7 @@ import {
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
   connectedInstanceSelector: jest.fn().mockReturnValue({
+    id: 'instance-1',
     name: 'prod-cache',
     host: 'localhost',
     port: 6379,
@@ -71,6 +72,7 @@ describe('ProductionWriteConfirmationProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockedConnectedInstanceSelector.mockReturnValue({
+      id: 'instance-1',
       name: 'prod-cache',
       host: 'localhost',
       port: 6379,
@@ -139,6 +141,7 @@ describe('ProductionWriteConfirmationProvider', () => {
 
   it('falls back to host:port when DB name is empty', () => {
     mockedConnectedInstanceSelector.mockReturnValue({
+      id: 'instance-1',
       name: '',
       host: 'localhost',
       port: 6379,
@@ -184,5 +187,242 @@ describe('ProductionWriteConfirmationProvider', () => {
     expect(
       screen.queryByTestId('type-to-confirm-modal-input'),
     ).not.toBeInTheDocument()
+  })
+
+  it('hides the skip-for-session checkbox when commandId is not provided', () => {
+    mockEnvironment(Environment.Production)
+
+    renderWithProvider(<Trigger onConfirm={jest.fn()} />)
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-skip-checkbox'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the skip-for-session checkbox when commandId is provided', () => {
+    mockEnvironment(Environment.Production)
+
+    renderWithProvider(
+      <Trigger onConfirm={jest.fn()} overrides={{ commandId: 'edit-value' }} />,
+    )
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-skip-checkbox'),
+    ).toBeInTheDocument()
+  })
+
+  it('skips the modal on subsequent calls with the same commandId when user opts in', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(
+      <Trigger onConfirm={action} overrides={{ commandId: 'edit-value' }} />,
+    )
+
+    // First call shows the modal; confirm with "don't ask again" checked
+    fireEvent.click(screen.getByTestId('trigger'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+
+    // Second call with the same commandId should bypass the modal entirely
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(action).toHaveBeenCalledTimes(2)
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-input'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('still shows the modal on subsequent calls when user did not opt in', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(
+      <Trigger onConfirm={action} overrides={{ commandId: 'edit-value' }} />,
+    )
+
+    fireEvent.click(screen.getByTestId('trigger'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-input'),
+    ).toBeInTheDocument()
+  })
+
+  it('does not skip the modal for a different commandId', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    const Multi = () => {
+      const { requestConfirmation } = useProductionWriteConfirmation()
+      return (
+        <>
+          <button
+            type="button"
+            data-testid="trigger-edit"
+            onClick={() =>
+              requestConfirmation({
+                actionDescription: 'edit',
+                commandId: 'edit-value',
+                onConfirm: action,
+              })
+            }
+          >
+            edit
+          </button>
+          <button
+            type="button"
+            data-testid="trigger-rename"
+            onClick={() =>
+              requestConfirmation({
+                actionDescription: 'rename',
+                commandId: 'rename-key',
+                onConfirm: action,
+              })
+            }
+          >
+            rename
+          </button>
+        </>
+      )
+    }
+
+    renderWithProvider(<Multi />)
+
+    fireEvent.click(screen.getByTestId('trigger-edit'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    // The other commandId must still trigger the modal
+    fireEvent.click(screen.getByTestId('trigger-rename'))
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-input'),
+    ).toBeInTheDocument()
+  })
+
+  it('only skips when every commandId in an array request is already in the skip set', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    renderWithProvider(
+      <Trigger
+        onConfirm={action}
+        overrides={{ commandId: ['FLUSHALL', 'FLUSHDB'] }}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('trigger'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(action).toHaveBeenCalledTimes(1)
+
+    // Same array — fully covered → no modal
+    fireEvent.click(screen.getByTestId('trigger'))
+    expect(action).toHaveBeenCalledTimes(2)
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-input'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not skip when an array request contains a not-yet-skipped commandId', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    const Multi = () => {
+      const { requestConfirmation } = useProductionWriteConfirmation()
+      return (
+        <>
+          <button
+            type="button"
+            data-testid="trigger-flushall"
+            onClick={() =>
+              requestConfirmation({
+                actionDescription: 'flushall',
+                commandId: 'FLUSHALL',
+                onConfirm: action,
+              })
+            }
+          >
+            flushall
+          </button>
+          <button
+            type="button"
+            data-testid="trigger-mixed"
+            onClick={() =>
+              requestConfirmation({
+                actionDescription: 'mixed',
+                commandId: ['FLUSHALL', 'DEBUG'],
+                onConfirm: action,
+              })
+            }
+          >
+            mixed
+          </button>
+        </>
+      )
+    }
+
+    renderWithProvider(<Multi />)
+
+    // Opt out of FLUSHALL only
+    fireEvent.click(screen.getByTestId('trigger-flushall'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    // Array contains DEBUG which is not in the skip set → must prompt
+    fireEvent.click(screen.getByTestId('trigger-mixed'))
+    expect(
+      screen.getByTestId('type-to-confirm-modal-input'),
+    ).toBeInTheDocument()
+  })
+
+  it('resets the skip list when the connected database changes', () => {
+    mockEnvironment(Environment.Production)
+    const action = jest.fn()
+
+    const { unmount } = renderWithProvider(
+      <Trigger onConfirm={action} overrides={{ commandId: 'edit-value' }} />,
+    )
+
+    fireEvent.click(screen.getByTestId('trigger'))
+    typeInConfirmInput('prod-cache')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    // A fresh mount represents switching DBs (provider unmounts with the
+    // previous KeyDetails subtree and re-mounts when a new key is opened
+    // on the new database).
+    unmount()
+    mockedConnectedInstanceSelector.mockReturnValue({
+      id: 'instance-2',
+      name: 'another-db',
+      host: 'localhost',
+      port: 6380,
+    })
+
+    renderWithProvider(
+      <Trigger onConfirm={action} overrides={{ commandId: 'edit-value' }} />,
+    )
+
+    fireEvent.click(screen.getByTestId('trigger'))
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-input'),
+    ).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
@@ -2,7 +2,9 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { useSelector } from 'react-redux'
@@ -14,6 +16,13 @@ import {
   ProductionWriteConfirmationContextValue,
   ProductionWriteConfirmationRequest,
 } from './ProductionWriteConfirmationProvider.types'
+
+const toCommandIdArray = (
+  commandId: ProductionWriteConfirmationRequest['commandId'],
+): string[] => {
+  if (!commandId) return []
+  return Array.isArray(commandId) ? commandId : [commandId]
+}
 
 const ProductionWriteConfirmationContext =
   createContext<ProductionWriteConfirmationContextValue | null>(null)
@@ -32,9 +41,16 @@ interface Props {
 
 export const ProductionWriteConfirmationProvider = ({ children }: Props) => {
   const { environment } = useDatabaseEnvironment()
-  const { name, host, port } = useSelector(connectedInstanceSelector)
+  const { id, name, host, port } = useSelector(connectedInstanceSelector)
   const [pending, setPending] =
     useState<ProductionWriteConfirmationRequest | null>(null)
+  const skippedCommandsRef = useRef<Set<string>>(new Set())
+
+  // Reset the per-session skip list whenever the connected database changes
+  // so opting out of a confirmation never leaks across databases.
+  useEffect(() => {
+    skippedCommandsRef.current = new Set()
+  }, [id])
 
   // Fall back to host:port when name is empty so the modal never matches
   // an empty input (which would bypass the type-to-confirm safety check).
@@ -42,11 +58,19 @@ export const ProductionWriteConfirmationProvider = ({ children }: Props) => {
 
   const requestConfirmation = useCallback(
     (confirmation: ProductionWriteConfirmationRequest) => {
-      if (environment === Environment.Production) {
-        setPending(confirmation)
+      if (environment !== Environment.Production) {
+        confirmation.onConfirm()
         return
       }
-      confirmation.onConfirm()
+      const commandIds = toCommandIdArray(confirmation.commandId)
+      if (
+        commandIds.length > 0 &&
+        commandIds.every((id) => skippedCommandsRef.current.has(id))
+      ) {
+        confirmation.onConfirm()
+        return
+      }
+      setPending(confirmation)
     },
     [environment],
   )
@@ -63,7 +87,13 @@ export const ProductionWriteConfirmationProvider = ({ children }: Props) => {
           actionDescription={pending.actionDescription}
           confirmButtonText={pending.confirmButtonText}
           cancelButtonText={pending.cancelButtonText}
-          onConfirm={() => {
+          showSkipForSession={toCommandIdArray(pending.commandId).length > 0}
+          onConfirm={(skipForSession) => {
+            if (skipForSession) {
+              toCommandIdArray(pending.commandId).forEach((id) =>
+                skippedCommandsRef.current.add(id),
+              )
+            }
             pending.onConfirm()
             setPending(null)
           }}

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
@@ -14,15 +14,10 @@ import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
 import {
   ProductionWriteConfirmationContextValue,
+  ProductionWriteConfirmationProviderProps,
   ProductionWriteConfirmationRequest,
 } from './ProductionWriteConfirmationProvider.types'
-
-const toCommandIdArray = (
-  commandId: ProductionWriteConfirmationRequest['commandId'],
-): string[] => {
-  if (!commandId) return []
-  return Array.isArray(commandId) ? commandId : [commandId]
-}
+import { toCommandIdArray } from './ProductionWriteConfirmationProvider.utils'
 
 const ProductionWriteConfirmationContext =
   createContext<ProductionWriteConfirmationContextValue | null>(null)
@@ -35,11 +30,9 @@ export const useProductionWriteConfirmation =
   (): ProductionWriteConfirmationContextValue =>
     useContext(ProductionWriteConfirmationContext) ?? fallbackValue
 
-interface Props {
-  children: React.ReactNode
-}
-
-export const ProductionWriteConfirmationProvider = ({ children }: Props) => {
+export const ProductionWriteConfirmationProvider = ({
+  children,
+}: ProductionWriteConfirmationProviderProps) => {
   const { environment } = useDatabaseEnvironment()
   const { id, name, host, port } = useSelector(connectedInstanceSelector)
   const [pending, setPending] =

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
@@ -7,6 +7,16 @@ export interface ProductionWriteConfirmationRequest {
   cancelButtonText?: string
   onConfirm: () => void
   onCancel?: () => void
+  /**
+   * When provided, the user can opt to skip future confirmations for this
+   * command id (or set of ids) for the rest of the session (until the
+   * connected database changes or the app is reopened).
+   *
+   * When an array is passed (e.g. multiple dangerous commands run together
+   * in Workbench), the modal is skipped only when *every* id has previously
+   * been opted out, and opting in adds *every* id to the skip set.
+   */
+  commandId?: string | string[]
 }
 
 export interface ProductionWriteConfirmationContextValue {

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.types.ts
@@ -24,3 +24,7 @@ export interface ProductionWriteConfirmationContextValue {
     confirmation: ProductionWriteConfirmationRequest,
   ) => void
 }
+
+export interface ProductionWriteConfirmationProviderProps {
+  children: React.ReactNode
+}

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.utils.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.utils.ts
@@ -1,0 +1,20 @@
+import { ProductionWriteConfirmationRequest } from './ProductionWriteConfirmationProvider.types'
+import { REDIS_CONFIRMATION_COMMAND_PREFIX } from './ProductionWriteConfirmationProvider.constants'
+
+/**
+ * Build the commandId used by CLI and Workbench for a Redis verb (e.g.
+ * `FLUSHDB`). Callers should pass an already-uppercased verb.
+ */
+export const toRedisConfirmationCommandId = (verb: string): string =>
+  `${REDIS_CONFIRMATION_COMMAND_PREFIX}${verb}`
+
+/**
+ * Normalize the optional commandId field of a confirmation request into an
+ * array, so the provider can treat single and multi-id requests uniformly.
+ */
+export const toCommandIdArray = (
+  commandId: ProductionWriteConfirmationRequest['commandId'],
+): string[] => {
+  if (!commandId) return []
+  return Array.isArray(commandId) ? commandId : [commandId]
+}

--- a/redisinsight/ui/src/components/production-write-confirmation/commandIds.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/commandIds.ts
@@ -1,0 +1,35 @@
+/**
+ * Stable identifiers for production-write confirmation requests.
+ *
+ * The user can opt to skip future confirmations for a given commandId for the
+ * rest of the session (see ProductionWriteConfirmationProvider). Keeping all
+ * ids in one place makes it easy to audit what can be skipped and to avoid
+ * collisions across features.
+ *
+ * Two namespaces are in use:
+ *  - `browser:*` — discrete browser key-details operations (one id per op type).
+ *  - `cmd:*`    — arbitrary Redis commands run via CLI / Workbench. The skip
+ *                 set is shared between CLI and Workbench, so opting out of a
+ *                 verb in one feature also skips it in the other.
+ */
+
+export enum BrowserConfirmationCommandId {
+  EditValue = 'browser:edit-value',
+  EditRejsonValue = 'browser:edit-rejson-value',
+  AddZsetMembers = 'browser:add-zset-members',
+  AddListElements = 'browser:add-list-elements',
+  AddSetMembers = 'browser:add-set-members',
+  AddHashFields = 'browser:add-hash-fields',
+  AddStreamEntry = 'browser:add-stream-entry',
+  RenameKey = 'browser:rename-key',
+  ChangeTtl = 'browser:change-ttl',
+}
+
+const REDIS_CONFIRMATION_COMMAND_PREFIX = 'cmd:'
+
+/**
+ * Build the commandId used by CLI and Workbench for a Redis verb (e.g.
+ * `FLUSHDB`). Callers should pass an already-uppercased verb.
+ */
+export const toRedisConfirmationCommandId = (verb: string): string =>
+  `${REDIS_CONFIRMATION_COMMAND_PREFIX}${verb}`

--- a/redisinsight/ui/src/components/production-write-confirmation/index.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/index.ts
@@ -6,3 +6,7 @@ export type {
   ProductionWriteConfirmationContextValue,
   ProductionWriteConfirmationRequest,
 } from './ProductionWriteConfirmationProvider.types'
+export {
+  BrowserConfirmationCommandId,
+  toRedisConfirmationCommandId,
+} from './commandIds'

--- a/redisinsight/ui/src/components/production-write-confirmation/index.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/index.ts
@@ -4,9 +4,8 @@ export {
 } from './ProductionWriteConfirmationProvider'
 export type {
   ProductionWriteConfirmationContextValue,
+  ProductionWriteConfirmationProviderProps,
   ProductionWriteConfirmationRequest,
 } from './ProductionWriteConfirmationProvider.types'
-export {
-  BrowserConfirmationCommandId,
-  toRedisConfirmationCommandId,
-} from './commandIds'
+export { BrowserConfirmationCommandId } from './ProductionWriteConfirmationProvider.constants'
+export { toRedisConfirmationCommandId } from './ProductionWriteConfirmationProvider.utils'

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.spec.tsx
@@ -148,4 +148,53 @@ describe('TypeToConfirmModal', () => {
       screen.getByTestId('type-to-confirm-modal-cancel-btn'),
     ).toHaveTextContent('Back')
   })
+
+  it('should not render the skip-for-session checkbox by default', () => {
+    render(<TypeToConfirmModal {...mockProps} />)
+
+    expect(
+      screen.queryByTestId('type-to-confirm-modal-skip-checkbox'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render the skip-for-session checkbox when showSkipForSession is true', () => {
+    render(<TypeToConfirmModal {...mockProps} showSkipForSession />)
+
+    expect(
+      screen.getByTestId('type-to-confirm-modal-skip-checkbox'),
+    ).toBeInTheDocument()
+  })
+
+  it('should pass skipForSession=false to onConfirm when checkbox is not checked', () => {
+    const onConfirm = jest.fn()
+    render(
+      <TypeToConfirmModal
+        {...mockProps}
+        onConfirm={onConfirm}
+        showSkipForSession
+      />,
+    )
+
+    typeInConfirmInput('prod-cache-eu-west-1')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(onConfirm).toHaveBeenCalledWith(false)
+  })
+
+  it('should pass skipForSession=true to onConfirm when checkbox is checked', () => {
+    const onConfirm = jest.fn()
+    render(
+      <TypeToConfirmModal
+        {...mockProps}
+        onConfirm={onConfirm}
+        showSkipForSession
+      />,
+    )
+
+    typeInConfirmInput('prod-cache-eu-west-1')
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+    fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+    expect(onConfirm).toHaveBeenCalledWith(true)
+  })
 })

--- a/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
+++ b/redisinsight/ui/src/components/type-to-confirm-modal/TypeToConfirmModal.tsx
@@ -7,6 +7,7 @@ import {
   DestructiveButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
@@ -14,11 +15,13 @@ import { Text } from 'uiSrc/components/base/text'
 export interface Props {
   confirmationText: string
   actionDescription: React.ReactNode
-  onConfirm: () => void
+  onConfirm: (skipForSession: boolean) => void
   onCancel: () => void
   title?: React.ReactNode
   confirmButtonText?: string
   cancelButtonText?: string
+  showSkipForSession?: boolean
+  skipForSessionLabel?: React.ReactNode
 }
 
 const TypeToConfirmModal = ({
@@ -29,13 +32,16 @@ const TypeToConfirmModal = ({
   title = 'Confirm action',
   confirmButtonText = 'Confirm',
   cancelButtonText = 'Cancel',
+  showSkipForSession = false,
+  skipForSessionLabel = "Don't ask again for this command in this session",
 }: Props) => {
   const [value, setValue] = useState('')
+  const [skipForSession, setSkipForSession] = useState(false)
   const isMatch = value === confirmationText
 
   const handleConfirm = () => {
     if (!isMatch) return
-    onConfirm()
+    onConfirm(skipForSession)
   }
 
   return (
@@ -75,6 +81,17 @@ const TypeToConfirmModal = ({
                   data-testid="type-to-confirm-modal-input"
                 />
               </FormField>
+              {showSkipForSession && (
+                <Checkbox
+                  id="type-to-confirm-modal-skip-checkbox"
+                  name="skip-for-session"
+                  label={skipForSessionLabel}
+                  labelSize="M"
+                  checked={skipForSession}
+                  onChange={(e) => setSkipForSession(e.target.checked)}
+                  data-testid="type-to-confirm-modal-skip-checkbox"
+                />
+              )}
             </Col>
           }
         />

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
@@ -111,6 +111,7 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
           </>
         ),
         confirmButtonText: 'Rename',
+        commandId: 'browser:rename-key',
         onConfirm: () =>
           onEditKey(keyBuffer, newKeyBuffer, () => setKey(keyProp)),
         onCancel: () => setKey(keyProp),

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
@@ -27,7 +27,10 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiTooltip } from 'uiSrc/components'
 import { CopyButton } from 'uiSrc/components/copy-button'
 import { TextInput } from 'uiSrc/components/base/inputs'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 const StyledInputWrapper = styled(Row)`
@@ -111,7 +114,7 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
           </>
         ),
         confirmButtonText: 'Rename',
-        commandId: 'browser:rename-key',
+        commandId: BrowserConfirmationCommandId.RenameKey,
         onConfirm: () =>
           onEditKey(keyBuffer, newKeyBuffer, () => setKey(keyProp)),
         onCancel: () => setKey(keyProp),

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
@@ -72,6 +72,7 @@ const KeyDetailsHeaderTTL = ({ onEditTTL }: Props) => {
           </>
         ),
         confirmButtonText: 'Change TTL',
+        commandId: 'browser:change-ttl',
         onConfirm: () => onEditTTL(keyBuffer, +ttlValue),
         onCancel: () => setTTL(`${ttlProp}`),
       })

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
@@ -15,7 +15,10 @@ import { FlexItem, Grid } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { TextInput } from 'uiSrc/components/base/inputs'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -72,7 +75,7 @@ const KeyDetailsHeaderTTL = ({ onEditTTL }: Props) => {
           </>
         ),
         confirmButtonText: 'Change TTL',
-        commandId: 'browser:change-ttl',
+        commandId: BrowserConfirmationCommandId.ChangeTtl,
         onConfirm: () => onEditTTL(keyBuffer, +ttlValue),
         onCancel: () => setTTL(`${ttlProp}`),
       })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
@@ -21,7 +21,6 @@ import {
 } from 'uiSrc/telemetry'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { isTruncatedString, Nullable } from 'uiSrc/utils'
-import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { NoKeySelected } from './components/no-key-selected'
 import { DynamicTypeDetails } from './components/dynamic-type-details'
 
@@ -132,14 +131,12 @@ const KeyDetails = (props: Props) => {
             onClosePanel={onCloseKey}
           />
         ) : (
-          <ProductionWriteConfirmationProvider>
-            <DynamicTypeDetails
-              {...props}
-              keyType={keyType}
-              onOpenAddItemPanel={onOpenAddItemPanel}
-              onCloseAddItemPanel={onCloseAddItemPanel}
-            />
-          </ProductionWriteConfirmationProvider>
+          <DynamicTypeDetails
+            {...props}
+            keyType={keyType}
+            onOpenAddItemPanel={onOpenAddItemPanel}
+            onCloseAddItemPanel={onCloseAddItemPanel}
+          />
         )}
       </div>
     </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -168,6 +168,7 @@ const AddHashFields = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add fields',
+      commandId: 'browser:add-hash-fields',
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -32,7 +32,10 @@ import {
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { AddFieldsToHashDto, HashFieldDto } from 'apiClient'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -168,7 +171,7 @@ const AddHashFields = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add fields',
-      commandId: 'browser:add-hash-fields',
+      commandId: BrowserConfirmationCommandId.AddHashFields,
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -24,7 +24,10 @@ import {
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { ListElementDestination, PushElementToListDto } from 'apiClient'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -128,7 +131,7 @@ const AddListElements = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add elements',
-      commandId: 'browser:add-list-elements',
+      commandId: BrowserConfirmationCommandId.AddListElements,
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -128,6 +128,7 @@ const AddListElements = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add elements',
+      commandId: 'browser:add-list-elements',
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
@@ -13,7 +13,10 @@ import {
   Nullable,
 } from 'uiSrc/utils'
 import FieldMessage from 'uiSrc/components/field-message/FieldMessage'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import { JSONScalarProps } from '../interfaces'
 import {
@@ -69,7 +72,7 @@ const RejsonScalar = (props: JSONScalarProps) => {
       actionDescription:
         'You are about to modify a JSON value on a production database.',
       confirmButtonText: 'Save',
-      commandId: 'browser:edit-rejson-value',
+      commandId: BrowserConfirmationCommandId.EditRejsonValue,
       onConfirm: () => {
         dispatch<any>(
           setReJSONDataAction(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
@@ -69,6 +69,7 @@ const RejsonScalar = (props: JSONScalarProps) => {
       actionDescription:
         'You are about to modify a JSON value on a production database.',
       confirmButtonText: 'Save',
+      commandId: 'browser:edit-rejson-value',
       onConfirm: () => {
         dispatch<any>(
           setReJSONDataAction(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -143,6 +143,7 @@ const AddSetMembers = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add members',
+      commandId: 'browser:add-set-members',
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -30,7 +30,10 @@ import {
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -143,7 +146,7 @@ const AddSetMembers = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add members',
-      commandId: 'browser:add-set-members',
+      commandId: BrowserConfirmationCommandId.AddSetMembers,
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
@@ -25,7 +25,10 @@ import {
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { AddStreamEntriesDto } from 'apiClient'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import StreamEntryFields from './StreamEntryFields/StreamEntryFields'
 import { Panel } from 'uiSrc/components/panel'
@@ -141,7 +144,7 @@ const AddStreamEntries = (props: Props) => {
       actionDescription:
         'You are about to add a new entry to a stream on a production database.',
       confirmButtonText: 'Add entry',
-      commandId: 'browser:add-stream-entry',
+      commandId: BrowserConfirmationCommandId.AddStreamEntry,
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
@@ -141,6 +141,7 @@ const AddStreamEntries = (props: Props) => {
       actionDescription:
         'You are about to add a new entry to a stream on a production database.',
       confirmButtonText: 'Add entry',
+      commandId: 'browser:add-stream-entry',
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -200,6 +200,7 @@ const StringDetailsValue = (props: Props) => {
       actionDescription:
         'You are about to modify a value on a production database.',
       confirmButtonText: 'Save',
+      commandId: 'browser:edit-value',
       onConfirm: () => {
         const data = stringToSerializedBufferFormat(viewFormat, areaValue)
         const onSuccess = () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -60,7 +60,10 @@ import { Text } from 'uiSrc/components/base/text'
 import { TextArea } from 'uiSrc/components/base/inputs'
 import { RiTooltip } from 'uiSrc/components'
 import { ProgressBarLoader } from 'uiSrc/components/base/display'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 const MIN_ROWS = 8
@@ -200,7 +203,7 @@ const StringDetailsValue = (props: Props) => {
       actionDescription:
         'You are about to modify a value on a production database.',
       confirmButtonText: 'Save',
-      commandId: 'browser:edit-value',
+      commandId: BrowserConfirmationCommandId.EditValue,
       onConfirm: () => {
         const data = stringToSerializedBufferFormat(viewFormat, areaValue)
         const onSuccess = () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -26,7 +26,10 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 
 import { EntryContent } from '../../common/AddKeysContainer.styled'
 
@@ -185,7 +188,7 @@ const AddZsetMembers = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add members',
-      commandId: 'browser:add-zset-members',
+      commandId: BrowserConfirmationCommandId.AddZsetMembers,
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -185,6 +185,7 @@ const AddZsetMembers = (props: Props) => {
         </>
       ),
       confirmButtonText: 'Add members',
+      commandId: 'browser:add-zset-members',
       onConfirm: submitData,
     })
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -9,7 +9,10 @@ import { Props as InlineItemEditorProps } from 'uiSrc/components/inline-item-edi
 import { Text } from 'uiSrc/components/base/text'
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -108,7 +111,7 @@ const EditableInput = (props: Props) => {
               actionDescription:
                 'You are about to modify a value on a production database.',
               confirmButtonText: 'Save',
-              commandId: 'browser:edit-value',
+              commandId: BrowserConfirmationCommandId.EditValue,
               onConfirm: () => {
                 onApply(value)
                 onEdit?.(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -108,6 +108,7 @@ const EditableInput = (props: Props) => {
               actionDescription:
                 'You are about to modify a value on a production database.',
               confirmButtonText: 'Save',
+              commandId: 'browser:edit-value',
               onConfirm: () => {
                 onApply(value)
                 onEdit?.(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -90,6 +90,7 @@ const EditablePopover = (props: Props) => {
       actionDescription:
         'You are about to modify a value on a production database.',
       confirmButtonText: 'Save',
+      commandId: 'browser:edit-value',
       onConfirm: () => {
         setIsPopoverOpen(false)
         onApply()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -10,7 +10,10 @@ import {
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { Loader } from 'uiSrc/components/base/display'
 import { RiPopover } from 'uiSrc/components/base'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -90,7 +93,7 @@ const EditablePopover = (props: Props) => {
       actionDescription:
         'You are about to modify a value on a production database.',
       confirmButtonText: 'Save',
-      commandId: 'browser:edit-value',
+      commandId: BrowserConfirmationCommandId.EditValue,
       onConfirm: () => {
         setIsPopoverOpen(false)
         onApply()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -159,6 +159,7 @@ const EditableTextArea = (props: Props) => {
                   actionDescription:
                     'You are about to modify a value on a production database.',
                   confirmButtonText: 'Save',
+                  commandId: 'browser:edit-value',
                   onConfirm: () => {
                     onApply(value)
                     setValue(initialValue)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -9,7 +9,10 @@ import { Text } from 'uiSrc/components/base/text'
 import { EditIcon } from 'uiSrc/components/base/icons'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { TextArea } from 'uiSrc/components/base/inputs'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -159,7 +162,7 @@ const EditableTextArea = (props: Props) => {
                   actionDescription:
                     'You are about to modify a value on a production database.',
                   confirmButtonText: 'Save',
-                  commandId: 'browser:edit-value',
+                  commandId: BrowserConfirmationCommandId.EditValue,
                   onConfirm: () => {
                     onApply(value)
                     setValue(initialValue)

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx
@@ -22,11 +22,19 @@ import {
   workbenchResultsSelector,
 } from 'uiSrc/slices/workbench/wb-results'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { Environment } from 'apiClient'
 import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 
 import WBViewWrapper from './WBViewWrapper'
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(
+    <ProductionWriteConfirmationProvider>
+      {ui}
+    </ProductionWriteConfirmationProvider>,
+  )
 
 let store: typeof mockedStore
 beforeEach(() => {
@@ -203,7 +211,7 @@ describe('WBViewWrapper', () => {
         isDangerousCommand: () => false,
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       act(() => {
         capturedOnSubmit?.('PING')
       })
@@ -222,7 +230,7 @@ describe('WBViewWrapper', () => {
           ['FLUSHALL', 'FLUSHDB'].includes(cmd.toUpperCase()),
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       act(() => {
         capturedOnSubmit?.('PING\nFLUSHALL\nFLUSHDB')
       })
@@ -244,7 +252,7 @@ describe('WBViewWrapper', () => {
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       // Monaco joins continuation lines (the leading whitespace on the next
       // line is preserved), so the verb arrives with an embedded newline.
       act(() => {
@@ -270,7 +278,7 @@ describe('WBViewWrapper', () => {
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       act(() => {
         capturedOnSubmit?.('FLUSHALL')
       })
@@ -286,7 +294,7 @@ describe('WBViewWrapper', () => {
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       act(() => {
         capturedOnSubmit?.('PING\nFLUSHALL')
       })
@@ -309,7 +317,7 @@ describe('WBViewWrapper', () => {
         isDangerousCommand: (cmd: string) => cmd.toUpperCase() === 'FLUSHALL',
       })
 
-      render(<WBViewWrapper />)
+      renderWithProvider(<WBViewWrapper />)
       act(() => {
         capturedOnSubmit?.('FLUSHALL')
       })
@@ -320,6 +328,67 @@ describe('WBViewWrapper', () => {
         screen.queryByTestId('type-to-confirm-modal-title'),
       ).not.toBeInTheDocument()
       expect(sendWbQueryAction).not.toHaveBeenCalled()
+    })
+
+    it('skips the modal on subsequent runs of the same dangerous batch after opt-in', () => {
+      useDatabaseEnvironmentMock.mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) =>
+          ['FLUSHALL', 'FLUSHDB'].includes(cmd.toUpperCase()),
+      })
+
+      renderWithProvider(<WBViewWrapper />)
+
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL\nFLUSHDB')
+      })
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: instance.name },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
+
+      // Same dangerous batch — should bypass the modal entirely
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL\nFLUSHDB')
+      })
+
+      expect(sendWbQueryAction).toHaveBeenCalledTimes(2)
+      expect(
+        screen.queryByTestId('type-to-confirm-modal-title'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('still prompts when the batch includes a not-yet-skipped dangerous command', () => {
+      useDatabaseEnvironmentMock.mockReturnValue({
+        environment: Environment.Production,
+        isDangerousCommand: (cmd: string) =>
+          ['FLUSHALL', 'FLUSHDB', 'DEBUG'].includes(cmd.toUpperCase()),
+      })
+
+      renderWithProvider(<WBViewWrapper />)
+
+      // Opt out of FLUSHALL only
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL')
+      })
+      fireEvent.change(screen.getByTestId('type-to-confirm-modal-input'), {
+        target: { value: instance.name },
+      })
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-skip-checkbox'))
+      fireEvent.click(screen.getByTestId('type-to-confirm-modal-confirm-btn'))
+
+      // New batch contains DEBUG — must still prompt
+      act(() => {
+        capturedOnSubmit?.('FLUSHALL\nDEBUG SLEEP 1')
+      })
+
+      expect(
+        screen.getByTestId('type-to-confirm-modal-title'),
+      ).toBeInTheDocument()
+      expect(sendWbQueryAction).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -51,7 +51,10 @@ import {
 } from 'uiSrc/slices/panels/sidePanels'
 import { InsightsPanelTabs, SidePanels } from 'uiSrc/slices/interfaces/insights'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
-import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
+import {
+  toRedisConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
 import { getCommandsForExecution } from 'uiSrc/utils/monaco/monacoUtils'
 import WBView from './WBView'
 
@@ -274,8 +277,8 @@ const WBViewWrapper = () => {
     if (dangerousCommands.length > 0) {
       const dangerousVerbs = Array.from(
         new Set(
-          dangerousCommands.map(
-            (cmd) => `cmd:${cmd.split(/\s+/)[0].toUpperCase()}`,
+          dangerousCommands.map((cmd) =>
+            toRedisConfirmationCommandId(cmd.split(/\s+/)[0].toUpperCase()),
           ),
         ),
       )

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -51,16 +51,9 @@ import {
 } from 'uiSrc/slices/panels/sidePanels'
 import { InsightsPanelTabs, SidePanels } from 'uiSrc/slices/interfaces/insights'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
-import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal'
+import { useProductionWriteConfirmation } from 'uiSrc/components/production-write-confirmation'
 import { getCommandsForExecution } from 'uiSrc/utils/monaco/monacoUtils'
 import WBView from './WBView'
-
-interface PendingSubmit {
-  value: string
-  commandId?: Nullable<string>
-  executeParams: CodeButtonParams
-  dangerousCommands: string[]
-}
 
 interface IState {
   loading: boolean
@@ -101,11 +94,10 @@ const WBViewWrapper = () => {
   const [script, setScript] = useState(scriptContext)
   const [scriptEl, setScriptEl] =
     useState<Nullable<monacoEditor.editor.IStandaloneCodeEditor>>(null)
-  const [pendingSubmit, setPendingSubmit] =
-    useState<Nullable<PendingSubmit>>(null)
 
   const instance = useSelector(connectedInstanceSelector)
   const { isDangerousCommand } = useDatabaseEnvironment()
+  const { requestConfirmation } = useProductionWriteConfirmation()
   const { visualizations = [] } = useSelector(appPluginsSelector)
   state = {
     scriptEl,
@@ -264,6 +256,9 @@ const WBViewWrapper = () => {
     }
   }
 
+  const confirmationText =
+    instance?.name || `${instance?.host}:${instance?.port}`
+
   const sourceValueSubmit = (
     value: string = script,
     commandId?: Nullable<string>,
@@ -277,11 +272,27 @@ const WBViewWrapper = () => {
       isDangerousCommand(cmd.split(/\s+/)[0]),
     )
     if (dangerousCommands.length > 0) {
-      setPendingSubmit({
-        value: effectiveValue,
-        commandId,
-        executeParams,
-        dangerousCommands,
+      const dangerousVerbs = Array.from(
+        new Set(
+          dangerousCommands.map(
+            (cmd) => `cmd:${cmd.split(/\s+/)[0].toUpperCase()}`,
+          ),
+        ),
+      )
+      requestConfirmation({
+        title: 'Run dangerous commands?',
+        actionDescription: (
+          <>
+            You&apos;re about to run{' '}
+            <strong>{dangerousCommands.join(', ')}</strong> against the
+            production database <strong>{confirmationText}</strong>.
+          </>
+        ),
+        confirmButtonText: 'Run command',
+        commandId: dangerousVerbs,
+        onConfirm: () => {
+          runSubmission(effectiveValue, commandId, executeParams)
+        },
       })
       return
     }
@@ -289,58 +300,25 @@ const WBViewWrapper = () => {
     runSubmission(effectiveValue, commandId, executeParams)
   }
 
-  const handleConfirmPendingSubmit = () => {
-    if (!pendingSubmit) return
-    const submission = pendingSubmit
-    setPendingSubmit(null)
-    runSubmission(
-      submission.value,
-      submission.commandId,
-      submission.executeParams,
-    )
-  }
-
-  const confirmationText =
-    instance?.name || `${instance?.host}:${instance?.port}`
-
   return (
-    <>
-      <WBView
-        items={items}
-        clearing={clearing}
-        processing={processing}
-        isResultsLoaded={isLoaded}
-        script={script}
-        setScript={setScript}
-        setScriptEl={setScriptEl}
-        scrollDivRef={scrollDivRef}
-        activeMode={activeRunQueryMode}
-        onSubmit={sourceValueSubmit}
-        onQueryOpen={handleQueryOpen}
-        onQueryDelete={handleQueryDelete}
-        onAllQueriesDelete={handleAllQueriesDelete}
-        onQueryChangeMode={handleChangeQueryRunMode}
-        resultsMode={resultsMode}
-        onChangeGroupMode={handleChangeGroupMode}
-      />
-      {pendingSubmit && (
-        <TypeToConfirmModal
-          title="Run dangerous commands?"
-          confirmationText={confirmationText}
-          actionDescription={
-            <>
-              You&apos;re about to run{' '}
-              <strong>{pendingSubmit.dangerousCommands.join(', ')}</strong>{' '}
-              against the production database{' '}
-              <strong>{confirmationText}</strong>.
-            </>
-          }
-          confirmButtonText="Run command"
-          onConfirm={handleConfirmPendingSubmit}
-          onCancel={() => setPendingSubmit(null)}
-        />
-      )}
-    </>
+    <WBView
+      items={items}
+      clearing={clearing}
+      processing={processing}
+      isResultsLoaded={isLoaded}
+      script={script}
+      setScript={setScript}
+      setScriptEl={setScriptEl}
+      scrollDivRef={scrollDivRef}
+      activeMode={activeRunQueryMode}
+      onSubmit={sourceValueSubmit}
+      onQueryOpen={handleQueryOpen}
+      onQueryDelete={handleQueryDelete}
+      onAllQueriesDelete={handleAllQueriesDelete}
+      onQueryChangeMode={handleChangeQueryRunMode}
+      resultsMode={resultsMode}
+      onChangeGroupMode={handleChangeGroupMode}
+    />
   )
 }
 

--- a/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
+++ b/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
@@ -19,6 +19,7 @@ import {
 import { ImperativePanelGroupHandle } from 'uiSrc/components/base/layout/resize'
 import { AppNavigation } from 'uiSrc/components'
 import { AppNavigationActionsProvider } from 'uiSrc/contexts/AppNavigationActionsProvider'
+import { ProductionWriteConfirmationProvider } from 'uiSrc/components/production-write-confirmation'
 import { Nullable } from 'uiSrc/utils'
 import { useNavigation } from 'uiSrc/components/navigation-menu/hooks/useNavigation'
 
@@ -100,42 +101,44 @@ const InstancePageTemplate = (props: Props) => {
         routes={privateRoutes}
       />
       <Spacer size="m" />
-      <ResizableContainer
-        ref={ref}
-        direction="vertical"
-        onLayout={onPanelWidthChange}
-      >
-        <ResizablePanel
-          id={firstPanelId}
-          minSize={7}
-          defaultSize={isShowBottomGroup ? sizes[0] : 100}
-          data-testid={firstPanelId}
+      <ProductionWriteConfirmationProvider>
+        <ResizableContainer
+          ref={ref}
+          direction="vertical"
+          onLayout={onPanelWidthChange}
         >
-          <AppNavigationActionsProvider
-            value={{
-              actions,
-              setActions,
-            }}
+          <ResizablePanel
+            id={firstPanelId}
+            minSize={7}
+            defaultSize={isShowBottomGroup ? sizes[0] : 100}
+            data-testid={firstPanelId}
           >
-            <ExplorePanelTemplate>{children}</ExplorePanelTemplate>
-          </AppNavigationActionsProvider>
-        </ResizablePanel>
-        <ResizablePanelHandle
-          direction="horizontal"
-          id="resize-btn-browser-cli"
-          data-testid="resize-btn-browser-cli"
-          style={{ display: isShowBottomGroup ? 'inherit' : 'none' }}
-        />
-        {!isShowBottomGroup && <Spacer size="l" />}
-        <ButtonGroupResizablePanel
-          id={secondPanelId}
-          defaultSize={isShowBottomGroup ? sizes[1] : 0}
-          minSize={isShowBottomGroup ? 20 : 0}
-          data-testid={secondPanelId}
-        >
-          <BottomGroupComponents />
-        </ButtonGroupResizablePanel>
-      </ResizableContainer>
+            <AppNavigationActionsProvider
+              value={{
+                actions,
+                setActions,
+              }}
+            >
+              <ExplorePanelTemplate>{children}</ExplorePanelTemplate>
+            </AppNavigationActionsProvider>
+          </ResizablePanel>
+          <ResizablePanelHandle
+            direction="horizontal"
+            id="resize-btn-browser-cli"
+            data-testid="resize-btn-browser-cli"
+            style={{ display: isShowBottomGroup ? 'inherit' : 'none' }}
+          />
+          {!isShowBottomGroup && <Spacer size="l" />}
+          <ButtonGroupResizablePanel
+            id={secondPanelId}
+            defaultSize={isShowBottomGroup ? sizes[1] : 0}
+            minSize={isShowBottomGroup ? 20 : 0}
+            data-testid={secondPanelId}
+          >
+            <BottomGroupComponents />
+          </ButtonGroupResizablePanel>
+        </ResizableContainer>
+      </ProductionWriteConfirmationProvider>
     </>
   )
 }


### PR DESCRIPTION
# What

In `TypeToConfirmModal` (shown for production-environment databases) the user now sees an optional **"Don't ask again for this command in this session"** checkbox. When ticked, subsequent requests sharing the same `commandId` bypass the modal until the connected database changes or the app is reopened.

**Refactors** `CliBodyWrapper` and `WBViewWrapper` to go through `ProductionWriteConfirmationProvider` (same path the browser key-details modules already used) instead of mounting `TypeToConfirmModal` directly. The provider is hoisted into `InstancePageTemplate` so all three consumers share a single session-scoped skip set per database. RDI template is untouched.

**CommandId namespacing**:
- `browser:*` — key-details ops (`browser:edit-value`, `browser:rename-key`, `browser:change-ttl`, …)
- `cmd:*` — Redis verbs (shared between CLI and Workbench, so opting out of `FLUSHDB` in the CLI also skips it for a subsequent Workbench `FLUSHDB`)

The provider accepts `commandId: string | string[]`; Workbench passes the array of dangerous verbs in a batch, and the modal is skipped only when *every* id is in the skip set.

<img width="589" height="441" alt="Screenshot 2026-05-28 at 11 36 20" src="https://github.com/user-attachments/assets/ff556241-8880-442c-9e78-841d97b0fc26" />

# Testing

1. Connect to a database flagged as **Production** (env-aware feature flag enabled).
2. **Browser**: edit a string value → modal appears → type DB name, tick the checkbox, confirm → edit another string value → modal no longer appears. Switch to a different (or non-production) database and edit again → modal returns.
3. **CLI**: run `FLUSHDB` → modal appears → tick the checkbox, confirm → run `FLUSHDB` again → no modal. Run `DEBUG SLEEP 1` → modal still appears (different verb).
4. **Workbench**: submit `FLUSHALL\nFLUSHDB` → modal lists both → tick + confirm → submit `FLUSHALL\nFLUSHDB` again → no modal. Submit `FLUSHALL\nDEBUG SLEEP 1` → modal returns (DEBUG not in skip set).
5. Cross-feature consistency: opt out of `FLUSHDB` in CLI → run `FLUSHDB` from Workbench → no modal.
6. Switch databases or restart the app → skip set resets; first dangerous command prompts again.

- [ ] yarn lint
- [ ] yarn test
- [ ] manual flows above

---

Closes RI-8200


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Users can bypass repeat confirmations for dangerous Redis commands and production writes after one typed confirm; scope is limited to session and per-database, but it still weakens the guardrail for destructive operations.
> 
> **Overview**
> Adds an optional **"Don't ask again for this command in this session"** checkbox to production type-to-confirm flows. When checked, `ProductionWriteConfirmationProvider` remembers `commandId`(s) for the rest of the session and skips the modal on repeat requests until the connected database changes.
> 
> **CLI** and **Workbench** no longer mount `TypeToConfirmModal` locally; they use the shared provider with `cmd:*` ids (e.g. `cmd:FLUSHDB`) so opting out in one surface applies to the other. **Browser** key-details actions get stable `browser:*` ids; the provider moves from `KeyDetails` up to **`InstancePageTemplate`** so browser, CLI, and workbench share one skip set per database.
> 
> Workbench passes an array of dangerous verb ids for multi-command batches; skip only applies when every id in that batch was previously opted out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33198e609870751b481d15f44a0abc75bdc879c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->