### PR TITLE
chore(deps): refresh @types/node transitives in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15290,11 +15290,6 @@ underscore@1.13.6:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-undici-types@~7.12.0:
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
-  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
-
 undici-types@~7.18.0:
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"


### PR DESCRIPTION
Refreshes transitive dependency resolutions in the root `yarn.lock` after the recent Electron 40 + Node 24 bumps:

- `@types/node` (matched by the loose `*` and `>=13.7.0` constraints in our dep graph) bumps from a previous 24.x patch to `24.13.0`.
- `undici-types` follows, going from `7.12.0` → `7.18.2` (sub-dependency of `@types/node`).

No `package.json` changes. Lockfile-only.

# Why

When `electron@40.10.2` landed, it pinned `@types/node: ^24.9.0` in its own dependency manifest — first time the 24.x line of `@types/node` was anchored in our graph. Some transitives declare loose `@types/node` constraints (`*`, `>=13.7.0`), so running `yarn install` now picks up the newest matching 24.x patch on npm, which carries a newer `undici-types`.

Catching this drift in a small dedicated PR keeps the lockfile in sync with what a clean `yarn install` produces locally, avoiding noisy lockfile diffs sneaking into unrelated feature branches.

# Testing

- `yarn install` — clean
- `yarn type-check`, `yarn lint`, `yarn test`, `yarn test:api` — all pass
- No runtime behavior change (types-only dependency)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Types-only lockfile resolution with no application or runtime code changes.
> 
> **Overview**
> **Lockfile-only** refresh of transitive Node typings after Electron/Node 24 alignment in the dependency graph—no `package.json` edits.
> 
> Root `yarn.lock` now resolves loose `@types/node` constraints (`*`, `>=13.7.0`, `^24.9.0`) to **`24.13.0`**, and drops the older **`undici-types@7.12.0`** entry in favor of **`7.18.2`** (pulled via `@types/node`). Intent is to match a clean `yarn install` so unrelated PRs don’t pick up stray lockfile drift.
> 
> Types-only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c58cbcfaed78c1831e02a1899cc73f9a471d034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->