### PR TITLE
Fix Geodata plugin e2e tests after Redis UI migration

### DIFF
--- a/scripts/build-statics.cmd
+++ b/scripts/build-statics.cmd
@@ -33,6 +33,9 @@ call yarn --cwd "%RI_EXPLIAIN_DIR%"
 set CLIENTS_LIST_DIR=".\redisinsight\ui\src\packages\clients-list"
 call yarn --cwd "%CLIENTS_LIST_DIR%"
 
+set GEODATA_DIR=".\redisinsight\ui\src\packages\geodata"
+call yarn --cwd "%GEODATA_DIR%"
+
 ::  Build all plugins and common libraries
 call yarn --cwd "%PACKAGES_DIR%" build
 
@@ -72,3 +75,9 @@ if not exist "%PLUGINS_DIR%\clients-list" mkdir "%PLUGINS_DIR%\clients-list"
 if not exist "%PLUGINS_DIR%\clients-list\dist" mkdir "%PLUGINS_DIR%\clients-list\dist"
 xcopy "%CLIENTS_LIST_DIR%\dist" "%PLUGINS_DIR%\clients-list\dist\" /s /e /y
 copy "%CLIENTS_LIST_DIR%\package.json" "%PLUGINS_DIR%\clients-list\"
+
+:: Copy geodata plugin
+if not exist "%PLUGINS_DIR%\geodata" mkdir "%PLUGINS_DIR%\geodata"
+if not exist "%PLUGINS_DIR%\geodata\dist" mkdir "%PLUGINS_DIR%\geodata\dist"
+xcopy "%GEODATA_DIR%\dist" "%PLUGINS_DIR%\geodata\dist\" /s /e /y
+copy "%GEODATA_DIR%\package.json" "%PLUGINS_DIR%\geodata\"

--- a/tests/e2e-playwright/pages/index.ts
+++ b/tests/e2e-playwright/pages/index.ts
@@ -13,7 +13,7 @@ export {
   TagsDialog,
   DatabaseList,
 } from './databases';
-export { WorkbenchPage, Editor, ResultsPanel } from './workbench';
+export { WorkbenchPage, Editor, ResultsPanel, GeodataPlugin } from './workbench';
 export { AnalyticsPage } from './analytics';
 export { SettingsPage } from './settings';
 export { PubSubPage } from './pubsub';

--- a/tests/e2e-playwright/pages/workbench/WorkbenchPage.ts
+++ b/tests/e2e-playwright/pages/workbench/WorkbenchPage.ts
@@ -22,7 +22,6 @@ export class WorkbenchPage extends InstancePage {
   readonly clearResultsButton: Locator;
   readonly rawModeButton: Locator;
   readonly groupResultsButton: Locator;
-  readonly viewTypeSelect: Locator;
 
   // Tutorial links
   readonly introToSearchLink: Locator;
@@ -46,7 +45,6 @@ export class WorkbenchPage extends InstancePage {
     this.clearResultsButton = page.locator('button:has-text("Clear Results")');
     this.rawModeButton = page.getByTestId('btn-change-mode');
     this.groupResultsButton = page.getByTestId('btn-change-group-mode');
-    this.viewTypeSelect = page.getByTestId('select-view-type').first();
 
     // Tutorial links
     this.introToSearchLink = page.getByTestId('query-tutorials-link_sq-intro');
@@ -119,14 +117,6 @@ export class WorkbenchPage extends InstancePage {
    */
   async toggleGroupResults(): Promise<void> {
     await this.groupResultsButton.click();
-  }
-
-  /**
-   * Select a Workbench result plugin view by its visible label.
-   */
-  async selectPluginView(viewName: string): Promise<void> {
-    await this.viewTypeSelect.click();
-    await this.page.getByText(viewName, { exact: true }).last().click();
   }
 
   /**

--- a/tests/e2e-playwright/pages/workbench/components/GeodataPlugin.ts
+++ b/tests/e2e-playwright/pages/workbench/components/GeodataPlugin.ts
@@ -1,0 +1,70 @@
+import { Page, Locator, FrameLocator } from '@playwright/test';
+
+/**
+ * Geodata Workbench plugin component.
+ *
+ * The plugin renders inside a sandboxed iframe, so all content locators are
+ * scoped to the most recent plugin frame. View titles are plain text (rendered
+ * via Redis UI Typography, not semantic headings), so they are matched with
+ * getByText.
+ */
+export class GeodataPlugin {
+  readonly page: Page;
+  readonly frame: FrameLocator;
+
+  // View titles
+  readonly mapTitle: Locator;
+  readonly heatmapTitle: Locator;
+  readonly detailsTitle: Locator;
+
+  // Map / heatmap visualizations
+  readonly plot: Locator;
+  readonly heatmapCanvas: Locator;
+  readonly mapTilesDisabledMessage: Locator;
+
+  // Scalar details metric
+  readonly distanceLabel: Locator;
+  readonly distanceValue: Locator;
+
+  // View-type selector (lives on the result card, outside the iframe)
+  private readonly viewTypeSelect: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.frame = page.frameLocator('[data-testid="pluginIframe"]').first();
+    this.viewTypeSelect = page.getByTestId('select-view-type').first();
+
+    this.mapTitle = this.frame.getByText('Geospatial map', { exact: true });
+    this.heatmapTitle = this.frame.getByText('Geospatial heatmap', { exact: true });
+    this.detailsTitle = this.frame.getByText('Geospatial details', { exact: true });
+
+    this.plot = this.frame.getByRole('img', { name: 'Leaflet geospatial plot' });
+    this.heatmapCanvas = this.frame.locator('canvas').first();
+    this.mapTilesDisabledMessage = this.frame.getByText('Map tiles disabled');
+
+    this.distanceLabel = this.frame.getByText('Distance');
+    this.distanceValue = this.frame.getByText(/^\d+(\.\d+)? km$/);
+  }
+
+  /** Switch the result to the Geospatial map (markers) view. */
+  async showMarkers(): Promise<void> {
+    await this.selectView('Geospatial map');
+  }
+
+  /** Switch the result to the Geospatial heatmap view. */
+  async showHeatmap(): Promise<void> {
+    await this.selectView('Geospatial heatmap');
+  }
+
+  /**
+   * Result table cell for a given geospatial member (e.g. "Palermo").
+   */
+  memberCell(name: string): Locator {
+    return this.frame.getByRole('cell', { name });
+  }
+
+  private async selectView(viewName: string): Promise<void> {
+    await this.viewTypeSelect.click();
+    await this.page.getByText(viewName, { exact: true }).last().click();
+  }
+}

--- a/tests/e2e-playwright/pages/workbench/components/ResultsPanel.ts
+++ b/tests/e2e-playwright/pages/workbench/components/ResultsPanel.ts
@@ -1,4 +1,5 @@
 import { Page, Locator, FrameLocator } from '@playwright/test';
+import { GeodataPlugin } from './GeodataPlugin';
 
 /**
  * Results Panel component for Workbench
@@ -12,6 +13,7 @@ export class ResultsPanel {
   readonly resultText: Locator;
   readonly pluginResult: Locator;
   readonly pluginIframe: Locator;
+  readonly geodataPlugin: GeodataPlugin;
 
   constructor(page: Page) {
     this.page = page;
@@ -21,6 +23,7 @@ export class ResultsPanel {
     this.resultText = page.getByTestId('query-cli-card-result').first();
     this.pluginResult = page.getByTestId('query-plugin-result').first();
     this.pluginIframe = page.getByTestId('pluginIframe').first();
+    this.geodataPlugin = new GeodataPlugin(page);
   }
 
   /**

--- a/tests/e2e-playwright/pages/workbench/components/index.ts
+++ b/tests/e2e-playwright/pages/workbench/components/index.ts
@@ -1,2 +1,3 @@
 export { Editor } from './Editor';
 export { ResultsPanel } from './ResultsPanel';
+export { GeodataPlugin } from './GeodataPlugin';

--- a/tests/e2e-playwright/pages/workbench/index.ts
+++ b/tests/e2e-playwright/pages/workbench/index.ts
@@ -1,2 +1,2 @@
 export { WorkbenchPage } from './WorkbenchPage';
-export { Editor, ResultsPanel } from './components';
+export { Editor, ResultsPanel, GeodataPlugin } from './components';

--- a/tests/e2e-playwright/tests/parallel/workbench/geodata-plugin.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/workbench/geodata-plugin.spec.ts
@@ -2,9 +2,6 @@ import { test, expect } from 'e2eSrc/fixtures/base';
 import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
 import { DatabaseInstance } from 'e2eSrc/types';
 
-const MARKERS_VIEW_NAME = 'Geospatial map';
-const HEATMAP_VIEW_NAME = 'Geospatial heatmap';
-
 const GEO_KEY = 'Sicily';
 const GEOADD_COMMAND = [
   `GEOADD ${GEO_KEY}`,
@@ -43,39 +40,39 @@ test.describe('Workbench > Geodata plugin', () => {
   test('renders Geospatial map by default for coordinate search results', async ({ workbenchPage }) => {
     await workbenchPage.executeCommand(GEOSEARCH_COMMAND);
 
-    const frame = workbenchPage.resultsPanel.pluginFrame();
-    await expect(workbenchPage.resultsPanel.pluginResult).toBeVisible();
-    await expect(frame.getByRole('heading', { name: MARKERS_VIEW_NAME })).toBeVisible();
-    await expect(frame.getByRole('img', { name: 'Leaflet geospatial plot' })).toBeVisible();
-    await expect(frame.getByText('Map tiles disabled')).not.toBeVisible();
+    const { geodataPlugin, pluginResult } = workbenchPage.resultsPanel;
+    await expect(pluginResult).toBeVisible();
+    await expect(geodataPlugin.mapTitle).toBeVisible();
+    await expect(geodataPlugin.plot).toBeVisible();
+    await expect(geodataPlugin.mapTilesDisabledMessage).not.toBeVisible();
   });
 
   test('switches coordinate search results to Geospatial heatmap', async ({ workbenchPage }) => {
     await workbenchPage.executeCommand(GEOSEARCH_COMMAND);
-    await workbenchPage.selectPluginView(HEATMAP_VIEW_NAME);
 
-    const frame = workbenchPage.resultsPanel.pluginFrame();
-    await expect(frame.getByRole('heading', { name: HEATMAP_VIEW_NAME })).toBeVisible();
-    await expect(frame.locator('canvas').first()).toBeVisible();
+    const { geodataPlugin } = workbenchPage.resultsPanel;
+    await geodataPlugin.showHeatmap();
+    await expect(geodataPlugin.heatmapTitle).toBeVisible();
+    await expect(geodataPlugin.heatmapCanvas).toBeVisible();
   });
 
   test('switches coordinate search results back to Geospatial map', async ({ workbenchPage }) => {
     await workbenchPage.executeCommand(GEOSEARCH_COMMAND);
-    await workbenchPage.selectPluginView(HEATMAP_VIEW_NAME);
-    await workbenchPage.selectPluginView(MARKERS_VIEW_NAME);
 
-    const frame = workbenchPage.resultsPanel.pluginFrame();
-    await expect(frame.getByRole('heading', { name: MARKERS_VIEW_NAME })).toBeVisible();
-    await expect(frame.getByRole('img', { name: 'Leaflet geospatial plot' })).toBeVisible();
-    await expect(frame.getByRole('cell', { name: 'Palermo' })).toBeVisible();
+    const { geodataPlugin } = workbenchPage.resultsPanel;
+    await geodataPlugin.showHeatmap();
+    await geodataPlugin.showMarkers();
+    await expect(geodataPlugin.mapTitle).toBeVisible();
+    await expect(geodataPlugin.plot).toBeVisible();
+    await expect(geodataPlugin.memberCell('Palermo')).toBeVisible();
   });
 
   test('renders Geospatial details by default for scalar GEO commands', async ({ workbenchPage }) => {
     await workbenchPage.executeCommand(GEODIST_COMMAND);
 
-    const frame = workbenchPage.resultsPanel.pluginFrame();
-    await expect(frame.getByRole('heading', { name: 'Geospatial details' })).toBeVisible();
-    await expect(frame.getByText('Distance')).toBeVisible();
-    await expect(frame.getByText(/^\d+(\.\d+)? km$/)).toBeVisible();
+    const { geodataPlugin } = workbenchPage.resultsPanel;
+    await expect(geodataPlugin.detailsTitle).toBeVisible();
+    await expect(geodataPlugin.distanceLabel).toBeVisible();
+    await expect(geodataPlugin.distanceValue).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

The geodata Workbench plugin E2E tests were failing after the Redis UI migration. The plugin's view titles now render through `Typography.Heading`, which defaults to a `<div>` (no `role="heading"`), so the existing `getByRole('heading', …)` assertions could never match.

- **New page-object component** `GeodataPlugin` ([GeodataPlugin.ts](tests/e2e-playwright/pages/workbench/components/GeodataPlugin.ts)) encapsulating all plugin-iframe interactions
- Rewrote [geodata-plugin.spec.ts](tests/e2e-playwright/tests/parallel/workbench/geodata-plugin.spec.ts) to drive everything through the page object — no inline selectors or label strings in the test.

## Testing

- `npx playwright test geodata-plugin --project=chromium-parallel` → **4/4 pass**

<img width="1010" height="309" alt="image" src="https://github.com/user-attachments/assets/dc1820f3-b692-4701-bb50-10493dba74ae" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E page objects, spec refactors, and static plugin build wiring with no production app logic.
> 
> **Overview**
> Fixes **Geodata Workbench** Playwright coverage after the Redis UI migration by introducing a **`GeodataPlugin`** page object and routing assertions through **`resultsPanel.geodataPlugin`** instead of brittle iframe/`heading` selectors.
> 
> The new component scopes locators to the plugin iframe, matches view titles with **`getByText`** (Typography no longer exposes **`role="heading"`**), and owns view switching via **`showMarkers`** / **`showHeatmap`**. **`WorkbenchPage.selectPluginView`** is removed in favor of that encapsulation. **`build-statics.cmd`** now installs and copies the **geodata** package into static plugins like the other Workbench plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa8ef1e262c6aa5f3a7257d520860dce5a920af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->