### PR TITLE
RI-8205 Promote dev-prodMode flag to regular prodMode flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.8,
+  "version": 3.9,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -143,7 +143,7 @@
       "flag": false,
       "perc": [[0, 100]]
     },
-    "dev-prodMode": {
+    "prodMode": {
       "flag": false,
       "perc": [[0, 100]]
     }

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -37,7 +37,7 @@ export enum KnownFeatures {
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
   DevVectorSet = 'dev-vectorSet',
-  DevProdMode = 'dev-prodMode',
+  ProdMode = 'prodMode',
 }
 
 export interface IFeatureFlag {

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -87,8 +87,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevVectorSet,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.DevProdMode]: {
-    name: KnownFeatures.DevProdMode,
+  [KnownFeatures.ProdMode]: {
+    name: KnownFeatures.ProdMode,
     storage: FeatureStorage.Database,
   },
 };

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -104,7 +104,7 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
-      KnownFeatures.DevProdMode,
+      KnownFeatures.ProdMode,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
   }

--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.spec.tsx
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.spec.tsx
@@ -12,10 +12,10 @@ import {
 
 import { EnvironmentBadge } from './EnvironmentBadge'
 
-const withDevProdFlag = (flag: boolean) => {
+const withProdModeFlag = (flag: boolean) => {
   const state = set(
     cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.devProdMode}`,
+    `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
     { flag },
   )
   return { store: mockStore(state) }
@@ -25,7 +25,7 @@ describe('EnvironmentBadge', () => {
   it('renders the PROD badge for production environment', () => {
     render(
       <EnvironmentBadge environment={Environment.Production} />,
-      withDevProdFlag(true),
+      withProdModeFlag(true),
     )
 
     expect(
@@ -37,7 +37,7 @@ describe('EnvironmentBadge', () => {
   it('renders the DEV label for development environment', () => {
     render(
       <EnvironmentBadge environment={Environment.Development} />,
-      withDevProdFlag(true),
+      withProdModeFlag(true),
     )
 
     expect(
@@ -49,7 +49,7 @@ describe('EnvironmentBadge', () => {
   it('renders nothing for unspecified environment', () => {
     const { container } = render(
       <EnvironmentBadge environment={Environment.Unspecified} />,
-      withDevProdFlag(true),
+      withProdModeFlag(true),
     )
 
     expect(container).toBeEmptyDOMElement()
@@ -58,16 +58,16 @@ describe('EnvironmentBadge', () => {
   it('renders nothing when environment is undefined', () => {
     const { container } = render(
       <EnvironmentBadge environment={undefined} />,
-      withDevProdFlag(true),
+      withProdModeFlag(true),
     )
 
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders nothing when the dev-prodMode feature flag is off', () => {
+  it('renders nothing when the prodMode feature flag is off', () => {
     const { container } = render(
       <EnvironmentBadge environment={Environment.Production} />,
-      withDevProdFlag(false),
+      withProdModeFlag(false),
     )
 
     expect(container).toBeEmptyDOMElement()
@@ -79,7 +79,7 @@ describe('EnvironmentBadge', () => {
         environment={Environment.Production}
         dataTestId="custom-badge"
       />,
-      withDevProdFlag(true),
+      withProdModeFlag(true),
     )
 
     expect(screen.getByTestId('custom-badge')).toBeInTheDocument()

--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 
-import { appFeatureFlagDevProdModeSelector } from 'uiSrc/slices/app/features'
+import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import { RiBadge } from 'uiSrc/components/base/display/badge/RiBadge'
 import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
 
@@ -12,7 +12,7 @@ export const EnvironmentBadge = ({
   environment,
   dataTestId,
 }: EnvironmentBadgeProps) => {
-  const flagEnabled = useSelector(appFeatureFlagDevProdModeSelector)
+  const flagEnabled = useSelector(appFeatureFlagProdModeSelector)
 
   if (!flagEnabled || !environment) return null
 

--- a/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.spec.ts
+++ b/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from 'uiSrc/utils/test-utils'
-import { appFeatureFlagDevProdModeSelector } from 'uiSrc/slices/app/features'
+import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
   connectedInstanceDangerousCommandsSelector,
   connectedInstanceSelector,
@@ -10,7 +10,7 @@ import { useDatabaseEnvironment } from './useDatabaseEnvironment'
 
 jest.mock('uiSrc/slices/app/features', () => ({
   ...jest.requireActual('uiSrc/slices/app/features'),
-  appFeatureFlagDevProdModeSelector: jest.fn().mockReturnValue(false),
+  appFeatureFlagProdModeSelector: jest.fn().mockReturnValue(false),
 }))
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
@@ -21,7 +21,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   connectedInstanceDangerousCommandsSelector: jest.fn().mockReturnValue([]),
 }))
 
-const mockedFlag = appFeatureFlagDevProdModeSelector as jest.Mock
+const mockedFlag = appFeatureFlagProdModeSelector as jest.Mock
 const mockedInstance = connectedInstanceSelector as jest.Mock
 const mockedDangerousCommands =
   connectedInstanceDangerousCommandsSelector as jest.Mock

--- a/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
+++ b/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { Environment } from 'apiClient'
-import { appFeatureFlagDevProdModeSelector } from 'uiSrc/slices/app/features'
+import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
   connectedInstanceDangerousCommandsSelector,
   connectedInstanceSelector,
@@ -13,7 +13,7 @@ export interface UseDatabaseEnvironmentResult {
 }
 
 export const useDatabaseEnvironment = (): UseDatabaseEnvironmentResult => {
-  const flagEnabled = useSelector(appFeatureFlagDevProdModeSelector)
+  const flagEnabled = useSelector(appFeatureFlagProdModeSelector)
   const dangerousCommands = useSelector(
     connectedInstanceDangerousCommandsSelector,
   )

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
@@ -273,7 +273,7 @@ describe('InstanceHeader', () => {
 
       const state = set(
         cloneDeep(initialStateDefault),
-        `app.features.featureFlags.features.${FeatureFlags.devProdMode}`,
+        `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
         { flag: true },
       )
 
@@ -321,7 +321,7 @@ describe('InstanceHeader', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('does not render the badge when the dev-prodMode flag is off', () => {
+    it('does not render the badge when the prodMode flag is off', () => {
       mockedConnectedInstanceSelector.mockReturnValue({
         username: 'username',
         id: 'instanceId',
@@ -331,7 +331,7 @@ describe('InstanceHeader', () => {
 
       const state = set(
         cloneDeep(initialStateDefault),
-        `app.features.featureFlags.features.${FeatureFlags.devProdMode}`,
+        `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
         { flag: false },
       )
 

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -15,5 +15,5 @@ export enum FeatureFlags {
   devVectorSet = 'dev-vectorSet',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
-  devProdMode = 'dev-prodMode',
+  prodMode = 'prodMode',
 }

--- a/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.spec.tsx
@@ -15,12 +15,12 @@ import DatabasesListCellName from './DatabasesListCellName'
 
 const renderCell = (
   instance: Partial<Instance>,
-  { devProdMode = true }: { devProdMode?: boolean } = {},
+  { prodMode = true }: { prodMode?: boolean } = {},
 ) => {
   const state = set(
     cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.devProdMode}`,
-    { flag: devProdMode },
+    `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
+    { flag: prodMode },
   )
 
   const cellProps = { row: { original: instance as Instance } } as any
@@ -63,10 +63,10 @@ describe('DatabasesListCellName', () => {
       expect(screen.queryByText('DEV')).not.toBeInTheDocument()
     })
 
-    it('does not render the badge when the dev-prodMode flag is off', () => {
+    it('does not render the badge when the prodMode flag is off', () => {
       renderCell(
         { ...baseInstance, environment: Environment.Production },
-        { devProdMode: false },
+        { prodMode: false },
       )
 
       expect(

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -1413,9 +1413,9 @@ describe('InstanceForm', () => {
   })
 
   describe('Database mode select', () => {
-    it('should not render the dropdown when the devProdMode flag is off', () => {
+    it('should not render the dropdown when the prodMode flag is off', () => {
       ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
-        [FeatureFlags.devProdMode]: { flag: false },
+        [FeatureFlags.prodMode]: { flag: false },
       })
 
       render(
@@ -1429,9 +1429,9 @@ describe('InstanceForm', () => {
       expect(screen.queryByTestId('select-environment')).not.toBeInTheDocument()
     })
 
-    it('should render the dropdown when the devProdMode flag is on', () => {
+    it('should render the dropdown when the prodMode flag is on', () => {
       ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValue({
-        [FeatureFlags.devProdMode]: { flag: true },
+        [FeatureFlags.prodMode]: { flag: true },
       })
 
       render(

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
@@ -60,7 +60,7 @@ const AddConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
-          <FeatureFlagComponent name={FeatureFlags.devProdMode}>
+          <FeatureFlagComponent name={FeatureFlags.prodMode}>
             <>
               <Spacer size="m" />
               <Divider />

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -75,7 +75,7 @@ const EditConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
-          <FeatureFlagComponent name={FeatureFlags.devProdMode}>
+          <FeatureFlagComponent name={FeatureFlags.prodMode}>
             <>
               <Spacer size="m" />
               <Divider />

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -74,7 +74,7 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devBrowser]: {
         flag: false,
       },
-      [FeatureFlags.devProdMode]: {
+      [FeatureFlags.prodMode]: {
         flag: false,
       },
     },
@@ -210,9 +210,8 @@ export const appFeatureFlagsSelector = (state: RootState) =>
   state.app.features.featureFlags
 export const appFeatureFlagsFeaturesSelector = (state: RootState) =>
   state.app.features.featureFlags.features
-export const appFeatureFlagDevProdModeSelector = (state: RootState): boolean =>
-  state.app.features.featureFlags.features[FeatureFlags.devProdMode]?.flag ??
-  false
+export const appFeatureFlagProdModeSelector = (state: RootState): boolean =>
+  state.app.features.featureFlags.features[FeatureFlags.prodMode]?.flag ?? false
 
 export const isDevelopment = riConfig.app.env === 'development'
 

--- a/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
+++ b/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
@@ -156,7 +156,7 @@ export class AddDatabaseDialog {
 
   /**
    * Select an environment in the connection form's Environment dropdown.
-   * The dropdown is only rendered when the `dev-prodMode` feature flag is enabled.
+   * The dropdown is only rendered when the `prodMode` feature flag is enabled.
    *
    * Each `Environment` enum value (`unspecified` | `production` | `development`)
    * is rendered by the form as its capitalized counterpart in

--- a/tests/e2e-playwright/tests/parallel/browser/bulk-actions/environment-gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/bulk-actions/environment-gating.spec.ts
@@ -8,7 +8,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * type the database name in the type-to-confirm modal before the
  * destructive action runs against the real Redis backend.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('Browser > Bulk Actions — environment gating', () => {
   test.describe('Production DB', () => {

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/environment-gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/environment-gating.spec.ts
@@ -12,7 +12,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * per-component wiring, and per-action confirmation strings are covered by
  * unit tests.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 const uniqueId = () => faker.string.alphanumeric(6);
 

--- a/tests/e2e-playwright/tests/parallel/databases/list/environment-badge.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/databases/list/environment-badge.spec.ts
@@ -7,7 +7,7 @@ import { Environment } from 'e2eSrc/types';
  * verified against the rendered badge in the databases list and the
  * instance header after connecting.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('Database List — environment badge', () => {
   const createdDatabaseNames: string[] = [];

--- a/tests/e2e-playwright/tests/parallel/insights/tutorials.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/insights/tutorials.spec.ts
@@ -8,7 +8,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * provider — this verifies the integration, not the per-button gating
  * logic (which has its own unit tests).
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('Workbench > Tutorials — environment gating', () => {
   test.describe('Production DB', () => {

--- a/tests/e2e-playwright/tests/parallel/workbench/profiler.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/workbench/profiler.spec.ts
@@ -7,7 +7,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * confirmation popover. Cancelling keeps the profiler stopped; confirming
  * actually starts the profiler against the real Redis backend.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('Workbench > Profiler (Bottom Panel) — environment gating', () => {
   test.describe('Production DB', () => {

--- a/tests/e2e-playwright/tests/serial/cli/dangerous-commands.spec.ts
+++ b/tests/e2e-playwright/tests/serial/cli/dangerous-commands.spec.ts
@@ -13,7 +13,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * because the confirm branch issues `FLUSHDB`, which would otherwise wipe
  * keys other tests rely on on the shared standalone Redis.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('CLI Panel — environment gating', () => {
   test.describe('Production DB', () => {

--- a/tests/e2e-playwright/tests/serial/workbench/dangerous-commands.spec.ts
+++ b/tests/e2e-playwright/tests/serial/workbench/dangerous-commands.spec.ts
@@ -13,7 +13,7 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * because the confirm branch issues `FLUSHDB`, which would otherwise wipe
  * keys other tests rely on on the shared standalone Redis.
  */
-test.use({ featureFlags: { 'dev-prodMode': true } });
+test.use({ featureFlags: { prodMode: true } });
 
 test.describe('Workbench > Command Execution — environment gating', () => {
   test.describe('Production DB', () => {


### PR DESCRIPTION
# What

Promote the `dev-prodMode` feature flag to a regular `prodMode` flag.

- Renames the flag end-to-end: backend config (`features-config.json`, `KnownFeatures` enum, `known-features.ts` registry, `feature-flag.provider.ts` strategy registration), frontend enum (`FeatureFlags`) and slice selector (`appFeatureFlagProdModeSelector`), all UI consumers, and the E2E specs/page object.
- Bumps `features-config.json` version to `3.9`.
- Keeps the flag **default-off** for now — E2E specs that exercise production-mode UI keep their explicit `test.use({ featureFlags: { prodMode: true } })` override.

# Testing

- `yarn lint` passes on changed files.
- Unit tests for the 5 affected UI specs pass (83 tests):
  - `EnvironmentBadge.spec.tsx`
  - `useDatabaseEnvironment.spec.ts`
  - `InstanceHeader.spec.tsx`
  - `DatabasesListCellName.spec.tsx`
  - `ManualConnectionFrom.spec.tsx`
- Manually verify the production-mode UI (environment dropdown in the connection form, environment badge, dangerous-command confirmation) still gates on the renamed flag in both states (on and off).

---

Closes #RI-8205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the flag that gates production safety UX (confirmations, badges, environment selection); behavior is unchanged but misconfigured rollout could hide or expose those flows.
> 
> **Overview**
> Renames the **`dev-prodMode`** feature flag to **`prodMode`** across the API and UI so production-mode behavior (environment badges, connection environment picker, dangerous-command and write confirmations) is gated on a non-dev flag name.
> 
> **Backend:** `features-config.json` key and version **3.9**; `KnownFeatures.ProdMode`, registry, and feature-flag strategy registration updated.
> 
> **Frontend:** `FeatureFlags.prodMode`, `appFeatureFlagProdModeSelector`, and all consumers (`EnvironmentBadge`, `useDatabaseEnvironment`, manual connection forms, Redux defaults).
> 
> **Tests:** Unit and Playwright specs use `prodMode`; flag stays **default-off**, with E2E still overriding `{ prodMode: true }` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9691921af9e0dd71cf4c2d20879fe8a549c3a87a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->