### PR TITLE
ci(workflows): tolerate coverage-comment failures on Dependabot runs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Unit tests coverage
     if: ${{ inputs.type == 'unit' }}
+    continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -39,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration tests coverage
     if: ${{ inputs.type == 'integration' }}
+    continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
The coverage reporter jobs post a PR comment via GITHUB_TOKEN, which is read-only on Dependabot-triggered runs and 403s. Mark both coverage jobs as continue-on-error when github.actor is dependabot[bot] so the failed step doesn't fail the parent workflow on those PRs. Normal PRs still report failures as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no impact on application runtime or production behavior.
> 
> **Overview**
> Dependabot PRs use a read-only `GITHUB_TOKEN`, so coverage jobs that post PR comments can fail with 403 and block the parent test workflow.
> 
> Both **`coverage-unit`** and **`coverage-integration`** in `code-coverage.yml` now set **`continue-on-error`** when `github.actor` is `dependabot[bot]`, so those comment steps can fail without failing the overall run. Non-Dependabot PRs still fail the job on coverage/comment errors as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29b7152f33503afef0050fe2503cb039b44776c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->