### PR TITLE
RI-8208: Adopt typed Redux hooks (useAppDispatch / useAppSelector)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,24 @@ module.exports = {
         'prefer-template': 'error',
         'prefer-const': 'error',
         '@typescript-eslint/no-unused-vars': noUnusedVarsConfig,
+        // Force every UI callsite onto the typed Redux hooks so the
+        // `AppDispatch` (incl. thunk overload) and `RootState` types are
+        // never accidentally dropped. The wrapper file itself
+        // (`uiSrc/slices/hooks.ts`) is allowed to import the originals — see
+        // the override below.
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'react-redux',
+                importNames: ['useDispatch', 'useSelector'],
+                message:
+                  'Use useAppDispatch / useAppSelector from uiSrc/slices/hooks instead.',
+              },
+            ],
+          },
+        ],
         'import/order': [
           1,
           {
@@ -221,6 +239,14 @@ module.exports = {
             pathGroupsExcludedImportTypes: ['builtin'],
           },
         ],
+      },
+    },
+    // Typed Redux hooks wrapper — only file allowed to import the bare
+    // `useDispatch` / `useSelector` from `react-redux` (it's what wraps them).
+    {
+      files: ['redisinsight/ui/src/slices/hooks.ts'],
+      rules: {
+        'no-restricted-imports': 'off',
       },
     },
     // UI test files

--- a/redisinsight/ui/src/App.tsx
+++ b/redisinsight/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect } from 'react'
-import { Provider, useSelector } from 'react-redux'
+import { Provider } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Route, Switch } from 'react-router-dom'
 import { store } from 'uiSrc/slices/store'
@@ -46,7 +47,7 @@ const AppWrapper = ({ children }: { children?: ReactElement[] }) => (
   </Provider>
 )
 const App = ({ children }: { children?: ReactElement[] }) => {
-  const { loading: serverLoading } = useSelector(appInfoSelector)
+  const { loading: serverLoading } = useAppSelector(appInfoSelector)
   useEffect(() => {
     if (!serverLoading) {
       removePagePlaceholder()

--- a/redisinsight/ui/src/components/analytics-tabs/AnalyticsTabs.tsx
+++ b/redisinsight/ui/src/components/analytics-tabs/AnalyticsTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams, useHistory } from 'react-router-dom'
 
 import { Pages } from 'uiSrc/constants'
@@ -22,14 +22,14 @@ import Tabs, { TabInfo } from 'uiSrc/components/base/layout/tabs'
 import { Text } from 'uiSrc/components/base/text'
 
 const AnalyticsTabs = () => {
-  const { viewTab } = useSelector(analyticsSettingsSelector)
+  const { viewTab } = useAppSelector(analyticsSettingsSelector)
   const connectionType = useConnectionType()
-  const { currentStep } = useSelector(appFeatureOnboardingSelector)
+  const { currentStep } = useAppSelector(appFeatureOnboardingSelector)
   const history = useHistory()
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (

--- a/redisinsight/ui/src/components/bottom-group-components/BottomGroupComponents.stories.tsx
+++ b/redisinsight/ui/src/components/bottom-group-components/BottomGroupComponents.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React, { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import BottomGroupComponents from './BottomGroupComponents'
 import {
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>
 export const CLI: Story = {
   decorators: [
     (Story) => {
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
 
       useEffect(() => {
         dispatch(resetCliHelperSettings())
@@ -41,7 +41,7 @@ export const CLI: Story = {
 export const CLIHelper: Story = {
   decorators: [
     (Story) => {
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
 
       useEffect(() => {
         dispatch(resetCliHelperSettings())
@@ -60,7 +60,7 @@ export const CLIHelper: Story = {
 export const Monitor: Story = {
   decorators: [
     (Story) => {
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
 
       useEffect(() => {
         dispatch(resetCliHelperSettings())

--- a/redisinsight/ui/src/components/bottom-group-components/BottomGroupComponents.tsx
+++ b/redisinsight/ui/src/components/bottom-group-components/BottomGroupComponents.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import styled from 'styled-components'
 
@@ -26,8 +26,8 @@ const GroupComponents = styled.div`
 `
 
 const BottomGroupComponents = () => {
-  const { isShowCli, isShowHelper } = useSelector(cliSettingsSelector)
-  const { isShowMonitor } = useSelector(monitorSelector)
+  const { isShowCli, isShowHelper } = useAppSelector(cliSettingsSelector)
+  const { isShowMonitor } = useAppSelector(monitorSelector)
 
   return (
     <GroupComponentsWrapper>

--- a/redisinsight/ui/src/components/bottom-group-components/components/bottom-group-minimized/BottomGroupMinimized.tsx
+++ b/redisinsight/ui/src/components/bottom-group-components/components/bottom-group-minimized/BottomGroupMinimized.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
@@ -38,9 +38,9 @@ import {
 const BottomGroupMinimized = () => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
   const { isShowCli, cliClientUuid, isShowHelper, isMinimizedHelper } =
-    useSelector(cliSettingsSelector)
-  const { isShowMonitor, isMinimizedMonitor } = useSelector(monitorSelector)
-  const dispatch = useDispatch()
+    useAppSelector(cliSettingsSelector)
+  const { isShowMonitor, isMinimizedMonitor } = useAppSelector(monitorSelector)
+  const dispatch = useAppDispatch()
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Socket } from 'socket.io-client'
 
 import {
@@ -29,23 +29,23 @@ import { useIoConnection } from 'uiSrc/services/hooks/useIoConnection'
 import { getBaseUrl } from 'uiSrc/services/apiService'
 
 const BulkActionsConfig = () => {
-  const { id: instanceId = '', db } = useSelector(connectedInstanceSelector)
-  const { isConnected } = useSelector(bulkActionsSelector)
+  const { id: instanceId = '', db } = useAppSelector(connectedInstanceSelector)
+  const { isConnected } = useAppSelector(bulkActionsSelector)
   const {
     isActionTriggered: isDeleteTriggered,
     generateReport,
     filter,
     search,
     confirmedThrough,
-  } = useSelector(bulkActionsDeleteSelector)
-  const { token } = useSelector(appCsrfSelector)
+  } = useAppSelector(bulkActionsDeleteSelector)
+  const { token } = useAppSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
   const connectIo = useIoConnection(getSocketApiUrl('bulk-actions'), {
     token,
     query: { instanceId },
   })
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!isDeleteTriggered || !instanceId || socketRef.current?.connected) {

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBody/CliBody.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBody/CliBody.tsx
@@ -1,6 +1,6 @@
 import React, { Ref, useEffect, useRef, useState } from 'react'
 import { KeyboardKeys as keys } from 'uiSrc/constants/keys'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Nullable, scrollIntoView } from 'uiSrc/utils'
 import { isModifiedEvent } from 'uiSrc/services'
@@ -37,14 +37,14 @@ const CliBody = (props: Props) => {
   const [commandTabPos, setCommandTabPos] = useState<number>(commandTabPosInit)
   const [wordsTyped, setWordsTyped] = useState<number>(0)
   const [matchingCmds, setMatchingCmds] = useState<string[]>([])
-  const { loading: settingsLoading } = useSelector(cliSettingsSelector)
+  const { loading: settingsLoading } = useAppSelector(cliSettingsSelector)
   const { loading, commandHistory: commandHistoryStore } =
-    useSelector(outputSelector)
-  const { commandsArray } = useSelector(appRedisCommandsSelector)
+    useAppSelector(outputSelector)
+  const { commandsArray } = useAppSelector(appRedisCommandsSelector)
 
   const timerClickRef = useRef<NodeJS.Timeout>()
   const scrollDivRef: Ref<HTMLDivElement> = useRef(null)
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     inputEl?.focus()

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cloneDeep, first } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import {
   cleanup,
   fireEvent,
@@ -88,16 +88,16 @@ jest.mock('uiSrc/utils/cliHelper', () => ({
 const unsupportedCommands = ['sync', 'subscription']
 const cliCommandTestId = 'cli-command'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 describe('CliBodyWrapper', () => {
   beforeEach(() => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: any) => any) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-body/CliBodyWrapper.tsx
@@ -1,6 +1,6 @@
 import { decode } from 'html-entities'
 import React, { useEffect, useState } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useHistory, useParams } from 'react-router-dom'
 
@@ -58,9 +58,9 @@ const CliBodyWrapper = () => {
   const [command, setCommand] = useState('')
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { data = [] } = useSelector(outputSelector)
+  const { data = [] } = useAppSelector(outputSelector)
   const {
     errorClient: error,
     unsupportedCommands,
@@ -68,11 +68,11 @@ const CliBodyWrapper = () => {
     isSearching,
     matchedCommand,
     cliClientUuid,
-  } = useSelector(cliSettingsSelector)
-  const { connectionType, host, port, db, name } = useSelector(
+  } = useAppSelector(cliSettingsSelector)
+  const { connectionType, host, port, db, name } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { db: currentDbIndex } = useSelector(outputSelector)
+  const { db: currentDbIndex } = useAppSelector(outputSelector)
   const { isDangerousCommand } = useDatabaseEnvironment()
   const { requestConfirmation } = useProductionWriteConfirmation()
 

--- a/redisinsight/ui/src/components/cli/components/cli-header/CliHeader.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-header/CliHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -21,7 +21,7 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import styles from './styles.module.scss'
 
 const CliHeader = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 

--- a/redisinsight/ui/src/components/cli/components/cli-input/CliAutocomplete/CliAutocomplete.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-input/CliAutocomplete/CliAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { findIndex } from 'lodash'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import { ICommandArg } from 'uiSrc/constants'
 import { generateArgsNames } from 'uiSrc/utils'
@@ -26,7 +26,7 @@ const CliAutocomplete = (props: Props) => {
     wordsTyped,
   } = props
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(setMatchedCommand(commandName))

--- a/redisinsight/ui/src/components/cli/components/cli-input/CliInputWrapper.tsx
+++ b/redisinsight/ui/src/components/cli/components/cli-input/CliInputWrapper.tsx
@@ -1,6 +1,6 @@
 import { isUndefined } from 'lodash'
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { getCommandRepeat } from 'uiSrc/utils'
 import { appRedisCommandsSelector } from 'uiSrc/slices/app/redis-commands'
 import { outputSelector } from 'uiSrc/slices/cli/cli-output'
@@ -19,8 +19,8 @@ export interface Props {
 
 const CliInputWrapper = (props: Props) => {
   const { command = '', wordsTyped, setInputEl, setCommand, onKeyDown } = props
-  const { spec: ALL_REDIS_COMMANDS } = useSelector(appRedisCommandsSelector)
-  const { db } = useSelector(outputSelector)
+  const { spec: ALL_REDIS_COMMANDS } = useAppSelector(appRedisCommandsSelector)
+  const { db } = useAppSelector(outputSelector)
 
   const [commandLine, repeatCommand] = getCommandRepeat(command || '')
   const [firstCommand, secondCommand] = commandLine.split(' ')

--- a/redisinsight/ui/src/components/command-helper/CommandHelper/CommandHelper.tsx
+++ b/redisinsight/ui/src/components/command-helper/CommandHelper/CommandHelper.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { CommandGroup } from 'uiSrc/constants'
 import { goBackFromCommand } from 'uiSrc/slices/cli/cli-settings'
 import { getDocUrlForCommand } from 'uiSrc/utils'
@@ -39,7 +39,7 @@ const CommandHelper = (props: Props) => {
     since = '',
   } = props
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const handleBackClick = () => dispatch(goBackFromCommand())
 
   const readMore = (commandName = '') => {

--- a/redisinsight/ui/src/components/command-helper/CommandHelperHeader/CommandHelperHeader.tsx
+++ b/redisinsight/ui/src/components/command-helper/CommandHelperHeader/CommandHelperHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -19,7 +19,7 @@ import styles from './styles.module.scss'
 
 const CommandHelperHeader = () => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleCloseHelper = () => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/components/command-helper/CommandHelperWrapper.tsx
+++ b/redisinsight/ui/src/components/command-helper/CommandHelperWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import cn from 'classnames'
 
@@ -30,8 +30,8 @@ const CommandHelperWrapper = () => {
     isEnteringCommand,
     searchingCommand,
     searchingCommandFilter,
-  } = useSelector(cliSettingsSelector)
-  const { spec: ALL_REDIS_COMMANDS, commandsArray } = useSelector(
+  } = useAppSelector(cliSettingsSelector)
+  const { spec: ALL_REDIS_COMMANDS, commandsArray } = useAppSelector(
     appRedisCommandsSelector,
   )
   const { instanceId = '' } = useParams<{ instanceId: string }>()

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/CHSearchOutput.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/CHSearchOutput.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
@@ -28,8 +28,8 @@ const UnderlineReverseLink = styled(Link)`
 
 const CHSearchOutput = ({ searchedCommands }: Props) => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
-  const { spec: ALL_REDIS_COMMANDS } = useSelector(appRedisCommandsSelector)
+  const dispatch = useAppDispatch()
+  const { spec: ALL_REDIS_COMMANDS } = useAppSelector(appRedisCommandsSelector)
 
   const handleClickCommand = (
     e: React.MouseEvent<HTMLAnchorElement>,

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/CHSearchFilter.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchFilter/CHSearchFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { GROUP_TYPES_DISPLAY } from 'uiSrc/constants'
 import { appRedisCommandsSelector } from 'uiSrc/slices/app/redis-commands'
@@ -17,9 +17,9 @@ export interface Props {
 }
 
 const CHSearchFilter = ({ submitFilter, isLoading }: Props) => {
-  const { commandGroups = [] } = useSelector(appRedisCommandsSelector)
+  const { commandGroups = [] } = useAppSelector(appRedisCommandsSelector)
   const { isEnteringCommand, matchedCommand, searchingCommandFilter } =
-    useSelector(cliSettingsSelector)
+    useAppSelector(cliSettingsSelector)
 
   const [typeSelected, setTypeSelected] = useState<string>(
     searchingCommandFilter,

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchInput/CHSearchInput.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchInput/CHSearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { cliSettingsSelector } from 'uiSrc/slices/cli/cli-settings'
 
@@ -16,7 +16,7 @@ const CHSearchInput = ({ submitSearch, isLoading = false }: Props) => {
     isEnteringCommand,
     searchingCommand = '',
     matchedCommand = '',
-  } = useSelector(cliSettingsSelector)
+  } = useAppSelector(cliSettingsSelector)
   const [searchValue, setSearchValue] = useState<string>(
     matchedCommand || searchingCommand,
   )

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchWrapper.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search/CHSearchWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -18,10 +18,10 @@ import styles from './styles.module.scss'
 
 const CHSearchWrapper = () => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { loading } = useSelector(appRedisCommandsSelector)
+  const { loading } = useAppSelector(appRedisCommandsSelector)
   const [filterType, setFilterType] = useState<string>('')
   const [searchValue, setSearchValue] = useState<string>('')
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onChangeSearch = (value: string) => {
     setSearchValue(value)

--- a/redisinsight/ui/src/components/config/Config.tsx
+++ b/redisinsight/ui/src/components/config/Config.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation } from 'react-router-dom'
 import { isNumber } from 'lodash'
 import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
@@ -44,18 +44,18 @@ import { ThemeContext } from 'uiSrc/contexts/themeContext'
 
 const SETTINGS_PAGE_PATH = '/settings'
 const Config = () => {
-  const serverInfo = useSelector(appServerInfoSelector)
-  const { id } = useSelector(connectedInstanceSelector)
-  const { config, spec } = useSelector(userSettingsSelector)
+  const serverInfo = useAppSelector(appServerInfoSelector)
+  const { id } = useAppSelector(connectedInstanceSelector)
+  const { config, spec } = useAppSelector(userSettingsSelector)
   const {
     [FeatureFlags.cloudSso]: cloudSsoFeature,
     [FeatureFlags.envDependent]: envDependentFeature,
     [FeatureFlags.customTutorials]: customTutorialsFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const { changeTheme } = useContext(ThemeContext)
   const { pathname } = useLocation()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   useEffect(() => {
     dispatch(
       setCapability(localStorageService?.get(BrowserStorageItem.capability)),

--- a/redisinsight/ui/src/components/consents-settings/ConsentsNotifications/ConsentsNotifications.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsNotifications/ConsentsNotifications.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useFormik } from 'formik'
 import { has } from 'lodash'
 
@@ -26,9 +26,9 @@ const ConsentsNotifications = () => {
   )
   const [initialValues, setInitialValues] = useState<any>({})
 
-  const { config, spec } = useSelector(userSettingsSelector)
+  const { config, spec } = useAppSelector(userSettingsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const formik = useFormik({
     initialValues,

--- a/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useFormik } from 'formik'
 import { has } from 'lodash'
 
@@ -21,9 +21,9 @@ const ConsentsPrivacy = () => {
   const [privacyConsents, setPrivacyConsents] = useState<IConsent[]>([])
   const [initialValues, setInitialValues] = useState<any>({})
 
-  const { config, spec } = useSelector(userSettingsSelector)
+  const { config, spec } = useAppSelector(userSettingsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const formik = useFormik({
     initialValues,

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty, forEach } from 'lodash'
 import cx from 'classnames'
@@ -64,9 +64,9 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
   const [isRecommended, setIsRecommended] = useState<boolean>(false)
   const [valuesBuffer, setValuesBuffer] = useState<Values>({})
 
-  const { config, spec } = useSelector(userSettingsSelector)
+  const { config, spec } = useAppSelector(userSettingsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const submitIsDisabled = () => !isEmpty(errors)
 

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettingsPopup/ConsentsSettingsPopup.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettingsPopup/ConsentsSettingsPopup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { BuildType } from 'uiSrc/constants/env'
@@ -16,7 +16,7 @@ import styles from '../styles.module.scss'
 
 const ConsentsSettingsPopup = () => {
   const history = useHistory()
-  const { server } = useSelector(appInfoSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
   const handleSubmitted = () => {
     if (

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import {
   connectedInstanceOverviewSelector,
@@ -29,14 +29,14 @@ function getUsedMemoryPercent(
 
 export const useDatabaseOverview = () => {
   const { theme } = useContext(ThemeContext)
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [lastRefreshTime, setLastRefreshTime] = useState<number | null>(null)
-  const { id: connectedInstanceId = '', db } = useSelector(
+  const { id: connectedInstanceId = '', db } = useAppSelector(
     connectedInstanceSelector,
   )
-  const connectivityError = useSelector(appConnectivityError)
+  const connectivityError = useAppSelector(appConnectivityError)
 
-  const overview = useSelector(connectedInstanceOverviewSelector)
+  const overview = useAppSelector(connectedInstanceOverviewSelector)
   const {
     usedMemory,
     cloudDetails: {

--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import { RiBadge } from 'uiSrc/components/base/display/badge/RiBadge'
@@ -12,7 +12,7 @@ export const EnvironmentBadge = ({
   environment,
   dataTestId,
 }: EnvironmentBadgeProps) => {
-  const flagEnabled = useSelector(appFeatureFlagProdModeSelector)
+  const flagEnabled = useAppSelector(appFeatureFlagProdModeSelector)
 
   if (!flagEnabled || !environment) return null
 

--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { guideLinksSelector } from 'uiSrc/slices/content/guide-links'
 
@@ -16,13 +16,13 @@ import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
 import * as S from './ExploreGuides.styles'
 
 const ExploreGuides = () => {
-  const { data } = useSelector(guideLinksSelector)
-  const { provider } = useSelector(connectedInstanceSelector)
+  const { data } = useAppSelector(guideLinksSelector)
+  const { provider } = useAppSelector(connectedInstanceSelector)
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleLinkClick = (tutorialId: string) => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/components/feature-flag-component/FeatureFlagComponent.tsx
+++ b/redisinsight/ui/src/components/feature-flag-component/FeatureFlagComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { isArray } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 
@@ -13,7 +13,7 @@ export interface Props {
 
 const FeatureFlagComponent = (props: Props) => {
   const { children, name, otherwise, enabledByDefault } = props
-  const features = useSelector(appFeatureFlagsFeaturesSelector)
+  const features = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const nameArray = isArray(name) ? name : [name]
   const matchingFeatures = nameArray.map(

--- a/redisinsight/ui/src/components/formated-date/FormatedDate.tsx
+++ b/redisinsight/ui/src/components/formated-date/FormatedDate.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { DATETIME_FORMATTER_DEFAULT, TimezoneOption } from 'uiSrc/constants'
 import { userSettingsConfigSelector } from 'uiSrc/slices/user/user-settings'
 import { formatTimestamp } from 'uiSrc/utils'
@@ -11,7 +11,7 @@ export interface Props {
 }
 
 const FormatedDate = ({ date }: Props) => {
-  const config = useSelector(userSettingsConfigSelector)
+  const config = useAppSelector(userSettingsConfigSelector)
   const dateFormat = config?.dateFormat || DATETIME_FORMATTER_DEFAULT
   const timezone = config?.timezone || TimezoneOption.Local
 

--- a/redisinsight/ui/src/components/global-azure-auth/GlobalAzureAuth.tsx
+++ b/redisinsight/ui/src/components/global-azure-auth/GlobalAzureAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { getConfig } from 'uiSrc/config'
 
@@ -14,7 +14,6 @@ import {
   addErrorNotification,
   addMessageNotification,
 } from 'uiSrc/slices/app/notifications'
-import { AppDispatch } from 'uiSrc/slices/store'
 import {
   Pages,
   AzureAuthStatus,
@@ -42,9 +41,9 @@ const isElectron = riConfig.app.type === 'ELECTRON'
  * This component should be mounted in the main App for non-Electron builds.
  */
 const GlobalAzureAuth = () => {
-  const dispatch = useDispatch<AppDispatch>()
+  const dispatch = useAppDispatch()
   const history = useHistory()
-  const source = useSelector(azureAuthSourceSelector)
+  const source = useAppSelector(azureAuthSourceSelector)
   const sourceRef = useRef(source)
   sourceRef.current = source
 

--- a/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
+++ b/redisinsight/ui/src/components/global-subscriptions/CommonAppSubscription/CommonAppSubscription.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Socket } from 'socket.io-client'
 
 import {
@@ -22,9 +22,9 @@ import { useIoConnection } from 'uiSrc/services/hooks/useIoConnection'
 import { CloudJobInfo } from 'apiClient'
 
 const CommonAppSubscription = () => {
-  const { id: jobId = '' } = useSelector(oauthCloudJobSelector) ?? {}
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { token } = useSelector(appCsrfSelector)
+  const { id: jobId = '' } = useAppSelector(oauthCloudJobSelector) ?? {}
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { token } = useAppSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
   const connectIo = useIoConnection(getSocketApiUrl(), {
     forceNew: false,
@@ -32,7 +32,7 @@ const CommonAppSubscription = () => {
     reconnection: true,
   })
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (socketRef.current?.connected) {

--- a/redisinsight/ui/src/components/global-url-handler/GlobalUrlHandler.tsx
+++ b/redisinsight/ui/src/components/global-url-handler/GlobalUrlHandler.tsx
@@ -1,5 +1,5 @@
 import { useHistory, useLocation } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useEffect } from 'react'
 import { isNull, isNumber, every, values, pick, some } from 'lodash'
 import { Pages } from 'uiSrc/constants'
@@ -30,13 +30,13 @@ import { localStorageService } from 'uiSrc/services'
 import { AppStorageItem } from 'uiSrc/constants/storage'
 
 const GlobalUrlHandler = () => {
-  const { fromUrl } = useSelector(appRedirectionSelector)
+  const { fromUrl } = useAppSelector(appRedirectionSelector)
   const { isShowConceptsPopup: isShowConsents, config } =
-    useSelector(userSettingsSelector)
+    useAppSelector(userSettingsSelector)
   const { search } = useLocation()
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const location = useLocation()
 
   useEffect(() => {

--- a/redisinsight/ui/src/components/home-tabs/HomeTabs.tsx
+++ b/redisinsight/ui/src/components/home-tabs/HomeTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import Tabs from 'uiSrc/components/base/layout/tabs'
@@ -9,7 +9,7 @@ import { tabs } from './constants'
 const HomeTabs = () => {
   const history = useHistory()
   const { pathname } = useLocation()
-  const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
+  const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const filteredTabs = useMemo(
     () =>

--- a/redisinsight/ui/src/components/hooks/useAzureAuth.ts
+++ b/redisinsight/ui/src/components/hooks/useAzureAuth.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { getConfig } from 'uiSrc/config'
 
 import {
@@ -10,7 +10,6 @@ import {
   initiateAzureLoginAction,
 } from 'uiSrc/slices/oauth/azure'
 import { AzureLoginSource } from 'uiSrc/slices/interfaces'
-import { AppDispatch } from 'uiSrc/slices/store'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
 
 const riConfig = getConfig()
@@ -25,8 +24,8 @@ const POPUP_WIDTH = 500
 const POPUP_HEIGHT = 700
 
 export const useAzureAuth = () => {
-  const dispatch = useDispatch<AppDispatch>()
-  const { loading, account, error } = useSelector(azureAuthSelector)
+  const dispatch = useAppDispatch()
+  const { loading, account, error } = useAppSelector(azureAuthSelector)
   const popupRef = useRef<Window | null>(null)
 
   const openAuthUrl = useCallback((url: string) => {

--- a/redisinsight/ui/src/components/hooks/useConnectionType.ts
+++ b/redisinsight/ui/src/components/hooks/useConnectionType.ts
@@ -1,9 +1,9 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 
 export const useConnectionType = () => {
-  const { connectionType, forceStandalone } = useSelector(
+  const { connectionType, forceStandalone } = useAppSelector(
     connectedInstanceSelector,
   )
 

--- a/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
+++ b/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { Environment } from 'apiClient'
 import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
@@ -13,11 +13,11 @@ export interface UseDatabaseEnvironmentResult {
 }
 
 export const useDatabaseEnvironment = (): UseDatabaseEnvironmentResult => {
-  const flagEnabled = useSelector(appFeatureFlagProdModeSelector)
-  const dangerousCommands = useSelector(
+  const flagEnabled = useAppSelector(appFeatureFlagProdModeSelector)
+  const dangerousCommands = useAppSelector(
     connectedInstanceDangerousCommandsSelector,
   )
-  const connectedInstance = useSelector(connectedInstanceSelector)
+  const connectedInstance = useAppSelector(connectedInstanceSelector)
 
   const environment: Environment = flagEnabled
     ? connectedInstance.environment

--- a/redisinsight/ui/src/components/init/AppInit.tsx
+++ b/redisinsight/ui/src/components/init/AppInit.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   appInitSelector,
   initializeAppAction,
@@ -17,8 +17,8 @@ type Props = {
 }
 
 const AppInit = ({ children, onSuccess, onFail }: Props) => {
-  const dispatch = useDispatch()
-  const { status } = useSelector(appInitSelector)
+  const dispatch = useAppDispatch()
+  const { status } = useAppSelector(appInitSelector)
 
   const initApp = useCallback(
     () => dispatch(initializeAppAction(onSuccess, onFail)),

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.stories.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { BuildType } from 'uiSrc/constants/env'
 import { ConnectionType, Instance } from 'uiSrc/slices/interfaces'
 
@@ -25,7 +25,7 @@ interface InstanceHeaderArgs {
 }
 
 const StorePopulator = ({ args }: { args: InstanceHeaderArgs }) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     // Build instance from factory with optional overrides

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import cx from 'classnames'
 import { useTheme } from '@redis-ui/styles'
@@ -74,17 +74,17 @@ const InstanceHeader = ({ onChangeDbIndex }: Props) => {
     id,
     loading: instanceLoading,
     modules = [],
-  } = useSelector(connectedInstanceSelector)
-  const { version } = useSelector(connectedInstanceOverviewSelector)
-  const { server } = useSelector(appInfoSelector)
-  const { disabled: isDbIndexDisabled } = useSelector(appContextDbIndex)
-  const { databases = 0 } = useSelector(connectedInstanceInfoSelector)
-  const returnUrl = useSelector(appReturnUrlSelector)
+  } = useAppSelector(connectedInstanceSelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
+  const { server } = useAppSelector(appInfoSelector)
+  const { disabled: isDbIndexDisabled } = useAppSelector(appContextDbIndex)
+  const { databases = 0 } = useAppSelector(connectedInstanceInfoSelector)
+  const returnUrl = useAppSelector(appReturnUrlSelector)
   const {
     [FeatureFlags.databaseChat]: databaseChatFeature,
     [FeatureFlags.documentationChat]: documentationChatFeature,
     [FeatureFlags.envDependent]: envDependentFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isAnyChatAvailable = isAnyFeatureEnabled([
     databaseChatFeature,
     documentationChatFeature,
@@ -96,7 +96,7 @@ const InstanceHeader = ({ onChangeDbIndex }: Props) => {
   const [dbIndex, setDbIndex] = useState<string>(String(db || 0))
   const [isDbIndexEditing, setIsDbIndexEditing] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setDbIndex(String(db || 0))

--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/InstancesNavigationPopover.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/InstancesNavigationPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { instancesSelector as rdiInstancesSelector } from 'uiSrc/slices/rdi/instances'
 import { instancesSelector as dbInstancesSelector } from 'uiSrc/slices/instances/instances'
@@ -45,8 +45,8 @@ const InstancesNavigationPopover = ({ name }: Props) => {
     rdiInstanceId ? InstancesTabs.RDI : InstancesTabs.Databases,
   )
 
-  const { data: rdiInstances } = useSelector(rdiInstancesSelector)
-  const { data: dbInstances } = useSelector(dbInstancesSelector)
+  const { data: rdiInstances } = useAppSelector(rdiInstancesSelector)
+  const { data: dbInstances } = useAppSelector(dbInstancesSelector)
   const history = useHistory()
 
   useEffect(() => {

--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { checkConnectToRdiInstanceAction } from 'uiSrc/slices/rdi/instances'
 import {
@@ -45,7 +45,7 @@ const InstancesList = ({
     rdiInstanceId: string
   }>()
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const instances =
     selectedTab === InstancesTabs.Databases
       ? filteredDbInstances

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/CloudUserProfile.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/CloudUserProfile.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { cloudUserProfileSelector } from 'uiSrc/slices/user/cloud-user-profile'
 import UserProfileBadge from 'uiSrc/components/instance-header/components/user-profile/UserProfileBadge'
 
 export const CloudUserProfile = () => {
-  const { data, error } = useSelector(cloudUserProfileSelector)
+  const { data, error } = useAppSelector(cloudUserProfileSelector)
   if (!data?.name) {
     return null
   }

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfile.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfile.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { FeatureFlags } from 'uiSrc/constants'
 import { OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { OAuthUserProfile } from 'uiSrc/components'
@@ -12,7 +12,7 @@ const UserProfile = () => {
     [FeatureFlags.envDependent]: envDependentFeature,
     [FeatureFlags.cloudAds]: cloudAds,
     [FeatureFlags.cloudSso]: cloudSso,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   if (!envDependentFeature?.flag) {
     return (

--- a/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/user-profile/UserProfileBadge.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { logoutUserAction } from 'uiSrc/slices/oauth/cloud'
 
@@ -46,14 +46,14 @@ const UserProfileBadge = (props: UserProfileBadgeProps) => {
     'data-testid': dataTestId,
   } = props
 
-  const connectedInstance = useSelector(connectedInstanceSelector)
+  const connectedInstance = useAppSelector(connectedInstanceSelector)
 
   const riDesktopLink = buildRedisInsightUrl(connectedInstance)
 
   const [isProfileOpen, setIsProfileOpen] = useState(false)
   const [isImportLoading, setIsImportLoading] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   if (!data || error) {

--- a/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
+++ b/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import { isNull } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Text, ColorText } from 'uiSrc/components/base/text'
 
@@ -49,7 +49,7 @@ const KeysSummary = (props: Props) => {
       ? '~'
       : ''
 
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   return (
     <>

--- a/redisinsight/ui/src/components/main-router/MainRouter.tsx
+++ b/redisinsight/ui/src/components/main-router/MainRouter.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   Redirect,
   Route,
@@ -30,12 +30,12 @@ import DEFAULT_ROUTES from './constants/defaultRoutes'
 import { useActivityMonitor } from './hooks/useActivityMonitor'
 
 const MainRouter = () => {
-  const { server } = useSelector(appInfoSelector)
+  const { server } = useAppSelector(appInfoSelector)
   const { isShowConceptsPopup: isShowConsents } =
-    useSelector(userSettingsSelector)
-  const { workspace } = useSelector(appContextSelector)
+    useAppSelector(userSettingsSelector)
+  const { workspace } = useAppSelector(appContextSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   const { pathname } = useLocation()
   useActivityMonitor()

--- a/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.tsx
+++ b/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.tsx
@@ -1,4 +1,4 @@
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import React, { useEffect, useState } from 'react'
 import { Switch, useHistory } from 'react-router-dom'
 
@@ -24,7 +24,7 @@ interface IConnectionState {
 
 const Router = ({ databaseId = '' }: IProps) => {
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [connection, setConnection] = useState<IConnectionState>({
     loading: true,
     ready: false,

--- a/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.tsx
+++ b/redisinsight/ui/src/components/markdown/RedisUploadButton/RedisUploadButton.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
@@ -41,12 +41,12 @@ export interface Props {
 }
 
 const RedisUploadButton = ({ label, path }: Props) => {
-  const { pathsInProgress } = useSelector(customTutorialsBulkUploadSelector)
+  const { pathsInProgress } = useAppSelector(customTutorialsBulkUploadSelector)
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
   const { environment } = useDatabaseEnvironment()
   const isProduction = environment === Environment.Production

--- a/redisinsight/ui/src/components/messages/feature-not-available/FeatureNotAvailable.tsx
+++ b/redisinsight/ui/src/components/messages/feature-not-available/FeatureNotAvailable.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { OAuthSocialAction } from 'uiSrc/slices/interfaces'
 import {
@@ -27,7 +27,7 @@ const FeatureNotAvailable = ({
   onClose,
   content,
 }: FeatureNotAvailableProps) => {
-  const freeInstances = useSelector(freeInstancesSelector) || []
+  const freeInstances = useAppSelector(freeInstancesSelector) || []
   const learnMoreUtm = {
     medium: UTM_MEDIUMS.Main,
     campaign: UTM_CAMPAINGS[content.oauthSource],

--- a/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/ModuleNotLoadedMinimalized.tsx
+++ b/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/ModuleNotLoadedMinimalized.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import TelescopeImg from 'uiSrc/assets/img/telescope-dark.svg'
@@ -43,11 +43,11 @@ export interface Props {
 
 const ModuleNotLoadedMinimalized = (props: Props) => {
   const history = useHistory()
-  const { [FeatureFlags.cloudAds]: cloudAdsFeature } = useSelector(
+  const { [FeatureFlags.cloudAds]: cloudAdsFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
   const { moduleName, source, onClose } = props
-  const freeInstances = useSelector(freeInstancesSelector) || []
+  const freeInstances = useAppSelector(freeInstancesSelector) || []
 
   const sourceTutorial = getSourceTutorialByCapability(moduleName)
   const moduleText = cloudAdsFeature?.flag

--- a/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoaded.tsx
+++ b/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoaded.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import MobileIcon from 'uiSrc/assets/img/icons/mobile_module_not_loaded.svg?react'
 import DesktopIcon from 'uiSrc/assets/img/icons/module_not_loaded.svg?react'
@@ -67,8 +67,8 @@ const ModuleNotLoaded = ({
   onClose,
 }: IProps) => {
   const [width, setWidth] = useState(0)
-  const freeInstances = useSelector(freeInstancesSelector) || []
-  const { [FeatureFlags.cloudAds]: cloudAdsFeature } = useSelector(
+  const freeInstances = useAppSelector(freeInstancesSelector) || []
+  const { [FeatureFlags.cloudAds]: cloudAdsFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoadedButton.tsx
+++ b/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoadedButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { useHistory } from 'react-router-dom'
 import {
@@ -34,7 +34,7 @@ const ModuleNotLoadedButton = ({
   module,
 }: IProps) => {
   const history = useHistory()
-  const { [FeatureFlags.envDependent]: envDependentFeature } = useSelector(
+  const { [FeatureFlags.envDependent]: envDependentFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
+++ b/redisinsight/ui/src/components/monaco-laguages/MonacoLanguages.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { monaco } from 'react-monaco-editor'
 import { findIndex } from 'lodash'
 import { appRedisCommandsSelector } from 'uiSrc/slices/app/redis-commands'
@@ -21,7 +21,7 @@ import { ModuleCommandPrefix } from 'uiSrc/pages/workbench/constants'
 const MonacoLanguages = () => {
   const { theme } = useContext(ThemeContext)
   const { commandsArray: REDIS_COMMANDS_ARRAY, spec: COMMANDS_SPEC } =
-    useSelector(appRedisCommandsSelector)
+    useAppSelector(appRedisCommandsSelector)
 
   useEffect(() => {
     if (monaco?.editor) {

--- a/redisinsight/ui/src/components/monitor-config/MonitorConfig.tsx
+++ b/redisinsight/ui/src/components/monitor-config/MonitorConfig.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { debounce } from 'lodash'
 import { Socket } from 'socket.io-client'
 import { v4 as uuidv4 } from 'uuid'
@@ -35,7 +35,7 @@ interface IProps {
   retryDelay?: number
 }
 const MonitorConfig = ({ retryDelay = 15000 }: IProps) => {
-  const { id: instanceId = '' } = useSelector(connectedInstanceSelector)
+  const { id: instanceId = '' } = useAppSelector(connectedInstanceSelector)
   const {
     socket,
     isRunning,
@@ -43,8 +43,8 @@ const MonitorConfig = ({ retryDelay = 15000 }: IProps) => {
     isSaveToFile,
     isMinimizedMonitor,
     isShowMonitor,
-  } = useSelector(monitorSelector)
-  const { token } = useSelector(appCsrfSelector)
+  } = useAppSelector(monitorSelector)
+  const { token } = useAppSelector(appCsrfSelector)
 
   const socketRef = useRef<Nullable<Socket>>(null)
   const connectIo = useIoConnection(getSocketApiUrl('monitor'), {
@@ -56,7 +56,7 @@ const MonitorConfig = ({ retryDelay = 15000 }: IProps) => {
   const retryTimerRef = useRef<NodeJS.Timer>()
   const payloadsRef = useRef<IMonitorDataPayload[]>([])
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const setNewItems = debounce(
     (items, onSuccess?) => {

--- a/redisinsight/ui/src/components/monitor/MonitorHeader/MonitorHeader.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorHeader/MonitorHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
 
@@ -41,10 +41,10 @@ const MonitorHeader = ({ handleRunMonitor }: Props) => {
     items = [],
     error,
     loadingPause,
-  } = useSelector(monitorSelector)
+  } = useAppSelector(monitorSelector)
   const isErrorShown = !!error && !isRunning
   const disabledPause = isErrorShown || isResumeLocked || loadingPause
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleCloseMonitor = () => {
     if (isRunning) {

--- a/redisinsight/ui/src/components/monitor/MonitorLog/MonitorLog.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorLog/MonitorLog.tsx
@@ -1,6 +1,6 @@
 import { format, formatDuration, intervalToDuration } from 'date-fns'
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import {
@@ -28,8 +28,8 @@ const SMALL_SCREEN_RESOLUTION = 360 - PADDINGS_OUTSIDE
 const DOWNLOAD_IFRAME_NAME = 'logFileDownloadIFrame'
 
 const MonitorLog = () => {
-  const { timestamp, logFileId, isSaveToFile } = useSelector(monitorSelector)
-  const dispatch = useDispatch()
+  const { timestamp, logFileId, isSaveToFile } = useAppSelector(monitorSelector)
+  const dispatch = useAppDispatch()
 
   const duration = cutDurationText(
     formatDuration(

--- a/redisinsight/ui/src/components/monitor/MonitorWrapper.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -19,10 +19,10 @@ import styles from './Monitor/styles.module.scss'
 const MonitorWrapper = () => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
   const { items, isStarted, isRunning, isPaused, isSaveToFile, error } =
-    useSelector(monitorSelector)
-  const { isShowCli, isShowHelper } = useSelector(cliSettingsSelector)
+    useAppSelector(monitorSelector)
+  const { isShowCli, isShowHelper } = useAppSelector(cliSettingsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleRunMonitor = () => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 import { ReleaseNotesSource } from 'uiSrc/constants/telemetry'
@@ -32,13 +32,13 @@ import navStyles from '../../styles.module.scss'
 import styles from './styles.module.scss'
 
 const HelpMenu = () => {
-  const { id: connectedInstanceId = '' } = useSelector(
+  const { id: connectedInstanceId = '' } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { isReleaseNotesViewed } = useSelector(appElectronInfoSelector)
+  const { isReleaseNotesViewed } = useAppSelector(appElectronInfoSelector)
   const [isHelpMenuActive, setIsHelpMenuActive] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onKeyboardShortcutClick = () => {
     setIsHelpMenuActive(false)

--- a/redisinsight/ui/src/components/navigation-menu/components/notifications-center/NotificationCenter.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/notifications-center/NotificationCenter.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   fetchNotificationsAction,
   notificationCenterSelector,
@@ -16,11 +16,11 @@ import Notification from './Notification'
 import styles from './styles.module.scss'
 
 const NotificationCenter = () => {
-  const { isCenterOpen, notifications } = useSelector(
+  const { isCenterOpen, notifications } = useAppSelector(
     notificationCenterSelector,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (isCenterOpen) {

--- a/redisinsight/ui/src/components/navigation-menu/components/notifications-center/NotificationMenu.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/notifications-center/NotificationMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   notificationCenterSelector,
@@ -16,9 +16,11 @@ import PopoverNotification from './PopoverNotification'
 import styles from './styles.module.scss'
 
 const NavButton = () => {
-  const { isCenterOpen, totalUnread } = useSelector(notificationCenterSelector)
+  const { isCenterOpen, totalUnread } = useAppSelector(
+    notificationCenterSelector,
+  )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onClickIcon = () => {
     dispatch(setIsCenterOpen())

--- a/redisinsight/ui/src/components/navigation-menu/components/notifications-center/PopoverNotification/PopoverNotification.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/notifications-center/PopoverNotification/PopoverNotification.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   notificationCenterSelector,
   setIsCenterOpen,
@@ -20,14 +20,14 @@ const CLOSE_NOTIFICATION_TIME = 6000
 
 const PopoverNotification = () => {
   const { isNotificationOpen, isCenterOpen, lastReceivedNotification } =
-    useSelector(notificationCenterSelector)
+    useAppSelector(notificationCenterSelector)
   const [isHovering, setIsHovering] = useState(false)
   const [isShowNotification, setIsShowNotification] =
     useState(isNotificationOpen)
 
   const timeOutRef = useRef<NodeJS.Timeout>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (isShowNotification && isCenterOpen) {

--- a/redisinsight/ui/src/components/navigation-menu/components/redis-logo/RedisLogo.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/redis-logo/RedisLogo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { BuildType } from 'uiSrc/constants/env'
 import { appInfoSelector } from 'uiSrc/slices/app/info'
@@ -31,8 +31,8 @@ const RedisLogoIcon = styled.span`
 `
 
 export const RedisLogo = ({ isRdiWorkspace }: Props) => {
-  const { envDependent } = useSelector(appFeatureFlagsFeaturesSelector)
-  const { server } = useSelector(appInfoSelector)
+  const { envDependent } = useAppSelector(appFeatureFlagsFeaturesSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
   if (!envDependent?.flag) {
     return (

--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -1,6 +1,6 @@
 import { useHistory, useLocation } from 'react-router-dom'
 import { last } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { useEffect, useState } from 'react'
 import { Props as HighlightedFeatureProps } from 'uiSrc/components/hightlighted-feature/HighlightedFeature'
@@ -35,20 +35,20 @@ const pubSubPath = `/${PageNames.pubSub}`
 export function useNavigation() {
   const history = useHistory()
   const location = useLocation()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [activePage, setActivePage] = useState(Pages.home)
 
-  const { workspace } = useSelector(appContextSelector)
+  const { workspace } = useAppSelector(appContextSelector)
 
-  const { id: connectedInstanceId = '' } = useSelector(
+  const { id: connectedInstanceId = '' } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { id: connectedRdiInstanceId = '' } = useSelector(
+  const { id: connectedRdiInstanceId = '' } = useAppSelector(
     connectedRdiInstanceSelector,
   )
-  const highlightedPages = useSelector(appFeaturePagesHighlightingSelector)
-  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useSelector(
+  const highlightedPages = useAppSelector(appFeaturePagesHighlightingSelector)
+  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/components/notifications/Notifications.stories.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.stories.tsx
@@ -7,7 +7,7 @@ import {
   InfiniteMessagesIds,
 } from 'uiSrc/components/notifications/components'
 import { CloudJobStep } from 'uiSrc/electron/constants'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import {
   addInfiniteNotification,
   removeInfiniteNotification,
@@ -86,7 +86,7 @@ const sampleNotifications: SampleNotification[] = [
 ]
 
 const useNotificationUpdates = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const timeoutRefs = useRef<NodeJS.Timeout[]>([])
 
   useEffect(() => {

--- a/redisinsight/ui/src/components/notifications/components/cloud-capi-unauthorized/CloudCapiUnAuthorizedErrorContent.tsx
+++ b/redisinsight/ui/src/components/notifications/components/cloud-capi-unauthorized/CloudCapiUnAuthorizedErrorContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { ColorText } from 'uiSrc/components/base/text'
 import { removeCapiKeyAction } from 'uiSrc/slices/oauth/cloud'
@@ -24,7 +24,7 @@ const CloudCapiUnAuthorizedErrorContent = ({
   onClose = () => {},
   resourceId,
 }: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const handleRemoveCapi = () => {

--- a/redisinsight/ui/src/components/notifications/components/encryption-error-content/EncryptionErrorContent.tsx
+++ b/redisinsight/ui/src/components/notifications/components/encryption-error-content/EncryptionErrorContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { matchPath, useHistory, useLocation } from 'react-router-dom'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { Pages } from 'uiSrc/constants'
 import { ColorText } from 'uiSrc/components/base/text'
 import { updateUserConfigSettingsAction } from 'uiSrc/slices/user/user-settings'
@@ -21,7 +21,7 @@ const EncryptionErrorContent = (props: Props) => {
   const { onClose, instanceId } = props
   const { pathname } = useLocation()
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   // useParams() hook can't be used because the Notifications component is outside of the MainRouter
   const getInstanceIdFromUrl = (): string => {

--- a/redisinsight/ui/src/components/notifications/hooks/useErrorNotifications.ts
+++ b/redisinsight/ui/src/components/notifications/hooks/useErrorNotifications.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { IError } from 'uiSrc/slices/interfaces'
 import { DEFAULT_ERROR_MESSAGE } from 'uiSrc/utils'
@@ -16,8 +16,8 @@ const DEFAULT_ERROR_TITLE = 'Error'
 const AZURE_TOKEN_EXPIRED_TOAST_ID = 'azure-token-expired'
 
 export const useErrorNotifications = () => {
-  const errorsData = useSelector(errorsSelector)
-  const dispatch = useDispatch()
+  const errorsData = useAppSelector(errorsSelector)
+  const dispatch = useAppDispatch()
   const toastIdsRef = useRef(new Map<string, number | string>())
   const azureErrorIdsRef = useRef(new Set<string>())
 

--- a/redisinsight/ui/src/components/notifications/hooks/useInfiniteNotifications.ts
+++ b/redisinsight/ui/src/components/notifications/hooks/useInfiniteNotifications.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { riToast } from 'uiSrc/components/base/display/toast'
 import { InfiniteMessage } from 'uiSrc/slices/interfaces'
@@ -25,8 +25,8 @@ const showNotification = (notification: InfiniteMessage) => {
 }
 
 export const useInfiniteNotifications = () => {
-  const notifications = useSelector(infiniteNotificationsSelector)
-  const dispatch = useDispatch()
+  const notifications = useAppSelector(infiniteNotificationsSelector)
+  const dispatch = useAppDispatch()
   const notificationsData = useMemo(() => {
     return notifications.map(
       ({

--- a/redisinsight/ui/src/components/notifications/hooks/useMessageNotifications.tsx
+++ b/redisinsight/ui/src/components/notifications/hooks/useMessageNotifications.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { ToastVariant } from '@redis-ui/components'
 import { riToast } from 'uiSrc/components/base/display/toast'
 import { messagesSelector, removeMessage } from 'uiSrc/slices/app/notifications'
@@ -14,9 +14,9 @@ const getDescriptionText = (
 ) => <ColorText color={variant}>{text}</ColorText>
 
 export const useMessageNotifications = () => {
-  const messagesData = useSelector(messagesSelector)
+  const messagesData = useAppSelector(messagesSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const toastIdsRef = useRef(new Map<string, number | string>())
   const removeToast = (id: string) => {
     if (toastIdsRef.current.has(id)) {

--- a/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-connect-free-db/OAuthConnectFreeDb.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { useLocation } from 'react-router-dom'
 import cx from 'classnames'
@@ -36,14 +36,14 @@ const OAuthConnectFreeDb = ({
   onSuccessClick,
   className,
 }: Props) => {
-  const { loading } = useSelector(instancesSelector) ?? {}
-  const { modules, provider } = useSelector(connectedInstanceSelector) ?? {}
-  const [firstFreeInstance] = useSelector(freeInstancesSelector) ?? []
+  const { loading } = useAppSelector(instancesSelector) ?? {}
+  const { modules, provider } = useAppSelector(connectedInstanceSelector) ?? {}
+  const [firstFreeInstance] = useAppSelector(freeInstancesSelector) ?? []
 
   const targetDatabaseId = id || firstFreeInstance?.id
   const targetEnvironment = firstFreeInstance?.environment
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { search } = useLocation()
 
   if (!targetDatabaseId) {

--- a/redisinsight/ui/src/components/oauth/oauth-jobs/OAuthJobs.spec.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-jobs/OAuthJobs.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { AxiosError } from 'axios'
 import {
   cleanup,
@@ -34,9 +34,9 @@ import { CustomErrorCodes } from 'uiSrc/constants'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import OAuthJobs from './OAuthJobs'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/oauth/cloud', () => ({
@@ -58,7 +58,7 @@ describe('OAuthJobs', () => {
   beforeEach(() => {
     const state = store.getState() as RootState
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: any) => any) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/components/oauth/oauth-jobs/OAuthJobs.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-jobs/OAuthJobs.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { get } from 'lodash'
 
@@ -45,10 +45,10 @@ const OAuthJobs = () => {
     error,
     step,
     result,
-  } = useSelector(oauthCloudJobSelector) ?? {}
-  const { showProgress } = useSelector(oauthCloudSelector)
+  } = useAppSelector(oauthCloudJobSelector) ?? {}
+  const { showProgress } = useAppSelector(oauthCloudSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   useEffect(() => {

--- a/redisinsight/ui/src/components/oauth/oauth-select-account-dialog/OAuthSelectAccountDialog.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-select-account-dialog/OAuthSelectAccountDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useFormik } from 'formik'
 import { useHistory } from 'react-router-dom'
 
@@ -52,17 +52,17 @@ interface FormValues {
 }
 
 const OAuthSelectAccountDialog = () => {
-  const { ssoFlow, isRecommendedSettings } = useSelector(cloudSelector)
+  const { ssoFlow, isRecommendedSettings } = useAppSelector(cloudSelector)
   const { accounts = [], currentAccountId } =
-    useSelector(oauthCloudUserDataSelector) ?? {}
-  const { isOpenSelectAccountDialog } = useSelector(oauthCloudSelector)
-  const { loading } = useSelector(oauthCloudUserSelector)
-  const { loading: plansLoadings } = useSelector(oauthCloudPlanSelector)
+    useAppSelector(oauthCloudUserDataSelector) ?? {}
+  const { isOpenSelectAccountDialog } = useAppSelector(oauthCloudSelector)
+  const { loading } = useAppSelector(oauthCloudUserSelector)
+  const { loading: plansLoadings } = useAppSelector(oauthCloudPlanSelector)
 
   const isAutodiscoverySSO = ssoFlow === OAuthSocialAction.Import
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const initialValues = {
     accountId: `${currentAccountId}`,

--- a/redisinsight/ui/src/components/oauth/oauth-select-plan/OAuthSelectPlan.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-select-plan/OAuthSelectPlan.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { toNumber, filter, get, find, first } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   createFreeDbJob,
@@ -58,8 +58,8 @@ const OAuthSelectPlan = () => {
     isOpenDialog,
     data: plansInit = [],
     loading,
-  } = useSelector(oauthCloudPlanSelector)
-  const { [FeatureFlags.cloudSso]: cloudSsoFeature = {} } = useSelector(
+  } = useAppSelector(oauthCloudPlanSelector)
+  const { [FeatureFlags.cloudSso]: cloudSsoFeature = {} } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 
@@ -77,7 +77,7 @@ const OAuthSelectPlan = () => {
     getProviderRegions(rsRegions, providerSelected as OAuthProvider),
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setRsProviderRegions(

--- a/redisinsight/ui/src/components/oauth/oauth-sso-dialog/OAuthSsoDialog.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-sso-dialog/OAuthSsoDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import cx from 'classnames'
 import {
@@ -16,10 +16,10 @@ import { Modal } from 'uiSrc/components/base/display'
 import styles from './styles.module.scss'
 
 const OAuthSsoDialog = () => {
-  const { ssoFlow } = useSelector(cloudSelector)
-  const { isOpenSocialDialog, source } = useSelector(oauthCloudSelector)
+  const { ssoFlow } = useAppSelector(cloudSelector)
+  const { isOpenSocialDialog, source } = useAppSelector(oauthCloudSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleClose = useCallback(() => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/components/oauth/oauth-sso-handler-dialog/OAuthSsoHandlerDialog.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-sso-handler-dialog/OAuthSsoHandlerDialog.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import React from 'react'
 
 import { useHistory } from 'react-router-dom'
@@ -37,12 +37,12 @@ const telemetryEventByAction = {
 }
 
 const OAuthSsoHandlerDialog = ({ children }: Props) => {
-  const { data } = useSelector(oauthCloudUserSelector)
-  const { [FeatureFlags.cloudSso]: feature } = useSelector(
+  const { data } = useAppSelector(oauthCloudUserSelector)
+  const { [FeatureFlags.cloudSso]: feature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const ssoCloudHandlerClick = (

--- a/redisinsight/ui/src/components/oauth/oauth-sso/oauth-autodiscovery/OAuthAutodiscovery.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-sso/oauth-autodiscovery/OAuthAutodiscovery.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { find } from 'lodash'
 import { OAuthAgreement } from 'uiSrc/components/oauth/shared'
@@ -39,11 +39,11 @@ export interface Props {
 
 const OAuthAutodiscovery = (props: Props) => {
   const { inline, source = OAuthSocialSource.Autodiscovery, onClose } = props
-  const { data } = useSelector(oauthCloudUserSelector)
+  const { data } = useAppSelector(oauthCloudUserSelector)
 
   const [isDiscoverDisabled, setIsDiscoverDisabled] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const handleClickDiscover = () => {

--- a/redisinsight/ui/src/components/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-sso/oauth-create-db/OAuthCreateDb.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   createFreeDbJob,
   fetchPlans,
@@ -46,16 +46,16 @@ export interface Props {
 
 const OAuthCreateDb = (props: Props) => {
   const { source } = props
-  const { data } = useSelector(oauthCloudUserSelector)
+  const { data } = useAppSelector(oauthCloudUserSelector)
   const {
     [FeatureFlags.cloudSsoRecommendedSettings]: isRecommendedFeatureEnabled,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const [isRecommended, setIsRecommended] = useState(
     isRecommendedFeatureEnabled?.flag ? true : undefined,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleSocialButtonClick = (accountOption: string) => {
     dispatch(setIsRecommendedSettingsSSO(isRecommended))

--- a/redisinsight/ui/src/components/oauth/oauth-sso/oauth-sign-in/OAuthSignIn.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-sso/oauth-sign-in/OAuthSignIn.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { OAuthAdvantages, OAuthAgreement } from 'uiSrc/components/oauth/shared'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -21,7 +21,7 @@ export interface Props {
 const OAuthSignIn = (props: Props) => {
   const { source, action = OAuthSocialAction.SignIn } = props
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleSocialButtonClick = (accountOption: string) => {
     dispatch(setSSOFlow(action))

--- a/redisinsight/ui/src/components/oauth/oauth-user-profile/OAuthUserProfile.tsx
+++ b/redisinsight/ui/src/components/oauth/oauth-user-profile/OAuthUserProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import OAuthSignInButton from 'uiSrc/components/oauth/oauth-sign-in-button'
 import {
@@ -24,10 +24,10 @@ export interface Props {
 const OAuthUserProfile = (props: Props) => {
   const { source } = props
   const [selectingAccountId, setSelectingAccountId] = useState<number>()
-  const { error, data, initialLoading } = useSelector(oauthCloudUserSelector)
-  const { server } = useSelector(appInfoSelector)
+  const { error, data, initialLoading } = useAppSelector(oauthCloudUserSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (data || error) {

--- a/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-agreement/OAuthAgreement.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import cx from 'classnames'
 import { localStorageService } from 'uiSrc/services'
@@ -22,9 +22,9 @@ export interface Props {
 
 const OAuthAgreement = (props: Props) => {
   const { size = 'm' } = props
-  const agreement = useSelector(oauthCloudPAgreementSelector)
+  const agreement = useAppSelector(oauthCloudPAgreementSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {

--- a/redisinsight/ui/src/components/oauth/shared/oauth-form/OAuthForm.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-form/OAuthForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { signIn } from 'uiSrc/slices/oauth/cloud'
 import { OAuthSocialAction, OAuthStrategy } from 'uiSrc/slices/interfaces'
 import { ipcAuth } from 'uiSrc/electron/utils'
@@ -15,7 +15,7 @@ export interface Props extends OAuthSocialButtonsProps {
 }
 
 const OAuthForm = ({ children, action, onClick, ...rest }: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [authStrategy, setAuthStrategy] = useState('')
   const [disabled, setDisabled] = useState(false)

--- a/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { oauthCloudPAgreementSelector } from 'uiSrc/slices/oauth/cloud'
 import { OAuthStrategy } from 'uiSrc/slices/interfaces'
 
@@ -40,7 +40,7 @@ const socialLinks = [
 const OAuthSocialButtons = (props: Props) => {
   const { onClick, className, inline, disabled } = props
 
-  const agreement = useSelector(oauthCloudPAgreementSelector)
+  const agreement = useAppSelector(oauthCloudPAgreementSelector)
 
   return (
     <Row

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { isString, partialRight } from 'lodash'
 import { keysDataSelector } from 'uiSrc/slices/browser/keys'
@@ -67,10 +67,10 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserPage,
     title: 'Browser',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
-      const { total } = useSelector(keysDataSelector)
+      const { total } = useAppSelector(keysDataSelector)
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         total
@@ -99,7 +99,7 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserTreeView,
     title: 'Tree view',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const telemetryArgs: TelemetryArgs = [
@@ -120,19 +120,19 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserFilterSearch,
     title: 'Filter and search',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const {
         [FeatureFlags.databaseChat]: databaseChatFeature,
         [FeatureFlags.documentationChat]: documentationChatFeature,
-      } = useSelector(appFeatureFlagsFeaturesSelector)
+      } = useAppSelector(appFeatureFlagsFeaturesSelector)
       const isAnyChatAvailable = isAnyFeatureEnabled([
         databaseChatFeature,
         documentationChatFeature,
       ])
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.BrowserFilters,
@@ -162,11 +162,11 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserCopilot,
     title: 'Try Redis Copilot',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.BrowserCopilot,
@@ -189,19 +189,19 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserCLI,
     title: 'CLI',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const {
         [FeatureFlags.databaseChat]: databaseChatFeature,
         [FeatureFlags.documentationChat]: documentationChatFeature,
-      } = useSelector(appFeatureFlagsFeaturesSelector)
+      } = useAppSelector(appFeatureFlagsFeaturesSelector)
       const isAnyChatAvailable = isAnyFeatureEnabled([
         databaseChatFeature,
         documentationChatFeature,
       ])
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.BrowserCLI,
@@ -231,10 +231,10 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserCommandHelper,
     title: 'Command Helper',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.BrowserCommandHelper,
@@ -265,13 +265,13 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.BrowserProfiler,
     title: 'Profiler',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } =
-        useSelector(appFeatureFlagsFeaturesSelector)
+        useAppSelector(appFeatureFlagsFeaturesSelector)
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const history = useHistory()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
@@ -317,11 +317,11 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.VectorSearchPage,
     title: 'Search',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const history = useHistory()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
@@ -356,14 +356,14 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.WorkbenchPage,
     title: 'Try Workbench!',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } =
-        useSelector(appFeatureFlagsFeaturesSelector)
+        useAppSelector(appFeatureFlagsFeaturesSelector)
       const [firstIndex, setFirstIndex] = useState<Nullable<string>>(null)
 
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const history = useHistory()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
@@ -467,7 +467,7 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.Tutorials,
     title: 'Explore and learn more',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const telemetryArgs: TelemetryArgs = [
@@ -476,7 +476,7 @@ const ONBOARDING_FEATURES = {
       ]
 
       const history = useHistory()
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
 
       return {
         content:
@@ -499,11 +499,11 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.CustomTutorials,
     title: 'Upload your tutorials',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const history = useHistory()
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.ExploreCustomTutorials,
@@ -542,11 +542,11 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.AnalyticsOverview,
     title: 'Cluster Overview',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const history = useHistory()
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.ClusterOverview,
@@ -577,11 +577,11 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.AnalyticsDatabaseAnalysis,
     title: 'Database Analysis',
     Inner: () => {
-      const { data } = useSelector(dbAnalysisSelector)
-      const { id: connectedInstanceId = '', connectionType } = useSelector(
+      const { data } = useAppSelector(dbAnalysisSelector)
+      const { id: connectedInstanceId = '', connectionType } = useAppSelector(
         connectedInstanceSelector,
       )
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const history = useHistory()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
@@ -629,7 +629,7 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.AnalyticsRecommendations,
     title: 'Database Tips',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const history = useHistory()
@@ -654,12 +654,12 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.AnalyticsSlowLog,
     title: 'Slow Log',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
-      const { data } = useSelector(dbAnalysisSelector)
+      const { data } = useAppSelector(dbAnalysisSelector)
       const history = useHistory()
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.SlowLog,
@@ -700,7 +700,7 @@ const ONBOARDING_FEATURES = {
     step: OnboardingSteps.PubSubPage,
     title: 'Pub/Sub',
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const history = useHistory()
@@ -741,11 +741,11 @@ const ONBOARDING_FEATURES = {
       </>
     ),
     Inner: () => {
-      const { id: connectedInstanceId = '' } = useSelector(
+      const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
       const history = useHistory()
-      const dispatch = useDispatch()
+      const dispatch = useAppDispatch()
       const telemetryArgs: TelemetryArgs = [
         connectedInstanceId,
         OnboardingStepName.Finish,

--- a/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
+++ b/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 
 import {
@@ -53,7 +53,7 @@ const OnboardingTour = (props: Props) => {
     onSkip = () => {},
   } = Inner ? Inner() : {}
 
-  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useSelector(
+  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 
@@ -71,7 +71,7 @@ const OnboardingTour = (props: Props) => {
     }
   }, [currentStep, totalSteps, vectorSearchFeature?.flag])
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsOpen(step === currentStep && isActive)

--- a/redisinsight/ui/src/components/onboarding-tour/OnboardingTourWrapper.tsx
+++ b/redisinsight/ui/src/components/onboarding-tour/OnboardingTourWrapper.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import React, { useEffect, useState } from 'react'
 import { PopoverAnchorPosition } from '@elastic/eui/src/components/popover/popover'
 import { appFeatureOnboardingSelector } from 'uiSrc/slices/app/features'
@@ -21,7 +21,7 @@ export interface Props {
 const OnboardingTourWrapper = (props: Props) => {
   const { options, children, delay, rerenderWithDelay } = props
   const { step } = options
-  const { currentStep, isActive, totalSteps } = useSelector(
+  const { currentStep, isActive, totalSteps } = useAppSelector(
     appFeatureOnboardingSelector,
   )
   const [isDelayed, setIsDelayed] = useState(true)

--- a/redisinsight/ui/src/components/page-header/PageHeader.tsx
+++ b/redisinsight/ui/src/components/page-header/PageHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import cx from 'classnames'
@@ -34,14 +34,14 @@ const PageHeader = (props: Props) => {
   const {
     [FeatureFlags.databaseChat]: databaseChatFeature,
     [FeatureFlags.documentationChat]: documentationChatFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isAnyChatAvailable = isAnyFeatureEnabled([
     databaseChatFeature,
     documentationChatFeature,
   ])
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const resetConnections = () => {
     dispatch(resetDataRedisCluster())

--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { Environment } from 'apiClient'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import TypeToConfirmModal from 'uiSrc/components/type-to-confirm-modal'
@@ -34,7 +34,7 @@ export const ProductionWriteConfirmationProvider = ({
   children,
 }: ProductionWriteConfirmationProviderProps) => {
   const { environment } = useDatabaseEnvironment()
-  const { id, name, host, port } = useSelector(connectedInstanceSelector)
+  const { id, name, host, port } = useAppSelector(connectedInstanceSelector)
   const [pending, setPending] =
     useState<ProductionWriteConfirmationRequest | null>(null)
   const skippedCommandsRef = useRef<Set<string>>(new Set())

--- a/redisinsight/ui/src/components/pub-sub-config/PubSubConfig.tsx
+++ b/redisinsight/ui/src/components/pub-sub-config/PubSubConfig.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Socket } from 'socket.io-client'
 
 import { SocketEvent } from 'uiSrc/constants'
@@ -24,17 +24,17 @@ interface IProps {
 }
 
 const PubSubConfig = ({ retryDelay = 5000 }: IProps) => {
-  const { id: instanceId = '' } = useSelector(connectedInstanceSelector)
+  const { id: instanceId = '' } = useAppSelector(connectedInstanceSelector)
   const { isSubscribeTriggered, isConnected, subscriptions } =
-    useSelector(pubSubSelector)
-  const { token } = useSelector(appCsrfSelector)
+    useAppSelector(pubSubSelector)
+  const { token } = useAppSelector(appCsrfSelector)
   const socketRef = useRef<Nullable<Socket>>(null)
   const connectIo = useIoConnection(getSocketApiUrl('pub-sub'), {
     token,
     query: { instanceId },
   })
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!isSubscribeTriggered || !instanceId || socketRef.current?.connected) {

--- a/redisinsight/ui/src/components/query/hooks/useRedisCompletions.ts
+++ b/redisinsight/ui/src/components/query/hooks/useRedisCompletions.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { monaco as monacoEditor } from 'react-monaco-editor'
 
 import { MonacoLanguage } from 'uiSrc/constants'
@@ -57,9 +57,9 @@ export const useRedisCompletions = ({
   const disposeSignatureRef = useRef<() => void>(() => {})
 
   const { commandsArray: REDIS_COMMANDS_ARRAY, spec: REDIS_COMMANDS_SPEC } =
-    useSelector(appRedisCommandsSelector)
+    useAppSelector(appRedisCommandsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const compositeTokens = useMemo(
     () =>

--- a/redisinsight/ui/src/components/query/query-card/QueryCard.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
 import { isNull } from 'lodash'
@@ -145,7 +145,7 @@ const QueryCard = (props: Props) => {
     db,
   } = props
 
-  const { visualizations = [] } = useSelector(appPluginsSelector)
+  const { visualizations = [] } = useAppSelector(appPluginsSelector)
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false)

--- a/redisinsight/ui/src/components/query/query-card/QueryCardCliPlugin/QueryCardCliPlugin.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardCliPlugin/QueryCardCliPlugin.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { v4 as uuidv4 } from 'uuid'
 import { useParams } from 'react-router-dom'
@@ -70,9 +70,9 @@ const QueryCardCliPlugin = (props: Props) => {
     commandId,
     mode = RunQueryMode.Raw,
   } = props
-  const { visualizations = [], staticPath } = useSelector(appPluginsSelector)
-  const { modules = [] } = useSelector(connectedInstanceSelector)
-  const serverInfo = useSelector(appServerInfoSelector)
+  const { visualizations = [], staticPath } = useAppSelector(appPluginsSelector)
+  const { modules = [] } = useAppSelector(connectedInstanceSelector)
+  const serverInfo = useAppSelector(appServerInfoSelector)
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const [currentView, setCurrentView] = useState<Nullable<any>>(null)
@@ -84,7 +84,7 @@ const QueryCardCliPlugin = (props: Props) => {
   const generatedIframeNameRef = useRef<string>('')
   const { theme } = useContext(ThemeContext)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const sendMessageToPlugin = (data = {}) => {
     const event: any = document.createEvent('Event')

--- a/redisinsight/ui/src/components/query/query-card/QueryCardCommonResult/components/CommonErrorResponse/CommonErrorResponse.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardCommonResult/components/CommonErrorResponse/CommonErrorResponse.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   checkUnsupportedCommand,
@@ -28,9 +28,9 @@ import { showMonitor } from 'uiSrc/slices/cli/monitor'
 const CommonErrorResponse = (id: string, command = '', result?: any) => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
   const { unsupportedCommands: cliUnsupportedCommands, blockingCommands } =
-    useSelector(cliSettingsSelector)
-  const { modules } = useSelector(connectedInstanceSelector)
-  const dispatch = useDispatch()
+    useAppSelector(cliSettingsSelector)
+  const { modules } = useAppSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
   const unsupportedCommands = [
     SelectCommand.toLowerCase(),
     ...cliUnsupportedCommands,

--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { findIndex, isNumber } from 'lodash'
 import { ColorText } from 'uiSrc/components/base/text'
@@ -125,8 +125,8 @@ const QueryCardHeader = (props: Props) => {
     db,
   } = props
 
-  const { visualizations = [] } = useSelector(appPluginsSelector)
-  const { spec: COMMANDS_SPEC } = useSelector(appRedisCommandsSelector)
+  const { visualizations = [] } = useAppSelector(appPluginsSelector)
+  const { spec: COMMANDS_SPEC } = useAppSelector(appRedisCommandsSelector)
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const { theme } = useContext(ThemeContext)

--- a/redisinsight/ui/src/components/query/query-tutorials/QueryTutorials.tsx
+++ b/redisinsight/ui/src/components/query/query-tutorials/QueryTutorials.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { findTutorialPath } from 'uiSrc/utils'
@@ -47,7 +47,7 @@ const QueryTutorialsButton = styled(EmptyButton)`
 `
 
 const QueryTutorials = ({ tutorials, source }: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   const { instanceId } = useParams<{ instanceId: string }>()
 

--- a/redisinsight/ui/src/components/rdi-instance-header/RdiInstanceHeader.tsx
+++ b/redisinsight/ui/src/components/rdi-instance-header/RdiInstanceHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { CopilotTrigger, InsightsTrigger } from 'uiSrc/components/triggers'
@@ -20,11 +20,11 @@ import InstancesNavigationPopover from '../instance-header/components/instances-
 import styles from './styles.module.scss'
 
 const RdiInstanceHeader = () => {
-  const { name = '' } = useSelector(connectedInstanceSelector)
+  const { name = '' } = useAppSelector(connectedInstanceSelector)
   const {
     [FeatureFlags.databaseChat]: databaseChatFeature,
     [FeatureFlags.documentationChat]: documentationChatFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isAnyChatAvailable = isAnyFeatureEnabled([
     databaseChatFeature,
     documentationChatFeature,

--- a/redisinsight/ui/src/components/recommendation/recommendation-voting/RecommendationVoting.tsx
+++ b/redisinsight/ui/src/components/recommendation/recommendation-voting/RecommendationVoting.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { userSettingsConfigSelector } from 'uiSrc/slices/user/user-settings'
 import { Vote } from 'uiSrc/constants/recommendations'
@@ -25,7 +25,7 @@ const RecommendationVoting = ({
   live = false,
   containerClass = '',
 }: Props) => {
-  const config = useSelector(userSettingsConfigSelector)
+  const config = useAppSelector(userSettingsConfigSelector)
   const [popover, setPopover] = useState<string>('')
 
   return (

--- a/redisinsight/ui/src/components/recommendation/recommendation-voting/components/vote-option/VoteOption.tsx
+++ b/redisinsight/ui/src/components/recommendation/recommendation-voting/components/vote-option/VoteOption.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 import { Vote } from 'uiSrc/constants/recommendations'
@@ -78,11 +78,11 @@ const VoteOption = (props: Props) => {
     name,
   } = props
 
-  const dispatch = useDispatch()
-  const { id: instanceId = '', provider } = useSelector(
+  const dispatch = useAppDispatch()
+  const { id: instanceId = '', provider } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { content: recommendationsContent } = useSelector(
+  const { content: recommendationsContent } = useAppSelector(
     recommendationsSelector,
   )
 

--- a/redisinsight/ui/src/components/shortcuts-flyout/ShortcutsFlyout.tsx
+++ b/redisinsight/ui/src/components/shortcuts-flyout/ShortcutsFlyout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { appInfoSelector, setShortcutsFlyoutState } from 'uiSrc/slices/app/info'
 import { KeyboardShortcut } from 'uiSrc/components'
 import { BuildType } from 'uiSrc/constants/env'
@@ -15,9 +15,9 @@ import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
 import { SHORTCUTS, ShortcutGroup, separator } from './schema'
 
 const ShortcutsFlyout = () => {
-  const { isShortcutsFlyoutOpen, server } = useSelector(appInfoSelector)
+  const { isShortcutsFlyoutOpen, server } = useAppSelector(appInfoSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const tableColumns: ColumnDefinition<any>[] = [
     {

--- a/redisinsight/ui/src/components/side-panels/SidePanels.tsx
+++ b/redisinsight/ui/src/components/side-panels/SidePanels.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import cx from 'classnames'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 import { KeyboardKeys as keys } from 'uiSrc/constants/keys'
 
@@ -31,13 +31,13 @@ export interface Props {
 
 const SidePanelsWrapper = (props: Props) => {
   const { panelClassName } = props
-  const { openedPanel } = useSelector(sidePanelsSelector)
-  const { tabSelected } = useSelector(insightsPanelSelector)
-  const { provider } = useSelector(connectedInstanceSelector)
+  const { openedPanel } = useAppSelector(sidePanelsSelector)
+  const { tabSelected } = useAppSelector(insightsPanelSelector)
+  const { provider } = useAppSelector(connectedInstanceSelector)
   const {
     [FeatureFlags.databaseChat]: databaseChatFeature,
     [FeatureFlags.documentationChat]: documentationChatFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isAnyChatAvailable = isAnyFeatureEnabled([
     databaseChatFeature,
     documentationChatFeature,
@@ -46,7 +46,7 @@ const SidePanelsWrapper = (props: Props) => {
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false)
 
   const { pathname } = useLocation()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
   const pathnameRef = useRef<string>(pathname)
 

--- a/redisinsight/ui/src/components/side-panels/components/insights-panel/InsightsPanel.tsx
+++ b/redisinsight/ui/src/components/side-panels/components/insights-panel/InsightsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { Header } from 'uiSrc/components/side-panels/components'
 import { InsightsPanelTabs } from 'uiSrc/slices/interfaces/insights'
@@ -30,12 +30,12 @@ export interface Props {
 
 const InsightsPanel = (props: Props) => {
   const { isFullScreen, onToggleFullScreen, onClose } = props
-  const { tabSelected } = useSelector(insightsPanelSelector)
+  const { tabSelected } = useAppSelector(insightsPanelSelector)
   const {
     data: { totalUnread },
-  } = useSelector(recommendationsSelector)
+  } = useAppSelector(recommendationsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const handleChangeTab = (name: InsightsPanelTabs) => {

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/AiAssistant.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/AiAssistant.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { oauthCloudUserSelector } from 'uiSrc/slices/oauth/cloud'
 import { FeatureFlags } from 'uiSrc/constants'
@@ -9,15 +9,15 @@ import { WelcomeAiAssistant, ChatsWrapper } from './components'
 import styles from './styles.module.scss'
 
 const AiAssistant = () => {
-  const { data: userOAuthProfile } = useSelector(oauthCloudUserSelector)
-  const { [FeatureFlags.cloudSso]: cloudSsoFeature } = useSelector(
+  const { data: userOAuthProfile } = useAppSelector(oauthCloudUserSelector)
+  const { [FeatureFlags.cloudSso]: cloudSsoFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 
   const currentAccountIdRef = useRef(userOAuthProfile?.id)
   const isShowAuth = cloudSsoFeature?.flag && !userOAuthProfile
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     // user logout

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/assistance-chat/AssistanceChat.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/assistance-chat/AssistanceChat.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   aiAssistantChatSelector,
@@ -34,11 +34,11 @@ import {
 import styles from './styles.module.scss'
 
 const AssistanceChat = () => {
-  const { id, messages, agreements, loading } = useSelector(
+  const { id, messages, agreements, loading } = useAppSelector(
     aiAssistantChatSelector,
   )
-  const { modules, provider } = useSelector(connectedInstanceSelector)
-  const { commandsArray: REDIS_COMMANDS_ARRAY } = useSelector(
+  const { modules, provider } = useAppSelector(connectedInstanceSelector)
+  const { commandsArray: REDIS_COMMANDS_ARRAY } = useAppSelector(
     appRedisCommandsSelector,
   )
 
@@ -46,7 +46,7 @@ const AssistanceChat = () => {
     useState<Nullable<AiChatMessage>>(null)
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!id || messages.length) return

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { filter } from 'lodash'
 import { aiChatSelector, setSelectedTab } from 'uiSrc/slices/panels/aiAssistant'
 import { AiChatType } from 'uiSrc/slices/interfaces/aiAssistant'
@@ -23,11 +23,11 @@ interface ChatWithTabs {
 }
 
 const ChatsWrapper = () => {
-  const { activeTab } = useSelector(aiChatSelector)
+  const { activeTab } = useAppSelector(aiChatSelector)
   const {
     [FeatureFlags.documentationChat]: documentationChatFeature,
     [FeatureFlags.databaseChat]: databaseChatFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const chats = filter<ChatWithTabs>(
     [
@@ -43,7 +43,7 @@ const ChatsWrapper = () => {
     ({ feature }) => !!feature?.flag,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!chats.length) return

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/ExpertChat.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/ExpertChat.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import {
   aiExpertChatSelector,
@@ -40,17 +40,17 @@ import { ChatForm, ChatHistory } from '../shared'
 import styles from './styles.module.scss'
 
 const ExpertChat = () => {
-  const { messages, agreements, loading } = useSelector(aiExpertChatSelector)
+  const { messages, agreements, loading } = useAppSelector(aiExpertChatSelector)
   const {
     name: connectedInstanceName,
     modules,
     provider,
-  } = useSelector(connectedInstanceSelector)
-  const { commandsArray: REDIS_COMMANDS_ARRAY } = useSelector(
+  } = useAppSelector(connectedInstanceSelector)
+  const { commandsArray: REDIS_COMMANDS_ARRAY } = useAppSelector(
     appRedisCommandsSelector,
   )
-  const { data: userOAuthProfile } = useSelector(oauthCloudUserSelector)
-  const freeInstances = useSelector(freeInstancesSelector) || []
+  const { data: userOAuthProfile } = useAppSelector(oauthCloudUserSelector)
+  const freeInstances = useAppSelector(freeInstancesSelector) || []
 
   const [isNoIndexes, setIsNoIndexes] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -63,7 +63,7 @@ const ExpertChat = () => {
   const isAgreementsAccepted =
     agreements.includes(instanceId) || messages.length > 0
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   useEffect(() => {

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/components/expert-chat-header/ExpertChatHeader.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/components/expert-chat-header/ExpertChatHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import cx from 'classnames'
 
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -37,7 +37,7 @@ const ExpertChatHeader = (props: Props) => {
     props
   const [isTutorialsPopoverOpen, setIsTutorialsPopoverOpen] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const handleOpenTutorials = () => {

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/markdown-message/components/code-block/CodeBlock.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/markdown-message/components/code-block/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { CodeButtonParams } from 'uiSrc/constants'
 import { sendWbQueryAction } from 'uiSrc/slices/workbench/wb-results'
 import { CodeButtonBlock } from 'uiSrc/components/markdown'
@@ -16,7 +16,7 @@ export interface Props {
 const CodeBlock = (props: Props) => {
   const { children, lang, modules, onRunCommand } = props
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleApply = (params?: CodeButtonParams, onFinish?: () => void) => {
     onRunCommand?.(children)

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/welcome-ai-assistant/WelcomeAiAssistant.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/welcome-ai-assistant/WelcomeAiAssistant.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { OAuthAgreement } from 'uiSrc/components/oauth/shared'
 
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
@@ -13,7 +13,7 @@ import { Text } from 'uiSrc/components/base/text'
 import styles from './styles.module.scss'
 
 const WelcomeAiAssistant = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleSsoClick = (accountOption: string) => {
     dispatch(setSSOFlow(OAuthSocialAction.SignIn))

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/EnablementArea.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/EnablementArea.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { IEnablementAreaItem } from 'uiSrc/slices/interfaces'
 import {
@@ -50,12 +50,12 @@ const EnablementArea = (props: Props) => {
   } = props
   const { search } = useLocation()
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const {
     manifest,
     search: searchEAContext,
     isPageOpen: isInternalPageVisible,
-  } = useSelector(explorePanelSelector)
+  } = useAppSelector(explorePanelSelector)
 
   const contextManifestPath = new URLSearchParams(searchEAContext).get('path')
 

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Code/Code.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Code/Code.tsx
@@ -1,7 +1,7 @@
 import { startCase } from 'lodash'
 import React, { useContext } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import EnablementAreaContext from 'uiSrc/pages/workbench/contexts/enablementAreaContext'
 import { CodeButtonParams } from 'uiSrc/constants'
 import { parseParams } from 'uiSrc/utils'
@@ -29,7 +29,7 @@ const Code = (props: Props) => {
     provider,
     modules = [],
     isFreeDb,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
 
   const { search } = useLocation()
   const { setScript } = useContext(EnablementAreaContext)

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Group/Group.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Group/Group.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -54,7 +54,7 @@ const Group = (props: Props) => {
     isShowFolder,
     hasChildren = true,
   } = props
-  const { deleting: deletingCustomTutorials } = useSelector(
+  const { deleting: deletingCustomTutorials } = useAppSelector(
     workbenchCustomTutorialsSelector,
   )
   const { instanceId = '' } = useParams<{ instanceId: string }>()

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/InternalPage/InternalPage.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/InternalPage/InternalPage.tsx
@@ -3,7 +3,7 @@ import JsxParser from 'react-jsx-parser'
 import cx from 'classnames'
 import { debounce } from 'lodash'
 import { useLocation, useParams } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { ChevronLeftIcon, RocketIcon } from 'uiSrc/components/base/icons'
 import { HorizontalRule, LoadingContent } from 'uiSrc/components'
@@ -83,8 +83,8 @@ const InternalPage = (props: Props) => {
   }
   const containerRef = useRef<HTMLDivElement>(null)
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { source } = useSelector(appContextCapability)
-  const { free = false } = useSelector(connectedInstanceCDSelector) ?? {}
+  const { source } = useAppSelector(appContextCapability)
+  const { free = false } = useAppSelector(connectedInstanceCDSelector) ?? {}
   const [showCapabilityPopover, setShowCapabilityPopover] = useState(false)
   const tutorialCapability = getTutorialCapability(source!)
 

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/LazyInternalPage/LazyInternalPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { startCase } from 'lodash'
 import { useHistory } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { AxiosError } from 'axios'
 
 import { getApiErrorMessage, isStatusSuccessful, Nullable } from 'uiSrc/utils'
@@ -67,17 +67,19 @@ const LazyInternalPage = ({
     itemScrollTop,
     data: contentContext,
     url,
-  } = useSelector(explorePanelSelector)
-  const { loading: tutorialsLoading } = useSelector(workbenchTutorialsSelector)
-  const { loading: customTutorialsLoading } = useSelector(
+  } = useAppSelector(explorePanelSelector)
+  const { loading: tutorialsLoading } = useAppSelector(
+    workbenchTutorialsSelector,
+  )
+  const { loading: customTutorialsLoading } = useAppSelector(
     workbenchCustomTutorialsSelector,
   )
   const { [FeatureFlags.customTutorials]: customTutorialsFeature } =
-    useSelector(appFeatureFlagsFeaturesSelector)
+    useAppSelector(appFeatureFlagsFeaturesSelector)
   const [isLoading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
   const [pageData, setPageData] = useState<IPageData>(DEFAULT_PAGE_DATA)
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const scrollTopRef = useRef(0)
 

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 import { isArray } from 'lodash'
 import { useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Group as ListGroup } from 'uiSrc/components/base/layout/list'
 import {
   EnablementAreaComponent,
@@ -69,15 +69,15 @@ const PATHS = {
 
 const Navigation = (props: Props) => {
   const { tutorials, customTutorials, isInternalPageVisible } = props
-  const { currentStep, isActive } = useSelector(appFeatureOnboardingSelector)
+  const { currentStep, isActive } = useAppSelector(appFeatureOnboardingSelector)
   const {
     [FeatureFlags.envDependent]: envDependentFeature,
     [FeatureFlags.customTutorials]: customTutorialsFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const [isCreateOpen, setIsCreateOpen] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const isCustomTutorialsOnboarding =

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementAreaWrapper.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementAreaWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { IInternalPage } from 'uiSrc/pages/workbench/contexts/enablementAreaContext'
 import { workbenchTutorialsSelector } from 'uiSrc/slices/workbench/wb-tutorials'
@@ -17,14 +17,14 @@ import EnablementArea from './EnablementArea'
 export interface Props {}
 
 const EnablementAreaWrapper = () => {
-  const { loading: loadingTutorials, items: tutorials } = useSelector(
+  const { loading: loadingTutorials, items: tutorials } = useAppSelector(
     workbenchTutorialsSelector,
   )
   const { loading: loadingCustomTutorials, items: customTutorials } =
-    useSelector(workbenchCustomTutorialsSelector)
+    useAppSelector(workbenchCustomTutorialsSelector)
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const openScript = (
     script: string,

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/LiveTimeRecommendations.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/LiveTimeRecommendations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { remove } from 'lodash'
 import styled from 'styled-components'
@@ -62,22 +62,22 @@ const FooterLink = styled.button<{
 `
 
 const LiveTimeRecommendations = () => {
-  const { provider, connectionType } = useSelector(connectedInstanceSelector)
+  const { provider, connectionType } = useAppSelector(connectedInstanceSelector)
   const {
     loading,
     data: { recommendations },
     content: recommendationsContent,
-  } = useSelector(recommendationsSelector)
+  } = useAppSelector(recommendationsSelector)
   const {
     showHiddenRecommendations: isShowHidden,
     treeViewDelimiter = [DEFAULT_DELIMITER],
-  } = useSelector(appContextDbConfig)
+  } = useAppSelector(appContextDbConfig)
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const [isShowApproveRun, setIsShowApproveRun] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const isShowHiddenDisplayed = recommendations.filter((r) => r.hide).length > 0

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { isUndefined } from 'lodash'
 
@@ -123,7 +123,7 @@ const Recommendation = ({
   recommendationsContent,
 }: IProps) => {
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const {

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/welcome-screen/WelcomeScreen.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/welcome-screen/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -24,17 +24,17 @@ import PopoverRunAnalyze from '../popover-run-analyze'
 import styles from './styles.module.scss'
 
 const NoRecommendationsScreen = () => {
-  const { provider, connectionType } = useSelector(connectedInstanceSelector)
+  const { provider, connectionType } = useAppSelector(connectedInstanceSelector)
   const {
     data: { recommendations },
-  } = useSelector(recommendationsSelector)
+  } = useAppSelector(recommendationsSelector)
   const { treeViewDelimiter = [DEFAULT_DELIMITER] } =
-    useSelector(appContextDbConfig)
+    useAppSelector(appContextDbConfig)
 
   const [isShowInfo, setIsShowInfo] = useState(false)
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const handleClickDbAnalysisLink = () => {

--- a/redisinsight/ui/src/components/triggers/copilot-trigger/CopilotTrigger.tsx
+++ b/redisinsight/ui/src/components/triggers/copilot-trigger/CopilotTrigger.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   sidePanelsSelector,
   toggleSidePanel,
@@ -11,8 +11,8 @@ import { SidePanels } from 'uiSrc/slices/interfaces/insights'
 import { CopilotWrapper, CopilotIconButton } from './CopilotTrigger.styles'
 
 const CopilotTrigger = () => {
-  const { openedPanel } = useSelector(sidePanelsSelector)
-  const dispatch = useDispatch()
+  const { openedPanel } = useAppSelector(sidePanelsSelector)
+  const dispatch = useAppDispatch()
 
   const handleClickTrigger = () => {
     dispatch(toggleSidePanel(SidePanels.AiAssistant))

--- a/redisinsight/ui/src/components/triggers/insights-trigger/InsightsTrigger.tsx
+++ b/redisinsight/ui/src/components/triggers/insights-trigger/InsightsTrigger.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
@@ -37,14 +37,14 @@ export interface Props {
 
 const InsightsTrigger = (props: Props) => {
   const { source = 'overview' } = props
-  const { openedPanel } = useSelector(sidePanelsSelector)
-  const { tabSelected } = useSelector(insightsPanelSelector)
-  const { isHighlighted } = useSelector(recommendationsSelector)
-  const { provider } = useSelector(connectedInstanceSelector)
+  const { openedPanel } = useAppSelector(sidePanelsSelector)
+  const { tabSelected } = useAppSelector(insightsPanelSelector)
+  const { isHighlighted } = useAppSelector(recommendationsSelector)
+  const { provider } = useAppSelector(connectedInstanceSelector)
 
   const isInsightsOpen = openedPanel === SidePanels.Insights
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { pathname, search } = useLocation()
   const { instanceId } = useParams<{ instanceId: string }>()
 

--- a/redisinsight/ui/src/electron/components/ConfigAzureAuth/ConfigAzureAuth.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigAzureAuth/ConfigAzureAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -14,7 +14,6 @@ import {
   addMessageNotification,
 } from 'uiSrc/slices/app/notifications'
 import { AzureAuthStatus, Pages } from 'uiSrc/constants'
-import { AppDispatch } from 'uiSrc/slices/store'
 
 interface MsalAccountInfo {
   homeAccountId: string
@@ -29,9 +28,9 @@ interface AzureAuthCallbackResponse {
 }
 
 const ConfigAzureAuth = () => {
-  const dispatch = useDispatch<AppDispatch>()
+  const dispatch = useAppDispatch()
   const history = useHistory()
-  const source = useSelector(azureAuthSourceSelector)
+  const source = useAppSelector(azureAuthSourceSelector)
   const sourceRef = useRef(source)
   sourceRef.current = source
 

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { UpdateInfo } from 'electron-updater'
 import { IParsedDeepLink } from 'uiSrc/electron/constants'
@@ -19,10 +19,10 @@ import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
 
 const ConfigElectron = () => {
   let isCheckedUpdates = false
-  const { isReleaseNotesViewed } = useSelector(appElectronInfoSelector)
-  const serverInfo = useSelector(appServerInfoSelector)
+  const { isReleaseNotesViewed } = useAppSelector(appElectronInfoSelector)
+  const serverInfo = useAppSelector(appServerInfoSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   useEffect(() => {

--- a/redisinsight/ui/src/electron/components/ConfigOAuth/ConfigOAuth.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigOAuth/ConfigOAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -38,14 +38,14 @@ import { localStorageService } from 'uiSrc/services'
 import { CustomError, OAuthSocialAction } from 'uiSrc/slices/interfaces'
 
 const ConfigOAuth = () => {
-  const { ssoFlow, isRecommendedSettings } = useSelector(cloudSelector)
+  const { ssoFlow, isRecommendedSettings } = useAppSelector(cloudSelector)
 
   const ssoFlowRef = useRef(ssoFlow)
   const isRecommendedSettingsRef = useRef(isRecommendedSettings)
   const isFlowInProgress = useRef(false)
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     window.app?.cloudOauthCallback?.(cloudOauthCallback)

--- a/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
+++ b/redisinsight/ui/src/pages/analytics/AnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams, useLocation } from 'react-router-dom'
 import { Pages } from 'uiSrc/constants'
 import {
@@ -20,10 +20,10 @@ const AnalyticsPage = ({ routes = [] }: Props) => {
   const { instanceId } = useParams<{ instanceId: string }>()
   const { pathname } = useLocation()
   const connectionType = useConnectionType()
-  const { lastViewedPage } = useSelector(appContextAnalytics)
+  const { lastViewedPage } = useAppSelector(appContextAnalytics)
   const pathnameRef = useRef<string>('')
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/pages/autodiscover-azure/azure-databases/AzureDatabasesPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-azure/azure-databases/AzureDatabasesPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Pages } from 'uiSrc/constants'
 import { setTitle } from 'uiSrc/utils'
@@ -11,7 +11,6 @@ import successMessages from 'uiSrc/components/notifications/success-messages'
 import errorMessages from 'uiSrc/components/notifications/error-messages'
 import { riToast } from 'uiSrc/components/base/display/toast'
 import { defaultContainerId } from 'uiSrc/components/notifications/constants'
-import { AppDispatch } from 'uiSrc/slices/store'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {
   ActionStatus,
@@ -80,10 +79,10 @@ const showErrorToast = (
 
 const AzureDatabasesPage = () => {
   const history = useHistory()
-  const dispatch = useDispatch<AppDispatch>()
-  const account = useSelector(azureAuthAccountSelector)
+  const dispatch = useAppDispatch()
+  const account = useAppSelector(azureAuthAccountSelector)
   const { loading, error, databases, selectedSubscription, loaded } =
-    useSelector(azureSelector)
+    useAppSelector(azureSelector)
 
   // Local state for selected databases (UI state)
   const [selectedDatabases, setSelectedDatabases] = useState<

--- a/redisinsight/ui/src/pages/autodiscover-azure/azure-manual-connection/AzureManualConnectionPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-azure/azure-manual-connection/AzureManualConnectionPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { useFormik, FormikErrors } from 'formik'
 import { isEmpty } from 'lodash'
 
@@ -19,7 +19,6 @@ import {
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { azureAuthAccountSelector } from 'uiSrc/slices/oauth/azure'
-import { AppDispatch } from 'uiSrc/slices/store'
 import { createInstanceStandaloneAction } from 'uiSrc/slices/instances/instances'
 import { Instance } from 'uiSrc/slices/interfaces'
 
@@ -51,8 +50,8 @@ const getFormErrors = (
 
 const AzureManualConnectionPage = () => {
   const history = useHistory()
-  const dispatch = useDispatch<AppDispatch>()
-  const account = useSelector(azureAuthAccountSelector)
+  const dispatch = useAppDispatch()
+  const account = useAppSelector(azureAuthAccountSelector)
 
   const [loading, setLoading] = useState(false)
 

--- a/redisinsight/ui/src/pages/autodiscover-azure/azure-subscriptions/AzureSubscriptions/AzureSubscriptions.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-azure/azure-subscriptions/AzureSubscriptions/AzureSubscriptions.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Spacer } from 'uiSrc/components/base/layout'
 import { AutodiscoveryPageTemplate } from 'uiSrc/templates'
@@ -52,7 +52,7 @@ const AzureSubscriptions = ({
   onRefresh,
   onManualConnection,
 }: Props) => {
-  const account = useSelector(azureAuthAccountSelector)
+  const account = useAppSelector(azureAuthAccountSelector)
   const [items, setItems] = useState<AzureSubscription[]>(subscriptions)
   const [selectedId, setSelectedId] = useState<string | null>(null)
 

--- a/redisinsight/ui/src/pages/autodiscover-azure/azure-subscriptions/AzureSubscriptionsPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-azure/azure-subscriptions/AzureSubscriptionsPage.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Pages } from 'uiSrc/constants'
 import { setTitle } from 'uiSrc/utils'
 import { useAzureAuth } from 'uiSrc/components/hooks/useAzureAuth'
 import { AzureSubscription } from 'uiSrc/slices/interfaces'
-import { AppDispatch } from 'uiSrc/slices/store'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {
   azureSelector,
@@ -18,9 +17,10 @@ import AzureSubscriptions from './AzureSubscriptions/AzureSubscriptions'
 
 const AzureSubscriptionsPage = () => {
   const history = useHistory()
-  const dispatch = useDispatch<AppDispatch>()
+  const dispatch = useAppDispatch()
   const { initiateLogin, account } = useAzureAuth()
-  const { loading, error, subscriptions, loaded } = useSelector(azureSelector)
+  const { loading, error, subscriptions, loaded } =
+    useAppSelector(azureSelector)
 
   useEffect(() => {
     // Redirect to home if not authenticated

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/hooks/useCloudDatabasesResultConfig.ts
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/hooks/useCloudDatabasesResultConfig.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { Pages } from 'uiSrc/constants'
@@ -15,11 +15,11 @@ import { UseCloudDatabasesResultConfigReturn } from './useCloudDatabasesResultCo
 
 export const useCloudDatabasesResultConfig =
   (): UseCloudDatabasesResultConfigReturn => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
     const history = useHistory()
 
     const { data: instancesForOptions, dataAdded: instances } =
-      useSelector(cloudSelector)
+      useAppSelector(cloudSelector)
 
     useEffect(() => {
       if (!instances.length) {

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/hooks/useCloudDatabasesConfig.ts
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/hooks/useCloudDatabasesConfig.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -24,7 +24,7 @@ import { UseCloudDatabasesConfigReturn } from './useCloudDatabasesConfig.types'
 import { colFactory } from '../utils/colFactory'
 
 export const useCloudDatabasesConfig = (): UseCloudDatabasesConfigReturn => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const {
@@ -33,8 +33,8 @@ export const useCloudDatabasesConfig = (): UseCloudDatabasesConfigReturn => {
     loading,
     data: instances,
     dataAdded: instancesAdded,
-  } = useSelector(cloudSelector)
-  const { data: userOAuthProfile } = useSelector(oauthCloudUserSelector)
+  } = useAppSelector(cloudSelector)
+  const { data: userOAuthProfile } = useAppSelector(oauthCloudUserSelector)
 
   const currentAccountIdRef = useRef(userOAuthProfile?.id)
   const ssoFlowRef = useRef(ssoFlow)

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/hooks/useCloudSubscriptionConfig.ts
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/hooks/useCloudSubscriptionConfig.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -26,7 +26,7 @@ import { UseCloudSubscriptionConfigReturn } from './useCloudSubscriptionConfig.t
 
 export const useCloudSubscriptionConfig =
   (): UseCloudSubscriptionConfigReturn => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
     const history = useHistory()
 
     const {
@@ -37,8 +37,8 @@ export const useCloudSubscriptionConfig =
       error: subscriptionsError,
       loaded: { instances: instancesLoaded },
       account: { error: accountError, data: account },
-    } = useSelector(cloudSelector)
-    const { data: userOAuthProfile } = useSelector(oauthCloudUserSelector)
+    } = useAppSelector(cloudSelector)
+    const { data: userOAuthProfile } = useAppSelector(oauthCloudUserSelector)
     const currentAccountIdRef = useRef(userOAuthProfile?.id)
     const ssoFlowRef = useRef(ssoFlow)
 

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/components/SentinelDatabasesResult/SentinelDatabasesResult.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { sentinelSelector } from 'uiSrc/slices/instances/sentinel'
 import { type ModifiedSentinelMaster } from 'uiSrc/slices/interfaces'
@@ -43,7 +43,7 @@ const SentinelDatabasesResult = ({
   const [items, setItems] = useState<ModifiedSentinelMaster[]>(masters)
   const [message, setMessage] = useState(loadingMsg)
 
-  const { loading } = useSelector(sentinelSelector)
+  const { loading } = useAppSelector(sentinelSelector)
 
   const countFailAdded = masters?.length
     ? masters.length - countSuccessAdded

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/useSentinelDatabasesResultConfig.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/useSentinelDatabasesResultConfig.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { ApiStatusCode, Pages } from 'uiSrc/constants'
@@ -72,7 +72,7 @@ export const useSentinelDatabasesResultConfig = () => {
   const [items, setItems] = useState<ModifiedSentinelMaster[]>([])
   const [isInvalid, setIsInvalid] = useState(true)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const handleBackAdding = useCallback(() => {
@@ -85,7 +85,7 @@ export const useSentinelDatabasesResultConfig = () => {
     history.push(Pages.home)
   }, [])
 
-  const { data: masters } = useSelector(sentinelSelector)
+  const { data: masters } = useAppSelector(sentinelSelector)
   const mastersLength = masters.length
 
   const countSuccessAdded = masters.filter(

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/components/SentinelDatabases/SentinelDatabases.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/components/SentinelDatabases/SentinelDatabases.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { sentinelSelector } from 'uiSrc/slices/instances/sentinel'
 import { type ModifiedSentinelMaster } from 'uiSrc/slices/interfaces'
@@ -52,7 +52,7 @@ const SentinelDatabases = ({
   const [message, setMessage] = useState(loadingMsg)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
-  const { loading } = useSelector(sentinelSelector)
+  const { loading } = useAppSelector(sentinelSelector)
 
   const handleSubmit = () => {
     onSubmit(selection)

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/useSentinelDatabasesConfig.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/useSentinelDatabasesConfig.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { map, pick } from 'lodash'
 import { useHistory } from 'react-router-dom'
 
@@ -70,10 +70,10 @@ export const getRowId = (row: ModifiedSentinelMaster) => row.id || ''
 export const useSentinelDatabasesConfig = () => {
   const [items, setItems] = useState<ModifiedSentinelMaster[]>([])
 
-  const { data: masters } = useSelector(sentinelSelector)
+  const { data: masters } = useAppSelector(sentinelSelector)
 
   const [selection, setSelection] = useState<ModifiedSentinelMaster[]>([])
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   useEffect(() => {
     if (masters.length) {

--- a/redisinsight/ui/src/pages/browser/BrowserPage.test.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import React from 'react'
 import { cloneDeep } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import {
   render,
   screen,
@@ -25,9 +25,9 @@ import {
 import BrowserPage from './BrowserPage'
 import KeyList, { Props as KeyListProps } from './components/key-list/KeyList'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('./components/key-list/KeyList', () => ({
@@ -63,7 +63,7 @@ beforeEach(() => {
 })
 
 const selectKey = (state: any, selectedKey: any, data?: any = {}) => {
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,
@@ -125,7 +125,7 @@ describe('BrowserPage', () => {
   }
 
   beforeAll(() => {
-    ;(useSelector as jest.Mock).mockImplementation(originalUseSelector)
+    ;(useAppSelector as jest.Mock).mockImplementation(originalUseSelector)
   })
 
   it.each([true, false])(

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { isNumber } from 'lodash'
 
 import {
@@ -74,23 +74,23 @@ const BrowserPage = () => {
     name: connectedInstanceName,
     db = 0,
     isFreeDb,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
   const {
     panelSizes,
     keyList: { selectedKey: selectedKeyContext },
     bulkActions: { opened: bulkActionOpenContext },
-  } = useSelector(appContextBrowser)
-  const { contextInstanceId } = useSelector(appContextSelector)
+  } = useAppSelector(appContextBrowser)
+  const { contextInstanceId } = useAppSelector(appContextSelector)
 
-  const { isBrowserFullScreen } = useSelector(keysSelector)
-  const { type } = useSelector(selectedKeyDataSelector) ?? {
+  const { isBrowserFullScreen } = useAppSelector(keysSelector)
+  const { type } = useAppSelector(selectedKeyDataSelector) ?? {
     type: '',
     length: 0,
   }
-  const { viewType, searchMode } = useSelector(keysSelector)
-  const { openedPanel: openedSidePanel } = useSelector(sidePanelsSelector)
-  const overview = useSelector(connectedInstanceOverviewSelector)
-  const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
+  const { viewType, searchMode } = useAppSelector(keysSelector)
+  const { openedPanel: openedSidePanel } = useAppSelector(sidePanelsSelector)
+  const overview = useAppSelector(connectedInstanceOverviewSelector)
+  const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isDevBrowser = featureFlags?.[FeatureFlags.devBrowser]?.flag ?? false
   const isVectorSearch =
     featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
@@ -119,7 +119,7 @@ const BrowserPage = () => {
   const isSidePanelOpenRef = useRef<boolean>(!!openedSidePanel)
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const dbName = `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)}`
   setTitle(`${dbName} - Browser`)

--- a/redisinsight/ui/src/pages/browser/components/actions/Actions.tsx
+++ b/redisinsight/ui/src/pages/browser/components/actions/Actions.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   getBasedOnViewTypeEvent,
   sendEventTelemetry,
@@ -27,9 +27,9 @@ export interface Props {
   handleBulkActionsPanel: (value: boolean) => void
 }
 const Actions = ({ handleAddKeyPanel, handleBulkActionsPanel }: Props) => {
-  const dispatch = useDispatch()
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType, search, filter } = useSelector(keysSelector)
+  const dispatch = useAppDispatch()
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType, search, filter } = useAppSelector(keysSelector)
   const openAddKeyPanel = () => {
     handleAddKeyPanel(true)
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import { shallowEqual, useDispatch, useSelector } from 'react-redux'
+import { shallowEqual } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import Divider from 'uiSrc/components/divider/Divider'
 import { KeyTypes } from 'uiSrc/constants'
@@ -56,25 +57,25 @@ export interface Props {
 }
 const AddKey = (props: Props) => {
   const { onAddKeyPanel, onClosePanel, arePanelsCollapsed } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
-  const { loading } = useSelector(addKeyStateSelector)
-  const { id: instanceId, modules = [] } = useSelector(
+  const { loading } = useAppSelector(addKeyStateSelector)
+  const { id: instanceId, modules = [] } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { version } = useSelector(connectedInstanceOverviewSelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
   // Resolve each option's optional `isEnabledSelector` against the store so
   // the option config is the single source of truth for which key types are
   // gated (e.g. behind dev/feature flags). `shallowEqual` keeps the filtered
   // array stable across renders when membership doesn't change.
-  const enabledOptions = useSelector(
+  const enabledOptions = useAppSelector(
     (state: RootState) =>
       ADD_KEY_TYPE_OPTIONS.filter(
         ({ isEnabledSelector }) => isEnabledSelector?.(state) ?? true,
       ),
     shallowEqual,
   )
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   useEffect(
     () =>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyHash/AddKeyHash.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyHash/AddKeyHash.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 import {
   isVersionHigherOrEquals,
@@ -31,10 +31,10 @@ export interface Props {
 
 const AddKeyHash = (props: Props) => {
   const { keyName = '', keyTTL, onCancel } = props
-  const { loading } = useSelector(addKeyStateSelector)
-  const { version } = useSelector(connectedInstanceOverviewSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
   const { [FeatureFlags.hashFieldExpiration]: hashFieldExpirationFeature } =
-    useSelector(appFeatureFlagsFeaturesSelector)
+    useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const [fields, setFields] = useState<IHashFieldState[]>([
     { ...INITIAL_HASH_FIELD_STATE },
@@ -47,7 +47,7 @@ const AddKeyHash = (props: Props) => {
     hashFieldExpirationFeature?.flag &&
     isVersionHigherOrEquals(version, CommandsVersions.HASH_TTL.since)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsFormValid(`${keyName}`.length > 0)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyList/AddKeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyList/AddKeyList.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addListKey } from 'uiSrc/slices/browser/keys'
@@ -30,9 +30,9 @@ const AddKeyList = (props: Props) => {
 
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
-  const { loading } = useSelector(addKeyStateSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsFormValid(keyName.length > 0)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
@@ -23,11 +23,11 @@ export interface Props {
 
 const AddKeyReJSON = (props: Props) => {
   const { keyName = '', keyTTL, onCancel } = props
-  const { loading } = useSelector(addKeyStateSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
   const [ReJSONValue, setReJSONValue] = useState<string>('')
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeySet/AddKeySet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeySet/AddKeySet.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addSetKey } from 'uiSrc/slices/browser/keys'
 
@@ -21,7 +21,7 @@ export interface Props {
 
 const AddKeySet = (props: Props) => {
   const { keyName = '', keyTTL, onCancel } = props
-  const { loading } = useSelector(addKeyStateSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
   const [members, setMembers] = useState<ISetMemberState[]>([
     { ...INITIAL_SET_MEMBER_STATE },
   ])
@@ -29,7 +29,7 @@ const AddKeySet = (props: Props) => {
   const lastAddedMemberName = useRef<HTMLInputElement>(null)
   const prevCountMembers = useRef<number>(0)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsFormValid(keyName.length > 0)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyStream/AddKeyStream.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyStream/AddKeyStream.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { addStreamKey } from 'uiSrc/slices/browser/keys'
 import {
   entryIdRegex,
@@ -36,7 +36,7 @@ const AddKeyStream = (props: Props) => {
   ])
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     const isValid = isRequiredStringsValid(keyName) && !entryIdError

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyString/AddKeyString.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyString/AddKeyString.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 
@@ -19,11 +19,11 @@ export interface Props {
 
 const AddKeyString = (props: Props) => {
   const { keyName = '', keyTTL, onCancel } = props
-  const { loading } = useSelector(addKeyStateSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
   const [value, setValue] = useState<string>('')
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsFormValid(keyName.length > 0)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyVectorSet/AddKeyVectorSet.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 
 import { stringToBuffer } from 'uiSrc/utils'
@@ -53,9 +53,9 @@ const AddKeyVectorSet = ({
   setKeyName,
   setKeyNameDisabled,
 }: Props) => {
-  const dispatch = useDispatch()
-  const { loading } = useSelector(addKeyStateSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const { loading } = useAppSelector(addKeyStateSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const [populateMode, setPopulateMode] = useState<PopulateMode>(
     PopulateMode.Manual,

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 import { Maybe, stringToBuffer, validateScoreNumber } from 'uiSrc/utils'
 import { isNaNConvertedString } from 'uiSrc/utils/numbers'
@@ -26,7 +26,7 @@ export interface Props {
 
 const AddKeyZset = (props: Props) => {
   const { keyName = '', keyTTL, onCancel } = props
-  const { loading } = useSelector(addKeyStateSelector)
+  const { loading } = useAppSelector(addKeyStateSelector)
   const [members, setMembers] = useState<IZsetMemberState[]>([
     { ...INITIAL_ZSET_MEMBER_STATE },
   ])
@@ -34,7 +34,7 @@ const AddKeyZset = (props: Props) => {
   const lastAddedMemberName = useRef<HTMLInputElement>(null)
   const prevCountMembers = useRef<number>(0)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     members.every((member) => {

--- a/redisinsight/ui/src/pages/browser/components/browser-left-panel/BrowserLeftPanelLegacy.tsx
+++ b/redisinsight/ui/src/pages/browser/components/browser-left-panel/BrowserLeftPanelLegacy.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -54,11 +54,13 @@ const BrowserLeftPanelLegacy = (props: Props) => {
   } = props
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const patternKeysState = useSelector(keysDataSelector)
-  const redisearchKeysState = useSelector(redisearchDataSelector)
+  const patternKeysState = useAppSelector(keysDataSelector)
+  const redisearchKeysState = useAppSelector(redisearchDataSelector)
   const { loading: redisearchLoading, isSearched: redisearchIsSearched } =
-    useSelector(redisearchSelector)
-  const { loading: redisearchListLoading } = useSelector(redisearchListSelector)
+    useAppSelector(redisearchSelector)
+  const { loading: redisearchListLoading } = useAppSelector(
+    redisearchListSelector,
+  )
   const {
     loading: patternLoading,
     viewType,
@@ -67,8 +69,8 @@ const BrowserLeftPanelLegacy = (props: Props) => {
     filter,
     deleting,
     error: keysError,
-  } = useSelector(keysSelector)
-  const { contextInstanceId } = useSelector(appContextSelector)
+  } = useAppSelector(keysSelector)
+  const { contextInstanceId } = useAppSelector(appContextSelector)
   const {
     keyList: {
       isDataPatternLoaded,
@@ -76,13 +78,13 @@ const BrowserLeftPanelLegacy = (props: Props) => {
       scrollPatternTopPosition,
       scrollRedisearchTopPosition,
     },
-  } = useSelector(appContextBrowser)
+  } = useAppSelector(appContextBrowser)
 
   const keyListRef = useRef<any>()
 
   const [sortedColumn, setSortedColumn] = useState<ISortedColumn | null>(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const isDataLoaded =
     searchMode === SearchMode.Pattern

--- a/redisinsight/ui/src/pages/browser/components/browser-right-panel/BrowserRightPanel.tsx
+++ b/redisinsight/ui/src/pages/browser/components/browser-right-panel/BrowserRightPanel.tsx
@@ -1,6 +1,6 @@
 import { every } from 'lodash'
 import React, { useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import AddKey from 'uiSrc/pages/browser/components/add-key/AddKey'
@@ -46,16 +46,16 @@ const BrowserRightPanel = (props: Props) => {
     closeRightPanels,
   } = props
 
-  const { isBrowserFullScreen, viewType } = useSelector(keysSelector)
+  const { isBrowserFullScreen, viewType } = useAppSelector(keysSelector)
   const { total, lastRefreshTime: keysLastRefreshTime } =
-    useSelector(keysDataSelector)
-  const { type, length } = useSelector(selectedKeyDataSelector) ?? {
+    useAppSelector(keysDataSelector)
+  const { type, length } = useAppSelector(selectedKeyDataSelector) ?? {
     type: '',
     length: 0,
   }
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const closePanel = () => {
     dispatch(toggleBrowserFullScreen(true))

--- a/redisinsight/ui/src/pages/browser/components/browser-search-panel/BrowserSearchPanel.tsx
+++ b/redisinsight/ui/src/pages/browser/components/browser-search-panel/BrowserSearchPanel.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-this-in-sfc */
 /* eslint-disable react/destructuring-assignment */
 import React, { useCallback, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import styled from 'styled-components'
 
 import {
@@ -66,13 +66,13 @@ const SwitchSearchModeButtonGroup = styled(ButtonGroup)`
 
 const BrowserSearchPanel = (props: Props) => {
   const { handleCreateIndexPanel } = props
-  const { viewType, searchMode } = useSelector(keysSelector)
-  const { id: instanceId, modules } = useSelector(connectedInstanceSelector)
+  const { viewType, searchMode } = useAppSelector(keysSelector)
+  const { id: instanceId, modules } = useAppSelector(connectedInstanceSelector)
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [isVersionModalOpen, setIsVersionModalOpen] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const hasRedisearch = isRedisearchAvailable(modules)
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { mock } from 'ts-mockito'
 import { cloneDeep } from 'lodash'
 
@@ -38,15 +38,15 @@ jest.mock('uiSrc/slices/browser/bulkActions', () => ({
   }),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 beforeEach(() => {
   const state: any = store.getState()
 
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,
@@ -75,7 +75,7 @@ describe('BulkActions', () => {
   it('bulk actions summary should render with any search', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: any) => any) =>
         callback({
           ...state,
@@ -108,7 +108,7 @@ describe('BulkActions', () => {
   it('bulk actions summary should render with any filter', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: any) => any) =>
         callback({
           ...state,
@@ -150,7 +150,7 @@ describe('BulkActions', () => {
   describe('Telemetry', () => {
     it('should call proper telemetry events', async () => {
       const state: any = store.getState()
-      ;(useSelector as jest.Mock).mockImplementation(
+      ;(useAppSelector as jest.Mock).mockImplementation(
         (callback: (arg0: any) => any) =>
           callback({
             ...state,

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -50,10 +50,10 @@ const BulkActions = (props: Props) => {
   } = props
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
-  const { filter, search } = useSelector(keysSelector)
-  const { type } = useSelector(selectedBulkActionsSelector)
+  const { filter, search } = useAppSelector(keysSelector)
+  const { type } = useAppSelector(selectedBulkActionsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsTabs/BulkActionsTabs.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActionsTabs/BulkActionsTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { BulkActionsType } from 'uiSrc/constants'
 import { selectedBulkActionsSelector } from 'uiSrc/slices/browser/bulkActions'
@@ -23,9 +23,9 @@ export interface Props {
 
 const BulkActionsTabs = (props: Props) => {
   const { onChangeType } = props
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { filter, search } = useSelector(keysSelector)
-  const { type } = useSelector(selectedBulkActionsSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { filter, search } = useAppSelector(keysSelector)
+  const { type } = useAppSelector(selectedBulkActionsSelector)
 
   const onSelectedTabChanged = (id: string) => {
     const eventData: Record<string, any> = {

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDelete.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { isUndefined } from 'lodash'
 import { Text } from 'uiSrc/components/base/text'
@@ -19,13 +19,13 @@ export interface Props {
 
 const BulkDelete = (props: Props) => {
   const { onCancel } = props
-  const { filter, search, loading } = useSelector(bulkActionsDeleteSelector)
+  const { filter, search, loading } = useAppSelector(bulkActionsDeleteSelector)
   const {
     status,
     filter: { match, type: filterType },
     progress,
     error,
-  } = useSelector(bulkActionsDeleteOverviewSelector) ?? { filter: {} }
+  } = useAppSelector(bulkActionsDeleteOverviewSelector) ?? { filter: {} }
 
   const hasSearchOrFilter = !!search || filter !== null
 

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { cloneDeep } from 'lodash'
 
 import { RootState } from 'uiSrc/slices/store'
@@ -21,15 +21,15 @@ jest.mock('uiSrc/slices/browser/bulkActions', () => ({
   }),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 beforeEach(() => {
   const state: any = store.getState()
 
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteContent/BulkDeleteContent.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { ListChildComponentProps, VariableSizeList as List } from 'react-window'
 import AutoSizer from 'react-virtualized-auto-sizer'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { MAX_BULK_ACTION_ERRORS_LENGTH } from 'uiSrc/constants'
 import { Text } from 'uiSrc/components/base/text'
@@ -12,7 +12,7 @@ const MIN_ROW_HEIGHT = 30
 const PROTRUDING_OFFSET = 2
 
 const BulkDeleteContent = () => {
-  const { errors = [] } = useSelector(bulkActionsDeleteSummarySelector) ?? {}
+  const { errors = [] } = useAppSelector(bulkActionsDeleteSummarySelector) ?? {}
 
   const outerRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<List>(null)

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteFooter/BulkDeleteFooter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { Environment } from 'apiClient'
 
@@ -45,12 +45,12 @@ export interface Props {
 const BulkDeleteFooter = (props: Props) => {
   const { onCancel } = props
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { scanned, total } = useSelector(keysDataSelector)
-  const { loading, generateReport, filter, search } = useSelector(
+  const { scanned, total } = useAppSelector(keysDataSelector)
+  const { loading, generateReport, filter, search } = useAppSelector(
     bulkActionsDeleteSelector,
   )
-  const { name, host, port } = useSelector(connectedInstanceSelector)
-  const { status } = useSelector(bulkActionsDeleteOverviewSelector) ?? {}
+  const { name, host, port } = useAppSelector(connectedInstanceSelector)
+  const { status } = useAppSelector(bulkActionsDeleteOverviewSelector) ?? {}
   const { environment } = useDatabaseEnvironment()
   const isProduction = environment === Environment.Production
   // Fall back to host:port when name is empty so the modal never matches an
@@ -60,7 +60,7 @@ const BulkDeleteFooter = (props: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false)
   const [isTypeToConfirmOpen, setIsTypeToConfirmOpen] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleDelete = () => {
     setIsPopoverOpen(false)

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { cloneDeep } from 'lodash'
 
 import { RootState } from 'uiSrc/slices/store'
@@ -21,15 +21,15 @@ jest.mock('uiSrc/slices/browser/bulkActions', () => ({
   }),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 beforeEach(() => {
   const state: any = store.getState()
 
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,
@@ -54,7 +54,7 @@ describe('BulkDeleteSummary', () => {
   it('summary should contain calculated text', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,
@@ -83,7 +83,7 @@ describe('BulkDeleteSummary', () => {
   it('should show folder key count when keyCount is set (folder delete)', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,
@@ -120,7 +120,7 @@ describe('BulkDeleteSummary', () => {
   it('should show approximate title for folder delete when scan not complete', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,
@@ -154,7 +154,7 @@ describe('BulkDeleteSummary', () => {
   it('should show N/A when scanned is 0 (avoid division by zero)', () => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { isUndefined } from 'lodash'
 
 import { numberWithSpaces, nullableNumberWithSpaces } from 'uiSrc/utils/numbers'
@@ -19,12 +19,12 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 
 const BulkDeleteSummary = () => {
   const [title, setTitle] = useState<string>('')
-  const { scanned = 0, total = 0, keys } = useSelector(keysDataSelector)
-  const { keyCount } = useSelector(bulkActionsDeleteSelector)
+  const { scanned = 0, total = 0, keys } = useAppSelector(keysDataSelector)
+  const { keyCount } = useAppSelector(bulkActionsDeleteSelector)
   const { processed, succeed, failed } =
-    useSelector(bulkActionsDeleteSummarySelector) ?? {}
+    useAppSelector(bulkActionsDeleteSummarySelector) ?? {}
   const { duration = 0, status } =
-    useSelector(bulkActionsDeleteOverviewSelector) ?? {}
+    useAppSelector(bulkActionsDeleteOverviewSelector) ?? {}
 
   // Check if this is a folder delete (keyCount is set)
   const isFolderDelete = keyCount !== null && keyCount !== undefined

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkUpload/BulkUpload.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkUpload/BulkUpload.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Nullable } from 'uiSrc/utils'
 import { BulkActionsStatus, BulkActionsType } from 'uiSrc/constants'
@@ -49,12 +49,12 @@ const MAX_FILE_SIZE = MAX_MB_FILE * 1024 * 1024
 
 const BulkUpload = (props: Props) => {
   const { onCancel } = props
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { loading, fileName } = useSelector(bulkActionsUploadSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { loading, fileName } = useAppSelector(bulkActionsUploadSelector)
   const { status, progress, duration } =
-    useSelector(bulkActionsUploadOverviewSelector) ?? {}
+    useAppSelector(bulkActionsUploadOverviewSelector) ?? {}
   const { succeed, processed, failed } =
-    useSelector(bulkActionsUploadSummarySelector) ?? {}
+    useAppSelector(bulkActionsUploadSummarySelector) ?? {}
 
   const [files, setFiles] = useState<Nullable<FileList>>(null)
   const [isInvalid, setIsInvalid] = useState<boolean>(false)
@@ -63,7 +63,7 @@ const BulkUpload = (props: Props) => {
 
   const isCompleted = status && status === BulkActionsStatus.Completed
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onStartAgain = () => {
     dispatch(setBulkUploadStartAgain())

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.tsx
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
-import { shallowEqual, useDispatch, useSelector } from 'react-redux'
+import { shallowEqual } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   SCAN_COUNT_DEFAULT,
@@ -53,14 +54,14 @@ const FilterKeyType = ({ modules }: Props) => {
   const [isVersionSupported, setIsVersionSupported] = useState<boolean>(true)
   const [isInfoPopoverOpen, setIsInfoPopoverOpen] = useState<boolean>(false)
 
-  const { version } = useSelector(connectedInstanceOverviewSelector)
-  const { filter, viewType, searchMode } = useSelector(keysSelector)
-  const features = useSelector(appFeatureFlagsFeaturesSelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
+  const { filter, viewType, searchMode } = useAppSelector(keysSelector)
+  const features = useAppSelector(appFeatureFlagsFeaturesSelector)
   // Resolve each option's optional `isEnabledSelector` against the store so
   // the option config is the single source of truth for which key types are
   // gated (e.g. behind dev/feature flags). `shallowEqual` keeps the filtered
   // array stable across renders when membership doesn't change.
-  const enabledOptions = useSelector(
+  const enabledOptions = useAppSelector(
     (state: RootState) =>
       FILTER_KEY_TYPE_OPTIONS.filter(
         ({ isEnabledSelector }) => isEnabledSelector?.(state) ?? true,
@@ -69,7 +70,7 @@ const FilterKeyType = ({ modules }: Props) => {
   )
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsVersionSupported(

--- a/redisinsight/ui/src/pages/browser/components/key-list/KeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-list/KeyList.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { debounce, findIndex, isUndefined, orderBy, reject } from 'lodash'
 
@@ -89,14 +89,14 @@ const KeyList = forwardRef((props: Props, ref) => {
   const { instanceId = '' } = useParams<{ instanceId: string }>()
   const { handler: keyFormatConvertor } = useKeyFormat()
 
-  const selectedKey = useSelector(selectedKeySelector)
-  const { nextCursor, previousResultCount } = useSelector(keysDataSelector)
-  const { isSearched, isFiltered, searchMode } = useSelector(keysSelector)
-  const { shownColumns } = useSelector(appContextDbConfig)
+  const selectedKey = useAppSelector(selectedKeySelector)
+  const { nextCursor, previousResultCount } = useAppSelector(keysDataSelector)
+  const { isSearched, isFiltered, searchMode } = useAppSelector(keysSelector)
+  const { shownColumns } = useAppSelector(appContextDbConfig)
   const visibleColumns = visibleColumnsProp ?? shownColumns
   const {
     keyList: { isNotRendered: isNotRenderedContext },
-  } = useSelector(appContextBrowser)
+  } = useAppSelector(appContextBrowser)
 
   const [, rerender] = useState({})
   const [firstDataLoaded, setFirstDataLoaded] = useState<boolean>(
@@ -111,7 +111,7 @@ const KeyList = forwardRef((props: Props, ref) => {
   const renderedRowsIndexesRef = useRef({ startIndex: 0, lastIndex: 0 })
   const sortedColumnMountedRef = useRef(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const prevIncludeSize = useRef(shownColumns?.includes(BrowserColumns.Size))
   const prevIncludeTTL = useRef(shownColumns?.includes(BrowserColumns.TTL))

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTree.tsx
@@ -4,7 +4,7 @@ import React, {
   useImperativeHandle,
   useState,
 } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
 import { escapeRegExp } from 'lodash'
@@ -67,11 +67,11 @@ const KeyTree = forwardRef((props: KeyTreeProps, ref) => {
   } = props
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const { openNodes } = useSelector(appContextBrowserTree)
+  const { openNodes } = useAppSelector(appContextBrowserTree)
   const { treeViewDelimiter, treeViewSort: sorting } =
-    useSelector(appContextDbConfig)
+    useAppSelector(appContextDbConfig)
   const { nameString: selectedKeyName = null } =
-    useSelector(selectedKeyDataSelector) ?? {}
+    useAppSelector(selectedKeyDataSelector) ?? {}
 
   const [statusOpen, setStatusOpen] = useState(openNodes)
   const [constructingTree, setConstructingTree] = useState(false)
@@ -86,7 +86,7 @@ const KeyTree = forwardRef((props: KeyTreeProps, ref) => {
   const delimiters = comboBoxToArray(treeViewDelimiter)
   const delimiterPattern = delimiters.map(escapeRegExp).join('|')
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useImperativeHandle(ref, () => ({
     handleLoadMoreItems(config: { startIndex: number; stopIndex: number }) {

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/KeyTreeSettings.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/KeyTreeSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { isEqual } from 'lodash'
 import styled from 'styled-components'
@@ -61,7 +61,7 @@ const KeyTreeSettings = ({ loading }: Props) => {
   const {
     treeViewDelimiter = [DEFAULT_DELIMITER],
     treeViewSort = DEFAULT_TREE_SORTING,
-  } = useSelector(appContextDbConfig)
+  } = useAppSelector(appContextDbConfig)
   const [sorting, setSorting] = useState<SortOrder>(treeViewSort)
   const [delimiters, setDelimiters] =
     useState<AutoTagOption[]>(treeViewDelimiter)
@@ -69,7 +69,7 @@ const KeyTreeSettings = ({ loading }: Props) => {
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setSorting(treeViewSort)

--- a/redisinsight/ui/src/pages/browser/components/keys-browser-panel/contexts/Context.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-browser-panel/contexts/Context.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -78,11 +78,13 @@ export const Context = ({
   children,
 }: Props & { children: React.ReactNode }) => {
   const { instanceId } = useParams<{ instanceId: string }>()
-  const patternKeysState = useSelector(keysDataSelector)
-  const redisearchKeysState = useSelector(redisearchDataSelector)
+  const patternKeysState = useAppSelector(keysDataSelector)
+  const redisearchKeysState = useAppSelector(redisearchDataSelector)
   const { loading: redisearchLoading, isSearched: redisearchIsSearched } =
-    useSelector(redisearchSelector)
-  const { loading: redisearchListLoading } = useSelector(redisearchListSelector)
+    useAppSelector(redisearchSelector)
+  const { loading: redisearchListLoading } = useAppSelector(
+    redisearchListSelector,
+  )
   const {
     loading: patternLoading,
     viewType,
@@ -92,13 +94,13 @@ export const Context = ({
     filter,
     deleting,
     error: keysError,
-  } = useSelector(keysSelector)
-  const { id: connectedInstanceId, keyNameFormat } = useSelector(
+  } = useAppSelector(keysSelector)
+  const { id: connectedInstanceId, keyNameFormat } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { contextInstanceId } = useSelector(appContextSelector)
-  const { shownColumns } = useSelector(appContextDbConfig)
-  const { selectedIndex } = useSelector(redisearchSelector)
+  const { contextInstanceId } = useAppSelector(appContextSelector)
+  const { shownColumns } = useAppSelector(appContextDbConfig)
+  const { selectedIndex } = useAppSelector(redisearchSelector)
   const {
     keyList: {
       isDataPatternLoaded,
@@ -106,10 +108,10 @@ export const Context = ({
       scrollPatternTopPosition,
       scrollRedisearchTopPosition,
     },
-  } = useSelector(appContextBrowser)
+  } = useAppSelector(appContextBrowser)
 
   const keyListRef = useRef<any>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { effectiveColumns, containerRef } = useResponsiveColumns(shownColumns)
 

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-this-in-sfc */
 import React, { Ref, useEffect, useRef, useState } from 'react'
 import { Environment } from 'apiClient'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { IconType, EqualIcon, FoldersIcon } from 'uiSrc/components/base/icons'
 import KeysSummary from 'uiSrc/components/keys-summary'
@@ -109,19 +109,19 @@ const KeysHeader = (props: Props) => {
     onChangeSorting,
   } = props
 
-  const { id: instanceId, keyNameFormat } = useSelector(
+  const { id: instanceId, keyNameFormat } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { viewType, searchMode, isFiltered } = useSelector(keysSelector)
-  const { shownColumns } = useSelector(appContextDbConfig)
-  const { selectedIndex } = useSelector(redisearchSelector)
+  const { viewType, searchMode, isFiltered } = useAppSelector(keysSelector)
+  const { shownColumns } = useAppSelector(appContextDbConfig)
+  const { selectedIndex } = useAppSelector(redisearchSelector)
   const { environment } = useDatabaseEnvironment()
 
   const [columnsConfigShown, setColumnsConfigShown] = useState(false)
 
   const rootDivRef: Ref<HTMLDivElement> = useRef(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (environment !== Environment.Production || !instanceId) return

--- a/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.tsx
+++ b/redisinsight/ui/src/pages/browser/components/load-sample-data/LoadSampleData.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import cx from 'classnames'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import {
@@ -32,12 +32,12 @@ const LoadSampleData = (props: Props) => {
   const { anchorClassName, onSuccess } = props
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
 
-  const { id } = useSelector(connectedInstanceSelector)
-  const { loading } = useSelector(bulkActionsSelector)
+  const { id } = useAppSelector(connectedInstanceSelector)
+  const { loading } = useAppSelector(bulkActionsSelector)
   const { environment } = useDatabaseEnvironment()
   const isProduction = environment === Environment.Production
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleSampleData = () => {
     setIsConfirmationOpen(false)

--- a/redisinsight/ui/src/pages/browser/components/make-searchable-button/MakeSearchableButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/make-searchable-button/MakeSearchableButton.spec.tsx
@@ -17,9 +17,9 @@ jest.mock('uiSrc/telemetry', () => ({
 }))
 
 const mockUseSelector = jest.fn()
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (...args: unknown[]) => mockUseSelector(...args),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: (...args: unknown[]) => mockUseSelector(...args),
 }))
 
 const mockInstanceId = faker.string.uuid()

--- a/redisinsight/ui/src/pages/browser/components/make-searchable-button/MakeSearchableButton.tsx
+++ b/redisinsight/ui/src/pages/browser/components/make-searchable-button/MakeSearchableButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { PrimaryButton } from 'uiSrc/components/base/forms/buttons'
 import { RiTooltip } from 'uiSrc/components'
@@ -18,7 +18,7 @@ export const MakeSearchableButton = ({
   keyType,
 }: MakeSearchableButtonProps) => {
   const { openMakeSearchableModal } = useMakeSearchableModal()
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const prefix = useMemo(() => extractNamespace(keyNameString), [keyNameString])
 

--- a/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.spec.tsx
@@ -29,9 +29,9 @@ jest.mock('react-router-dom', () => ({
 }))
 
 const mockUseSelector = jest.fn()
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (...args: unknown[]) => mockUseSelector(...args),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: (...args: unknown[]) => mockUseSelector(...args),
 }))
 
 const TestConsumer = () => {

--- a/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.tsx
+++ b/redisinsight/ui/src/pages/browser/components/make-searchable-modal/MakeSearchableModalProvider.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Pages } from 'uiSrc/constants'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -50,7 +50,7 @@ export const MakeSearchableModalProvider = ({
 }) => {
   const [config, setConfig] = useState<MakeSearchableModalConfig | null>(null)
   const history = useHistory()
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const openMakeSearchableModal = useCallback(
     (cfg: MakeSearchableModalConfig) => setConfig(cfg),

--- a/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
+++ b/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import NoDataImg from 'uiSrc/assets/img/no-data.svg'
 
@@ -32,10 +32,10 @@ export interface Props {
 
 const NoKeysFound = (props: Props) => {
   const { onAddKeyPanel } = props
-  const { openedPanel } = useSelector(sidePanelsSelector)
-  const { viewType } = useSelector(keysSelector)
+  const { openedPanel } = useAppSelector(sidePanelsSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const onSuccessLoadData = () => {

--- a/redisinsight/ui/src/pages/browser/components/no-keys-message/NoKeysMessage.tsx
+++ b/redisinsight/ui/src/pages/browser/components/no-keys-message/NoKeysMessage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { SearchMode } from 'uiSrc/slices/interfaces/keys'
 
 import {
@@ -26,12 +26,12 @@ const NoKeysMessage = (props: Props) => {
   const { total, scanned, onAddKeyPanel, isLoading } = props
 
   const { selectedIndex, isSearched: redisearchIsSearched } =
-    useSelector(redisearchSelector)
+    useAppSelector(redisearchSelector)
   const {
     isSearched: patternIsSearched,
     isFiltered,
     searchMode,
-  } = useSelector(keysSelector)
+  } = useAppSelector(keysSelector)
 
   if (searchMode === SearchMode.Redisearch) {
     if (!selectedIndex) {

--- a/redisinsight/ui/src/pages/browser/components/onboarding-start-popover/OnboardingStartPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/components/onboarding-start-popover/OnboardingStartPopover.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   appFeatureOnboardingSelector,
   setOnboardNextStep,
@@ -18,11 +18,11 @@ import { Row } from 'uiSrc/components/base/layout/flex'
 import styles from './styles.module.scss'
 
 const OnboardingStartPopover = () => {
-  const { id: connectedInstanceId = '' } = useSelector(
+  const { id: connectedInstanceId = '' } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { isActive, currentStep } = useSelector(appFeatureOnboardingSelector)
-  const dispatch = useDispatch()
+  const { isActive, currentStep } = useAppSelector(appFeatureOnboardingSelector)
+  const dispatch = useAppDispatch()
 
   const sendTelemetry = (action: string) =>
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
@@ -1,8 +1,7 @@
 import { merge } from 'lodash'
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
-import { useSelector } from 'react-redux'
-
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import {
   cleanup,
   clearStoreActions,
@@ -55,9 +54,9 @@ beforeEach(() => {
 
 const mockedProps = mock<Props>()
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/browser/keys', () => ({
@@ -102,7 +101,7 @@ describe('RediSearchIndexesList', () => {
   beforeEach(() => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: any) => any) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import {
@@ -53,21 +53,21 @@ export interface Props {
 const RediSearchIndexesList = (props: Props) => {
   const { onCreateIndex } = props
 
-  const { viewType, searchMode } = useSelector(keysSelector)
-  const { selectedIndex } = useSelector(redisearchSelector)
-  const { data: list = [], loading } = useSelector(redisearchListSelector)
+  const { viewType, searchMode } = useAppSelector(keysSelector)
+  const { selectedIndex } = useAppSelector(redisearchSelector)
+  const { data: list = [], loading } = useAppSelector(redisearchListSelector)
   const {
     id: instanceId,
     modules,
     host: instanceHost,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
 
   const selectedValue = selectedIndex ? bufferToString(selectedIndex) : ''
-  const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
+  const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isVectorSearch =
     featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const location = useLocation()
   const history = useHistory()
 

--- a/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 
 import * as keys from 'uiSrc/constants/keys'
@@ -53,20 +53,20 @@ const placeholders = {
 }
 
 const SearchKeyList = () => {
-  const { id } = useSelector(connectedInstanceSelector)
-  const { search, filter, viewType, searchMode } = useSelector(keysSelector)
+  const { id } = useAppSelector(connectedInstanceSelector)
+  const { search, filter, viewType, searchMode } = useAppSelector(keysSelector)
   const { search: redisearchQuery, selectedIndex } =
-    useSelector(redisearchSelector)
+    useAppSelector(redisearchSelector)
   const { data: rediSearchHistory, loading: rediSearchHistoryLoading } =
-    useSelector(redisearchHistorySelector)
-  const { data: searchHistory, loading: searchHistoryLoading } = useSelector(
+    useAppSelector(redisearchHistorySelector)
+  const { data: searchHistory, loading: searchHistoryLoading } = useAppSelector(
     keysSearchHistorySelector,
   )
 
   const [value, setValue] = useState(search || '')
   const [disableSubmit, setDisableSubmit] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (id) {

--- a/redisinsight/ui/src/pages/browser/components/use-key-format/useKeyFormat.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/use-key-format/useKeyFormat.spec.tsx
@@ -1,15 +1,15 @@
 import { renderHook } from '@testing-library/react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { KeyValueFormat } from 'uiSrc/constants'
 import { bufferToHex, bufferToString } from 'uiSrc/utils'
 import useKeyFormat from './useKeyFormat'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
-const mockUseSelector = useSelector as jest.Mock
+const mockUseSelector = useAppSelector as jest.Mock
 
 describe('useKeyFormat hook', () => {
   const renderUseKeyFormat = () => renderHook(() => useKeyFormat())

--- a/redisinsight/ui/src/pages/browser/components/use-key-format/useKeyFormat.ts
+++ b/redisinsight/ui/src/pages/browser/components/use-key-format/useKeyFormat.ts
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { KeyValueFormat } from 'uiSrc/constants'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { bufferToHex, bufferToString } from 'uiSrc/utils'
@@ -9,7 +9,7 @@ const encodingHandlerMap = {
 }
 
 const useKeyFormat = () => {
-  const { keyNameFormat } = useSelector(connectedInstanceSelector)
+  const { keyNameFormat } = useAppSelector(connectedInstanceSelector)
   const format = keyNameFormat || KeyValueFormat.Unicode
   const handler = encodingHandlerMap[format]
 

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/VirtualTree.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/VirtualTree.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { debounce, get, set } from 'lodash'
 import { TreeWalker, TreeWalkerValue, FixedSizeTree as Tree } from 'react-vtree'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import { bufferToString, Nullable, stringToBuffer } from 'uiSrc/utils'
 import { useDisposableWebworker } from 'uiSrc/services'
@@ -66,7 +66,7 @@ const VirtualTree = (props: VirtualTreeProps) => {
 
   const { result, run: runWebworker } = useDisposableWebworker(webworkerFn)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NodePublicState } from 'react-vtree/dist/es/Tree'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import * as keys from 'uiSrc/constants/keys'
 import { Maybe } from 'uiSrc/utils'
@@ -78,13 +78,13 @@ const Node = ({
   const delimiterView = delimiters.length === 1 ? delimiters[0] : '-'
   const folderPrefix = `${fullName}${delimiterView}`
 
-  const { shownColumns } = useSelector(appContextDbConfig)
+  const { shownColumns } = useAppSelector(appContextDbConfig)
   const visibleColumns = visibleColumnsProp ?? shownColumns
   const includeSize = visibleColumns.includes(BrowserColumns.Size)
   const includeTTL = visibleColumns.includes(BrowserColumns.TTL)
 
   const { openMakeSearchableModal } = useMakeSearchableModal()
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const [deletePopoverId, setDeletePopoverId] =
     useState<Maybe<string>>(undefined)

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react'
 import { isUndefined } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import {
@@ -76,22 +76,22 @@ const KeyDetailsHeader = ({
   Actions,
 }: KeyDetailsHeaderProps) => {
   const { refreshing, loading, lastRefreshTime, isRefreshDisabled } =
-    useSelector(selectedKeySelector)
+    useAppSelector(selectedKeySelector)
   const {
     type,
     length,
     name: keyBuffer,
     nameString: keyName,
-  } = useSelector(selectedKeyDataSelector) ?? initialKeyInfo
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType } = useSelector(keysSelector)
+  } = useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const isSearchableType = SEARCHABLE_KEY_TYPES.includes(type as KeyTypes)
   const { indexes, status: keyIndexedStatus } = useIsKeyIndexed(
     isSearchableType ? keyName || '' : '',
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleRefreshKey = () => {
     dispatch(refreshKey(keyBuffer!, type, undefined, length))

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-delete/KeyDetailsHeaderDelete.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Environment } from 'apiClient'
 import {
@@ -33,9 +33,9 @@ const KeyDetailsHeaderDelete = ({ onDelete }: Props) => {
     type,
     nameString: keyProp,
     name: keyBuffer,
-  } = useSelector(selectedKeyDataSelector) ?? initialKeyInfo
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType } = useSelector(keysSelector)
+  } = useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const [isPopoverDeleteOpen, setIsPopoverDeleteOpen] = useState(false)
   const { environment } = useDatabaseEnvironment()

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -38,16 +38,17 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
   const { width } = props
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { viewType } = useSelector(keysSelector)
-  const { viewFormat } = useSelector(selectedKeySelector)
-  const { type: keyType, length } = useSelector(selectedKeyDataSelector) ?? {}
-  const { value: keyValue } = useSelector(stringDataSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { viewFormat } = useAppSelector(selectedKeySelector)
+  const { type: keyType, length } =
+    useAppSelector(selectedKeyDataSelector) ?? {}
+  const { value: keyValue } = useAppSelector(stringDataSelector)
 
   const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false)
   const [typeSelected, setTypeSelected] = useState<KeyValueFormat>(viewFormat)
   const [options, setOptions] = useState<any[]>([])
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const isStringFormattingEnabled =
     keyType === KeyTypes.String

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import cx from 'classnames'
 import { isNull } from 'lodash'
 import styled from 'styled-components'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { formatLongName, isEqualBuffers, stringToBuffer } from 'uiSrc/utils'
 import InlineItemEditor from 'uiSrc/components/inline-item-editor/InlineItemEditor'
@@ -53,15 +53,15 @@ export interface Props {
 const COPY_KEY_NAME_ICON = 'copyKeyNameIcon'
 
 const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
-  const { loading } = useSelector(selectedKeySelector)
+  const { loading } = useAppSelector(selectedKeySelector)
   const {
     ttl: ttlProp,
     type,
     nameString: keyProp,
     name: keyBuffer,
-  } = useSelector(selectedKeyDataSelector) ?? initialKeyInfo
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType } = useSelector(keysSelector)
+  } = useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const [key, setKey] = useState(keyProp)
   const [keyIsEditing, setKeyIsEditing] = useState(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   LENGTH_NAMING_BY_TYPE,
@@ -23,7 +23,7 @@ export interface Props {
 
 const KeyDetailsHeaderSizeLength = ({ width }: Props) => {
   const { type, size, length, quantType, vectorDim } =
-    useSelector(selectedKeyDataSelector) ?? initialKeyInfo
+    useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
 
   const isSizeTooLarge = size === -1
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-ttl/KeyDetailsHeaderTTL.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import InlineItemEditor from 'uiSrc/components/inline-item-editor/InlineItemEditor'
 import {
@@ -26,12 +26,12 @@ export interface Props {
 }
 
 const KeyDetailsHeaderTTL = ({ onEditTTL }: Props) => {
-  const { loading } = useSelector(selectedKeySelector)
+  const { loading } = useAppSelector(selectedKeySelector)
   const {
     ttl: ttlProp,
     nameString: keyProp,
     name: keyBuffer,
-  } = useSelector(selectedKeyDataSelector) ?? initialKeyInfo
+  } = useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
 
   const [ttl, setTTL] = useState(`${ttlProp}`)
   const [ttlIsEditing, setTTLIsEditing] = useState(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { isNull } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -42,19 +42,19 @@ const KeyDetails = (props: Props) => {
   const { onCloseKey, keyProp, totalKeys, keysLastRefreshTime } = props
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
   const {
     loading,
     error = '',
     data,
     viewFormat,
-  } = useSelector(selectedKeySelector)
-  const isKeySelected = !isNull(useSelector(selectedKeyDataSelector))
-  const { type: keyType } = useSelector(selectedKeyDataSelector) ?? {
+  } = useAppSelector(selectedKeySelector)
+  const isKeySelected = !isNull(useAppSelector(selectedKeyDataSelector))
+  const { type: keyType } = useAppSelector(selectedKeyDataSelector) ?? {
     type: KeyTypes.String,
   }
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (keyProp === null) return

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/useChangeEditorType.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/useChangeEditorType.spec.ts
@@ -1,13 +1,14 @@
-import * as reactRedux from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { renderHook, act } from '@testing-library/react-hooks'
 import { EditorType } from 'uiSrc/slices/interfaces'
 import { FeatureFlags } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
 import { useChangeEditorType } from './useChangeEditorType'
 
-jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/browser/rejson', () => ({
@@ -15,8 +16,8 @@ jest.mock('uiSrc/slices/browser/rejson', () => ({
   fetchReJSON: jest.fn((key) => ({ type: 'FETCH_REJSON', payload: key })),
 }))
 
-const mockedUseDispatch = reactRedux.useDispatch as jest.Mock
-const mockedUseSelector = reactRedux.useSelector as jest.Mock
+const mockedUseDispatch = useAppDispatch as unknown as jest.Mock
+const mockedUseSelector = useAppSelector as unknown as jest.Mock
 const mockKeyName = stringToBuffer('test-key')
 
 describe('useChangeEditorType', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/useChangeEditorType.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/useChangeEditorType.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { FeatureFlags } from 'uiSrc/constants'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import {
@@ -12,13 +12,13 @@ import { EditorType } from 'uiSrc/slices/interfaces'
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 
 export const useChangeEditorType = () => {
-  const dispatch = useDispatch()
-  const { editorType, isWithinThreshold } = useSelector(rejsonSelector)
-  const { [FeatureFlags.envDependent]: envDependentFeature } = useSelector(
+  const dispatch = useAppDispatch()
+  const { editorType, isWithinThreshold } = useAppSelector(rejsonSelector)
+  const { [FeatureFlags.envDependent]: envDependentFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 
-  const selectedKey = useSelector(selectedKeyDataSelector)?.name
+  const selectedKey = useAppSelector(selectedKeyDataSelector)?.name
 
   const isTextEditorDisabled = !isWithinThreshold && !envDependentFeature?.flag
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import {
   KeyTypes,
   MODULES_KEY_TYPES_NAMES,
@@ -30,7 +30,7 @@ export interface Props extends KeyDetailsHeaderProps {
 
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
-  const isDevVectorSet = useSelector(isDevVectorSetEnabledSelector)
+  const isDevVectorSet = useAppSelector(isDevVectorSetEnabledSelector)
 
   const TypeDetails: any = {
     [KeyTypes.ZSet]: <ZSetDetails {...props} />,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/HashDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/HashDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { useParams } from 'react-router-dom'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -33,11 +33,11 @@ const HashDetails = (props: Props) => {
   const keyType = KeyTypes.Hash
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
-  const { loading } = useSelector(selectedKeySelector)
-  const { version } = useSelector(connectedInstanceOverviewSelector)
+  const { loading } = useAppSelector(selectedKeySelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
   const { instanceId } = useParams<{ instanceId: string }>()
   const { [FeatureFlags.hashFieldExpiration]: hashFieldExpirationFeature } =
-    useSelector(appFeatureFlagsFeaturesSelector)
+    useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState<boolean>(false)
   const [showTtl, setShowTtl] = useState<boolean>(true)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 import {
   keysSelector,
@@ -46,16 +46,18 @@ export interface Props {
 
 const AddHashFields = (props: Props) => {
   const { isExpireFieldsAvailable, closePanel } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [fields, setFields] = useState<IHashFieldState[]>([
     { ...INITIAL_HASH_FIELD_STATE },
   ])
-  const { loading } = useSelector(updateHashValueStateSelector)
-  const { name: selectedKey = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { loading } = useAppSelector(updateHashValueStateSelector)
+  const { name: selectedKey = '' } = useAppSelector(
+    selectedKeyDataSelector,
+  ) ?? {
     name: undefined,
   }
-  const { viewType } = useSelector(keysSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const lastAddedFieldName = useRef<HTMLInputElement>(null)
   const { requestConfirmation } = useProductionWriteConfirmation()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames'
 import React, { Ref, useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { CellMeasurerCache } from 'react-virtualized'
 
 import { isNumber, toNumber } from 'lodash'
@@ -114,19 +114,21 @@ const HashDetailsTable = (props: Props) => {
     total,
     nextCursor,
     fields: loadedFields,
-  } = useSelector(hashDataSelector)
-  const { loading } = useSelector(hashSelector)
-  const { viewType } = useSelector(keysSelector)
-  const { id: instanceId, compressor = null } = useSelector(
+  } = useAppSelector(hashDataSelector)
+  const { loading } = useAppSelector(hashSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { id: instanceId, compressor = null } = useAppSelector(
     connectedInstanceSelector,
   )
   const { viewFormat: viewFormatProp, lastRefreshTime } =
-    useSelector(selectedKeySelector)
-  const { name: key, length } = useSelector(selectedKeyDataSelector) ?? {
+    useAppSelector(selectedKeySelector)
+  const { name: key, length } = useAppSelector(selectedKeyDataSelector) ?? {
     name: '',
   }
-  const { loading: updateLoading } = useSelector(updateHashValueStateSelector)
-  const { [KeyTypes.Hash]: hashSizes } = useSelector(
+  const { loading: updateLoading } = useAppSelector(
+    updateHashValueStateSelector,
+  )
+  const { [KeyTypes.Hash]: hashSizes } = useAppSelector(
     appContextBrowserKeyDetails,
   )
 
@@ -142,7 +144,7 @@ const HashDetailsTable = (props: Props) => {
   const formattedLastIndexRef = useRef(OVER_RENDER_BUFFER_COUNT)
   const tableRef: Ref<any> = useRef(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     resetState()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/ListDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/ListDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
@@ -27,7 +27,7 @@ export interface Props extends KeyDetailsHeaderProps {
 const ListDetails = (props: Props) => {
   const keyType = KeyTypes.List
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
-  const { loading } = useSelector(selectedKeySelector)
+  const { loading } = useAppSelector(selectedKeySelector)
 
   const [isRemoveItemPanelOpen, setIsRemoveItemPanelOpen] =
     useState<boolean>(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   selectedKeyDataSelector,
@@ -59,15 +59,17 @@ const AddListElements = (props: Props) => {
   const [elements, setElements] = useState<string[]>([''])
   const [destination, setDestination] =
     useState<ListElementDestination>(TAIL_DESTINATION)
-  const { name: selectedKey = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { name: selectedKey = '' } = useAppSelector(
+    selectedKeyDataSelector,
+  ) ?? {
     name: undefined,
   }
-  const { viewType } = useSelector(keysSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const elementInput = useRef<HTMLInputElement>(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React, { Ref, useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { isNull, isNumber } from 'lodash'
 import { CellMeasurerCache } from 'react-virtualized'
@@ -89,21 +89,23 @@ const cellCache = new CellMeasurerCache({
 interface IListElement extends SetListElementResponse {}
 
 const ListDetailsTable = () => {
-  const { loading } = useSelector(listSelector)
-  const { loading: updateLoading } = useSelector(updateListValueStateSelector)
+  const { loading } = useAppSelector(listSelector)
+  const { loading: updateLoading } = useAppSelector(
+    updateListValueStateSelector,
+  )
   const {
     elements: loadedElements,
     total,
     searchedIndex,
-  } = useSelector(listDataSelector)
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  const { id: instanceId, compressor = null } = useSelector(
+  } = useAppSelector(listDataSelector)
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { id: instanceId, compressor = null } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
   const { viewFormat: viewFormatProp, lastRefreshTime } =
-    useSelector(selectedKeySelector)
-  const { [KeyTypes.List]: listSizes } = useSelector(
+    useAppSelector(selectedKeySelector)
+  const { [KeyTypes.List]: listSizes } = useAppSelector(
     appContextBrowserKeyDetails,
   )
 
@@ -116,7 +118,7 @@ const ListDetailsTable = () => {
   const formattedLastIndexRef = useRef(OVER_RENDER_BUFFER_COUNT)
   const tableRef: Ref<any> = useRef(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     resetState()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 
 import { Text } from 'uiSrc/components/base/text'
@@ -84,23 +84,23 @@ const RemoveListElements = (props: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false)
 
   const [canRemoveMultiple, setCanRemoveMultiple] = useState<boolean>(true)
-  const { name: selectedKey = '', length } = useSelector(
+  const { name: selectedKey = '', length } = useAppSelector(
     selectedKeyDataSelector,
   ) ?? {
     name: undefined,
     length: 0,
   }
-  const { version: databaseVersion = '' } = useSelector(
+  const { version: databaseVersion = '' } = useAppSelector(
     connectedInstanceOverviewSelector,
   )
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType } = useSelector(keysSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
   const { environment } = useDatabaseEnvironment()
   const bypassConfirmation = environment === Environment.Development
 
   const countInput = useRef<HTMLInputElement>(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     // ComponentDidMount

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/modules-type-details/ModulesTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/modules-type-details/ModulesTypeDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Text } from 'uiSrc/components/base/text'
 import { Pages } from 'uiSrc/constants'
@@ -19,7 +19,7 @@ const ModulesTypeDetails = ({
   onClose,
 }: ModulesTypeDetailsProps) => {
   const history = useHistory()
-  const { id: connectedInstanceId = '' } = useSelector(
+  const { id: connectedInstanceId = '' } = useAppSelector(
     connectedInstanceSelector,
   )
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/no-key-selected/NoKeySelected.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/no-key-selected/NoKeySelected.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import ExploreGuides from 'uiSrc/components/explore-guides'
 import { Nullable } from 'uiSrc/utils'
 
@@ -22,7 +22,7 @@ export interface Props {
 export const NoKeySelected = (props: Props) => {
   const { keyProp, totalKeys, onClosePanel, error, keysLastRefreshTime } = props
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleClosePanel = () => {
     dispatch(toggleBrowserFullScreen(true))

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { instance, mock } from 'ts-mockito'
 import { render } from 'uiSrc/utils/test-utils'
 import { EditorType } from 'uiSrc/slices/interfaces'
@@ -7,9 +7,13 @@ import { stringToBuffer } from 'uiSrc/utils'
 
 import { RejsonDetailsWrapper, Props } from './RejsonDetailsWrapper'
 
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
+}))
+
 jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
   connect: () => (Component: any) => Component,
 }))
 
@@ -27,8 +31,8 @@ jest.mock('uiSrc/components/hooks/useDatabaseEnvironment', () => ({
 
 const mockedProps = mock<Props>()
 
-const mockUseSelector = useSelector as jest.Mock
-const mockUseDispatch = useDispatch as jest.Mock
+const mockUseSelector = useAppSelector as jest.Mock
+const mockUseDispatch = useAppDispatch as jest.Mock
 
 type Selector = {
   name: string

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/RejsonDetailsWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { isUndefined } from 'lodash'
 
 import { rejsonDataSelector, rejsonSelector } from 'uiSrc/slices/browser/rejson'
@@ -30,16 +30,16 @@ import styles from './styles.module.scss'
 export interface Props extends KeyDetailsHeaderProps {}
 
 const RejsonDetailsWrapper = (props: Props) => {
-  const { loading, editorType } = useSelector(rejsonSelector)
-  const { data, downloaded, type, path } = useSelector(rejsonDataSelector)
+  const { loading, editorType } = useAppSelector(rejsonSelector)
+  const { data, downloaded, type, path } = useAppSelector(rejsonDataSelector)
 
   const {
     name: selectedKey,
     nameString,
     length,
-  } = useSelector(selectedKeyDataSelector) || {}
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { viewType } = useSelector(keysSelector)
+  } = useAppSelector(selectedKeyDataSelector) || {}
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mock } from 'ts-mockito'
 import { fireEvent, waitFor } from '@testing-library/react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { render, screen } from 'uiSrc/utils/test-utils'
 
 import AddItem, { Props } from './AddItem'
@@ -9,12 +9,12 @@ import { JSONErrors } from '../../constants'
 
 const mockedProps = mock<Props>()
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
-const mockUseSelector = useSelector as jest.Mock
+const mockUseSelector = useAppSelector as jest.Mock
 
 describe('AddItem', () => {
   beforeEach(() => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import styled from 'styled-components'
 
 import * as keys from 'uiSrc/constants/keys'
@@ -39,7 +39,7 @@ const AddItem = (props: Props) => {
   const [isConfirmationVisible, setIsConfirmationVisible] =
     useState<boolean>(false)
 
-  const { data } = useSelector(rejsonDataSelector)
+  const { data } = useAppSelector(rejsonDataSelector)
   const jsonContent = parseJsonData(data)
 
   const [key, setKey] = useState<string>('')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/monaco-editor/MonacoEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { monaco } from 'react-monaco-editor'
 import JSONbig from 'json-bigint'
 
@@ -30,7 +30,7 @@ const jsonToReadableString = (data: any) =>
 
 const MonacoEditor = (props: BaseProps) => {
   const { data, length, selectedKey } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
 
   const originalData = jsonToReadableString(data)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import cx from 'classnames'
 import { PlusIcon } from 'uiSrc/components/base/icons'
@@ -35,7 +35,7 @@ const RejsonDetails = (props: BaseProps) => {
 
   const [addRootKVPair, setAddRootKVPair] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleFetchVisualisationResults = (
     path: string,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-object/RejsonObject.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-object/RejsonObject.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { AxiosError } from 'axios'
 import { isTruncatedString } from 'uiSrc/utils'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
@@ -54,7 +54,7 @@ const RejsonObject = (props: JSONObjectProps) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!expandedRows?.has(path)) {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 
 import { setReJSONDataAction } from 'uiSrc/slices/browser/rejson'
@@ -49,7 +49,7 @@ const RejsonScalar = (props: JSONScalarProps) => {
   const [editing, setEditing] = useState<boolean>(false)
   const [deleting, setDeleting] = useState<string>('')
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/SetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/SetDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
@@ -24,7 +24,7 @@ const SetDetails = (props: Props) => {
   const keyType = KeyTypes.Set
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
-  const { loading } = useSelector(selectedKeySelector)
+  const { loading } = useAppSelector(selectedKeySelector)
 
   const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState<boolean>(false)
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { ColorText } from 'uiSrc/components/base/text'
 
 import {
@@ -43,16 +43,18 @@ export interface Props {
 
 const AddSetMembers = (props: Props) => {
   const { closePanel } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [members, setMembers] = useState<ISetMemberState[]>([
     { ...INITIAL_SET_MEMBER_STATE },
   ])
-  const { loading } = useSelector(setSelector)
-  const { name: selectedKey = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { loading } = useAppSelector(setSelector)
+  const { name: selectedKey = '' } = useAppSelector(
+    selectedKeyDataSelector,
+  ) ?? {
     name: undefined,
   }
-  const { viewType } = useSelector(keysSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
   const lastAddedMemberName = useRef<HTMLInputElement>(null)
   const { requestConfirmation } = useProductionWriteConfirmation()
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/set-details-table/SetDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/set-details-table/SetDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { CellMeasurerCache } from 'react-virtualized'
 
@@ -70,18 +70,19 @@ export interface Props {
 const SetDetailsTable = (props: Props) => {
   const { onRemoveKey } = props
 
-  const { loading } = useSelector(setSelector)
+  const { loading } = useAppSelector(setSelector)
   const {
     members: loadedMembers,
     total,
     nextCursor,
-  } = useSelector(setDataSelector)
-  const { length = 0, name: key } = useSelector(selectedKeyDataSelector) ?? {}
-  const { id: instanceId, compressor = null } = useSelector(
+  } = useAppSelector(setDataSelector)
+  const { length = 0, name: key } =
+    useAppSelector(selectedKeyDataSelector) ?? {}
+  const { id: instanceId, compressor = null } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { viewType } = useSelector(keysSelector)
-  const { viewFormat: viewFormatProp } = useSelector(selectedKeySelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { viewFormat: viewFormatProp } = useAppSelector(selectedKeySelector)
 
   const [match, setMatch] = useState('*')
   const [deleting, setDeleting] = useState('')
@@ -92,7 +93,7 @@ const SetDetailsTable = (props: Props) => {
 
   const formattedLastIndexRef = useRef(OVER_RENDER_BUFFER_COUNT)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setMembers(loadedMembers)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/StreamDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/StreamDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import {
@@ -31,8 +31,8 @@ const StreamDetails = (props: Props) => {
   const keyType = KeyTypes.Stream
   const { onOpenAddItemPanel, onCloseAddItemPanel } = props
 
-  const { loading } = useSelector(selectedKeySelector)
-  const { viewType: streamViewType } = useSelector(streamSelector)
+  const { loading } = useAppSelector(selectedKeySelector)
+  const { viewType: streamViewType } = useAppSelector(streamSelector)
 
   const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState<boolean>(false)
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
@@ -1,6 +1,6 @@
 import { toNumber } from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { entryIdRegex, stringToBuffer } from 'uiSrc/utils'
 import {
   keysSelector,
@@ -41,12 +41,12 @@ export interface Props {
 
 const AddStreamEntries = (props: Props) => {
   const { closePanel } = props
-  const { lastGeneratedId } = useSelector(streamDataSelector)
-  const { name: keyName = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { lastGeneratedId } = useAppSelector(streamDataSelector)
+  const { name: keyName = '' } = useAppSelector(selectedKeyDataSelector) ?? {
     name: undefined,
   }
-  const { viewType } = useSelector(keysSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { viewType } = useAppSelector(keysSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   const [entryID, setEntryID] = useState<string>('*')
   const [entryIdError, setEntryIdError] = useState('')
@@ -55,7 +55,7 @@ const AddStreamEntries = (props: Props) => {
   ])
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { lastDeliveredIDTooltipText } from 'uiSrc/constants/texts'
@@ -35,7 +35,7 @@ export interface Props {
 
 const AddStreamGroup = (props: Props) => {
   const { closePanel } = props
-  const { name: keyName = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { name: keyName = '' } = useAppSelector(selectedKeyDataSelector) ?? {
     name: undefined,
   }
 
@@ -47,7 +47,7 @@ const AddStreamGroup = (props: Props) => {
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     const isValid = !!groupName.length && !idError

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersView/ConsumersView.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersView/ConsumersView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { orderBy } from 'lodash'
 
@@ -32,8 +32,8 @@ const ConsumersView = (props: Props) => {
     noItemsMessageString = 'Your Consumer Group has no Consumers available.',
   } = props
 
-  const { loading } = useSelector(streamGroupsSelector)
-  const { name: key = '' } = useSelector(selectedKeyDataSelector) ?? {}
+  const { loading } = useAppSelector(streamGroupsSelector)
+  const { name: key = '' } = useAppSelector(selectedKeyDataSelector) ?? {}
 
   const [consumers, setConsumers] = useState(data)
   const [sortedColumnName, setSortedColumnName] = useState<string>('name')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -38,7 +38,7 @@ const actionsWidth = 50
 export interface Props {}
 
 const ConsumersViewWrapper = (props: Props) => {
-  const { name: key = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { name: key = '' } = useAppSelector(selectedKeyDataSelector) ?? {
     name: '',
   }
   const {
@@ -46,13 +46,13 @@ const ConsumersViewWrapper = (props: Props) => {
     nameString: selectedGroupNameString = '',
     lastRefreshTime,
     data: loadedConsumers = [],
-  } = useSelector(selectedGroupSelector) ?? {}
+  } = useAppSelector(selectedGroupSelector) ?? {}
 
   const isTruncatedGroupName = isTruncatedString(selectedGroupName)
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [deleting, setDeleting] = useState<string>('')
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsView/GroupsView.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsView/GroupsView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { orderBy } from 'lodash'
 
@@ -30,8 +30,8 @@ export interface Props {
 const ConsumerGroups = (props: Props) => {
   const { data = [], columns = [], onClosePopover, onSelectGroup } = props
 
-  const { loading } = useSelector(streamGroupsSelector)
-  const { name: key = '' } = useSelector(selectedKeyDataSelector) ?? {}
+  const { loading } = useAppSelector(streamGroupsSelector)
+  const { name: key = '' } = useAppSelector(selectedKeyDataSelector) ?? {}
 
   const [groups, setGroups] = useState<IConsumerGroup[]>([])
   const [sortedColumnName, setSortedColumnName] = useState<string>('name')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 import { lastDeliveredIDTooltipText } from 'uiSrc/constants/texts'
@@ -63,12 +63,12 @@ const GroupsViewWrapper = (props: Props) => {
     lastRefreshTime,
     data: loadedGroups = [],
     loading,
-  } = useSelector(streamGroupsSelector)
-  const { name: selectedKey, nameString: selectedKeyString } = useSelector(
+  } = useAppSelector(streamGroupsSelector)
+  const { name: selectedKey, nameString: selectedKeyString } = useAppSelector(
     selectedKeyDataSelector,
   ) ?? { name: '', nameString: '' }
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [groups, setGroups] = useState<IConsumerGroup[]>([])
   const [deleting, setDeleting] = useState<string>('')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, ChangeEvent } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { useFormik } from 'formik'
 import { orderBy, filter } from 'lodash'
@@ -84,8 +84,8 @@ const MessageClaimPopover = (props: Props) => {
     handleCancelClaim,
   } = props
 
-  const { data: consumers = [] } = useSelector(selectedGroupSelector) ?? {}
-  const { name: currentConsumerName, pending = 0 } = useSelector(
+  const { data: consumers = [] } = useAppSelector(selectedGroupSelector) ?? {}
+  const { name: currentConsumerName, pending = 0 } = useAppSelector(
     selectedConsumerSelector,
   ) ?? { name: '' }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessagesView/MessagesView.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessagesView/MessagesView.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 
 import { streamGroupsSelector } from 'uiSrc/slices/browser/stream'
@@ -32,8 +32,8 @@ const MessagesView = (props: Props) => {
     noItemsMessageString = 'Your Consumer has no pending messages.',
   } = props
 
-  const { loading } = useSelector(streamGroupsSelector)
-  const { name: key = '' } = useSelector(selectedKeyDataSelector) ?? {}
+  const { loading } = useAppSelector(streamGroupsSelector)
+  const { name: key = '' } = useAppSelector(selectedKeyDataSelector) ?? {}
 
   return (
     <>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessagesViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessagesViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { last, toNumber } from 'lodash'
 import cx from 'classnames'
@@ -49,15 +49,15 @@ const MessagesViewWrapper = (props: Props) => {
     data: loadedMessages = [],
     name: consumerName,
     pending = 0,
-  } = useSelector(selectedConsumerSelector) ?? {}
+  } = useAppSelector(selectedConsumerSelector) ?? {}
   const isTruncatedConsumerName = isTruncatedString(consumerName)
-  const { name: group } = useSelector(selectedGroupSelector) ?? { name: '' }
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { name: group } = useAppSelector(selectedGroupSelector) ?? { name: '' }
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const [openPopover, setOpenPopover] = useState<string>('')
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(updateSelectedKeyRefreshTime(lastRefreshTime))

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataView/StreamDataView.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataView/StreamDataView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { flatMap, isNull } from 'lodash'
 import cx from 'classnames'
 import { useParams } from 'react-router-dom'
@@ -46,13 +46,13 @@ const StreamDataView = (props: Props) => {
     onClosePopover,
     loadMoreItems,
   } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { viewType } = useSelector(keysSelector)
-  const { loading } = useSelector(streamSelector)
-  const { total, firstEntry, lastEntry } = useSelector(streamDataSelector)
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { viewType } = useAppSelector(keysSelector)
+  const { loading } = useAppSelector(streamSelector)
+  const { total, firstEntry, lastEntry } = useAppSelector(streamDataSelector)
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
 
   const [sortedColumnName, setSortedColumnName] = useState<string>('id')
   const [sortedColumnOrder, setSortedColumnOrder] = useState<SortOrder>(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { last, mergeWith, toNumber } from 'lodash'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
@@ -60,14 +60,14 @@ const StreamDataViewWrapper = (props: Props) => {
     keyName: key,
     keyNameString: keyString,
     lastRefreshTime,
-  } = useSelector(streamDataSelector)
-  const { id: instanceId, compressor = null } = useSelector(
+  } = useAppSelector(streamDataSelector)
+  const { id: instanceId, compressor = null } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { viewType: browserViewType } = useSelector(keysSelector)
-  const { viewFormat: viewFormatProp } = useSelector(selectedKeySelector)
+  const { viewType: browserViewType } = useAppSelector(keysSelector)
+  const { viewFormat: viewFormatProp } = useAppSelector(selectedKeySelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   // for Manager columns
   // const [uniqFields, setUniqFields] = useState({})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-details-body/StreamDetailsBody.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-details-body/StreamDetailsBody.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { isNull, last, toString } from 'lodash'
 import cx from 'classnames'
 
@@ -42,14 +42,14 @@ const StreamDetailsBody = (props: Props) => {
     viewType,
     loading,
     sortOrder: entryColumnSortOrder,
-  } = useSelector(streamSelector)
-  const { loading: loadingGroups } = useSelector(streamGroupsSelector)
-  const { start, end } = useSelector(streamRangeSelector)
-  const { firstEntry, lastEntry, entries } = useSelector(streamDataSelector)
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(streamSelector)
+  const { loading: loadingGroups } = useAppSelector(streamGroupsSelector)
+  const { start, end } = useAppSelector(streamRangeSelector)
+  const { firstEntry, lastEntry, entries } = useAppSelector(streamDataSelector)
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const firstEntryTimeStamp = useMemo(
     () => getTimestampFromId(firstEntry?.id),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-tabs/StreamTabs.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-tabs/StreamTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -19,16 +19,16 @@ import Tabs, { TabInfo } from 'uiSrc/components/base/layout/tabs'
 import { ConsumerGroupDto } from 'apiClient'
 
 const StreamTabs = () => {
-  const { viewType } = useSelector(streamSelector)
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { viewType } = useAppSelector(streamSelector)
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
   const { nameString: selectedGroupName = '' } =
-    useSelector(selectedGroupSelector) ?? {}
+    useAppSelector(selectedGroupSelector) ?? {}
   const { nameString: selectedConsumerName = '' } =
-    useSelector(selectedConsumerSelector) ?? {}
+    useAppSelector(selectedConsumerSelector) ?? {}
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onSuccessLoadedConsumerGroups = (data: ConsumerGroupDto[]) => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   initialKeyInfo,
@@ -44,10 +44,10 @@ const StringDetails = (props: Props) => {
   const keyType = KeyTypes.String
 
   const { loading, viewFormat: viewFormatProp } =
-    useSelector(selectedKeySelector)
-  const { length } = useSelector(selectedKeyDataSelector) ?? initialKeyInfo
-  const { value: keyValue } = useSelector(stringDataSelector)
-  const { isCompressed: isStringCompressed } = useSelector(stringSelector)
+    useAppSelector(selectedKeySelector)
+  const { length } = useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
+  const { value: keyValue } = useAppSelector(stringDataSelector)
+  const { isCompressed: isStringCompressed } = useAppSelector(stringSelector)
 
   const isTruncatedValue = isTruncatedString(keyValue)
   const isEditable =
@@ -66,7 +66,7 @@ const StringDetails = (props: Props) => {
 
   const [editItem, setEditItem] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleRefreshKey = (
     key: RedisResponseBuffer,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.spec.tsx
@@ -68,9 +68,9 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => jest.fn().mockReturnValue(() => jest.fn()),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: () => jest.fn().mockReturnValue(() => jest.fn()),
 }))
 
 beforeEach(async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   bufferToSerializedFormat,
@@ -85,16 +85,16 @@ export interface Props {
 const StringDetailsValue = (props: Props) => {
   const { isEditItem, setIsEdit, onRefresh } = props
 
-  const { compressor = null } = useSelector(connectedInstanceSelector)
-  const { loading } = useSelector(stringSelector)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { value: initialValue } = useSelector(stringDataSelector)
+  const { compressor = null } = useAppSelector(connectedInstanceSelector)
+  const { loading } = useAppSelector(stringSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { value: initialValue } = useAppSelector(stringDataSelector)
   const {
     name: key,
     type: keyType,
     length,
-  } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  const { viewFormat: viewFormatProp } = useSelector(selectedKeySelector)
+  } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { viewFormat: viewFormatProp } = useAppSelector(selectedKeySelector)
   const isTruncatedValue = isTruncatedString(initialValue)
 
   const [rows, setRows] = useState<number>(MIN_ROWS)
@@ -111,7 +111,7 @@ const StringDetailsValue = (props: Props) => {
   const textAreaRef: Ref<HTMLTextAreaElement> = useRef(null)
   const containerRef: Ref<HTMLDivElement> = useRef(null)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   useEffect(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/VectorSetDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   selectedKeyDataSelector,
@@ -45,10 +45,10 @@ export interface Props extends KeyDetailsHeaderProps {
 const VectorSetDetails = (props: Props) => {
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
-  const dispatch = useDispatch()
-  const { loading } = useSelector(selectedKeySelector)
-  const selectedKeyData = useSelector(selectedKeyDataSelector)
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const { loading } = useAppSelector(selectedKeySelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
   const keyName = selectedKeyData?.name
     ? bufferToString(selectedKeyData.name)
     : ''
@@ -136,7 +136,7 @@ const VectorSetDetails = (props: Props) => {
     total = 0,
     elements: vectorSetElements = [],
     isPaginationSupported,
-  } = useSelector(vectorSetDataSelector) ?? {}
+  } = useAppSelector(vectorSetDataSelector) ?? {}
 
   // Similarity-search results take precedence; otherwise fall back to the
   // element-list preview, which is only shown for non-paginated vector sets.

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/element-details/ElementDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
@@ -36,9 +36,9 @@ const ElementDetails = ({
   onClose,
   onDrawerDidClose,
 }: ElementDetailsProps) => {
-  const dispatch = useDispatch()
-  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const { name: keyName } = useAppSelector(selectedKeyDataSelector) ?? {}
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   const {
     isEditing,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useAddElementPanel/useAddElementPanel.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useAddElementPanel/useAddElementPanel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { bufferToString } from 'uiSrc/utils'
@@ -13,7 +13,7 @@ export const useAddElementPanel = ({
   onOpenAddItemPanel,
   onCloseAddItemPanel,
 }: UseAddElementPanelParams): UseAddElementPanelResult => {
-  const selectedKeyData = useSelector(selectedKeyDataSelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
   const keyName = bufferToString(selectedKeyData?.name)
 
   const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useAddElements/useAddElements.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useAddElements/useAddElements.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import {
@@ -14,10 +14,10 @@ import { SubmitElement } from '../../vector-set-element-form'
 import { UseAddElementsResult } from './useAddElements.types'
 
 export const useAddElements = (): UseAddElementsResult => {
-  const dispatch = useDispatch()
-  const selectedKeyData = useSelector(selectedKeyDataSelector)
-  const { loading } = useSelector(addVectorSetElementsStateSelector)
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+  const { loading } = useAppSelector(addVectorSetElementsStateSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   const submitElements = useCallback(
     (elements: SubmitElement[], onSuccess?: () => void) => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementAttributeEditor/useElementAttributeEditor.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { setVectorSetElementAttribute } from 'uiSrc/slices/browser/vectorSet'
@@ -16,9 +16,9 @@ import {
 export const useElementAttributeEditor = ({
   element,
 }: UseElementAttributeEditorParams): UseElementAttributeEditorResult => {
-  const dispatch = useDispatch()
-  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const { name: keyName } = useAppSelector(selectedKeyDataSelector) ?? {}
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   const [isEditing, setIsEditing] = useState(false)
   const [value, setValue] = useState('')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails/useElementDetails.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useElementDetails/useElementDetails.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { getVectorSetElementDetails } from 'uiSrc/slices/browser/vectorSet'
@@ -10,8 +10,8 @@ import { VectorSetActionTarget } from '../../vector-set-element-list/VectorSetEl
 import { UseElementDetailsResult } from './useElementDetails.types'
 
 export const useElementDetails = (): UseElementDetailsResult => {
-  const dispatch = useDispatch()
-  const { name: keyName } = useSelector(selectedKeyDataSelector) ?? {}
+  const dispatch = useAppDispatch()
+  const { name: keyName } = useAppSelector(selectedKeyDataSelector) ?? {}
   const keyNameString = bufferToString(keyName)
 
   const [viewedElement, setViewedElement] = useState<VectorSetElement | null>(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { debounce } from 'lodash'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
@@ -35,10 +35,10 @@ import { areKeysEqual } from './useSimilaritySearch.utils'
 const PREVIEW_DEBOUNCE_MS = 250
 
 export const useSimilaritySearch = (): UseSimilaritySearchResult => {
-  const dispatch = useDispatch()
-  const selectedKeyData = useSelector(selectedKeyDataSelector)
-  const { loading } = useSelector(vectorSetSimilaritySearchSelector)
-  const { loading: previewLoading, preview } = useSelector(
+  const dispatch = useAppDispatch()
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+  const { loading } = useAppSelector(vectorSetSimilaritySearchSelector)
+  const { loading: previewLoading, preview } = useAppSelector(
     vectorSetSimilaritySearchPreviewSelector,
   )
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearchResults/useSimilaritySearchResults.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearchResults/useSimilaritySearchResults.ts
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { vectorSetSimilaritySearchSelector } from 'uiSrc/slices/browser/vectorSet'
 import { VectorSetSimilarityMatch } from 'uiSrc/slices/interfaces/vectorSet'
@@ -9,7 +9,7 @@ const EMPTY_MATCHES: VectorSetSimilarityMatch[] = []
 
 export const useSimilaritySearchResults =
   (): UseSimilaritySearchResultsResult => {
-    const { data } = useSelector(vectorSetSimilaritySearchSelector)
+    const { data } = useAppSelector(vectorSetSimilaritySearchSelector)
 
     const matches = data?.elements ?? EMPTY_MATCHES
     const hasResults = data !== undefined

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetActionsConfig/useVectorSetActionsConfig.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetActionsConfig/useVectorSetActionsConfig.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import {
@@ -35,11 +35,11 @@ export const useVectorSetActionsConfig = ({
   onRemoveKey,
   onViewElement,
 }: UseVectorSetActionsConfigParams): UseVectorSetActionsConfigResult => {
-  const dispatch = useDispatch()
-  const selectedKeyData = useSelector(selectedKeyDataSelector)
+  const dispatch = useAppDispatch()
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
   const keyNameBuffer = selectedKeyData?.name
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
-  const { total = 0 } = useSelector(vectorSetDataSelector) ?? {}
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
+  const { total = 0 } = useAppSelector(vectorSetDataSelector) ?? {}
 
   // Element-mode prefill for the similarity-search form. Tagged with the key
   // it was set for so the prefill never crosses key boundaries — when the

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useVectorSetElementListData/useVectorSetElementListData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { PaginationState } from 'uiSrc/components/base/layout/table'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -31,19 +31,19 @@ import {
 export const useVectorSetElementListData = ({
   actionsConfig,
 }: UseVectorSetElementListDataParams): UseVectorSetElementListDataResult => {
-  const { loading } = useSelector(vectorSetSelector)
-  const { elements, nextCursor, total, isPaginationSupported } = useSelector(
+  const { loading } = useAppSelector(vectorSetSelector)
+  const { elements, nextCursor, total, isPaginationSupported } = useAppSelector(
     vectorSetDataSelector,
   )
-  const { name: key } = useSelector(selectedKeyDataSelector) ?? { name: '' }
-  const { compressor = null } = useSelector(
+  const { name: key } = useAppSelector(selectedKeyDataSelector) ?? { name: '' }
+  const { compressor = null } = useAppSelector(
     connectedInstanceSelector,
   ) as unknown as {
     compressor: Nullable<KeyValueCompressor>
   }
-  const { viewFormat } = useSelector(selectedKeySelector)
+  const { viewFormat } = useAppSelector(selectedKeySelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-syntax-help-popover/FilterSyntaxHelpPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-syntax-help-popover/FilterSyntaxHelpPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   IconButton,
@@ -20,7 +20,7 @@ const TEST_ID = 'similarity-search-filter-help'
 
 export const FilterSyntaxHelpPopover = () => {
   const [isOpen, setIsOpen] = useState(false)
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   const handleTriggerClick = () => {
     setIsOpen((prev) => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { RiTooltip } from 'uiSrc/components'
 import { ButtonGroup } from 'uiSrc/components/base/forms/button-group/ButtonGroup'
@@ -52,7 +52,7 @@ export const SimilaritySearchForm = ({
   const [state, setState] =
     useState<SimilaritySearchFormState>(initialFormState)
 
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   // React to external prefill requests: switch to Element mode and seed the
   // element input. Keyed on `nonce` so re-requesting the same value still

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/SimilaritySearchResultsTable.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -29,8 +29,8 @@ const SimilaritySearchResultsTable = memo(
     parsedAttributesCache,
     actionsConfig,
   }: SimilaritySearchResultsTableProps) => {
-    const { compressor = null } = useSelector(connectedInstanceSelector)
-    const { viewFormat } = useSelector(selectedKeySelector)
+    const { compressor = null } = useAppSelector(connectedInstanceSelector)
+    const { viewFormat } = useAppSelector(selectedKeySelector)
 
     const sortedMatches = useMemo(
       () => [...matches].sort((a, b) => b.score - a.score),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-results/components/SimilarityColumnsPopover/SimilarityColumnsPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { MIDDLE_SCREEN_RESOLUTION } from 'uiSrc/constants'
 import { RiPopover } from 'uiSrc/components/base'
@@ -34,7 +34,7 @@ const SimilarityColumnsPopover = ({
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
   const showLabel = width > MIDDLE_SCREEN_RESOLUTION
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
 
   const toggle = () => setIsOpen((v) => !v)
   const close = () => setIsOpen(false)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/ZSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/ZSetDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
@@ -25,7 +25,7 @@ const ZSetDetails = (props: Props) => {
   const keyType = KeyTypes.ZSet
   const { onRemoveKey, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
-  const { loading } = useSelector(selectedKeySelector)
+  const { loading } = useAppSelector(selectedKeySelector)
 
   const [isAddItemPanelOpen, setIsAddItemPanelOpen] = useState<boolean>(false)
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber } from 'lodash'
 
 import { stringToBuffer, validateScoreNumber } from 'uiSrc/utils'
@@ -39,13 +39,15 @@ export interface Props {
 
 const AddZsetMembers = (props: Props) => {
   const { closePanel } = props
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [isFormValid, setIsFormValid] = useState<boolean>(false)
   const [members, setMembers] = useState<IZsetMemberState[]>([
     { ...INITIAL_ZSET_MEMBER_STATE },
   ])
-  const { loading } = useSelector(updateZsetScoreStateSelector)
-  const { name: selectedKey = '' } = useSelector(selectedKeyDataSelector) ?? {
+  const { loading } = useAppSelector(updateZsetScoreStateSelector)
+  const { name: selectedKey = '' } = useAppSelector(
+    selectedKeyDataSelector,
+  ) ?? {
     name: undefined,
   }
   const lastAddedMemberName = useRef<HTMLInputElement>(null)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/zset-details-table/ZSetDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/zset-details-table/ZSetDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React, { Ref, useCallback, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { toNumber, isNumber } from 'lodash'
 import cx from 'classnames'
 import { CellMeasurerCache } from 'react-virtualized'
@@ -96,23 +96,25 @@ export interface Props {
 const ZSetDetailsTable = (props: Props) => {
   const { onRemoveKey } = props
 
-  const { loading, searching } = useSelector(zsetSelector)
-  const { loading: updateLoading } = useSelector(updateZsetScoreStateSelector)
+  const { loading, searching } = useAppSelector(zsetSelector)
+  const { loading: updateLoading } = useAppSelector(
+    updateZsetScoreStateSelector,
+  )
   const [sortedColumnOrder, setSortedColumnOrder] = useState(SortOrder.ASC)
-  const { name: key, length } = useSelector(selectedKeyDataSelector) ?? {
+  const { name: key, length } = useAppSelector(selectedKeyDataSelector) ?? {
     name: '',
   }
   const {
     total,
     nextCursor,
     members: loadedMembers,
-  } = useSelector(zsetDataSelector)
-  const { id: instanceId, compressor = null } = useSelector(
+  } = useAppSelector(zsetDataSelector)
+  const { id: instanceId, compressor = null } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { viewType } = useSelector(keysSelector)
-  const { viewFormat: viewFormatProp } = useSelector(selectedKeySelector)
-  const { [KeyTypes.ZSet]: ZSetSizes } = useSelector(
+  const { viewType } = useAppSelector(keysSelector)
+  const { viewFormat: viewFormatProp } = useAppSelector(selectedKeySelector)
+  const { [KeyTypes.ZSet]: ZSetSizes } = useAppSelector(
     appContextBrowserKeyDetails,
   )
 
@@ -124,7 +126,7 @@ const ZSetDetailsTable = (props: Props) => {
   const [expandedRows, setExpandedRows] = useState<number[]>([])
   const [viewFormat, setViewFormat] = useState(viewFormatProp)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const formattedLastIndexRef = useRef(OVER_RENDER_BUFFER_COUNT)
   const tableRef: Ref<any> = useRef(null)

--- a/redisinsight/ui/src/pages/cluster-details/ClusterDetailsPage.tsx
+++ b/redisinsight/ui/src/pages/cluster-details/ClusterDetailsPage.tsx
@@ -1,6 +1,6 @@
 import { orderBy } from 'lodash'
 import React, { useContext, useEffect, useState, useMemo } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { ClusterNodeDetails } from 'apiClient'
 
@@ -49,13 +49,13 @@ const ClusterDetailsPage = () => {
     db,
     name: connectedInstanceName,
     connectionType,
-  } = useSelector(connectedInstanceSelector)
-  const { viewTab } = useSelector(analyticsSettingsSelector)
-  const { loading, data } = useSelector(clusterDetailsSelector)
+  } = useAppSelector(connectedInstanceSelector)
+  const { viewTab } = useAppSelector(analyticsSettingsSelector)
+  const { loading, data } = useAppSelector(clusterDetailsSelector)
 
   const [isPageViewSent, setIsPageViewSent] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { theme } = useContext(ThemeContext)
 
   const dbName = `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)}`

--- a/redisinsight/ui/src/pages/cluster-details/components/cluster-details-header/ClusterDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/cluster-details/components/cluster-details-header/ClusterDetailsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { LoadingContent } from 'uiSrc/components/base/layout'
 import {
@@ -38,9 +38,9 @@ const ClusterDetailsHeader = () => {
   const {
     username = DEFAULT_USERNAME,
     connectionType = ConnectionType.Cluster,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
 
-  const { data, loading } = useSelector(clusterDetailsSelector)
+  const { data, loading } = useAppSelector(clusterDetailsSelector)
 
   const metrics: IMetrics[] = [
     {

--- a/redisinsight/ui/src/pages/database-analysis/DatabaseAnalysisPage.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/DatabaseAnalysisPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -25,22 +25,22 @@ import { formatLongName, getDbIndex, setTitle } from 'uiSrc/utils'
 import { DatabaseAnalysisPageView } from './DatabaseAnalysisPageView'
 
 export const DatabaseAnalysisPage = () => {
-  const { viewTab } = useSelector(analyticsSettingsSelector)
-  const { loading: analysisLoading, data } = useSelector(dbAnalysisSelector)
-  const { data: reports, selectedAnalysis } = useSelector(
+  const { viewTab } = useAppSelector(analyticsSettingsSelector)
+  const { loading: analysisLoading, data } = useAppSelector(dbAnalysisSelector)
+  const { data: reports, selectedAnalysis } = useAppSelector(
     dbAnalysisReportsSelector,
   )
   const {
     name: connectedInstanceName,
     db,
     provider,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const [isPageViewSent, setIsPageViewSent] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const dbName = `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)}`
   setTitle(`${dbName} - Database Analysis`)
 

--- a/redisinsight/ui/src/pages/database-analysis/DatabaseAnalysisPageView.stories.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/DatabaseAnalysisPageView.stories.tsx
@@ -8,7 +8,7 @@ import {
   loadDBAnalysisReportsSuccess,
   setSelectedAnalysisId,
 } from 'uiSrc/slices/analytics/dbAnalysis'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { fn } from 'storybook/test'
 
 const meta: Meta<typeof DatabaseAnalysisPageView> = {
@@ -36,7 +36,7 @@ export const Loading: Story = {
 }
 
 const WithDataRender = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { data, reports } = useMemo(
     () => buildDatabaseAnalysisWithTopKeys(),
     [],

--- a/redisinsight/ui/src/pages/database-analysis/components/analysis-data-view/AnalysisDataView.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/analysis-data-view/AnalysisDataView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {
@@ -23,9 +23,9 @@ import {
 import { ContentWrapper } from './AnalysisDataView.styles'
 
 const AnalysisDataView = () => {
-  const { id: instanceId, provider } = useSelector(connectedInstanceSelector)
-  const { loading, data } = useSelector(dbAnalysisSelector)
-  const { data: reports } = useSelector(dbAnalysisReportsSelector)
+  const { id: instanceId, provider } = useAppSelector(connectedInstanceSelector)
+  const { loading, data } = useAppSelector(dbAnalysisSelector)
+  const { data: reports } = useAppSelector(dbAnalysisReportsSelector)
 
   const [extrapolation, setExtrapolation] = useState(DEFAULT_EXTRAPOLATION)
 

--- a/redisinsight/ui/src/pages/database-analysis/components/analysis-ttl-view/ExpirationGroupsView.stories.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/analysis-ttl-view/ExpirationGroupsView.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import ExpirationGroupsView from './ExpirationGroupsView'
 import { setShowNoExpiryGroup } from 'uiSrc/slices/analytics/dbAnalysis'
@@ -37,7 +37,7 @@ const sampleData = {
 }
 
 const DefaultRender = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const data = useMemo(() => sampleData, [])
 

--- a/redisinsight/ui/src/pages/database-analysis/components/analysis-ttl-view/ExpirationGroupsView.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/analysis-ttl-view/ExpirationGroupsView.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import React, { useEffect, useState } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
@@ -51,11 +51,11 @@ const ExpirationGroupsView = (props: Props) => {
   const { data, loading, extrapolation, onSwitchExtrapolation } = props
   const { totalMemory, totalKeys } = data || {}
 
-  const { showNoExpiryGroup } = useSelector(dbAnalysisReportsSelector)
+  const { showNoExpiryGroup } = useAppSelector(dbAnalysisReportsSelector)
   const [expirationGroups, setExpirationGroups] = useState<BarChartData[]>([])
   const [isExtrapolated, setIsExtrapolated] = useState<boolean>(true)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsExtrapolated(extrapolation !== DEFAULT_EXTRAPOLATION)

--- a/redisinsight/ui/src/pages/database-analysis/components/data-nav-tabs/DatabaseAnalysisTabs.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/data-nav-tabs/DatabaseAnalysisTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { isNull } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { EmptyMessage } from 'uiSrc/pages/database-analysis/constants'
 import { EmptyAnalysisMessage } from 'uiSrc/pages/database-analysis/components'
 import {
@@ -34,15 +34,15 @@ export interface Props {
 const DatabaseAnalysisTabs = (props: Props) => {
   const { loading, reports, data } = props
 
-  const viewTab = useSelector(dbAnalysisViewTabSelector)
-  const { id: instanceId = '', provider } = useSelector(
+  const viewTab = useAppSelector(dbAnalysisViewTabSelector)
+  const { id: instanceId = '', provider } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { content: recommendationsContent } = useSelector(
+  const { content: recommendationsContent } = useAppSelector(
     recommendationsSelector,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const tabs: TabInfo[] = useMemo(
     () => [

--- a/redisinsight/ui/src/pages/database-analysis/components/header/Header.spec.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/header/Header.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { instance, mock } from 'ts-mockito'
 import { getDBAnalysis } from 'uiSrc/slices/analytics/dbAnalysis'
 import { RootState } from 'uiSrc/slices/store'
@@ -45,13 +45,13 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 const connectType = (state: any, connectionType: any) => {
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,

--- a/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { CaretRightIcon } from 'uiSrc/components/base/icons'
 import { createNewAnalysis } from 'uiSrc/slices/analytics/dbAnalysis'
@@ -43,12 +43,12 @@ const Header = (props: Props) => {
     analysisLoading,
   } = props
 
-  const { connectionType, provider } = useSelector(connectedInstanceSelector)
+  const { connectionType, provider } = useAppSelector(connectedInstanceSelector)
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { treeViewDelimiter = [DEFAULT_DELIMITER] } =
-    useSelector(appContextDbConfig)
+    useAppSelector(appContextDbConfig)
 
   const analysisOptions = items.map((item) => {
     const { createdAt, id, db } = item

--- a/redisinsight/ui/src/pages/database-analysis/components/recommendations-view/Recommendations.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/recommendations-view/Recommendations.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { isNull } from 'lodash'
 import cx from 'classnames'
@@ -43,16 +43,16 @@ const RecommendationContent = styled(Card)`
 `
 
 const Recommendations = () => {
-  const { data, loading } = useSelector(dbAnalysisSelector)
-  const { provider } = useSelector(connectedInstanceSelector)
-  const { content: recommendationsContent } = useSelector(
+  const { data, loading } = useAppSelector(dbAnalysisSelector)
+  const { provider } = useAppSelector(connectedInstanceSelector)
+  const { content: recommendationsContent } = useAppSelector(
     recommendationsSelector,
   )
   const { recommendations = [] } = data ?? {}
 
   const { theme } = useContext(ThemeContext)
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const handleToggle = (isOpen: boolean, id: string) =>

--- a/redisinsight/ui/src/pages/database-analysis/components/top-keys/TopKeysTable.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/top-keys/TopKeysTable.tsx
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash'
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 
 import { GroupBadge, RiTooltip } from 'uiSrc/components'
@@ -55,11 +55,11 @@ const TopKeysTable = ({
   dataTestid = '',
 }: Props) => {
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const handleRedirect = (name: string) => {
     dispatch(changeSearchMode(SearchMode.Pattern))

--- a/redisinsight/ui/src/pages/database-analysis/components/top-namespace/TopNamespace.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/top-namespace/TopNamespace.tsx
@@ -1,6 +1,6 @@
 import { isNull } from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { Pages } from 'uiSrc/constants'
 import {
@@ -44,7 +44,7 @@ const TopNamespace = (props: Props) => {
 
   const { instanceId } = useParams<{ instanceId: string }>()
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsExtrapolated(extrapolation !== DEFAULT_EXTRAPOLATION)

--- a/redisinsight/ui/src/pages/database-analysis/components/top-namespace/TopNamespacesTable.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/top-namespace/TopNamespacesTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   extrapolate,
@@ -55,11 +55,11 @@ const NameSpacesTable = ({
   dataTestid = '',
 }: Props) => {
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const { viewType } = useSelector(keysSelector)
+  const { viewType } = useAppSelector(keysSelector)
 
   const handleRedirect = (nsp: string, filter: string | null) => {
     dispatch(changeSearchMode(SearchMode.Pattern))

--- a/redisinsight/ui/src/pages/home/HomePage.tsx
+++ b/redisinsight/ui/src/pages/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   clusterSelector,
   resetDataRedisCluster,
@@ -73,12 +73,12 @@ enum OpenDialogName {
 const HomePage = () => {
   const { openDialog, setOpenDialog } = useHomePageDataProvider()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
-  const { credentials: clusterCredentials } = useSelector(clusterSelector)
-  const { credentials: cloudCredentials } = useSelector(cloudSelector)
-  const { instance: sentinelInstance } = useSelector(sentinelSelector)
-  const { action, dbConnection } = useSelector(appRedirectionSelector)
+  const { credentials: clusterCredentials } = useAppSelector(clusterSelector)
+  const { credentials: cloudCredentials } = useAppSelector(cloudSelector)
+  const { instance: sentinelInstance } = useAppSelector(sentinelSelector)
+  const { action, dbConnection } = useAppSelector(appRedirectionSelector)
 
   const {
     loading,
@@ -86,11 +86,11 @@ const HomePage = () => {
     data: instances,
     changedSuccessfully: isChangedInstance,
     deletedSuccessfully: isDeletedInstance,
-  } = useSelector(instancesSelector)
+  } = useAppSelector(instancesSelector)
 
-  const { data: editedInstance } = useSelector(editedInstanceSelector)
+  const { data: editedInstance } = useAppSelector(editedInstanceSelector)
 
-  const { contextInstanceId } = useSelector(appContextSelector)
+  const { contextInstanceId } = useAppSelector(appContextSelector)
 
   const hideDbList = instances.length === 0 && !loading && !loadingChanging
 

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useFormik } from 'formik'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router'
 import { toNumber } from 'lodash'
 
@@ -62,9 +62,9 @@ const ConnectionUrlError = (
 const AddDatabaseScreen = (props: Props) => {
   const { onSelectOption, onClose } = props
   const [isInvalid, setIsInvalid] = useState<Boolean>(false)
-  const { loadingChanging: isLoading } = useSelector(instancesSelector)
+  const { loadingChanging: isLoading } = useAppSelector(instancesSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const validate = (values: Values) => {

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.ts
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/hooks/useConnectivityOptions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { isAzureEntraIdEnabledSelector } from 'uiSrc/slices/app/features'
@@ -21,7 +21,7 @@ export const useConnectivityOptions = ({
   onClickOption,
 }: UseConnectivityOptionsProps): ConnectivityOption[] => {
   const history = useHistory()
-  const isAzureEntraIdEnabled = useSelector(isAzureEntraIdEnabledSelector)
+  const isAzureEntraIdEnabled = useAppSelector(isAzureEntraIdEnabledSelector)
   const {
     initiateLogin,
     cancelLogin,

--- a/redisinsight/ui/src/pages/home/components/cloud-connection/CloudConnectionFormWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/cloud-connection/CloudConnectionFormWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { Pages } from 'uiSrc/constants'
@@ -25,10 +25,10 @@ export interface ICloudConnectionSubmit {
 }
 
 const CloudConnectionFormWrapper = ({ onClose }: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const history = useHistory()
-  const { loading, credentials } = useSelector(cloudSelector)
+  const { loading, credentials } = useAppSelector(cloudSelector)
 
   const { setModalHeader } = useModalHeader()
 

--- a/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty } from 'lodash'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import * as keys from 'uiSrc/constants/keys'
 import { validateField } from 'uiSrc/utils/validations'
@@ -69,7 +69,7 @@ const options = [
 const CloudConnectionForm = (props: Props) => {
   const { accessKey, secretKey, onClose, onSubmit, loading } = props
 
-  const { [FeatureFlags.cloudSso]: cloudSsoFeature } = useSelector(
+  const { [FeatureFlags.cloudSso]: cloudSsoFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/pages/home/components/cluster-connection/ClusterConnectionFormWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/cluster-connection/ClusterConnectionFormWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -31,12 +31,12 @@ const ClusterConnectionFormWrapper = ({ onClose }: Props) => {
   })
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { setModalHeader } = useModalHeader()
 
   const formRef = useRef<HTMLDivElement>(null)
 
-  const { loading, credentials } = useSelector(clusterSelector)
+  const { loading, credentials } = useAppSelector(clusterSelector)
 
   useEffect(() => {
     setModalHeader(<Title size="M">Redis Software</Title>, true)

--- a/redisinsight/ui/src/pages/home/components/database-list-header/DatabaseListHeader.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-header/DatabaseListHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { isEmpty } from 'lodash'
 import cx from 'classnames'
 
@@ -39,9 +39,9 @@ export interface Props {
 }
 
 const DatabaseListHeader = ({ onAddInstance }: Props) => {
-  const { data: instances, shownColumns } = useSelector(instancesSelector)
-  const featureFlags = useSelector(appFeatureFlagsFeaturesSelector)
-  const { loading, data } = useSelector(contentSelector)
+  const { data: instances, shownColumns } = useAppSelector(instancesSelector)
+  const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
+  const { loading, data } = useAppSelector(contentSelector)
 
   const [promoData, setPromoData] = useState<ContentCreateRedis>()
 
@@ -50,7 +50,7 @@ const DatabaseListHeader = ({ onAddInstance }: Props) => {
     featureFlags
   const isShowPromoBtn = !enhancedCloudUIFeature?.flag
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (loading || !data || isEmpty(data)) {

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.spec.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { updateInstanceAction } from 'uiSrc/slices/instances/instances'
 
 import { Instance } from 'uiSrc/slices/interfaces'
 import { ManageTagsModal, ManageTagsModalProps } from './ManageTagsModal'
 
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+}))
+
 jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
   connect: () => (Component: any) => Component,
 }))
 
@@ -15,7 +19,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   updateInstanceAction: jest.fn().mockReturnValue({ type: 'UPDATE_INSTANCE' }),
 }))
 
-const mockDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
+const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
 const mockInstance: Partial<Instance> = {
   id: '1',
   name: 'Test Instance',

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.spec.tsx
@@ -19,7 +19,9 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   updateInstanceAction: jest.fn().mockReturnValue({ type: 'UPDATE_INSTANCE' }),
 }))
 
-const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
+const mockDispatch = useAppDispatch as jest.MockedFunction<
+  typeof useAppDispatch
+>
 const mockInstance: Partial<Instance> = {
   id: '1',
   name: 'Test Instance',

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/ManageTagsModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React, { useCallback, useMemo, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { PlusIcon } from 'uiSrc/components/base/icons'
 import { ConnectionProvider, Instance } from 'uiSrc/slices/interfaces'
 import { FormDialog } from 'uiSrc/components'
@@ -36,7 +36,7 @@ export const ManageTagsModal = ({
   instance,
   onClose,
 }: ManageTagsModalProps) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const editedInstanceTags = useMemo(
     () => (instance?.tags || []).map(({ key, value }) => ({ key, value })),
     [instance?.tags],

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagInputField.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagInputField.spec.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { act, fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
 import { TagInputField } from './TagInputField'
 
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
+}))
+
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
   connect: () => (Component: any) => Component,
 }))
 
-const mockSelector = useSelector as jest.MockedFunction<typeof useSelector>
+const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
 
 describe('TagInputField', () => {
   const mockOnChange = jest.fn()

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagInputField.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagInputField.spec.tsx
@@ -12,7 +12,9 @@ jest.mock('react-redux', () => ({
   connect: () => (Component: any) => Component,
 }))
 
-const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+const mockSelector = useAppSelector as jest.MockedFunction<
+  typeof useAppSelector
+>
 
 describe('TagInputField', () => {
   const mockOnChange = jest.fn()

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
-
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 
 import { Tag } from 'uiSrc/slices/interfaces/tag'
 import { TagSuggestions, TagSuggestionsProps } from './TagSuggestions'
 import { presetTagSuggestions } from './constants'
 
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
+}))
+
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
   connect: () => (Component: any) => Component,
 }))
 
-const mockSelector = useSelector as jest.MockedFunction<typeof useSelector>
+const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
 
 const mockTags: Tag[] = [
   {

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.spec.tsx
@@ -15,7 +15,9 @@ jest.mock('react-redux', () => ({
   connect: () => (Component: any) => Component,
 }))
 
-const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+const mockSelector = useAppSelector as jest.MockedFunction<
+  typeof useAppSelector
+>
 
 const mockTags: Tag[] = [
   {

--- a/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-manage-tags-modal/TagSuggestions.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { uniqBy } from 'lodash'
 import { tagsSelector } from 'uiSrc/slices/instances/tags'
 import { Text, Title } from 'uiSrc/components/base/text'
@@ -24,7 +24,7 @@ export const TagSuggestions = ({
   currentTagKeys,
   onChange,
 }: TagSuggestionsProps) => {
-  const { data: allTags } = useSelector(tagsSelector)
+  const { data: allTags } = useAppSelector(tagsSelector)
   const tagsSuggestions: SelectOption[] = useMemo(() => {
     const options = uniqBy(presetTagSuggestions.concat(allTags), (tag) =>
       targetKey ? tag.value : tag.key,

--- a/redisinsight/ui/src/pages/home/components/database-panel-dialog/DatabasePanelDialog.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-panel-dialog/DatabasePanelDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Nullable } from 'uiSrc/utils'
 import { UrlHandlingActions } from 'uiSrc/slices/interfaces/urlHandling'
@@ -57,12 +57,12 @@ const DatabasePanelDialog = (props: Props) => {
   const [modalHeader, setModalHeader] =
     useState<Nullable<React.ReactNode>>(null)
 
-  const { credentials: clusterCredentials } = useSelector(clusterSelector)
-  const { credentials: cloudCredentials } = useSelector(cloudSelector)
-  const { data: sentinelMasters } = useSelector(sentinelSelector)
-  const { action, dbConnection } = useSelector(appRedirectionSelector)
+  const { credentials: clusterCredentials } = useAppSelector(clusterSelector)
+  const { credentials: cloudCredentials } = useAppSelector(cloudSelector)
+  const { data: sentinelMasters } = useAppSelector(sentinelSelector)
+  const { action, dbConnection } = useAppSelector(appRedirectionSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (editMode) return

--- a/redisinsight/ui/src/pages/home/components/databases-list/hooks/useDatabaseListData.ts
+++ b/redisinsight/ui/src/pages/home/components/databases-list/hooks/useDatabaseListData.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback, useRef } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { Instance } from 'uiSrc/slices/interfaces'
 import { instancesSelector } from 'uiSrc/slices/instances/instances'
@@ -20,7 +20,7 @@ const useDatabaseListData = () => {
     data: instances,
     loading,
     shownColumns,
-  } = useSelector(instancesSelector)
+  } = useAppSelector(instancesSelector)
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const resetRowSelection = useCallback(() => {
     setRowSelection({})

--- a/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
+++ b/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { differenceInDays } from 'date-fns'
 
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { getTutorialCapability, Maybe } from 'uiSrc/utils'
 
 import { appContextCapability } from 'uiSrc/slices/app/context'
@@ -48,7 +48,7 @@ const LAST_CONNECTION_L = 16
 const DbStatus = (props: Props) => {
   const { id, lastConnection, createdAt, isNew, isFree } = props
 
-  const { source } = useSelector(appContextCapability)
+  const { source } = useAppSelector(appContextCapability)
   const capability = getTutorialCapability(source!)
   const isCapabilityNotShown = Boolean(isShowCapabilityTutorialPopover(isFree))
   let daysDiff = 0

--- a/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { FormikProps } from 'formik'
 
 import { BuildType } from 'uiSrc/constants/env'
@@ -55,7 +55,7 @@ const DatabaseForm = (props: Props) => {
     readyOnlyFields = [],
   } = props
 
-  const { server } = useSelector(appInfoSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
   const isShowPort =
     server?.buildType !== BuildType.RedisStack && showFields.port

--- a/redisinsight/ui/src/pages/home/components/form/DbInfo.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DbInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { capitalize } from 'lodash'
 
 import { Text } from 'uiSrc/components/base/text'
@@ -93,7 +93,7 @@ const DbInfo = (props: Props) => {
     isFromCloud,
   } = props
 
-  const { server } = useSelector(appInfoSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
   const dbInfo: DbInfoLabelValue[] = [
     {

--- a/redisinsight/ui/src/pages/home/components/form/TlsDetails.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/TlsDetails.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useState } from 'react'
 import cx from 'classnames'
 import { FormikProps } from 'formik'
 
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { Nullable, validateCertName, validateField } from 'uiSrc/utils'
 import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
 
@@ -38,7 +38,7 @@ export interface Props {
 }
 
 const TlsDetails = (props: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { formik, caCertificates, certificates } = props
   const [activeCertId, setActiveCertId] = useState<Nullable<string>>(null)
 

--- a/redisinsight/ui/src/pages/home/components/import-database/ImportDatabase.tsx
+++ b/redisinsight/ui/src/pages/home/components/import-database/ImportDatabase.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import ReactDOM from 'react-dom'
 
 import {
@@ -34,13 +34,13 @@ const MAX_FILE_SIZE = MAX_MB_FILE * 1024 * 1024
 
 const ImportDatabase = (props: Props) => {
   const { onClose } = props
-  const { loading, data, error } = useSelector(importInstancesSelector)
+  const { loading, data, error } = useAppSelector(importInstancesSelector)
   const [files, setFiles] = useState<Nullable<FileList>>(null)
   const [isInvalid, setIsInvalid] = useState<boolean>(false)
   const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true)
   const [domReady, setDomReady] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { setModalHeader } = useModalHeader()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/ManualConnectionWrapper.tsx
@@ -1,6 +1,6 @@
 import { pick, toNumber, omit } from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router'
 
 import {
@@ -76,16 +76,17 @@ const ManualConnectionWrapper = (props: Props) => {
 
   const [isCloneMode, setIsCloneMode] = useState<boolean>(false)
 
-  const { loadingChanging: loadingStandalone } = useSelector(instancesSelector)
-  const { server } = useSelector(appInfoSelector)
-  const { properties: urlHandlingProperties } = useSelector(
+  const { loadingChanging: loadingStandalone } =
+    useAppSelector(instancesSelector)
+  const { server } = useAppSelector(appInfoSelector)
+  const { properties: urlHandlingProperties } = useAppSelector(
     appRedirectionSelector,
   )
 
   const connectionType = editedInstance?.connectionType ?? DbType.STANDALONE
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(fetchCaCerts())

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionForm.tsx
@@ -2,7 +2,7 @@ import { FormikErrors, useFormik } from 'formik'
 import { isEmpty, pick } from 'lodash'
 import React, { useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import * as keys from 'uiSrc/constants/keys'
 import { resetInstanceUpdateAction } from 'uiSrc/slices/instances/instances'
@@ -89,10 +89,10 @@ const ManualConnectionForm = (props: Props) => {
     modules,
   } = formFields
 
-  const { action } = useSelector(appRedirectionSelector)
-  const { data: caCertificates } = useSelector(caCertsSelector)
-  const { data: certificates } = useSelector(clientCertsSelector)
-  const { server } = useSelector(appInfoSelector)
+  const { action } = useAppSelector(appRedirectionSelector)
+  const { data: caCertificates } = useAppSelector(caCertsSelector)
+  const { data: certificates } = useAppSelector(clientCertsSelector)
+  const { server } = useAppSelector(appInfoSelector)
 
   const [errors, setErrors] = useState<FormikErrors<DbConnectionInfo>>(
     getInitFieldsDisplayNames({ host, port, name }),
@@ -103,7 +103,7 @@ const ManualConnectionForm = (props: Props) => {
 
   const { setModalHeader } = useModalHeader()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const formRef = useRef<HTMLDivElement>(null)
 

--- a/redisinsight/ui/src/pages/home/components/search-databases-list/SearchDatabasesList.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/search-databases-list/SearchDatabasesList.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { cloneDeep } from 'lodash'
 import {
   cleanup,
@@ -15,9 +15,9 @@ import { Environment } from 'apiClient'
 import { ConnectionType, Instance } from 'uiSrc/slices/interfaces'
 import SearchDatabasesList from './SearchDatabasesList'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 let storeMock: typeof mockedStore
@@ -108,7 +108,7 @@ const mockInitialState = (
   instances: Instance[],
   options?: { selectedTags?: Set<string> },
 ) => {
-  ;(useSelector as jest.Mock).mockImplementation(
+  ;(useAppSelector as jest.Mock).mockImplementation(
     (callback: (arg0: RootState) => RootState) =>
       callback({
         ...state,

--- a/redisinsight/ui/src/pages/home/components/search-databases-list/SearchDatabasesList.tsx
+++ b/redisinsight/ui/src/pages/home/components/search-databases-list/SearchDatabasesList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   instancesSelector,
@@ -20,10 +20,10 @@ export const instanceHasTags = (
 
 const SearchDatabasesList = () => {
   const [value, setValue] = useState('')
-  const { data: instances } = useSelector(instancesSelector)
-  const { selectedTags } = useSelector(tagsSelector)
+  const { data: instances } = useAppSelector(instancesSelector)
+  const { selectedTags } = useAppSelector(tagsSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     const isInitialRender =

--- a/redisinsight/ui/src/pages/home/components/sentinel-connection/SentinelConnectionWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/sentinel-connection/SentinelConnectionWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router'
 
 import {
@@ -49,12 +49,12 @@ const SentinelConnectionWrapper = (props: Props) => {
   const { onClose } = props
   const [initialValues, setInitialValues] = useState(INITIAL_VALUES)
 
-  const { loading } = useSelector(sentinelSelector)
-  const { data: caCertificates } = useSelector(caCertsSelector)
-  const { data: certificates } = useSelector(clientCertsSelector)
+  const { loading } = useAppSelector(sentinelSelector)
+  const { data: caCertificates } = useAppSelector(caCertsSelector)
+  const { data: certificates } = useAppSelector(clientCertsSelector)
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { setModalHeader } = useModalHeader()
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/home/components/tags-cell/TagsCellHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/tags-cell/TagsCellHeader.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   fireEvent,
   render,
@@ -10,14 +9,18 @@ import {
 import { Tag } from 'uiSrc/slices/interfaces/tag'
 import { TagsCellHeader } from './TagsCellHeader'
 
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
+}))
+
 jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
   connect: () => (Component: any) => Component,
 }))
 
-const mockDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
-const mockSelector = useSelector as jest.MockedFunction<typeof useSelector>
+const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
+const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
 
 const mockTags: Tag[] = [
   {

--- a/redisinsight/ui/src/pages/home/components/tags-cell/TagsCellHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/tags-cell/TagsCellHeader.spec.tsx
@@ -19,8 +19,12 @@ jest.mock('react-redux', () => ({
   connect: () => (Component: any) => Component,
 }))
 
-const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
-const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+const mockDispatch = useAppDispatch as jest.MockedFunction<
+  typeof useAppDispatch
+>
+const mockSelector = useAppSelector as jest.MockedFunction<
+  typeof useAppSelector
+>
 
 const mockTags: Tag[] = [
   {

--- a/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.spec.ts
+++ b/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.spec.ts
@@ -27,8 +27,12 @@ const mockTags: Tag[] = [
   },
 ]
 
-const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
-const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+const mockDispatch = useAppDispatch as jest.MockedFunction<
+  typeof useAppDispatch
+>
+const mockSelector = useAppSelector as jest.MockedFunction<
+  typeof useAppSelector
+>
 
 describe('useFilterTags', () => {
   beforeEach(() => {

--- a/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.spec.ts
+++ b/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.spec.ts
@@ -1,13 +1,13 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import { useDispatch, useSelector } from 'react-redux'
-
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { setSelectedTags } from 'uiSrc/slices/instances/tags'
 import { Tag } from 'uiSrc/slices/interfaces/tag'
 import { useFilterTags } from './useFilterTags'
 
-jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
 }))
 
 const mockTags: Tag[] = [
@@ -27,8 +27,8 @@ const mockTags: Tag[] = [
   },
 ]
 
-const mockDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
-const mockSelector = useSelector as jest.MockedFunction<typeof useSelector>
+const mockDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
+const mockSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
 
 describe('useFilterTags', () => {
   beforeEach(() => {

--- a/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.ts
+++ b/redisinsight/ui/src/pages/home/components/tags-cell/useFilterTags.ts
@@ -1,10 +1,10 @@
 import { useState, useCallback, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { tagsSelector, setSelectedTags } from 'uiSrc/slices/instances/tags'
 
 export const useFilterTags = () => {
-  const dispatch = useDispatch()
-  const { data: tagsData, selectedTags } = useSelector(tagsSelector)
+  const dispatch = useAppDispatch()
+  const { data: tagsData, selectedTags } = useAppSelector(tagsSelector)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [tagSearch, setTagSearch] = useState('')
 

--- a/redisinsight/ui/src/pages/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
@@ -44,18 +44,18 @@ const InstancePage = ({ routes = [] }: Props) => {
   const [isShouldChildrenRerender, setIsShouldChildrenRerender] =
     useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { pathname } = useLocation()
 
-  const { data: rdiInstances } = useSelector(rdiInstancesSelector)
-  const { data: dbInstances } = useSelector(dbInstancesSelector)
+  const { data: rdiInstances } = useAppSelector(rdiInstancesSelector)
+  const { data: dbInstances } = useAppSelector(dbInstancesSelector)
 
   const { instanceId: connectionInstanceId } = useParams<{
     instanceId: string
   }>()
-  const { contextInstanceId } = useSelector(appContextSelector)
-  const connectivityError = useSelector(appConnectivityError)
-  const { [FeatureFlags.envDependent]: envDependent } = useSelector(
+  const { contextInstanceId } = useAppSelector(appContextSelector)
+  const connectivityError = useAppSelector(appConnectivityError)
+  const { [FeatureFlags.envDependent]: envDependent } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/pages/instance/instanceConnectionLost.tsx
+++ b/redisinsight/ui/src/pages/instance/instanceConnectionLost.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { appConnectivity, retryConnection } from 'uiSrc/slices/app/connectivity'
 import ConnectivityError from 'uiSrc/components/connectivity-error/ConnectivityError'
 
 const InstanceConnectionLost = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId: connectionInstanceId } = useParams<{
     instanceId: string
   }>()
-  const { error, loading: isLoading } = useSelector(appConnectivity)
+  const { error, loading: isLoading } = useAppSelector(appConnectivity)
 
   const onRetry = () => {
     dispatch(retryConnection(connectionInstanceId))

--- a/redisinsight/ui/src/pages/not-found-error/NotFoundErrorPage.tsx
+++ b/redisinsight/ui/src/pages/not-found-error/NotFoundErrorPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import { getConfig } from 'uiSrc/config'
@@ -15,7 +15,7 @@ import styles from './styles.module.scss'
 const NotFoundErrorPage = () => {
   const history = useHistory()
   const config = getConfig()
-  const { [FeatureFlags.envDependent]: envDependentFeature } = useSelector(
+  const { [FeatureFlags.envDependent]: envDependentFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/pages/pub-sub/PubSubPage.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/PubSubPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -27,14 +27,14 @@ const FooterPanel = styled(FlexItem)`
 `
 
 const PubSubPage = () => {
-  const { name: connectedInstanceName, db } = useSelector(
+  const { name: connectedInstanceName, db } = useAppSelector(
     connectedInstanceSelector,
   )
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const [isPageViewSent, setIsPageViewSent] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const dbName = `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)}`
   setTitle(`${dbName} - Pub/Sub`)

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.stories.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import { PubSubMessage } from 'uiSrc/slices/interfaces/pubsub'
 import {
@@ -29,7 +29,7 @@ interface MessagesListTableArgs {
 const SAMPLE_MESSAGES: PubSubMessage[] = PubSubMessageFactory.buildList(20)
 
 const StorePopulator = ({ args }: { args: MessagesListTableArgs }) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(setInitialPubSubState())

--- a/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/messages-list/MessagesListTable/MessagesListTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { connectedInstanceOverviewSelector } from 'uiSrc/slices/instances/instances'
 import { pubSubSelector } from 'uiSrc/slices/pubsub/pubsub'
@@ -29,9 +29,9 @@ const MessagesListTable = () => {
     messages = [],
     isSubscribed,
     subscriptions,
-  } = useSelector(pubSubSelector)
+  } = useAppSelector(pubSubSelector)
   const connectionType = useConnectionType()
-  const { version } = useSelector(connectedInstanceOverviewSelector)
+  const { version } = useAppSelector(connectedInstanceOverviewSelector)
 
   const channels = subscriptions?.length
     ? subscriptions.map((sub) => sub.channel).join(' ')

--- a/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   appContextPubSub,
@@ -25,7 +25,7 @@ const HIDE_BADGE_TIMER = 3000
 
 const PublishMessage = () => {
   const { channel: channelContext, message: messageContext } =
-    useSelector(appContextPubSub)
+    useAppSelector(appContextPubSub)
   const connectionType = useConnectionType()
 
   const [channel, setChannel] = useState<string>(channelContext)
@@ -37,7 +37,7 @@ const PublishMessage = () => {
   const timeOutRef = useRef<NodeJS.Timeout>()
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/pages/pub-sub/components/subscribe-form/SubscribeForm.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/subscribe-form/SubscribeForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   DeleteIcon,
@@ -24,10 +24,10 @@ import * as S from './SubscribeForm.styles'
 import SubscribeInformation from '../subscribe-information'
 
 const SubscribeForm = (props: SubscribeFormProps) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { isSubscribed, subscriptions, loading, count } =
-    useSelector(pubSubSelector)
+    useAppSelector(pubSubSelector)
   const { instanceId = '' } = useParams<{ instanceId: string }>()
 
   const [channels, setChannels] = useState(() =>

--- a/redisinsight/ui/src/pages/rdi/home/RdiPage.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/RdiPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import cx from 'classnames'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
@@ -48,7 +48,7 @@ const RdiPage = () => {
     setIsConnectionFormOpen,
   } = useRdiPageDataProvider()
 
-  const { data, loading, loadingChanging } = useSelector(instancesSelector)
+  const { data, loading, loadingChanging } = useAppSelector(instancesSelector)
   const hideInstancesList = data.length === 0 && !loading && !loadingChanging
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/hooks/useRdiInstancesListData.ts
+++ b/redisinsight/ui/src/pages/rdi/home/components/rdi-instances-list/hooks/useRdiInstancesListData.ts
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState, useCallback } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
   ColumnDef,
@@ -20,7 +20,7 @@ const useRdiInstancesListData = () => {
     data: instances,
     loading,
     shownColumns,
-  } = useSelector(instancesSelector)
+  } = useAppSelector(instancesSelector)
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const resetRowSelection = useCallback(() => setRowSelection({}), [])

--- a/redisinsight/ui/src/pages/rdi/home/header/RdiHeader.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/header/RdiHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { instancesSelector, setShownColumns } from 'uiSrc/slices/rdi/instances'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
@@ -16,8 +16,8 @@ export interface Props {
 }
 
 const RdiHeader = ({ onRdiInstanceClick }: Props) => {
-  const dispatch = useDispatch()
-  const { data: instances, shownColumns } = useSelector(instancesSelector)
+  const dispatch = useAppDispatch()
+  const { data: instances, shownColumns } = useAppSelector(instancesSelector)
 
   if (instances.length === 0) {
     return null

--- a/redisinsight/ui/src/pages/rdi/home/search/SearchRdiList.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/search/SearchRdiList.spec.tsx
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash'
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
 import { loadInstancesSuccess } from 'uiSrc/slices/rdi/instances'
 import { RootState, store } from 'uiSrc/slices/store'
@@ -16,9 +16,9 @@ import {
 
 import SearchRdiList from './SearchRdiList'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/telemetry', () => ({
@@ -57,7 +57,7 @@ describe('SearchRdiList', () => {
     storeMock.clearActions()
 
     const state: RootState = store.getState()
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/pages/rdi/home/search/SearchRdiList.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/search/SearchRdiList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { SearchInput } from 'uiSrc/components/base/inputs'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
@@ -11,9 +11,9 @@ import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
 import { lastConnectionFormat } from 'uiSrc/utils'
 
 const SearchRdiList = () => {
-  const { data: instances } = useSelector(instancesSelector)
+  const { data: instances } = useAppSelector(instancesSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onQueryChange = (term: string) => {
     const value = term?.toLowerCase()

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 import {
   appContextSelector,
@@ -33,15 +33,15 @@ export interface Props {
 }
 
 const RdiInstancePage = ({ routes = [] }: Props) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   const { pathname } = useLocation()
   const { privateRdiRoutes } = useNavigation()
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const { lastPage, contextRdiInstanceId } = useSelector(appContextSelector)
-  const { data: rdiInstances } = useSelector(rdiInstancesSelector)
-  const { data: dbInstances } = useSelector(dbInstancesSelector)
+  const { lastPage, contextRdiInstanceId } = useAppSelector(appContextSelector)
+  const { data: rdiInstances } = useAppSelector(rdiInstancesSelector)
+  const { data: dbInstances } = useAppSelector(dbInstancesSelector)
 
   const [actions, setActions] = useState<Nullable<React.ReactNode>>(null)
 

--- a/redisinsight/ui/src/pages/rdi/instance/components/download/Download.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/download/Download.tsx
@@ -1,7 +1,7 @@
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { rdiPipelineSelector } from 'uiSrc/slices/rdi/pipeline'
@@ -13,7 +13,7 @@ export interface Props {
 }
 
 const Download = ({ onClose, trigger }: Props) => {
-  const { loading, jobs, config } = useSelector(rdiPipelineSelector)
+  const { loading, jobs, config } = useAppSelector(rdiPipelineSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/RdiPipelineHeader.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/RdiPipelineHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -24,10 +24,10 @@ const StyledRdiPipelineHeader = styled(Row)`
 const RdiPipelineHeader = () => {
   const [headerLoading, setHeaderLoading] = useState(true)
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const { data: statusData, error: statusError } = useSelector(
+  const { data: statusData, error: statusError } = useAppSelector(
     rdiPipelineStatusSelector,
   )
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   let intervalId: any
 

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -32,10 +32,10 @@ const DeployPipelineButton = ({ loading, disabled, onReset }: Props) => {
   const [resetPipeline, setResetPipeline] = useState(false)
 
   const { config, jobs, resetChecked, isPipelineValid } =
-    useSelector(rdiPipelineSelector)
+    useAppSelector(rdiPipelineSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const updatePipelineStatus = () => {
     if (resetChecked) {

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import styled from 'styled-components'
@@ -48,14 +48,14 @@ const PipelineActions = ({ pipelineStatus }: Props) => {
     jobNameSchema,
     config,
     jobs,
-  } = useSelector(rdiPipelineSelector)
-  const { loading: actionLoading, action } = useSelector(
+  } = useAppSelector(rdiPipelineSelector)
+  const { loading: actionLoading, action } = useAppSelector(
     rdiPipelineActionSelector,
   )
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!jobs && !config) {

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { IRoute, PageNames, Pages } from 'uiSrc/constants'
 import { connectedInstanceSelector } from 'uiSrc/slices/rdi/instances'
@@ -33,15 +33,15 @@ export interface Props {
 
 const PipelineManagementPage = ({ routes = [] }: Props) => {
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const { lastViewedPage } = useSelector(appContextPipelineManagement)
-  const { name: connectedRdiInstanceName } = useSelector(
+  const { lastViewedPage } = useAppSelector(appContextPipelineManagement)
+  const { name: connectedRdiInstanceName } = useAppSelector(
     connectedInstanceSelector,
   )
 
   const pathnameRef = useRef<string>('')
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { pathname } = useLocation()
 
   const rdiInstanceName = formatLongName(connectedRdiInstanceName, 33, 0, '...')

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/download-from-server-modal/DownloadFromServerModal.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/download-from-server-modal/DownloadFromServerModal.tsx
@@ -6,7 +6,7 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   fetchRdiPipeline,
   rdiPipelineSelector,
@@ -22,13 +22,13 @@ export interface Props {
 const DownloadFromServerModal = (props: Props) => {
   const { trigger, onClose } = props
 
-  const { loading, data } = useSelector(rdiPipelineSelector)
+  const { loading, data } = useAppSelector(rdiPipelineSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
   const [isOpen, setIsOpen] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleDownloadFromServer = () => {
     dispatch(

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/dry-run-job-commands/DryRunJobCommands.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/dry-run-job-commands/DryRunJobCommands.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import parse from 'html-react-parser'
 import { monaco } from 'react-monaco-editor'
 
@@ -14,7 +14,7 @@ export interface Props {
 const NO_COMMANDS_MESSAGE = 'No Redis commands provided by the server.'
 
 const DryRunJobCommands = ({ target }: Props) => {
-  const { results } = useSelector(rdiDryRunJobSelector)
+  const { results } = useAppSelector(rdiDryRunJobSelector)
   const [commands, setCommands] = useState<string>('')
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/dry-run-job-transformations/DryRunJobTransformations.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/dry-run-job-transformations/DryRunJobTransformations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { rdiDryRunJobSelector } from 'uiSrc/slices/rdi/dryRun'
 import MonacoJson from 'uiSrc/components/monaco-editor/components/monaco-json'
@@ -8,7 +8,7 @@ const NO_TRANSFORMATION_MESSAGE =
   'No transformation results provided by the server.'
 
 const DryRunJobTransformations = () => {
-  const { results } = useSelector(rdiDryRunJobSelector)
+  const { results } = useAppSelector(rdiDryRunJobSelector)
 
   const [transformations, setTransformations] = useState('')
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-panel/Panel.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-panel/Panel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { isArray, upperFirst } from 'lodash'
 
@@ -56,7 +56,8 @@ const getTargetOption = (value: string) => {
 
 const DryRunJobPanel = (props: Props) => {
   const { job, name, onClose } = props
-  const { loading: isDryRunning, results } = useSelector(rdiDryRunJobSelector)
+  const { loading: isDryRunning, results } =
+    useAppSelector(rdiDryRunJobSelector)
 
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false)
   const [selectedTab, changeSelectedTab] = useState<PipelineJobsTabs>(
@@ -67,7 +68,7 @@ const DryRunJobPanel = (props: Props) => {
   const [targetOptions, setTargetOptions] = useState<RiSelectOption[]>([])
   const [selectedTarget, setSelectedTarget] = useState<string>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { Nullable } from 'uiSrc/utils'
@@ -33,7 +33,7 @@ const Navigation = () => {
   const history = useHistory()
   const { pathname } = useLocation()
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const { loading } = useSelector(rdiPipelineSelector)
+  const { loading } = useAppSelector(rdiPipelineSelector)
 
   const onSelectedTabChanged = (id: string | RdiPipelineTabs) => {
     if (id === RdiPipelineTabs.Config) {

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/cards/hooks/useConfigurationState.ts
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/cards/hooks/useConfigurationState.ts
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { rdiPipelineSelector } from 'uiSrc/slices/rdi/pipeline'
 
 export interface ConfigurationState {
@@ -8,7 +8,8 @@ export interface ConfigurationState {
 }
 
 export const useConfigurationState = (): ConfigurationState => {
-  const { changes, configValidationErrors } = useSelector(rdiPipelineSelector)
+  const { changes, configValidationErrors } =
+    useAppSelector(rdiPipelineSelector)
 
   const hasChanges = !!changes.config
   const isValid = configValidationErrors.length === 0

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/cards/jobs/JobsCard.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/cards/jobs/JobsCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 import { isNumber } from 'lodash'
 
@@ -44,9 +44,9 @@ const JobsCard = (props: JobsCardProps) => {
     jobs = [],
     jobsValidationErrors,
     changes = {},
-  } = useSelector(rdiPipelineSelector)
+  } = useAppSelector(rdiPipelineSelector)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
   const { pathname } = useLocation()
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/source-pipeline-dialog/SourcePipelineModal.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/source-pipeline-dialog/SourcePipelineModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { keys } from '@elastic/eui'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -34,11 +34,11 @@ const SourcePipelineDialog = () => {
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
-  const { isOpenDialog } = useSelector(appContextPipelineManagement)
+  const { isOpenDialog } = useAppSelector(appContextPipelineManagement)
 
   // data is original response from the server converted to config and jobs yaml strings
   // since by default it is null we can determine if it was fetched and it's content
-  const { data } = useSelector(rdiPipelineSelector)
+  const { data } = useAppSelector(rdiPipelineSelector)
 
   useEffect(() => {
     if (data?.config === '') {
@@ -46,7 +46,7 @@ const SourcePipelineDialog = () => {
     }
   }, [data])
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onSelect = (option: PipelineSourceOptions) => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-button/TemplateButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-button/TemplateButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { useParams } from 'react-router-dom'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
@@ -19,9 +19,9 @@ export interface TemplateButtonProps {
 }
 
 const TemplateButton = ({ setFieldValue, value }: TemplateButtonProps) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const { loading, data } = useSelector(rdiPipelineStrategiesSelector)
+  const { loading, data } = useAppSelector(rdiPipelineStrategiesSelector)
 
   const templateOption = data?.length
     ? data.find((strategy) => strategy.strategy === INGEST_OPTION)?.strategy ||

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -58,7 +58,7 @@ export const getTooltipContent = (
 const TemplateForm = (props: Props) => {
   const { closePopover, setTemplate, source, value } = props
 
-  const { loading, data } = useSelector(rdiPipelineStrategiesSelector)
+  const { loading, data } = useAppSelector(rdiPipelineStrategiesSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
@@ -70,7 +70,7 @@ const TemplateForm = (props: Props) => {
   const [selectedDbType, setSelectedDbType] = useState<string>('')
   const [selectedPipelineType, setSelectedPipelineType] = useState<string>('')
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleCancel = () => {
     closePopover()

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-popover/TemplatePopover.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-popover/TemplatePopover.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import TemplateForm from 'uiSrc/pages/rdi/pipeline-management/components/template-form'
@@ -32,7 +32,7 @@ const TemplatePopover = (props: Props) => {
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleOpen = () => {
     dispatch(fetchPipelineStrategies(rdiInstanceId))

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-panel/TestConnectionsPanel.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/test-connections-panel/TestConnectionsPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import TestConnectionsLog from 'uiSrc/pages/rdi/pipeline-management/components/test-connections-log'
 import { rdiTestConnectionsSelector } from 'uiSrc/slices/rdi/testConnections'
@@ -46,7 +46,7 @@ export interface Props {
 
 const TestConnectionsPanel = (props: Props) => {
   const { onClose } = props
-  const { loading, results } = useSelector(rdiTestConnectionsSelector)
+  const { loading, results } = useAppSelector(rdiTestConnectionsSelector)
 
   if (loading) {
     return (

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/upload-modal/UploadModal.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/upload-modal/UploadModal.tsx
@@ -1,6 +1,6 @@
 import JSZip from 'jszip'
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { validatePipeline } from 'uiSrc/components/yaml-validator'
@@ -39,11 +39,11 @@ const UploadModal = (props: Props) => {
     schema,
     monacoJobsSchema,
     jobNameSchema,
-  } = useSelector(rdiPipelineSelector)
+  } = useAppSelector(rdiPipelineSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const validateZip = (zip: JSZip) => {
     // check if config.yaml exists

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { get, throttle } from 'lodash'
 
@@ -51,14 +51,14 @@ const Config = () => {
     schema,
     data,
     config,
-  } = useSelector(rdiPipelineSelector)
-  const { loading: testingConnections } = useSelector(
+  } = useAppSelector(rdiPipelineSelector)
+  const { loading: testingConnections } = useAppSelector(
     rdiTestConnectionsSelector,
   )
-  const { isOpenDialog } = useSelector(appContextPipelineManagement)
+  const { isOpenDialog } = useAppSelector(appContextPipelineManagement)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     sendPageViewTelemetry({

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { throttle } from 'lodash'
 import { monaco as monacoEditor } from 'react-monaco-editor'
 
@@ -51,14 +51,14 @@ const Job = (props: Props) => {
   const [shouldOpenDedicatedEditor, setShouldOpenDedicatedEditor] =
     useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const jobIndexRef = useRef<number>(jobIndex)
   const deployedJobValueRef = useRef<Maybe<string>>(deployedJobValue)
   const jobNameRef = useRef<string>(name)
 
   const { loading, monacoJobsSchema, jobFunctions, jobs } =
-    useSelector(rdiPipelineSelector)
+    useAppSelector(rdiPipelineSelector)
 
   useEffect(() => {
     dispatch(fetchPipelineStrategies(rdiInstanceId))

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/JobWrapper.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/JobWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 import { findIndex } from 'lodash'
 
@@ -23,7 +23,7 @@ const JobWrapper = () => {
 
   const history = useHistory()
 
-  const { data, jobs } = useSelector(rdiPipelineSelector)
+  const { data, jobs } = useAppSelector(rdiPipelineSelector)
 
   useEffect(() => {
     const jobIndex = findIndex(jobs, ({ name }) => name === decodedJobName)

--- a/redisinsight/ui/src/pages/rdi/statistics/StatisticsPage.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/StatisticsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { Text } from 'uiSrc/components/base/text'
@@ -55,11 +55,11 @@ const StatisticsPage = () => {
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
   const [lastRefreshTime, setLastRefreshTime] = React.useState(Date.now())
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { loading: isStatisticsLoading, results: statisticsResults } =
-    useSelector(rdiStatisticsSelector)
-  const { name: connectedRdiInstanceName } = useSelector(
+    useAppSelector(rdiStatisticsSelector)
+  const { name: connectedRdiInstanceName } = useAppSelector(
     connectedInstanceSelector,
   )
   const rdiInstanceName = formatLongName(connectedRdiInstanceName, 33, 0, '...')

--- a/redisinsight/ui/src/pages/redis-cluster/useClusterDatabasesConfig.tsx
+++ b/redisinsight/ui/src/pages/redis-cluster/useClusterDatabasesConfig.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -50,7 +50,7 @@ const sendCancelEvent = () => {
   })
 }
 export const useClusterDatabasesConfig = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   const {
@@ -58,7 +58,7 @@ export const useClusterDatabasesConfig = () => {
     data: instances,
     dataAdded: instancesAdded,
     loading,
-  } = useSelector(clusterSelector)
+  } = useAppSelector(clusterSelector)
 
   useEffect(() => {
     setTitle('Auto-Discover Redis Enterprise Databases')

--- a/redisinsight/ui/src/pages/redis-stack/components/edit-connection/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/redis-stack/components/edit-connection/EditConnection.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -38,9 +38,9 @@ const DEFAULT_STATE = { loading: true, error: '', data: null }
 
 const EditConnection = () => {
   const history = useHistory()
-  const dispatch = useDispatch()
-  const { server } = useSelector(appInfoSelector)
-  const { data: createDbContent } = useSelector(contentSelector)
+  const dispatch = useAppDispatch()
+  const { server } = useAppSelector(appInfoSelector)
+  const { data: createDbContent } = useAppSelector(contentSelector)
   const [state, setState] = useState<IState>(DEFAULT_STATE)
   const { theme } = useContext(ThemeContext)
 

--- a/redisinsight/ui/src/pages/redis-stack/components/protected-route/ProtectedRoute.tsx
+++ b/redisinsight/ui/src/pages/redis-stack/components/protected-route/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Redirect, Route } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { Pages } from 'uiSrc/constants'
 
@@ -9,7 +9,7 @@ interface IProps {
 }
 
 const ProtectedRoute = ({ children, ...rest }: IProps) => {
-  const { id: connected } = useSelector(connectedInstanceSelector)
+  const { id: connected } = useAppSelector(connectedInstanceSelector)
   return (
     <Route
       {...rest}

--- a/redisinsight/ui/src/pages/settings/SettingsPage.tsx
+++ b/redisinsight/ui/src/pages/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { setTitle } from 'uiSrc/utils'
 import { FeatureFlags } from 'uiSrc/constants'
@@ -42,11 +42,11 @@ import styles from './styles.module.scss'
 
 const SettingsPage = () => {
   const [loading, setLoading] = useState(false)
-  const { loading: settingsLoading } = useSelector(userSettingsSelector)
+  const { loading: settingsLoading } = useAppSelector(userSettingsSelector)
 
   const initialOpenSection = globalThis.location.hash || ''
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     // componentDidMount

--- a/redisinsight/ui/src/pages/settings/components/advanced-settings/AdvancedSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/advanced-settings/AdvancedSettings.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { validateCountNumber } from 'uiSrc/utils'
 import { SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
@@ -11,9 +11,10 @@ import {
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 
 const AdvancedSettings = () => {
-  const { scanThreshold = '' } = useSelector(userSettingsConfigSelector) ?? {}
+  const { scanThreshold = '' } =
+    useAppSelector(userSettingsConfigSelector) ?? {}
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleApplyKeysToScanChanges = (value: string) => {
     // eslint-disable-next-line no-nested-ternary

--- a/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
+++ b/redisinsight/ui/src/pages/settings/components/app-version/AppVersion.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { appServerInfoSelector } from 'uiSrc/slices/app/info'
 import { Text } from 'uiSrc/components/base/text'
 
 const AppVersion = () => {
-  const server = useSelector(appServerInfoSelector)
+  const server = useAppSelector(appServerInfoSelector)
 
   if (!server?.appVersion) return null
 

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/CloudSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/CloudSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { DeleteIcon } from 'uiSrc/components/base/icons'
 import {
@@ -25,10 +25,10 @@ import UserApiKeysTable from './components/user-api-keys-table'
 import styles from './styles.module.scss'
 
 const CloudSettings = () => {
-  const { loading, data } = useSelector(oauthCapiKeysSelector)
+  const { loading, data } = useAppSelector(oauthCapiKeysSelector)
   const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(getCapiKeysAction())

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { format } from 'date-fns'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { isNull } from 'lodash'
 
 import { formatLongName, Nullable } from 'uiSrc/utils'
@@ -32,7 +32,7 @@ export interface Props {
 
 const UserApiKeysTable = ({ items, loading }: Props) => {
   const [deleting, setDeleting] = useState('')
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleCopy = () => {
     sendEventTelemetry({

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/DateTimeFormatter.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/DateTimeFormatter.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { formatTimestamp } from 'uiSrc/utils'
 import { DATETIME_FORMATTER_DEFAULT, TimezoneOption } from 'uiSrc/constants'
 import { userSettingsConfigSelector } from 'uiSrc/slices/user/user-settings'
@@ -13,7 +13,7 @@ import { TextInput } from 'uiSrc/components/base/inputs'
 
 const DateTimeFormatter = () => {
   const [preview, setPreview] = useState('')
-  const config = useSelector(userSettingsConfigSelector)
+  const config = useAppSelector(userSettingsConfigSelector)
 
   useEffect(() => {
     setPreview(

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useFormik } from 'formik'
 import { checkDateTimeFormat, formatTimestamp } from 'uiSrc/utils'
 import {
@@ -38,8 +38,8 @@ export interface Props {
 const DatetimeForm = ({ onFormatChange }: Props) => {
   const [error, setError] = useState('')
   const [saveFormatSucceed, setSaveFormatSucceed] = useState(false)
-  const config = useSelector(userSettingsConfigSelector)
-  const dispatch = useDispatch()
+  const config = useAppSelector(userSettingsConfigSelector)
+  const dispatch = useAppDispatch()
 
   const getInitialDateTime = (): InitialValuesType => {
     const format = config?.dateFormat || DATETIME_FORMATTER_DEFAULT

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useFormik } from 'formik'
 
 import { TimezoneOption, timezoneOptions } from 'uiSrc/constants'
@@ -18,8 +18,8 @@ interface InitialValuesType {
 }
 
 const TimezoneForm = () => {
-  const config = useSelector(userSettingsConfigSelector)
-  const dispatch = useDispatch()
+  const config = useAppSelector(userSettingsConfigSelector)
+  const dispatch = useAppDispatch()
 
   const getInitialValues: InitialValuesType = useMemo(
     () => ({ timezone: config?.timezone || TimezoneOption.Local }),

--- a/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
   updateUserConfigSettingsAction,
@@ -16,12 +16,12 @@ import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { Title } from 'uiSrc/components/base/text'
 
 const ThemeSettings = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const [selectedTheme, setSelectedTheme] = useState<string>(DEFAULT_THEME)
   const options = THEMES
   const themeContext = useContext(ThemeContext)
   const { theme, changeTheme } = themeContext
-  const { config } = useSelector(userSettingsSelector)
+  const { config } = useAppSelector(userSettingsSelector)
   const previousThemeRef = useRef<string>(theme)
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/settings/components/workbench-settings/WorkbenchSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/workbench-settings/WorkbenchSettings.tsx
@@ -1,6 +1,6 @@
 import { toNumber } from 'lodash'
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { SettingItem } from 'uiSrc/components'
 import { PIPELINE_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import {
@@ -18,11 +18,11 @@ import { Title } from 'uiSrc/components/base/text/Title'
 import { Link } from 'uiSrc/components/base/link/Link'
 
 const WorkbenchSettings = () => {
-  const { cleanup } = useSelector(userSettingsWBSelector)
+  const { cleanup } = useAppSelector(userSettingsWBSelector)
   const { batchSize = PIPELINE_COUNT_DEFAULT } =
-    useSelector(userSettingsConfigSelector) ?? {}
+    useAppSelector(userSettingsConfigSelector) ?? {}
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onSwitchWbCleanUp = (val: boolean) => {
     dispatch(setWorkbenchCleanUp(val))

--- a/redisinsight/ui/src/pages/slow-log/SlowLogPage.tsx
+++ b/redisinsight/ui/src/pages/slow-log/SlowLogPage.tsx
@@ -1,6 +1,6 @@
 import { minBy, toNumber } from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { AutoSizer } from 'react-virtualized'
 
@@ -59,19 +59,20 @@ const SlowLogPage = () => {
     connectionType,
     name: connectedInstanceName,
     db,
-  } = useSelector(connectedInstanceSelector)
-  const { data, loading, config } = useSelector(slowLogSelector)
-  const { slowLogDurationUnit: durationUnit } = useSelector(appContextDbConfig)
-  const { slowlogLogSlowerThan = 0, slowlogMaxLen } = useSelector(
+  } = useAppSelector(connectedInstanceSelector)
+  const { data, loading, config } = useAppSelector(slowLogSelector)
+  const { slowLogDurationUnit: durationUnit } =
+    useAppSelector(appContextDbConfig)
+  const { slowlogLogSlowerThan = 0, slowlogMaxLen } = useAppSelector(
     slowLogConfigSelector,
   )
-  const { viewTab } = useSelector(analyticsSettingsSelector)
+  const { viewTab } = useAppSelector(analyticsSettingsSelector)
   const { instanceId } = useParams<{ instanceId: string }>()
 
   const [count, setCount] = useState<string>(DEFAULT_COUNT_VALUE)
   const [isPageViewSent, setIsPageViewSent] = useState(false)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const lastTimestamp = minBy(data, 'time')?.time
   const dbName = `${formatLongName(connectedInstanceName, 33, 0, '...')} ${getDbIndex(db)}`

--- a/redisinsight/ui/src/pages/slow-log/components/Actions/Actions.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/Actions/Actions.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { DurationUnits } from 'uiSrc/constants'
@@ -37,8 +37,8 @@ const Actions = (props: Props) => {
     onRefresh,
   } = props
   const { instanceId } = useParams<{ instanceId: string }>()
-  const { name = '' } = useSelector(connectedInstanceSelector)
-  const { loading, lastRefreshTime } = useSelector(slowLogSelector)
+  const { name = '' } = useAppSelector(connectedInstanceSelector)
+  const { loading, lastRefreshTime } = useAppSelector(slowLogSelector)
 
   const [isClearModalOpen, setIsClearModalOpen] = useState(false)
   const [isPopoverConfigOpen, setIsPopoverConfigOpen] = useState(false)

--- a/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
@@ -1,6 +1,6 @@
 import { toNumber } from 'lodash'
 import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import {
   DEFAULT_SLOWLOG_DURATION_UNIT,
@@ -45,12 +45,12 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
   const options = DURATION_UNITS
   const { instanceId } = useParams<{ instanceId: string }>()
   const connectionType = useConnectionType()
-  const { loading } = useSelector(slowLogSelector)
-  const { slowLogDurationUnit } = useSelector(appContextDbConfig)
+  const { loading } = useAppSelector(slowLogSelector)
+  const { slowLogDurationUnit } = useAppSelector(appContextDbConfig)
   const {
     slowlogMaxLen = DEFAULT_SLOWLOG_MAX_LEN,
     slowlogLogSlowerThan = DEFAULT_SLOWLOG_SLOWER_THAN,
-  } = useSelector(slowLogConfigSelector)
+  } = useAppSelector(slowLogConfigSelector)
 
   const [durationUnit, setDurationUnit] = useState(
     slowLogDurationUnit ?? DEFAULT_SLOWLOG_DURATION_UNIT,
@@ -63,7 +63,7 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
       : `${MINUS_ONE}`,
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const onChangeUnit = (value: DurationUnits) => {
     setDurationUnit(value)

--- a/redisinsight/ui/src/pages/vector-search/components/command-view/CommandView.stories.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/command-view/CommandView.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { CommandView } from './index'
 import { MOCK_COMMANDS_SPEC } from 'uiSrc/constants'
 import { getRedisCommandsSuccess } from 'uiSrc/slices/app/redis-commands'
@@ -11,7 +11,7 @@ import MonacoLanguages from 'uiSrc/components/monaco-laguages'
 // Decorator to initialize Monaco environment and Redis commands for syntax highlighting
 const withMonacoSetup = (Story: React.ComponentType) => {
   const MonacoSetup = () => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
 
     React.useEffect(() => {
       // Initialize Redis commands with mock data so MonacoLanguages can register the language

--- a/redisinsight/ui/src/pages/vector-search/components/field-type-modal/hooks/useVectorDataTypeOptions.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/field-type-modal/hooks/useVectorDataTypeOptions.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { REDISEARCH_MODULES } from 'uiSrc/slices/interfaces'
 import { isRedisVersionSupported } from 'uiSrc/utils/comparisons/compareVersions'
@@ -13,7 +13,7 @@ import {
 const REDISEARCH_MODULE_SET = new Set(REDISEARCH_MODULES)
 
 export const useVectorDataTypeOptions = () => {
-  const { modules = [] } = useSelector(connectedInstanceSelector)
+  const { modules = [] } = useAppSelector(connectedInstanceSelector)
 
   return useMemo(() => {
     const rqeModule = modules.find((m) => REDISEARCH_MODULE_SET.has(m.name))

--- a/redisinsight/ui/src/pages/vector-search/components/keys-browser/__stories__/StorePopulator.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/keys-browser/__stories__/StorePopulator.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 import { faker } from '@faker-js/faker'
 import { stringToBuffer } from 'uiSrc/utils'
@@ -49,7 +49,7 @@ const buildMockKeysResponse = (keys: ReturnType<typeof generateMockKeys>) => ({
 })
 
 export const StorePopulator = ({ children }: { children: React.ReactNode }) => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   const [ready, setReady] = useState(false)
 

--- a/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -57,19 +57,19 @@ export const Provider = ({
   children,
 }: KeysBrowserProps & { children: React.ReactNode }) => {
   const { instanceId } = useParams<{ instanceId: string }>()
-  const keysState = useSelector(keysDataSelector)
+  const keysState = useAppSelector(keysDataSelector)
   const {
     loading,
     isSearched,
     isFiltered,
     filter,
     error: keysError,
-  } = useSelector(keysSelector)
-  const { id: connectedInstanceId } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(keysSelector)
+  const { id: connectedInstanceId } = useAppSelector(connectedInstanceSelector)
   const {
     keyList: { scrollPatternTopPosition },
-  } = useSelector(appContextBrowser)
-  const dispatch = useDispatch()
+  } = useAppSelector(appContextBrowser)
+  const dispatch = useAppDispatch()
 
   const [activeTab, setActiveTab] = useState<KeyTypes>(
     initialKeyType ?? SUPPORTED_TABS[0],

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditorWrapper.stories.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditorWrapper.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import type { Meta, StoryObj, StoryContext } from '@storybook/react-vite'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { fn } from 'storybook/test'
 
 import { MOCK_COMMANDS_SPEC } from 'uiSrc/constants'
@@ -22,7 +22,7 @@ const WithMonacoSetup = (Story: React.ComponentType, context: StoryContext) => {
   const isLoading = context.parameters?.loadingState === true
 
   const MonacoSetup = () => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
 
     useEffect(() => {
       if (isLoading) {

--- a/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditorWrapper.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-editor/QueryEditorWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { IRedisCommand } from 'uiSrc/constants'
@@ -77,7 +77,7 @@ export const QueryEditorWrapper = ({
 
   const decodedIndexName = indexName ? decodeURIComponent(indexName) : ''
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const queryLibraryService = useRef(new QueryLibraryService()).current
 
   const handleSaveSubmit = useCallback(
@@ -115,10 +115,10 @@ export const QueryEditorWrapper = ({
     [instanceId, decodedIndexName, query, dispatch],
   )
 
-  const { loading: isCommandsLoading, spec: COMMANDS_SPEC } = useSelector(
+  const { loading: isCommandsLoading, spec: COMMANDS_SPEC } = useAppSelector(
     appRedisCommandsSelector,
   )
-  const { data: indexes = [] } = useSelector(redisearchListSelector)
+  const { data: indexes = [] } = useAppSelector(redisearchListSelector)
 
   const REDIS_COMMANDS = useMemo(
     () =>

--- a/redisinsight/ui/src/pages/vector-search/components/query-library-item/QueryLibraryItem.stories.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/query-library-item/QueryLibraryItem.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { faker } from '@faker-js/faker'
 import styled from 'styled-components'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { MOCK_COMMANDS_SPEC } from 'uiSrc/constants'
 import { getRedisCommandsSuccess } from 'uiSrc/slices/app/redis-commands'
 import { Col } from 'uiSrc/components/base/layout/flex'
@@ -17,7 +17,7 @@ import {
 
 const withMonacoSetup = (Story: React.ComponentType) => {
   const MonacoSetup = () => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
 
     React.useEffect(() => {
       // @ts-ignore

--- a/redisinsight/ui/src/pages/vector-search/components/query-library-view/hooks/useQueryLibrary.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/query-library-view/hooks/useQueryLibrary.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { debounce } from 'lodash'
 
@@ -11,7 +11,7 @@ import { queryLibraryNotifications } from 'uiSrc/pages/vector-search/constants'
 const SEARCH_DEBOUNCE_MS = 300
 
 export const useQueryLibrary = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { instanceId: databaseId, indexName: rawIndexName } = useParams<{
     instanceId: string
     indexName?: string

--- a/redisinsight/ui/src/pages/vector-search/components/search-page-fallback/SearchPageFallback.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/search-page-fallback/SearchPageFallback.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import RqeIllustration from 'uiSrc/assets/img/vector-search/rqe-not-available.svg?react'
 import { FeatureFlags } from 'uiSrc/constants'
@@ -21,7 +21,7 @@ interface SearchPageFallbackProps {
 }
 
 export const SearchPageFallback = ({ content }: SearchPageFallbackProps) => {
-  const { [FeatureFlags.envDependent]: envDependentFeature } = useSelector(
+  const { [FeatureFlags.envDependent]: envDependentFeature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
 

--- a/redisinsight/ui/src/pages/vector-search/components/select-key-onboarding-popover/SelectKeyOnboardingPopover.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/select-key-onboarding-popover/SelectKeyOnboardingPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { RiPopover } from 'uiSrc/components/base'
 import { Button, IconButton } from 'uiSrc/components/base/forms/buttons'
@@ -22,7 +22,7 @@ interface PopoverContentProps {
 }
 
 const PopoverContent = ({ children, onDismiss }: PopoverContentProps) => {
-  const selectedKey = useSelector(selectedKeyDataSelector)
+  const selectedKey = useAppSelector(selectedKeyDataSelector)
 
   useEffect(() => {
     if (selectedKey?.name) {

--- a/redisinsight/ui/src/pages/vector-search/components/upgrade-redis-banner/UpgradeRedisBanner.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/upgrade-redis-banner/UpgradeRedisBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { OAuthSsoHandlerDialog } from 'uiSrc/components'
 import { CallOut } from 'uiSrc/components/base/display/call-out/CallOut'
@@ -14,7 +14,7 @@ export const UpgradeRedisBanner = () => {
   const {
     [FeatureFlags.cloudSso]: featureFlagCloudSsl,
     [FeatureFlags.cloudAds]: featureFlagCloudAds,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const isCloudSsoEnabled =
     featureFlagCloudSsl?.flag && featureFlagCloudAds?.flag

--- a/redisinsight/ui/src/pages/vector-search/context/create-index-page/CreateIndexPageProvider.tsx
+++ b/redisinsight/ui/src/pages/vector-search/context/create-index-page/CreateIndexPageProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import { Pages } from 'uiSrc/constants'
 import { RowSelectionState } from 'uiSrc/components/base/layout/table'
@@ -88,7 +88,7 @@ export const CreateIndexPageProvider = ({
   )
 
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   // --- Sample data mode hooks (only meaningful when isSampleData) ---
   const { command: sampleCommand } = useCreateIndexCommand(sampleData)

--- a/redisinsight/ui/src/pages/vector-search/hooks/useCreateIndexFlow/useCreateIndexFlow.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useCreateIndexFlow/useCreateIndexFlow.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 
 import { Pages } from 'uiSrc/constants'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
@@ -41,7 +41,7 @@ export interface UseCreateIndexFlowResult {
  */
 export const useCreateIndexFlow = (): UseCreateIndexFlowResult => {
   const history = useHistory()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const { run: createIndex } = useCreateIndex()
   const { stringData: existingIndexes } = useRedisearchListData()

--- a/redisinsight/ui/src/pages/vector-search/hooks/useHasExistingKeys/useHasExistingKeys.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useHasExistingKeys/useHasExistingKeys.spec.ts
@@ -9,9 +9,9 @@ jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(() => ({ pathname: '/test' })),
 }))
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn((selector) => {
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn((selector) => {
     const state = {
       connections: {
         instances: {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useHasExistingKeys/useHasExistingKeys.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useHasExistingKeys/useHasExistingKeys.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { apiService } from 'uiSrc/services'
 import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
@@ -23,8 +23,8 @@ export const useHasExistingKeys = (): UseHasExistingKeysResult => {
   const [loading, setLoading] = useState(true)
 
   const { pathname } = useLocation()
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { encoding } = useSelector(appInfoSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { encoding } = useAppSelector(appInfoSelector)
 
   const checkForKeys = useCallback(
     async (signal?: AbortSignal) => {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useIndexInfo/useIndexInfo.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useIndexInfo/useIndexInfo.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { apiService } from 'uiSrc/services'
 import { ApiEndpoints } from 'uiSrc/constants'
@@ -28,7 +28,7 @@ export const useIndexInfo = ({
   const [error, setError] = useState<string | null>(null)
 
   // Only selector needed - get instance ID for API URL
-  const connectedInstance = useSelector(connectedInstanceSelector)
+  const connectedInstance = useAppSelector(connectedInstanceSelector)
   const instanceId = connectedInstance?.id
 
   // Track the current fetch request to ignore stale responses

--- a/redisinsight/ui/src/pages/vector-search/hooks/useIndexListData/useIndexListData.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useIndexListData/useIndexListData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 
@@ -25,7 +25,7 @@ export const useIndexListData = (
   const [data, setData] = useState<IndexListRow[]>([])
   const [loading, setLoading] = useState(false)
 
-  const connectedInstance = useSelector(connectedInstanceSelector)
+  const connectedInstance = useAppSelector(connectedInstanceSelector)
   const instanceId = connectedInstance?.id
 
   const indexNamesKey = JSON.stringify(indexNames)

--- a/redisinsight/ui/src/pages/vector-search/hooks/useIsKeyIndexed/useIsKeyIndexed.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useIsKeyIndexed/useIsKeyIndexed.spec.ts
@@ -1,4 +1,4 @@
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { renderHook, act } from 'uiSrc/utils/test-utils'
 
 import { fetchKeyIndexesAction } from 'uiSrc/slices/browser/redisearch'
@@ -6,10 +6,10 @@ import { fetchKeyIndexesAction } from 'uiSrc/slices/browser/redisearch'
 import { useIsKeyIndexed } from './useIsKeyIndexed'
 import { UseIsKeyIndexedStatus } from './useIsKeyIndexed.types'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/browser/redisearch', () => ({
@@ -22,8 +22,8 @@ jest.mock('uiSrc/slices/browser/redisearch', () => ({
 
 describe('useIsKeyIndexed', () => {
   const mockDispatch = jest.fn()
-  const mockUseSelector = useSelector as jest.Mock
-  const mockUseDispatch = useDispatch as jest.Mock
+  const mockUseSelector = useAppSelector as jest.Mock
+  const mockUseDispatch = useAppDispatch as jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/redisinsight/ui/src/pages/vector-search/hooks/useIsKeyIndexed/useIsKeyIndexed.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useIsKeyIndexed/useIsKeyIndexed.ts
@@ -1,11 +1,10 @@
 import { useEffect, useCallback } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 
 import {
   keyIndexesSelector,
   fetchKeyIndexesAction,
 } from 'uiSrc/slices/browser/redisearch'
-import { AppDispatch } from 'uiSrc/slices/store'
 
 import {
   UseIsKeyIndexedResult,
@@ -20,8 +19,8 @@ import {
  * @returns { isIndexed, indexes, status, refresh }
  */
 export const useIsKeyIndexed = (keyName: string): UseIsKeyIndexedResult => {
-  const dispatch = useDispatch<AppDispatch>()
-  const keyIndexes = useSelector(keyIndexesSelector)
+  const dispatch = useAppDispatch()
+  const keyIndexes = useAppSelector(keyIndexesSelector)
   const entry = keyName ? keyIndexes[keyName] : undefined
 
   useEffect(() => {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import reactRouterDom from 'react-router-dom'
 import { faker } from '@faker-js/faker'
 import { renderHook, act } from 'uiSrc/utils/test-utils'
@@ -15,10 +15,10 @@ import { SearchIndexDetailsSource } from 'uiSrc/pages/vector-search/telemetry.co
 import { useListContent } from './useListContent'
 import { useIndexListData } from '../useIndexListData'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('../useIndexListData', () => ({
@@ -62,8 +62,8 @@ const mockInstanceId = faker.string.uuid()
 const mockDatabaseId = faker.string.uuid()
 
 describe('useListContent', () => {
-  const mockUseSelector = useSelector as jest.Mock
-  const mockUseDispatch = useDispatch as jest.Mock
+  const mockUseSelector = useAppSelector as jest.Mock
+  const mockUseDispatch = useAppDispatch as jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useParams } from 'react-router-dom'
 
 import { BrowserStorageItem, Pages } from 'uiSrc/constants'
@@ -28,12 +28,12 @@ import { IndexListAction } from '../../components/index-list/IndexList.types'
 import { useIndexListData } from '../useIndexListData'
 
 export const useListContent = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const history = useHistory()
   const { instanceId } = useParams<{ instanceId: string }>()
 
-  const { data: rawIndexes } = useSelector(redisearchListSelector)
-  const { id: databaseId } = useSelector(connectedInstanceSelector)
+  const { data: rawIndexes } = useAppSelector(redisearchListSelector)
+  const { id: databaseId } = useAppSelector(connectedInstanceSelector)
   const indexes = useMemo(
     () => rawIndexes.map((index) => bufferToString(index)),
     [rawIndexes],

--- a/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/useLoadKeyData.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useLoadKeyData/useLoadKeyData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { AxiosError } from 'axios'
 
 import { apiService } from 'uiSrc/services'
@@ -24,8 +24,8 @@ export const useLoadKeyData = (): UseLoadKeyDataResult => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
-  const { encoding } = useSelector(appInfoSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
+  const { encoding } = useAppSelector(appInfoSelector)
 
   const loadHashData = useCallback(
     async (key: RedisResponseBuffer): Promise<InferredFieldsResult> => {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useRedisInstanceCompatibility/useRedisInstanceCompatibility.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useRedisInstanceCompatibility/useRedisInstanceCompatibility.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import {
   connectedInstanceInfoSelector,
   connectedInstanceSelector,
@@ -26,9 +26,9 @@ const decodeModuleVersion = (version: number): string => {
 
 export const useRedisInstanceCompatibility =
   (): UseRedisInstanceCompatibilityReturn => {
-    const { version } = useSelector(connectedInstanceInfoSelector)
+    const { version } = useAppSelector(connectedInstanceInfoSelector)
 
-    const { loading, modules = [] } = useSelector(connectedInstanceSelector)
+    const { loading, modules = [] } = useAppSelector(connectedInstanceSelector)
 
     const isInitialized = loading !== undefined
 

--- a/redisinsight/ui/src/pages/vector-search/hooks/useRedisearchListData/useRedisearchListData.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useRedisearchListData/useRedisearchListData.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from 'uiSrc/utils/test-utils'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import {
   redisearchListSelector,
   fetchRedisearchListAction,
@@ -8,10 +8,10 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { isRedisearchAvailable, bufferToString } from 'uiSrc/utils'
 import { useRedisearchListData } from './useRedisearchListData'
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: jest.fn(),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/browser/redisearch', () => ({
@@ -30,8 +30,8 @@ jest.mock('uiSrc/utils', () => ({
 
 describe('useRedisearchListData', () => {
   const mockDispatch = jest.fn()
-  const mockUseSelector = useSelector as jest.Mock
-  const mockUseDispatch = useDispatch as jest.Mock
+  const mockUseSelector = useAppSelector as jest.Mock
+  const mockUseDispatch = useAppDispatch as jest.Mock
   const mockIsRedisearchAvailable = isRedisearchAvailable as jest.Mock
 
   beforeEach(() => {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useRedisearchListData/useRedisearchListData.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useRedisearchListData/useRedisearchListData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 
 import {
   redisearchListSelector,
@@ -9,9 +9,11 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { bufferToString, isRedisearchAvailable } from 'uiSrc/utils'
 
 export const useRedisearchListData = () => {
-  const dispatch = useDispatch()
-  const { loading, data, error } = useSelector(redisearchListSelector)
-  const { modules, host: instanceHost } = useSelector(connectedInstanceSelector)
+  const dispatch = useAppDispatch()
+  const { loading, data, error } = useAppSelector(redisearchListSelector)
+  const { modules, host: instanceHost } = useAppSelector(
+    connectedInstanceSelector,
+  )
 
   const stringData = useMemo(
     () => data.map((index) => bufferToString(index)),

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage/VectorSearchPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { TelemetryPageView } from 'uiSrc/telemetry'
 import { usePageViewTelemetry } from 'uiSrc/telemetry/usePageViewTelemetry'
@@ -32,7 +32,7 @@ export const VectorSearchPage = () => {
     db,
     provider,
     modules,
-  } = useSelector(connectedInstanceSelector)
+  } = useAppSelector(connectedInstanceSelector)
 
   const isReady = indexesLoading === false
 

--- a/redisinsight/ui/src/pages/workbench/WorkbenchPage.spec.tsx
+++ b/redisinsight/ui/src/pages/workbench/WorkbenchPage.spec.tsx
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash'
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { INSTANCE_ID_MOCK } from 'uiSrc/mocks/handlers/analytics/clusterDetailsHandlers'
 import { RunQueryMode } from 'uiSrc/slices/interfaces'
 import { RootState } from 'uiSrc/slices/store'
@@ -24,9 +24,9 @@ beforeEach(() => {
   store.clearActions()
 })
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
+jest.mock('uiSrc/slices/hooks', () => ({
+  ...jest.requireActual('uiSrc/slices/hooks'),
+  useAppSelector: jest.fn(),
 }))
 
 jest.mock('uiSrc/slices/app/plugins', () => ({
@@ -50,7 +50,7 @@ describe('WorkbenchPage', () => {
   beforeEach(() => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,
@@ -91,7 +91,7 @@ describe('Telemetry', () => {
   beforeEach(() => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,
@@ -258,7 +258,7 @@ describe('Raw mode', () => {
   beforeEach(() => {
     const state: any = store.getState()
 
-    ;(useSelector as jest.Mock).mockImplementation(
+    ;(useAppSelector as jest.Mock).mockImplementation(
       (callback: (arg0: RootState) => RootState) =>
         callback({
           ...state,

--- a/redisinsight/ui/src/pages/workbench/WorkbenchPage.tsx
+++ b/redisinsight/ui/src/pages/workbench/WorkbenchPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { formatLongName, getDbIndex, setTitle } from 'uiSrc/utils'
@@ -10,7 +10,7 @@ import WBViewWrapper from './components/wb-view'
 const WorkbenchPage = () => {
   const [isPageViewSent, setIsPageViewSent] = useState(false)
 
-  const { name: connectedInstanceName, db } = useSelector(
+  const { name: connectedInstanceName, db } = useAppSelector(
     connectedInstanceSelector,
   )
 

--- a/redisinsight/ui/src/pages/workbench/components/query/Query/Query.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/query/Query/Query.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { monaco as monacoEditor } from 'react-monaco-editor'
 
 import { MonacoLanguage } from 'uiSrc/constants'
@@ -41,10 +41,10 @@ const Query = (props: Props) => {
     items: execHistoryItems,
     loading,
     processing,
-  } = useSelector(workbenchResultsSelector)
+  } = useAppSelector(workbenchResultsSelector)
 
   const input = useRef<HTMLDivElement>(null)
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   // Command history
   const { onQuickHistoryAccess, resetHistoryPos, isHistoryScrolled } =

--- a/redisinsight/ui/src/pages/workbench/components/query/QueryWrapper.stories.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/query/QueryWrapper.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import type { Meta, StoryObj, StoryContext } from '@storybook/react-vite'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { fn } from 'storybook/test'
 
 import { MOCK_COMMANDS_SPEC } from 'uiSrc/constants'
@@ -23,7 +23,7 @@ const WithMonacoSetup = (Story: React.ComponentType, context: StoryContext) => {
   const isLoading = context.parameters?.loadingState === true
 
   const MonacoSetup = () => {
-    const dispatch = useDispatch()
+    const dispatch = useAppDispatch()
 
     useEffect(() => {
       if (isLoading) {

--- a/redisinsight/ui/src/pages/workbench/components/query/QueryWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/query/QueryWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import { LoadingContent } from 'uiSrc/components/base/layout'
 import { IRedisCommand } from 'uiSrc/constants'
@@ -34,10 +34,12 @@ const QueryWrapper = (props: Props) => {
     onClear,
     queryProps = {},
   } = props
-  const { loading: isCommandsLoading } = useSelector(appRedisCommandsSelector)
-  const { id: connectedInstanceId } = useSelector(connectedInstanceSelector)
-  const { data: indexes = [] } = useSelector(redisearchListSelector)
-  const { spec: COMMANDS_SPEC } = useSelector(appRedisCommandsSelector)
+  const { loading: isCommandsLoading } = useAppSelector(
+    appRedisCommandsSelector,
+  )
+  const { id: connectedInstanceId } = useAppSelector(connectedInstanceSelector)
+  const { data: indexes = [] } = useAppSelector(redisearchListSelector)
+  const { spec: COMMANDS_SPEC } = useAppSelector(appRedisCommandsSelector)
 
   const REDIS_COMMANDS = useMemo(
     () =>
@@ -48,7 +50,7 @@ const QueryWrapper = (props: Props) => {
     [COMMANDS_SPEC, SEARCH_COMMANDS_SPEC],
   )
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (!connectedInstanceId) return

--- a/redisinsight/ui/src/pages/workbench/components/wb-no-results-message/WbNoResultsMessage.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-no-results-message/WbNoResultsMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -25,10 +25,10 @@ import styles from './styles.module.scss'
 import { Panel } from 'uiSrc/components/panel'
 
 const WbNoResultsMessage = () => {
-  const { provider } = useSelector(connectedInstanceSelector)
+  const { provider } = useAppSelector(connectedInstanceSelector)
 
   const { instanceId } = useParams<{ instanceId: string }>()
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   const handleOpenInsights = () => {
     dispatch(changeSelectedTab(InsightsPanelTabs.Explore))

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBView/WBView.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBView/WBView.tsx
@@ -1,5 +1,5 @@
 import React, { Ref, useCallback, useEffect, useRef } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 import { isEmpty } from 'lodash'
 import { useParams } from 'react-router-dom'
@@ -101,15 +101,15 @@ const WBView = (props: Props) => {
   }
 
   const { instanceId = '' } = useParams<{ instanceId: string }>()
-  const { panelSizes } = useSelector(appContextWorkbench)
-  const { commandsArray: REDIS_COMMANDS_ARRAY } = useSelector(
+  const { panelSizes } = useAppSelector(appContextWorkbench)
+  const { commandsArray: REDIS_COMMANDS_ARRAY } = useAppSelector(
     appRedisCommandsSelector,
   )
   const { batchSize = PIPELINE_COUNT_DEFAULT } =
-    useSelector(userSettingsConfigSelector) ?? {}
+    useAppSelector(userSettingsConfigSelector) ?? {}
   const verticalPanelSizesRef = useRef(panelSizes)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-view/WBViewWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { Ref, useEffect, useRef, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useParams } from 'react-router-dom'
 import { monaco as monacoEditor } from 'react-monaco-editor'
 
@@ -89,20 +89,20 @@ const WBViewWrapper = () => {
     processing,
     activeRunQueryMode,
     resultsMode,
-  } = useSelector(workbenchResultsSelector)
+  } = useAppSelector(workbenchResultsSelector)
   const { unsupportedCommands, blockingCommands } =
-    useSelector(cliSettingsSelector)
-  const { cleanup: cleanupWB } = useSelector(userSettingsWBSelector)
-  const { script: scriptContext } = useSelector(appContextWorkbench)
+    useAppSelector(cliSettingsSelector)
+  const { cleanup: cleanupWB } = useAppSelector(userSettingsWBSelector)
+  const { script: scriptContext } = useAppSelector(appContextWorkbench)
 
   const [script, setScript] = useState(scriptContext)
   const [scriptEl, setScriptEl] =
     useState<Nullable<monacoEditor.editor.IStandaloneCodeEditor>>(null)
 
-  const instance = useSelector(connectedInstanceSelector)
+  const instance = useAppSelector(connectedInstanceSelector)
   const { isDangerousCommand } = useDatabaseEnvironment()
   const { requestConfirmation } = useProductionWriteConfirmation()
-  const { visualizations = [] } = useSelector(appPluginsSelector)
+  const { visualizations = [] } = useAppSelector(appPluginsSelector)
   state = {
     scriptEl,
     loading,
@@ -114,7 +114,7 @@ const WBViewWrapper = () => {
   const scrollDivRef: Ref<HTMLDivElement> = useRef(null)
   const scriptRef = useRef(script)
 
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(fetchWBHistoryAction(instanceId))

--- a/redisinsight/ui/src/services/hooks/useCabability.ts
+++ b/redisinsight/ui/src/services/hooks/useCabability.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import { setCapability } from 'uiSrc/slices/app/context'
 
 export const useCapability = (source = '') => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(setCapability({ source, tutorialPopoverShown: false }))

--- a/redisinsight/ui/src/services/hooks/useIoConnection.ts
+++ b/redisinsight/ui/src/services/hooks/useIoConnection.ts
@@ -1,11 +1,11 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useCallback } from 'react'
 import { WsParams, wsService } from 'uiSrc/services/wsService'
 import { FeatureFlags } from 'uiSrc/constants'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 
 export const useIoConnection = (url: string, params: WsParams) => {
-  const { [FeatureFlags.envDependent]: envDependent } = useSelector(
+  const { [FeatureFlags.envDependent]: envDependent } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
   return useCallback(

--- a/redisinsight/ui/src/services/hooks/useStateWithContext.ts
+++ b/redisinsight/ui/src/services/hooks/useStateWithContext.ts
@@ -1,11 +1,11 @@
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { appContextSelector } from 'uiSrc/slices/app/context'
 
 export const useStateWithContext = <T>(value: T, initialValue: T) => {
   const { instanceId } = useParams<{ instanceId: string }>()
-  const { contextInstanceId } = useSelector(appContextSelector)
+  const { contextInstanceId } = useAppSelector(appContextSelector)
 
   return useState<T>(instanceId === contextInstanceId ? value : initialValue)
 }

--- a/redisinsight/ui/src/slices/hooks.ts
+++ b/redisinsight/ui/src/slices/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from 'react-redux'
+import type { TypedUseSelectorHook } from 'react-redux'
+import type { AppDispatch, RootState } from './store'
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/redisinsight/ui/src/telemetry/tests/usePageViewTelemetry.spec.ts
+++ b/redisinsight/ui/src/telemetry/tests/usePageViewTelemetry.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, cleanup } from '@testing-library/react-hooks'
-import * as reactRedux from 'react-redux'
+import * as appHooks from 'uiSrc/slices/hooks'
 import { faker } from '@faker-js/faker'
 import { cloneDeep } from 'lodash'
 
@@ -32,7 +32,7 @@ describe('usePageViewTelemetry', () => {
     store = cloneDeep(mockedStore)
     store.clearActions()
 
-    mockUseSelector = jest.spyOn(reactRedux, 'useSelector')
+    mockUseSelector = jest.spyOn(appHooks, 'useAppSelector')
     mockUseSelector.mockReturnValue(INSTANCES_MOCK[0])
   })
 

--- a/redisinsight/ui/src/telemetry/usePageViewTelemetry.ts
+++ b/redisinsight/ui/src/telemetry/usePageViewTelemetry.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { sendPageViewTelemetry, TelemetryPageView } from 'uiSrc/telemetry'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
@@ -20,7 +20,7 @@ export const usePageViewTelemetry = ({
   ready = true,
 }: PageViewTelemetryProps): PageViewTelemetryHook => {
   const [isPageViewSent, setIsPageViewSent] = useState(false)
-  const { id: instanceId } = useSelector(connectedInstanceSelector)
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
 
   useEffect(() => {
     if (instanceId && ready && !isPageViewSent) {

--- a/redisinsight/ui/src/templates/explore-panel/ExplorePanelTemplate.tsx
+++ b/redisinsight/ui/src/templates/explore-panel/ExplorePanelTemplate.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { sidePanelsSelector } from 'uiSrc/slices/panels/sidePanels'
 import SidePanels from 'uiSrc/components/side-panels'
 
@@ -24,7 +24,7 @@ const SIDE_PANEL_MAX_SIZE = 50
 
 const ExplorePanelTemplate = (props: Props) => {
   const { children, panelClassName } = props
-  const { openedPanel } = useSelector(sidePanelsSelector)
+  const { openedPanel } = useAppSelector(sidePanelsSelector)
   const isPanelOpen = !!openedPanel
 
   useCapabilityAutoOpen()

--- a/redisinsight/ui/src/templates/explore-panel/useCapabilityAutoOpen.ts
+++ b/redisinsight/ui/src/templates/explore-panel/useCapabilityAutoOpen.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
 import { connectedInstanceCDSelector } from 'uiSrc/slices/instances/instances'
@@ -23,9 +23,9 @@ import { InsightsPanelTabs, SidePanels } from 'uiSrc/slices/interfaces/insights'
  * because SidePanelsWrapper is only mounted when a panel is already open.
  */
 export const useCapabilityAutoOpen = () => {
-  const { source: capabilitySource } = useSelector(appContextCapability)
-  const { free = false } = useSelector(connectedInstanceCDSelector) ?? {}
-  const dispatch = useDispatch()
+  const { source: capabilitySource } = useAppSelector(appContextCapability)
+  const { free = false } = useAppSelector(connectedInstanceCDSelector) ?? {}
+  const dispatch = useAppDispatch()
   const history = useHistory()
 
   useEffect(() => {

--- a/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.tsx
+++ b/redisinsight/ui/src/templates/home-page-template/HomePageTemplate.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { ExplorePanelTemplate } from 'uiSrc/templates'
 import HomeTabs from 'uiSrc/components/home-tabs'
@@ -30,14 +30,16 @@ const HomePageTemplate = (props: Props) => {
   const {
     [FeatureFlags.databaseChat]: databaseChatFeature,
     [FeatureFlags.documentationChat]: documentationChatFeature,
-  } = useSelector(appFeatureFlagsFeaturesSelector)
+  } = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isAnyChatAvailable = isAnyFeatureEnabled([
     databaseChatFeature,
     documentationChatFeature,
   ])
 
-  const { loading: instancesLoading } = useSelector(databaseInstancesSelector)
-  const { loading: rdiLoading } = useSelector(rdiInstancesSelector)
+  const { loading: instancesLoading } = useAppSelector(
+    databaseInstancesSelector,
+  )
+  const { loading: rdiLoading } = useAppSelector(rdiInstancesSelector)
 
   const loading = instancesLoading || rdiLoading
 

--- a/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
+++ b/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import styled from 'styled-components'
 
 import InstanceHeader from 'uiSrc/components/instance-header'
@@ -51,8 +51,8 @@ const InstancePageTemplate = (props: Props) => {
   const { children } = props
   const [sizes, setSizes] = useState<number[]>(getDefaultSizes())
 
-  const { isShowCli, isShowHelper } = useSelector(cliSettingsSelector)
-  const { isShowMonitor } = useSelector(monitorSelector)
+  const { isShowCli, isShowHelper } = useAppSelector(cliSettingsSelector)
+  const { isShowMonitor } = useAppSelector(monitorSelector)
   const { privateRoutes } = useNavigation()
 
   const ref = useRef<ImperativePanelGroupHandle>(null)

--- a/redisinsight/ui/src/utils/routerWithSubRoutes.tsx
+++ b/redisinsight/ui/src/utils/routerWithSubRoutes.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import { Redirect, Route } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from 'uiSrc/slices/hooks'
 import { userSettingsSelector } from 'uiSrc/slices/user/user-settings'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { IRoute, FeatureFlags, Pages } from 'uiSrc/constants'
 
 const PrivateRoute = (route: IRoute) => {
   const { path, exact, routes, featureFlag, redirect } = route
-  const { [featureFlag as FeatureFlags]: feature } = useSelector(
+  const { [featureFlag as FeatureFlags]: feature } = useAppSelector(
     appFeatureFlagsFeaturesSelector,
   )
   const { isShowConceptsPopup: haveToAcceptAgreements } =
-    useSelector(userSettingsSelector)
+    useAppSelector(userSettingsSelector)
 
   return (
     <Route


### PR DESCRIPTION
# What

Introduces `useAppDispatch` and `useAppSelector` typed wrappers in
`redisinsight/ui/src/slices/hooks.ts` and migrates the entire UI
codebase (~354 production callsites + spec mocks) from the bare
`useDispatch` / `useSelector` from `react-redux` to the typed versions.

No dependency bumps and no behavioral change - this lands cleanly
on the current Redux stack (RTK 1.6 / react-redux 7) and is purely
preparatory work so the upcoming Redux v5 / RTK 2 / react-redux 9
upgrade (RI-8208, follow-up PR) is a minimal, reviewable diff.

# Testing

- `yarn lint`, `yarn type-check`, and `yarn test` all pass.
- No runtime change is expected; a quick smoke of the app
  (browser, workbench, CLI, bulk actions) confirmed parity.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import and hook renames with lint enforcement; no store or slice logic changes, though broad touch surface warrants standard regression smoke tests.
> 
> **Overview**
> Introduces **`useAppDispatch`** and **`useAppSelector`** in `uiSrc/slices/hooks.ts` (typed to `AppDispatch` and `RootState`) and **replaces** direct `useDispatch` / `useSelector` from `react-redux` across the UI—including Storybook decorators and tests that now mock `uiSrc/slices/hooks` instead of `react-redux`.
> 
> **ESLint** enforces the migration: `no-restricted-imports` blocks `useDispatch` and `useSelector` from `react-redux` everywhere except the hooks wrapper file. Call sites that used `useDispatch<AppDispatch>()` can use the typed hook without a generic.
> 
> No intended runtime behavior change—this is prep for a future Redux / RTK / react-redux upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cec96fa7786e850e308f92af2c85ea5e997784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->