### PR TITLE
ci: skip Dependabot-incompatible housekeeping jobs across workflows

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -289,6 +289,7 @@ jobs:
           path: integration-coverage.txt
 
       - name: Delete Artifact
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,7 +221,7 @@ jobs:
 
   clean:
     uses: ./.github/workflows/clean-deployments.yml
-    if: always()
+    if: ${{ always() && github.actor != 'dependabot[bot]' }}
     permissions:
       actions: write
       contents: read
@@ -236,6 +236,7 @@ jobs:
   # Remove artifacts from github actions
   remove-artifacts:
     name: Remove artifacts
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs:
       [
         frontend-tests,


### PR DESCRIPTION
# What

Dependabot-triggered workflow runs use a read-only `GITHUB_TOKEN` by
GitHub security policy — no `permissions:` block in the workflow can
elevate it. Several housekeeping jobs that need write-scoped APIs
have been failing on Dependabot PRs with 403s ("Resource not
accessible by integration") and blocking the PR via required status
checks.

This PR skips those jobs on Dependabot runs and fixes one silent
failure.

**Skipped on Dependabot (`tests.yml`):**

- `clean` (deactivates and deletes deployment environments).
- `remove-artifacts` (deletes merged workflow artifacts).

**Fixed in `tests-integration.yml`:**

- `Final coverage` → `Delete Artifact` step - Gated by `if: github.actor != 'dependabot[bot]'` so the
     step is skipped cleanly on Dependabot rather than relying on
     the broken silent-pass behavior.

No downstream jobs depend on the skipped ones — checked end-to-end.
The trade-off is that artifacts and deployment records created on
Dependabot PRs are not actively cleaned up; they expire via the
repo's default artifact retention (~90 days) and stay as inactive
deployments otherwise. Volume is bounded and acceptable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only condition changes; no application code, auth, or data paths affected.
> 
> **Overview**
> Dependabot PRs use a read-only `GITHUB_TOKEN`, so jobs that call write APIs were failing required checks with 403s. This change **skips those housekeeping steps when `github.actor` is `dependabot[bot]`** instead of letting them fail.
> 
> In **`tests.yml`**, the **`clean`** deployment-cleanup job still runs with `always()` but only for non-Dependabot actors; **`remove-artifacts`** is gated the same way. In **`tests-integration.yml`**, the post-coverage **`Delete Artifact`** step is skipped on Dependabot so artifact deletion is not attempted with insufficient permissions.
> 
> Dependabot runs still execute tests and coverage upload paths that do not need elevated token scope; only deployment teardown, bulk artifact removal, and merged-artifact deletion are deferred (artifacts rely on default retention).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e61c12fd8f4f001b18b69309bc215c7f3c57402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->