### PR TITLE
Move rank column to first position in Vector Set similarity results

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.config.tsx
@@ -180,9 +180,9 @@ const actionsColumn: ColumnDef<VectorSetSimilarityMatch> = {
 export const buildSimilarityResultsColumns = (
   attributeKeys: string[],
 ): ColumnDef<VectorSetSimilarityMatch>[] => [
+  rankColumn,
   nameColumn,
   ...attributeKeys.map(buildAttributeColumn),
-  rankColumn,
   similarityColumn,
   actionsColumn,
 ]

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.spec.tsx
@@ -144,16 +144,16 @@ describe('SimilaritySearchResultsTable', () => {
 
       renderTable(matches)
 
-      // Header order: Element, then attributes alphabetically, then Rank, Similarity.
+      // Header order: Rank, Element, then attributes alphabetically, then Similarity, Actions.
       const headers = screen
         .getAllByRole('columnheader')
         .map((h) => h.textContent?.trim())
       expect(headers).toEqual([
+        'Rank',
         'Element',
         'alpha',
         'beta',
         'zeta',
-        'Rank',
         'Similarity',
         'Actions',
       ])
@@ -215,9 +215,9 @@ describe('SimilaritySearchResultsTable', () => {
         .getAllByRole('columnheader')
         .map((h) => h.textContent?.trim())
       expect(headers).toEqual([
+        'Rank',
         'Element',
         'count',
-        'Rank',
         'Similarity',
         'Actions',
       ])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/hooks/useSimilarityResultColumns.spec.ts
@@ -34,11 +34,11 @@ describe('useSimilarityResultColumns', () => {
 
     const ids = result.current.columns.map((c) => c.id)
     expect(ids).toEqual([
+      SimilarityResultsColumn.Rank,
       SimilarityResultsColumn.Name,
       attributeColumnId('alpha'),
       attributeColumnId('beta'),
       attributeColumnId('zeta'),
-      SimilarityResultsColumn.Rank,
       SimilarityResultsColumn.Similarity,
       SimilarityResultsColumn.Actions,
     ])


### PR DESCRIPTION
## Summary
Reorders the columns in the Vector Set similarity results table so that **Rank** appears first.

New column order: Rank → Element → attributes → Similarity → Actions.

<img width="607" height="638" alt="image" src="https://github.com/user-attachments/assets/964c7491-f160-4c00-86df-d9c1a9e3db6a" />


## Test plan
- [ ] Open a Vector Set key and run a similarity search
- [ ] Verify Rank is the first column in the results table


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only column reorder in the browser UI with no data, API, or security impact; coverage is limited to updated unit tests.
> 
> **Overview**
> Puts **Rank** as the leading column in the Vector Set similarity search results table by reordering the array returned from `buildSimilarityResultsColumns` (Rank → Element → attribute columns → Similarity → Actions). `useSimilarityResultColumns` already builds columns through that helper, so production and hook behavior follow the new order without further logic changes.
> 
> Specs for the table and column hook now assert the updated header/column id order, including when attribute columns are hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71b3d5c892c8efbb0ba1c08736b87f9aee1aeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->