### PR TITLE
ci: skip coverage comment jobs on Dependabot runs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Unit tests coverage
     if: ${{ inputs.type == 'unit' }}
-    continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -40,7 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration tests coverage
     if: ${{ inputs.type == 'integration' }}
-    continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,7 @@ jobs:
 
   frontend-tests-coverage:
     needs: frontend-tests
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/code-coverage.yml
     secrets: inherit
     with:
@@ -188,6 +189,7 @@ jobs:
 
   backend-tests-coverage:
     needs: backend-tests
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/code-coverage.yml
     secrets: inherit
     with:
@@ -210,6 +212,7 @@ jobs:
 
   integration-tests-coverage:
     needs: integration-tests
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/code-coverage.yml
     secrets: inherit
     with:


### PR DESCRIPTION
# What

Skip the three coverage caller jobs (`frontend-tests-coverage`,
`backend-tests-coverage`, `integration-tests-coverage`) when the
workflow is triggered by Dependabot.

Dependabot-triggered workflow runs use a read-only `GITHUB_TOKEN` as
a GitHub security control — no `permissions:` block in the workflow
can elevate it. The coverage jobs post PR comments via that token,
so they 403 on every Dependabot PR ("Resource not accessible by
integration"), which in turn marks the jobs red and blocks the PR
on required status checks.

Adding `if: ${{ github.actor != 'dependabot[bot]' }}` skips the jobs
before any runner spins up. The status checks report "skipped",
which GitHub treats as passing for branch protection, so Dependabot
PRs become mergeable again. Behavior is unchanged for any other
actor — humans and other bots still get coverage comments.

No downstream jobs depend on the coverage jobs; checked all `needs:`
references. `clean` and `remove-artifacts` depend on the test jobs,
not the coverage jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only gating change; no application code, auth, or runtime behavior affected.
> 
> **Overview**
> Dependabot PRs no longer run the three coverage follow-up jobs (`frontend-tests-coverage`, `backend-tests-coverage`, `integration-tests-coverage`). Each caller in `tests.yml` now has `if: ${{ github.actor != 'dependabot[bot]' }}`, so those jobs are **skipped** instead of executed.
> 
> The reusable `code-coverage.yml` workflow drops `continue-on-error` for Dependabot on the unit and integration coverage jobs—skipping happens upstream, so those jobs are not started for Dependabot at all.
> 
> For other actors, coverage comments and behavior are unchanged. Skipped required checks count as passing, which avoids red coverage jobs blocking Dependabot merges when `GITHUB_TOKEN` cannot post PR comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2d32b646deb74ada6d251b7e2f729bf06d7476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->