### PR TITLE
ci(e2e): mitigate Docker Hub pull rate limits in nightly tests

### DIFF
--- a/.github/actions/redis-test-env-down/action.yml
+++ b/.github/actions/redis-test-env-down/action.yml
@@ -1,0 +1,9 @@
+name: Stop Redis test environment
+description: Tear down the e2e-rte compose project and remove its volumes.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml down --volumes --remove-orphans

--- a/.github/actions/redis-test-env-up/action.yml
+++ b/.github/actions/redis-test-env-up/action.yml
@@ -1,0 +1,68 @@
+name: Start Redis test environment
+description: >
+  Log in to Docker Hub (to avoid anonymous pull rate limits), pull the test
+  environment images with retry, bring the compose project up, and wait for
+  the Redis clusters to be ready.
+
+inputs:
+  dockerhub-username:
+    description: Docker Hub username. When empty, login is skipped.
+    required: false
+    default: ''
+  dockerhub-token:
+    description: Docker Hub access token. Paired with dockerhub-username.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Docker Hub (avoid pull rate limits)
+      if: ${{ inputs.dockerhub-username != '' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Pull Redis test environment images (with retry)
+      shell: bash
+      run: |
+        DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
+        for i in 1 2 3 4 5; do
+          if $DC pull; then
+            echo "✅ Image pull succeeded on attempt $i"
+            exit 0
+          fi
+          BACKOFF=$((i * 30))
+          echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
+          sleep "$BACKOFF"
+        done
+        echo "::error::Image pull failed after 5 attempts"
+        exit 1
+
+    - name: Start Redis test environment
+      shell: bash
+      run: |
+        docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml up --detach --force-recreate
+
+    - name: Wait for Redis clusters to be ready
+      shell: bash
+      run: |
+        DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
+
+        wait_for_cluster() {
+          local svc=$1 label=$2
+          echo "Waiting for $label to form..."
+          for i in $(seq 1 60); do
+            if $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null | grep -q "cluster_state:ok"; then
+              echo "✅ $label ready after ~$((i*2))s"; return 0
+            fi
+            sleep 2
+          done
+          echo "::error::$label did NOT become ready within 120 s"
+          $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null || true
+          return 1
+        }
+
+        wait_for_cluster master-plain-7-1    "IP-based cluster (8200)"
+        wait_for_cluster master-hostname-7-1  "Hostname-based cluster (8210)"

--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -73,53 +73,11 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
-      - name: Login to Docker Hub (avoid pull rate limits)
-        continue-on-error: true
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Pull Redis test environment images (with retry)
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-          for i in 1 2 3 4 5; do
-            if $DC pull; then
-              echo "✅ Image pull succeeded on attempt $i"
-              exit 0
-            fi
-            BACKOFF=$((i * 30))
-            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
-            sleep "$BACKOFF"
-          done
-          echo "::error::Image pull failed after 5 attempts"
-          exit 1
-
       - name: Start Redis test environment
-        run: |
-          TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml up --detach --force-recreate
-
-      - name: Wait for Redis clusters to be ready
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-
-          wait_for_cluster() {
-            local svc=$1 label=$2
-            echo "Waiting for $label to form..."
-            for i in $(seq 1 60); do
-              if $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null | grep -q "cluster_state:ok"; then
-                echo "✅ $label ready after ~$((i*2))s"; return 0
-              fi
-              sleep 2
-            done
-            echo "::error::$label did NOT become ready within 120 s"
-            $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null || true
-            return 1
-          }
-
-          wait_for_cluster master-plain-7-1    "IP-based cluster (8200)"
-          wait_for_cluster master-hostname-7-1  "Hostname-based cluster (8210)"
+        uses: ./.github/actions/redis-test-env-up
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run Playwright tests (Chromium)
         working-directory: ${{ env.E2E_DIR }}
@@ -145,6 +103,5 @@ jobs:
 
       - name: Stop Redis test environment
         if: always()
-        run: |
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml down --volumes --remove-orphans
+        uses: ./.github/actions/redis-test-env-down
 

--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -73,6 +73,28 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
+      - name: Login to Docker Hub (avoid pull rate limits)
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull Redis test environment images (with retry)
+        run: |
+          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
+          for i in 1 2 3 4 5; do
+            if $DC pull; then
+              echo "✅ Image pull succeeded on attempt $i"
+              exit 0
+            fi
+            BACKOFF=$((i * 30))
+            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
+            sleep "$BACKOFF"
+          done
+          echo "::error::Image pull failed after 5 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -58,6 +58,28 @@ jobs:
         run: |
           docker image load -i ./release/docker/docker-linux-alpine.amd64.tar
 
+      - name: Login to Docker Hub (avoid pull rate limits)
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull Redis test environment images (with retry)
+        run: |
+          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
+          for i in 1 2 3 4 5; do
+            if $DC pull; then
+              echo "✅ Image pull succeeded on attempt $i"
+              exit 0
+            fi
+            BACKOFF=$((i * 30))
+            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
+            sleep "$BACKOFF"
+          done
+          echo "::error::Image pull failed after 5 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -58,53 +58,11 @@ jobs:
         run: |
           docker image load -i ./release/docker/docker-linux-alpine.amd64.tar
 
-      - name: Login to Docker Hub (avoid pull rate limits)
-        continue-on-error: true
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Pull Redis test environment images (with retry)
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-          for i in 1 2 3 4 5; do
-            if $DC pull; then
-              echo "✅ Image pull succeeded on attempt $i"
-              exit 0
-            fi
-            BACKOFF=$((i * 30))
-            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
-            sleep "$BACKOFF"
-          done
-          echo "::error::Image pull failed after 5 attempts"
-          exit 1
-
       - name: Start Redis test environment
-        run: |
-          TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml up --detach --force-recreate
-
-      - name: Wait for Redis clusters to be ready
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-
-          wait_for_cluster() {
-            local svc=$1 label=$2
-            echo "Waiting for $label to form..."
-            for i in $(seq 1 60); do
-              if $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null | grep -q "cluster_state:ok"; then
-                echo "✅ $label ready after ~$((i*2))s"; return 0
-              fi
-              sleep 2
-            done
-            echo "::error::$label did NOT become ready within 120 s"
-            $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null || true
-            return 1
-          }
-
-          wait_for_cluster master-plain-7-1    "IP-based cluster (8200)"
-          wait_for_cluster master-hostname-7-1  "Hostname-based cluster (8210)"
+        uses: ./.github/actions/redis-test-env-up
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start RedisInsight Docker container
         run: |
@@ -156,6 +114,5 @@ jobs:
 
       - name: Stop Redis test environment
         if: always()
-        run: |
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml down --volumes --remove-orphans
+        uses: ./.github/actions/redis-test-env-down
 

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -120,6 +120,28 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
+      - name: Login to Docker Hub (avoid pull rate limits)
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull Redis test environment images (with retry)
+        run: |
+          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
+          for i in 1 2 3 4 5; do
+            if $DC pull; then
+              echo "✅ Image pull succeeded on attempt $i"
+              exit 0
+            fi
+            BACKOFF=$((i * 30))
+            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
+            sleep "$BACKOFF"
+          done
+          echo "::error::Image pull failed after 5 attempts"
+          exit 1
+
       - name: Start Redis test environment
         run: |
           TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -120,53 +120,11 @@ jobs:
             echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
           fi
 
-      - name: Login to Docker Hub (avoid pull rate limits)
-        continue-on-error: true
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Pull Redis test environment images (with retry)
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-          for i in 1 2 3 4 5; do
-            if $DC pull; then
-              echo "✅ Image pull succeeded on attempt $i"
-              exit 0
-            fi
-            BACKOFF=$((i * 30))
-            echo "⚠️  Image pull failed on attempt $i; sleeping ${BACKOFF}s before retry..."
-            sleep "$BACKOFF"
-          done
-          echo "::error::Image pull failed after 5 attempts"
-          exit 1
-
       - name: Start Redis test environment
-        run: |
-          TEST_BIG_DB_DUMP=$TEST_BIG_DB_DUMP \
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml up --detach --force-recreate
-
-      - name: Wait for Redis clusters to be ready
-        run: |
-          DC="docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml"
-
-          wait_for_cluster() {
-            local svc=$1 label=$2
-            echo "Waiting for $label to form..."
-            for i in $(seq 1 60); do
-              if $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null | grep -q "cluster_state:ok"; then
-                echo "✅ $label ready after ~$((i*2))s"; return 0
-              fi
-              sleep 2
-            done
-            echo "::error::$label did NOT become ready within 120 s"
-            $DC exec -T "$svc" redis-cli CLUSTER INFO 2>/dev/null || true
-            return 1
-          }
-
-          wait_for_cluster master-plain-7-1    "IP-based cluster (8200)"
-          wait_for_cluster master-hostname-7-1  "Hostname-based cluster (8210)"
+        uses: ./.github/actions/redis-test-env-up
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Start Xvfb
         run: |
@@ -212,6 +170,5 @@ jobs:
 
       - name: Stop Redis test environment
         if: always()
-        run: |
-          docker compose -p e2e-rte -f tests/e2e/rte.docker-compose.yml down --volumes --remove-orphans
+        uses: ./.github/actions/redis-test-env-down
 


### PR DESCRIPTION
## Summary

Nightly E2E runs intermittently fail when bringing up the Redis test environment because the compose file pulls 16 images from Docker Hub anonymously, with no retry. Recent failures:

- https://github.com/redis/RedisInsight/actions/runs/26611318589/job/78418219534
- https://github.com/redis/RedisInsight/actions/runs/26347850180/job/77561206463

Both fail with the same error during `docker compose up`:

```
toomanyrequests: retry-after: <μs>, allowed: 44000/minute
Error response from daemon: toomanyrequests
##[error]Process completed with exit code 1.
```

This is the Docker Hub anonymous pull-quota for the runner's IP pool — GitHub-hosted runners share Azure ranges, so any peak-time spike in unauthenticated pulls makes the nightly cron flaky.

## Changes

For each of the three E2E workflows that start `tests/e2e/rte.docker-compose.yml` (`tests-e2e-playwright-electron.yml`, `tests-e2e-playwright-docker.yml`, `tests-e2e-playwright-chromium.yml`):

- **Optional Docker Hub login** before the pull. Uses `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets when set; `continue-on-error: true` so forks/PRs without the secret keep working. Authenticated pulls get a per-account quota that isn't shared with the anonymous IP pool.
- **Pre-pull with retry** (5 attempts, linear 30s → 150s backoff). A transient 429 from Docker Hub no longer fails the whole job; `docker compose up` then uses the already-pulled images.

## Follow-ups (not in this PR)

- Mirror the static set of images (`redislabs/redismod`, `redis:5/7/8`, `redislabs/redisgears:edge`, …) to GHCR so pulls bypass Docker Hub entirely.
- Pin floating tags (`redislabs/redismod`, `redis:latest`, `redislabs/redisgears:edge`) to digests to remove nondeterminism in nightlies.

## Test plan

- [ ] Trigger the affected workflows manually (`workflow_dispatch`) and confirm the new login + pull steps run.
- [ ] With the secrets configured, confirm the login step succeeds.
- [ ] Confirm `Start Redis test environment` still completes and tests proceed as before.
- [ ] Re-run a few nightlies to check that intermittent 429s no longer kill the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow refactor; no application runtime changes. Full mitigation depends on optional repo secrets for Docker Hub login.
> 
> **Overview**
> Extracts the duplicated **Start/Stop Redis test environment** logic from the Chromium, Docker, and Electron Playwright E2E workflows into composite actions **`redis-test-env-up`** and **`redis-test-env-down`**.
> 
> The **up** action adds **optional Docker Hub login** (when `DOCKERHUB_USERNAME` is set), **`docker compose pull` with up to 5 retries** and linear backoff, then the existing **compose up** and **cluster readiness** waits. Workflows pass **`DOCKERHUB_USERNAME`** / **`DOCKERHUB_TOKEN`** from secrets. **Down** is unchanged teardown via the shared action.
> 
> **Note:** Inline `TEST_BIG_DB_DUMP=...` on `compose up` was removed; jobs still set `TEST_BIG_DB_DUMP` at the job level for compose build args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6118ff1fd370cb2ccb7310cd6ebe805a52b0bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->