### PR TITLE
RED-194229 Deprecate custom tutorials behind feature flag

### DIFF
--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -113,6 +113,8 @@ export default {
     excludeRoutes: [],
     excludeAuthRoutes: [],
     databaseManagement: process.env.RI_DATABASE_MANAGEMENT !== 'false',
+    // Custom tutorials are deprecated (RED-194229) and disabled by default.
+    customTutorials: process.env.RI_CUSTOM_TUTORIALS_ENABLED === 'true',
     maxPayloadSize: process.env.RI_MAX_PAYLOAD_SIZE || '512MB',
     cors: {
       origin: process.env.RI_CORS_ORIGIN ? process.env.RI_CORS_ORIGIN : '*',

--- a/redisinsight/api/src/__mocks__/feature.ts
+++ b/redisinsight/api/src/__mocks__/feature.ts
@@ -216,6 +216,11 @@ export const mockFeatureDatabaseManagement = Object.assign(new Feature(), {
   flag: true,
 });
 
+export const mockFeatureCustomTutorials = Object.assign(new Feature(), {
+  name: KnownFeatures.CustomTutorials,
+  flag: false,
+});
+
 export const mockFeatureRedisClient = Object.assign(new Feature(), {
   name: KnownFeatures.RedisClient,
   flag: true,

--- a/redisinsight/api/src/app.module.ts
+++ b/redisinsight/api/src/app.module.ts
@@ -69,7 +69,8 @@ const STATICS_CONFIG = config.get('statics') as Config['statics'];
     NotificationModule.register(),
     BulkActionsModule,
     ClusterMonitorModule,
-    CustomTutorialModule.register(),
+    // Custom tutorials are deprecated (RED-194229).
+    ...(SERVER_CONFIG.customTutorials ? [CustomTutorialModule.register()] : []),
     DatabaseAnalysisModule,
     DatabaseImportModule,
     CloudModule.register(),

--- a/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.analytics.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.analytics.ts
@@ -4,6 +4,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TelemetryEvents } from 'src/constants';
 import { SessionMetadata } from 'src/common/models';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @Injectable()
 export class CustomTutorialAnalytics extends TelemetryBaseService {
   constructor(protected eventEmitter: EventEmitter2) {

--- a/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.controller.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.controller.ts
@@ -26,6 +26,10 @@ import { RootCustomTutorialManifest } from 'src/modules/custom-tutorial/models/c
 import { RequestSessionMetadata } from 'src/common/decorators';
 import { SessionMetadata } from 'src/common/models';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @ApiExtraModels(
   CreateCaCertificateDto,
   UseCaCertificateDto,

--- a/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.module.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.module.ts
@@ -7,6 +7,10 @@ import { CustomTutorialRepository } from 'src/modules/custom-tutorial/repositori
 import { LocalCustomTutorialRepository } from 'src/modules/custom-tutorial/repositories/local.custom-tutorial.repository';
 import { CustomTutorialAnalytics } from 'src/modules/custom-tutorial/custom-tutorial.analytics';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @Module({})
 export class CustomTutorialModule {
   static register(

--- a/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.service.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/custom-tutorial.service.ts
@@ -28,6 +28,11 @@ import { Validator } from 'class-validator';
 import { CustomTutorialAnalytics } from 'src/modules/custom-tutorial/custom-tutorial.analytics';
 import { SessionMetadata } from 'src/common/models';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
+
 @Injectable()
 export class CustomTutorialService {
   private logger = new Logger('CustomTutorialService');

--- a/redisinsight/api/src/modules/custom-tutorial/dto/upload.custom-tutorial.dto.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/dto/upload.custom-tutorial.dto.ts
@@ -7,6 +7,10 @@ import {
   MemoryStoredFile,
 } from 'nestjs-form-data';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 export class UploadCustomTutorialDto {
   @ApiPropertyOptional({
     type: 'string',

--- a/redisinsight/api/src/modules/custom-tutorial/entities/custom-tutorial.entity.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/entities/custom-tutorial.entity.ts
@@ -6,6 +6,10 @@ import {
 } from 'typeorm';
 import { Expose } from 'class-transformer';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @Entity('custom_tutorials')
 export class CustomTutorialEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.manifest.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.manifest.ts
@@ -11,12 +11,22 @@ import {
   ValidateNested,
 } from 'class-validator';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export enum CustomTutorialManifestType {
   CodeButton = 'code-button',
   Group = 'group',
   InternalLink = 'internal-link',
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export interface ICustomTutorialManifest {
   id: string;
   type: CustomTutorialManifestType;
@@ -27,6 +37,11 @@ export interface ICustomTutorialManifest {
   _path?: string;
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export class CustomTutorialManifestArgs {
   @ApiPropertyOptional({ type: Boolean })
   @IsOptional()
@@ -48,6 +63,11 @@ export class CustomTutorialManifestArgs {
   withBorder?: boolean;
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export class CustomTutorialManifest {
   @ApiProperty({ type: String })
   @Expose()
@@ -91,6 +111,11 @@ export class CustomTutorialManifest {
   children?: CustomTutorialManifest[];
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export class RootCustomTutorialManifest extends CustomTutorialManifest {
   @ApiPropertyOptional({ enum: CustomTutorialActions })
   @IsOptional()

--- a/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/models/custom-tutorial.ts
@@ -4,12 +4,22 @@ import config from 'src/utils/config';
 
 const PATH_CONFIG = config.get('dir_path');
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export enum CustomTutorialActions {
   CREATE = 'create',
   DELETE = 'delete',
   SYNC = 'sync',
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * are slated for removal.
+ */
 export class CustomTutorial {
   @Expose()
   id: string;

--- a/redisinsight/api/src/modules/custom-tutorial/providers/custom-tutorial.fs.provider.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/providers/custom-tutorial.fs.provider.ts
@@ -23,6 +23,10 @@ const UPLOAD_FROM_REMOTE_ORIGINS_WHITELIST = [
   'https://raw.githubusercontent.com',
 ];
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @Injectable()
 export class CustomTutorialFsProvider {
   private logger = new Logger('CustomTutorialFsProvider');

--- a/redisinsight/api/src/modules/custom-tutorial/providers/custom-tutorial.manifest.provider.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/providers/custom-tutorial.manifest.provider.ts
@@ -14,6 +14,10 @@ import { winPathToNormalPath } from 'src/utils';
 const MANIFEST_FILE = 'manifest.json';
 const SYS_MANIFEST_FILE = '_manifest.json';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 @Injectable()
 export class CustomTutorialManifestProvider {
   private logger = new Logger('CustomTutorialManifestProvider');

--- a/redisinsight/api/src/modules/custom-tutorial/repositories/custom-tutorial.repository.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/repositories/custom-tutorial.repository.ts
@@ -1,5 +1,9 @@
 import { CustomTutorial } from 'src/modules/custom-tutorial/models/custom-tutorial';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 export abstract class CustomTutorialRepository {
   /**
    * Create custom tutorial entity

--- a/redisinsight/api/src/modules/custom-tutorial/repositories/local.custom-tutorial.repository.ts
+++ b/redisinsight/api/src/modules/custom-tutorial/repositories/local.custom-tutorial.repository.ts
@@ -5,6 +5,10 @@ import { CustomTutorialEntity } from 'src/modules/custom-tutorial/entities/custo
 import { CustomTutorial } from 'src/modules/custom-tutorial/models/custom-tutorial';
 import { CustomTutorialRepository } from 'src/modules/custom-tutorial/repositories/custom-tutorial.repository';
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 export class LocalCustomTutorialRepository extends CustomTutorialRepository {
   constructor(
     @InjectRepository(CustomTutorialEntity)

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -31,6 +31,7 @@ export enum KnownFeatures {
   HashFieldExpiration = 'hashFieldExpiration',
   EnhancedCloudUI = 'enhancedCloudUI',
   DatabaseManagement = 'databaseManagement',
+  CustomTutorials = 'customTutorials',
   VectorSearchV2 = 'vectorSearchV2',
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -58,6 +58,14 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
       flag: SERVER_CONFIG.databaseManagement,
     }),
   },
+  [KnownFeatures.CustomTutorials]: {
+    name: KnownFeatures.CustomTutorials,
+    storage: FeatureStorage.Custom,
+    factory: () => ({
+      name: KnownFeatures.CustomTutorials,
+      flag: SERVER_CONFIG.customTutorials,
+    }),
+  },
   [KnownFeatures.VectorSearchV2]: {
     name: KnownFeatures.VectorSearchV2,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/local.feature.service.spec.ts
+++ b/redisinsight/api/src/modules/feature/local.feature.service.spec.ts
@@ -8,6 +8,7 @@ import {
   mockFeatureAnalytics,
   mockFeatureFlagProvider,
   mockFeatureRepository,
+  mockFeatureCustomTutorials,
   mockFeatureDatabaseManagement,
   mockFeaturesConfig,
   mockFeaturesConfigJson,
@@ -207,6 +208,7 @@ describe('FeatureService', () => {
           [KnownFeatures.InsightsRecommendations]: mockFeature,
           [KnownFeatures.CloudSso]: mockFeatureSso,
           [KnownFeatures.DatabaseManagement]: mockFeatureDatabaseManagement,
+          [KnownFeatures.CustomTutorials]: mockFeatureCustomTutorials,
         },
       });
     });
@@ -242,6 +244,7 @@ describe('FeatureService', () => {
             [KnownFeatures.InsightsRecommendations]: mockFeature,
             [KnownFeatures.CloudSso]: mockFeatureSso,
             [KnownFeatures.DatabaseManagement]: mockFeatureDatabaseManagement,
+            [KnownFeatures.CustomTutorials]: mockFeatureCustomTutorials,
           },
           force: {
             [KnownFeatures.CloudSso]: false,

--- a/redisinsight/api/src/modules/statics-management/statics-management.module.ts
+++ b/redisinsight/api/src/modules/statics-management/statics-management.module.ts
@@ -37,14 +37,19 @@ export class StaticsManagementModule {
             setHeaders: downloadableStaticFiles,
           },
         }),
-        ServeStaticModule.forRoot({
-          serveRoot: SERVER_CONFIG.customTutorialsUri,
-          rootPath: join(PATH_CONFIG.customTutorials),
-          serveStaticOptions: {
-            fallthrough: false,
-            setHeaders: downloadableStaticFiles,
-          },
-        }),
+        // Custom tutorials are deprecated (RED-194229)
+        ...(SERVER_CONFIG.customTutorials
+          ? [
+              ServeStaticModule.forRoot({
+                serveRoot: SERVER_CONFIG.customTutorialsUri,
+                rootPath: join(PATH_CONFIG.customTutorials),
+                serveStaticOptions: {
+                  fallthrough: false,
+                  setHeaders: downloadableStaticFiles,
+                },
+              }),
+            ]
+          : []),
         ServeStaticModule.forRoot({
           serveRoot: SERVER_CONFIG.contentUri,
           rootPath: join(PATH_CONFIG.content),

--- a/redisinsight/api/test/api/bulk-actions/POST-databases-id-bulk_actions-import-tutorial_data.test.ts
+++ b/redisinsight/api/test/api/bulk-actions/POST-databases-id-bulk_actions-import-tutorial_data.test.ts
@@ -29,7 +29,15 @@ const getZipArchive = () => {
   return zipArchive;
 };
 
-describe('POST /databases/:id/bulk-actions/import/tutorial-data', () => {
+// These tests use POST /custom-tutorials as a fixture to seed a tutorial
+// folder. Custom tutorials are deprecated (RED-194229) and the endpoint
+// is unregistered when RI_CUSTOM_TUTORIALS_ENABLED is not set, so the
+// fixture step returns 404 and the tests fail. Skip the suite while the
+// feature is gated off; switch back to `describe` when running locally
+// with the flag enabled.
+// TODO: rework these tests to seed via bundled tutorials, or remove
+// alongside the full custom-tutorials deletion.
+describe.skip('POST /databases/:id/bulk-actions/import/tutorial-data', () => {
   requirements('!rte.sharedData', '!rte.bigData', 'rte.serverType=local');
 
   beforeEach(async () => await rte.data.truncate());

--- a/redisinsight/api/test/api/custom-tutorials/POST-custom-tutorials.test.ts
+++ b/redisinsight/api/test/api/custom-tutorials/POST-custom-tutorials.test.ts
@@ -121,7 +121,9 @@ const globalManifest = {
 
 const nockScope = nock('https://github.com/somerepo');
 
-describe('POST /custom-tutorials', () => {
+// Custom tutorials are deprecated (RED-194229)
+// TODO: remove this file when the feature is fully deleted.
+describe.skip('POST /custom-tutorials', () => {
   requirements('rte.serverType=local');
 
   before(async () => {

--- a/redisinsight/api/test/api/feature/GET-features.test.ts
+++ b/redisinsight/api/test/api/feature/GET-features.test.ts
@@ -303,6 +303,10 @@ describe('GET /features', () => {
                 flag: true,
                 name: 'databaseManagement',
               },
+              customTutorials: {
+                flag: false,
+                name: 'customTutorials',
+              },
             },
           },
           () =>

--- a/redisinsight/api/test/api/feature/GET-features.test.ts
+++ b/redisinsight/api/test/api/feature/GET-features.test.ts
@@ -99,6 +99,10 @@ describe('GET /features', () => {
                 flag: true,
                 name: 'databaseManagement',
               },
+              customTutorials: {
+                flag: false,
+                name: 'customTutorials',
+              },
             },
           },
           syncEndpoint,
@@ -120,6 +124,10 @@ describe('GET /features', () => {
           databaseManagement: {
             flag: true,
             name: 'databaseManagement',
+          },
+          customTutorials: {
+            flag: false,
+            name: 'customTutorials',
           },
         });
         expect(body.controlNumber).to.eq(config.controlNumber);
@@ -168,6 +176,10 @@ describe('GET /features', () => {
                 flag: true,
                 name: 'databaseManagement',
               },
+              customTutorials: {
+                flag: false,
+                name: 'customTutorials',
+              },
             },
           },
           syncEndpoint,
@@ -187,6 +199,10 @@ describe('GET /features', () => {
           databaseManagement: {
             flag: true,
             name: 'databaseManagement',
+          },
+          customTutorials: {
+            flag: false,
+            name: 'customTutorials',
           },
         },
       },
@@ -238,6 +254,10 @@ describe('GET /features', () => {
                 flag: true,
                 name: 'databaseManagement',
               },
+              customTutorials: {
+                flag: false,
+                name: 'customTutorials',
+              },
             },
           },
           syncEndpoint,
@@ -257,6 +277,10 @@ describe('GET /features', () => {
           databaseManagement: {
             flag: true,
             name: 'databaseManagement',
+          },
+          customTutorials: {
+            flag: false,
+            name: 'customTutorials',
           },
         },
       },
@@ -303,6 +327,10 @@ describe('GET /features', () => {
           databaseManagement: {
             flag: true,
             name: 'databaseManagement',
+          },
+          customTutorials: {
+            flag: false,
+            name: 'customTutorials',
           },
         },
       },

--- a/redisinsight/ui/src/components/config/Config.spec.tsx
+++ b/redisinsight/ui/src/components/config/Config.spec.tsx
@@ -82,11 +82,13 @@ describe('Config', () => {
     )
 
     render(<Config />)
+    // Custom tutorials are deprecated and disabled by default
+    // (RED-194229), so `getWBCustomTutorials` is no longer dispatched on
+    // startup.
     const afterRenderActions = [
       setCapability(),
       getServerInfo(),
       getNotifications(),
-      getWBCustomTutorials(),
       processCliClient(),
       getRedisCommands(),
       getContentRecommendations(),
@@ -101,6 +103,21 @@ describe('Config', () => {
     )
   })
 
+  it('should dispatch getWBCustomTutorials when customTutorials feature flag is on', () => {
+    const initialStoreState = set(
+      cloneDeep(initialStateDefault),
+      `app.features.featureFlags.features.${FeatureFlags.customTutorials}`,
+      { flag: true },
+    )
+    const customStore = mockStore(initialStoreState)
+
+    render(<Config />, { store: customStore })
+
+    expect(customStore.getActions()).toEqual(
+      expect.arrayContaining([getWBCustomTutorials()]),
+    )
+  })
+
   it('should render w/o settings spec call', async () => {
     set(
       store,
@@ -110,11 +127,11 @@ describe('Config', () => {
 
     render(<Config />)
 
+    // Custom tutorials are deprecated (RED-194229); not dispatched on startup.
     const afterRenderActions = [
       setCapability(),
       getServerInfo(),
       getNotifications(),
-      getWBCustomTutorials(),
       processCliClient(),
       getRedisCommands(),
       getContentRecommendations(),
@@ -171,11 +188,11 @@ describe('Config', () => {
     })
     userSettingsSelector.mockImplementation(userSettingsSelectorMock)
     render(<Config />)
+    // Custom tutorials are deprecated (RED-194229); not dispatched on startup.
     const afterRenderActions = [
       setCapability(),
       getServerInfo(),
       getNotifications(),
-      getWBCustomTutorials(),
       processCliClient(),
       getRedisCommands(),
       getContentRecommendations(),

--- a/redisinsight/ui/src/components/config/Config.tsx
+++ b/redisinsight/ui/src/components/config/Config.tsx
@@ -50,6 +50,7 @@ const Config = () => {
   const {
     [FeatureFlags.cloudSso]: cloudSsoFeature,
     [FeatureFlags.envDependent]: envDependentFeature,
+    [FeatureFlags.customTutorials]: customTutorialsFeature,
   } = useSelector(appFeatureFlagsFeaturesSelector)
   const { changeTheme } = useContext(ThemeContext)
   const { pathname } = useLocation()
@@ -62,7 +63,9 @@ const Config = () => {
     if (envDependentFeature?.flag) {
       dispatch(fetchServerInfo())
       dispatch(fetchNotificationsAction())
-      dispatch(fetchCustomTutorials())
+      if (customTutorialsFeature?.flag) {
+        dispatch(fetchCustomTutorials())
+      }
     } else {
       dispatch(setServerLoaded())
     }

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/EnablementArea.spec.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/EnablementArea.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, set } from 'lodash'
 import { instance, mock } from 'ts-mockito'
 import reactRouterDom from 'react-router-dom'
 import {
   cleanup,
+  initialStateDefault,
   mockedStore,
+  mockStore,
   render,
   screen,
   fireEvent,
@@ -12,6 +14,7 @@ import {
   waitFor,
 } from 'uiSrc/utils/test-utils'
 import {
+  FeatureFlags,
   MOCK_TUTORIALS_ITEMS,
   MOCK_CUSTOM_TUTORIALS_ITEMS,
 } from 'uiSrc/constants'
@@ -37,6 +40,20 @@ beforeEach(() => {
   store = cloneDeep(mockedStore)
   store.clearActions()
 })
+
+// Custom tutorials are deprecated (RED-194229) and disabled by default.
+// Tests that exercise the upload/delete UI need to render with the flag
+// explicitly enabled and use the returned mock store for action assertions.
+const renderWithCustomTutorialsEnabled = (ui: React.ReactElement) => {
+  const initialStoreState = set(
+    cloneDeep(initialStateDefault),
+    `app.features.featureFlags.features.${FeatureFlags.customTutorials}`,
+    { flag: true },
+  )
+  const customStore = mockStore(initialStoreState)
+  const result = render(ui, { store: customStore })
+  return { ...result, store: customStore }
+}
 
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
@@ -169,7 +186,7 @@ describe('EnablementArea', () => {
 
   describe('Custom Tutorials', () => {
     it('should render custom tutorials', () => {
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
@@ -181,7 +198,7 @@ describe('EnablementArea', () => {
     })
 
     it('should render add button and open form', () => {
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
@@ -196,7 +213,7 @@ describe('EnablementArea', () => {
       const customTutorials = [
         { ...MOCK_CUSTOM_TUTORIALS_ITEMS[0], children: [] },
       ]
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={customTutorials}
@@ -206,14 +223,14 @@ describe('EnablementArea', () => {
     })
 
     it('should call proper actions after upload form submit', async () => {
-      render(
+      const { store: customStore } = renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
         />,
       )
 
-      const afterRenderActions = [...store.getActions()]
+      const afterRenderActions = [...customStore.getActions()]
 
       fireEvent.click(screen.getByTestId('open-upload-tutorial-btn'))
 
@@ -228,25 +245,25 @@ describe('EnablementArea', () => {
       })
 
       const expectedActions = [...afterRenderActions, uploadWbCustomTutorial()]
-      expect(store.getActions().slice(0, expectedActions.length)).toEqual(
+      expect(customStore.getActions().slice(0, expectedActions.length)).toEqual(
         expectedActions,
       )
     })
 
     it('should render delete button and call proper actions after click on delete', () => {
-      render(
+      const { store: customStore } = renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
         />,
       )
-      const afterRenderActions = [...store.getActions()]
+      const afterRenderActions = [...customStore.getActions()]
 
       fireEvent.click(screen.getByTestId('delete-tutorial-icon-12mfp-rem'))
       fireEvent.click(screen.getByTestId('delete-tutorial-12mfp-rem'))
 
       const expectedActions = [...afterRenderActions, deleteWbCustomTutorial()]
-      expect(store.getActions().slice(0, expectedActions.length)).toEqual(
+      expect(customStore.getActions().slice(0, expectedActions.length)).toEqual(
         expectedActions,
       )
     })
@@ -259,7 +276,7 @@ describe('EnablementArea', () => {
         () => sendEventTelemetryMock,
       )
 
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
@@ -283,7 +300,7 @@ describe('EnablementArea', () => {
         () => sendEventTelemetryMock,
       )
 
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}
@@ -322,7 +339,7 @@ describe('EnablementArea', () => {
         () => sendEventTelemetryMock,
       )
 
-      render(
+      renderWithCustomTutorialsEnabled(
         <EnablementArea
           {...instance(mockedProps)}
           customTutorials={MOCK_CUSTOM_TUTORIALS_ITEMS}

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
@@ -6,8 +6,10 @@ import { AxiosError } from 'axios'
 
 import { getApiErrorMessage, isStatusSuccessful, Nullable } from 'uiSrc/utils'
 import { resourcesService } from 'uiSrc/services'
+import { ApiEndpoints, FeatureFlags } from 'uiSrc/constants'
 import { IS_ABSOLUTE_PATH } from 'uiSrc/constants/regex'
 import { IEnablementAreaItem } from 'uiSrc/slices/interfaces'
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { workbenchTutorialsSelector } from 'uiSrc/slices/workbench/wb-tutorials'
 import { workbenchCustomTutorialsSelector } from 'uiSrc/slices/workbench/wb-custom-tutorials'
 
@@ -70,6 +72,8 @@ const LazyInternalPage = ({
   const { loading: customTutorialsLoading } = useSelector(
     workbenchCustomTutorialsSelector,
   )
+  const { [FeatureFlags.customTutorials]: customTutorialsFeature } =
+    useSelector(appFeatureFlagsFeaturesSelector)
   const [isLoading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
   const [pageData, setPageData] = useState<IPageData>(DEFAULT_PAGE_DATA)
@@ -106,6 +110,14 @@ const LazyInternalPage = ({
     try {
       if (IS_ABSOLUTE_PATH.test(path)) {
         throw new Error('External content is not allowed')
+      }
+
+      // Custom tutorials are deprecated (RED-194229)
+      if (
+        !customTutorialsFeature?.flag &&
+        path?.startsWith(ApiEndpoints.CUSTOM_TUTORIALS_PATH)
+      ) {
+        throw new Error('Custom tutorials are disabled')
       }
 
       const formatter = FormatSelector.selectFor(pageInfo.extension)

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.spec.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.spec.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
-import { render, screen } from 'uiSrc/utils/test-utils'
+import { cloneDeep, set } from 'lodash'
+import {
+  initialStateDefault,
+  mockStore,
+  render,
+  screen,
+} from 'uiSrc/utils/test-utils'
 
 import {
+  FeatureFlags,
   MOCK_CUSTOM_TUTORIALS_ITEMS,
   MOCK_TUTORIALS_ITEMS,
 } from 'uiSrc/constants'
@@ -12,6 +19,15 @@ const guides = {
   customTutorials: MOCK_CUSTOM_TUTORIALS_ITEMS,
 }
 
+const renderWithCustomTutorialsEnabled = (ui: React.ReactElement) => {
+  const initialStoreState = set(
+    cloneDeep(initialStateDefault),
+    `app.features.featureFlags.features.${FeatureFlags.customTutorials}`,
+    { flag: true },
+  )
+  return render(ui, { store: mockStore(initialStoreState) })
+}
+
 describe('Navigation', () => {
   it('should render', () => {
     expect(
@@ -19,12 +35,23 @@ describe('Navigation', () => {
     ).toBeTruthy()
   })
 
-  it('should render navigation groups', () => {
-    render(<Navigation {...guides} isInternalPageVisible />)
+  it('should render navigation groups when customTutorials feature is on', () => {
+    renderWithCustomTutorialsEnabled(
+      <Navigation {...guides} isInternalPageVisible />,
+    )
 
     expect(screen.queryByTestId('accordion-tutorials')).toBeInTheDocument()
     expect(
       screen.queryByTestId('accordion-custom-tutorials'),
     ).toBeInTheDocument()
+  })
+
+  it('should hide custom tutorials section when customTutorials feature is off', () => {
+    render(<Navigation {...guides} isInternalPageVisible />)
+
+    expect(screen.queryByTestId('accordion-tutorials')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('accordion-custom-tutorials'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
@@ -70,9 +70,10 @@ const PATHS = {
 const Navigation = (props: Props) => {
   const { tutorials, customTutorials, isInternalPageVisible } = props
   const { currentStep, isActive } = useSelector(appFeatureOnboardingSelector)
-  const { [FeatureFlags.envDependent]: envDependentFeature } = useSelector(
-    appFeatureFlagsFeaturesSelector,
-  )
+  const {
+    [FeatureFlags.envDependent]: envDependentFeature,
+    [FeatureFlags.customTutorials]: customTutorialsFeature,
+  } = useSelector(appFeatureFlagsFeaturesSelector)
 
   const [isCreateOpen, setIsCreateOpen] = useState(false)
 
@@ -262,6 +263,7 @@ const Navigation = (props: Props) => {
         renderTreeView(getManifestItems(tutorials), PATHS.tutorials)}
       {customTutorials &&
         envDependentFeature?.flag &&
+        customTutorialsFeature?.flag &&
         renderTreeView(
           getManifestItems(customTutorials),
           PATHS.customTutorials,

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/UploadTutorialForm/UploadTutorialForm.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/UploadTutorialForm/UploadTutorialForm.tsx
@@ -34,6 +34,10 @@ export interface Props {
   isPageOpened?: boolean
 }
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. Slated for removal.
+ */
 const UploadTutorialForm = (props: Props) => {
   const { onSubmit, onCancel, isPageOpened } = props
   const [errors, setErrors] = useState<FormikErrors<FormValues>>({})

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -10,6 +10,7 @@ export enum FeatureFlags {
   enhancedCloudUI = 'enhancedCloudUI',
   cloudAds = 'cloudAds',
   databaseManagement = 'databaseManagement',
+  customTutorials = 'customTutorials',
   vectorSearchV2 = 'vectorSearchV2',
   devVectorSet = 'dev-vectorSet',
   azureEntraId = 'azureEntraId',

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -53,6 +53,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.databaseManagement]: {
         flag: true,
       },
+      [FeatureFlags.customTutorials]: {
+        flag: false,
+      },
       [FeatureFlags.envDependent]: {
         flag: riConfig.features.envDependent.defaultFlag,
       },

--- a/redisinsight/ui/src/slices/workbench/wb-custom-tutorials.ts
+++ b/redisinsight/ui/src/slices/workbench/wb-custom-tutorials.ts
@@ -24,6 +24,11 @@ import successMessages from 'uiSrc/components/notifications/success-messages'
 import { getFileNameFromPath } from 'uiSrc/utils/pathUtil'
 import { AppDispatch, RootState } from '../store'
 
+/**
+ * @deprecated Custom tutorials are deprecated (RED-194229) and disabled by
+ * default via the `customTutorials` feature flag. All exports in this file
+ * (slice, actions, selectors, thunks) are slated for removal.
+ */
 export const defaultItems: IEnablementAreaItem[] = [
   {
     id: 'custom-tutorials',


### PR DESCRIPTION
# What

Deprecate the custom-tutorials feature. and hide it via a feature flag, for gradual removal.

**Two commits:**

1. `feat: add feature flag to disable custom tutorials`
2. `refactor: deprecate custom tutorials` 

Code is left in place for now to keep the diff focused and to leave the flag flippable for users who need a one-off re-enable. Full deletion is a separate ticket once we're confident no one is affected.

# Testing

**Flag off (default behaviour):**

- Open the Workbench enablement area: the "MY TUTORIALS" / custom tutorials section is hidden; bundled tutorials render as before.

**Flag on (`RI_CUSTOM_TUTORIALS_ENABLED=true`):**

- Upload a custom tutorial, browse its sections, run a code block, delete it. Everything works as before.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes disable an optional Workbench feature by default with env opt-in; core paths stay unchanged and no auth or data-model removals in this PR.
> 
> **Overview**
> **Custom tutorials** are deprecated (RED-194229) and **off by default**, with an opt-in path to restore prior behavior.
> 
> A new **`customTutorials`** feature is driven by **`RI_CUSTOM_TUTORIALS_ENABLED=true`** on the server and exposed via **`GET /features`**. When disabled, the API **does not register** `CustomTutorialModule`, **does not serve** custom-tutorial static files, and the UI **does not fetch** custom tutorials on startup, **hides** the Workbench “MY TUTORIALS” navigation, and **blocks** loading custom-tutorial content paths.
> 
> Implementation code is **kept in place** with **`@deprecated`** notes for a later removal. Tests that depend on **`POST /custom-tutorials`** are **skipped** until the feature is enabled or fixtures are reworked; UI/API tests were updated for the new flag defaulting to **false**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b050a56bdc65ebcd8eb7d87d1af142fb1c9aee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->