### PR TITLE
Simplify AppDispatch and remove redux-types workarounds

### DIFF
--- a/redisinsight/ui/src/slices/store.ts
+++ b/redisinsight/ui/src/slices/store.ts
@@ -1,9 +1,4 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
-import type {
-  ConfigureStoreOptions,
-  ThunkDispatch,
-  UnknownAction,
-} from '@reduxjs/toolkit'
 
 import { getConfig } from 'uiSrc/config'
 import instancesReducer from './instances/instances'
@@ -150,27 +145,10 @@ export const rootReducer = combineReducers({
   }),
 })
 
-// The middleware callback below trips TS2719 "two different types with this
-// name exist, but they are unrelated" between RTK 2 (whose `Middleware` is
-// redux@5's) and the `ThunkMiddleware` baked into `getDefaultMiddleware`'s
-// return type. We pin `redux@^5.0.1` as a direct dep so v5 wins yarn's
-// top-level hoist locally, but on a clean install (CI) the redux@4 copy
-// pulled in by `@elastic/eui` → `react-beautiful-dnd` → `@types/react-
-// redux@7` can still win that contest — yarn hoisting is non-deterministic
-// when two majors are equally eligible. The shapes are structurally
-// identical at runtime; only the type-checker rejects the assignment. We
-// cast to RTK 2's own expected callback type instead of `any` so the cast
-// still flags real shape regressions, and we keep the workaround local
-// rather than reaching for a yarn `resolutions` entry so the project stays
-// portable to npm `overrides`.
-type StoreMiddleware = NonNullable<
-  ConfigureStoreOptions<RootState>['middleware']
->
-
 const store = configureStore({
   reducer: rootReducer,
-  middleware: ((getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false })) as StoreMiddleware,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
   devTools: riConfig.app.env !== 'production',
 })
 
@@ -178,15 +156,6 @@ export { store }
 
 export type ReduxStore = typeof store
 export type RootState = ReturnType<typeof rootReducer>
-// Use ThunkDispatch explicitly so the thunk overload is always available on
-// AppDispatch. With RTK 2 + redux-thunk 3, the implicit `typeof store.dispatch`
-// can drop the ThunkDispatch overload in certain middleware-inference paths
-// and degrade to Dispatch<UnknownAction>, which would force every
-// dispatch(thunk()) callsite to fail with TS2345.
-export type AppDispatch = ThunkDispatch<RootState, unknown, UnknownAction> &
-  typeof store.dispatch
+export type AppDispatch = typeof store.dispatch
 
-// Bare dispatch reference used by callsites that don't have access to the
-// React hook. Typed as AppDispatch so non-hook handler files can dispatch
-// thunks without losing the thunk overload.
-export const dispatch: AppDispatch = store.dispatch as AppDispatch
+export const dispatch: AppDispatch = store.dispatch

--- a/redisinsight/ui/src/utils/test-store.ts
+++ b/redisinsight/ui/src/utils/test-store.ts
@@ -22,19 +22,16 @@ const getState: ReduxStore['getState'] = () => {
   return storeRef.getState()
 }
 
-// `action: any` because `AppDispatch` is an intersection of `ThunkDispatch`
-// overloads — TypeScript can't infer a single parameter type across the
-// overload set, so a direct `(action) => ...` form fails with TS7006. The
-// outer `as AppDispatch` keeps the exported binding correctly typed for
-// callers.
-export const dispatch = ((action: any) => {
+// `action: any` because TS can't infer a single parameter type when
+// implementing an overloaded call signature like `AppDispatch`.
+export const dispatch: AppDispatch = (action: any) => {
   if (!storeRef) {
     throw new Error(
       'Store not initialized. Make sure store-dynamic is imported after store creation.',
     )
   }
   return storeRef.dispatch(action)
-}) as AppDispatch
+}
 
 const subscribe: ReduxStore['subscribe'] = (listener: () => void) => {
   if (!storeRef) {


### PR DESCRIPTION
# What

Follow-up cleanup to #5994. The workarounds that PR introduced are no longer needed:

- `AppDispatch`: drop `ThunkDispatch<...> & typeof store.dispatch` intersection — `typeof store.dispatch` already carries the thunk overload in RTK 2.
- `configureStore`: drop the `StoreMiddleware` cast on the `middleware` callback.
- `test-store.ts`: drop the outer `as AppDispatch` cast and the long comment block; keep the `action: any` parameter (orthogonal TS-overload limitation).
- Remove the rationale comments that described the now-removed workarounds.

External typing surface for callers is unchanged. Aligns with the canonical RTK docs pattern.

# Testing

- `yarn type-check` — clean (1823 / 4080 / 512, unchanged from baseline)
- `yarn lint:ui`
- `yarn test redisinsight/ui/src/slices`

---

Builds on #5994

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only cleanup with no intended runtime behavior change; risk is limited to possible TypeScript inference regressions for thunk dispatch at compile time.
> 
> **Overview**
> Removes **Redux Toolkit / redux v5 typing workarounds** in `store.ts` and `test-store.ts` now that the upgraded dependency tree type-checks without them.
> 
> **`store.ts`:** Drops unused RTK imports and the long `StoreMiddleware` explanation; the `configureStore` **middleware** callback is passed through **without a cast**. **`AppDispatch`** is now **`typeof store.dispatch`** instead of a **`ThunkDispatch` ∩ `store.dispatch`** intersection, and the exported **`dispatch`** binding no longer needs an **`as AppDispatch`** assertion.
> 
> **`test-store.ts`:** Types the test **`dispatch`** wrapper directly as **`AppDispatch`** (still uses **`action: any`** for the overload limitation) and removes the outer cast and obsolete comments tied to the old **`AppDispatch`** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40346206c70691cade8b56716083d0b8a356e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->