### PR TITLE
RI-8197: fix GroupBadge label wrapping mid-word

### DIFF
--- a/redisinsight/ui/src/components/group-badge/GroupBadge.styles.ts
+++ b/redisinsight/ui/src/components/group-badge/GroupBadge.styles.ts
@@ -35,9 +35,12 @@ const compressedStyle = css`
 `
 export const StyledGroupBadge = styled(RiBadge)<StyledGroupBadgeProps>`
   min-width: ${({ theme }) => theme.core.space.space150};
+  flex-shrink: 0;
+  white-space: nowrap;
   & > p {
     display: flex;
     align-items: center;
+    white-space: nowrap;
   }
   ${({ $color }) =>
     `


### PR DESCRIPTION
## Summary

- Long type labels (e.g. multi-word group names) wrapped mid-word in the Command Helper info row.
- Sets `flex-shrink: 0` and `white-space: nowrap` on `StyledGroupBadge` so the label stays on a single line; surrounding args wrap to the next row instead.

Split out from [#5955](https://github.com/redis/RedisInsight/pull/5955), which was closed pending a decision on the proper Command Helper / Vector Set implementation. This styling fix is independent and worth landing on its own.

| before | after |
| --- | --- | 
| <img width="373" height="376" alt="image" src="https://github.com/user-attachments/assets/d82df160-9da2-4468-9faa-961d97ab6b11" /> | <img width="373" height="376" alt="image" src="https://github.com/user-attachments/assets/7df5902f-0057-45f5-aee6-2f210d2f2569" /> |

## Test plan

- [ ] Open Command Helper and inspect a command with a long group label — badge renders on a single line, args wrap to the next row when long
- [ ] `yarn type-check` passes with no new errors
- [ ] `yarn lint:ui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational CSS on a shared badge component with no logic, auth, or data changes.
> 
> **Overview**
> Fixes **Command Helper** (and other) **group/type badges** breaking long labels mid-word in tight flex rows.
> 
> `StyledGroupBadge` now uses **`flex-shrink: 0`** and **`white-space: nowrap`** on the badge and its inner `<p>`, so the label stays on one line and sibling content (e.g. command args) wraps to the next row instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8020a82eb1baa4dbc1a639add1ccd1728eeb51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->