### PR TITLE
Fix browser key filter leaking into Search page index creation

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.spec.tsx
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react'
+import { cloneDeep } from 'lodash'
+import { MemoryRouter } from 'react-router-dom'
+import { render, mockStore, initialStateDefault } from 'uiSrc/utils/test-utils'
+import { setPatternSearchMatch } from 'uiSrc/slices/browser/keys'
+
+import { KeysBrowserContext, Provider } from './Context'
+
+const Consumer = () => {
+  useContext(KeysBrowserContext)
+  return <div data-testid="consumer" />
+}
+
+const renderProvider = (search: string) => {
+  const state = cloneDeep(initialStateDefault)
+  state.browser.keys.search = search
+
+  const store = mockStore(state)
+
+  render(
+    <MemoryRouter>
+      <Provider onSelectKey={jest.fn()}>
+        <Consumer />
+      </Provider>
+    </MemoryRouter>,
+    { store },
+  )
+
+  return store
+}
+
+describe('KeysBrowserContext Provider (vector-search)', () => {
+  it('should clear the Browser page search pattern on mount so the key list is unfiltered', () => {
+    const store = renderProvider('user:*')
+
+    expect(store.getActions()).toContainEqual(setPatternSearchMatch(''))
+  })
+
+  it('should clear the search pattern even when no browser filter was set', () => {
+    const store = renderProvider('')
+
+    expect(store.getActions()).toContainEqual(setPatternSearchMatch(''))
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/keys-browser/contexts/Context.tsx
@@ -24,6 +24,7 @@ import {
   resetKeyInfo,
   resetKeysData,
   setFilter,
+  setPatternSearchMatch,
 } from 'uiSrc/slices/browser/keys'
 import { SearchMode } from 'uiSrc/slices/interfaces/keys'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
@@ -99,10 +100,12 @@ export const Provider = ({
     dispatch(resetKeysData(SearchMode.Pattern))
     dispatch(resetBrowserTree())
     dispatch(setFilter(activeTab))
+    dispatch(setPatternSearchMatch(''))
     loadKeys()
 
     return () => {
       dispatch(setFilter(null))
+      dispatch(setPatternSearchMatch(''))
       dispatch(resetKeyInfo())
       dispatch(resetKeysData(SearchMode.Pattern))
       dispatch(resetBrowserTree())


### PR DESCRIPTION
# What

The **Browser** page and the **Search** page's *"create index based on existing data"* flow reuse the same key-listing component, backed by the same `state.browser.keys` Redux slice.

The Browser page stores its search/filter pattern in `state.browser.keys.search`. The Search page's key browser reset the key-type filter on mount but **never cleared the search pattern**, so a filter typed on the Browser page leaked into the Search page and the user only saw a filtered subset of keys instead of all of them.


## Before

https://github.com/user-attachments/assets/3d2b37cf-a7a9-461f-a177-45ad956f30c3

## After

https://github.com/user-attachments/assets/d0a5e75d-7018-4739-a07d-60e71f8ccc7b


# Bug

When a filter is active on the Browser page, opening *create index from existing data* on the Search page applies that same filter and hides keys.

Fix: dispatch `setPatternSearchMatch('')` on mount (and on cleanup) in the vector-search keys-browser context, so the index-creation key list always starts unfiltered — and leaves no stale pattern behind in either direction.

# How to test 

1. Open Redis Insight and connect to a database that has **several keys of different types** (e.g. multiple Hash and JSON keys with different name prefixes).
2. Go to the **Browser** page.
3. In the filter/search bar at the top, type a pattern that matches only **some** keys (e.g. `user:*`) so the key list is filtered down to a subset.
4. Navigate to the **Search** page → **Create index** → choose **based on existing data**.
5. **Expected (fixed):** the key browser there shows **all** Hash/JSON keys, not just the `user:*` subset. **Before the fix:** only the filtered subset (`user:*`) appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Redux lifecycle change in the Search keys-browser provider with unit tests; no auth, security, or data-path changes.
> 
> **Overview**
> Stops **Browser** key search patterns from carrying into the **Search** “create index from existing data” key picker, which shares the same `state.browser.keys` Redux state.
> 
> The vector-search `KeysBrowserContext` provider now dispatches **`setPatternSearchMatch('')`** when it mounts and again on cleanup, alongside the existing key-type filter reset, so the index-creation list always loads unfiltered and does not leave a stale pattern in shared state. **Unit tests** assert that pattern is cleared on mount whether or not a prior filter was set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e22e66c5d60890aafbd45229be8ca8d632020c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->