### PR TITLE
feat(RI-8212): Add array feature flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.9,
+  "version": 3.10,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -140,6 +140,10 @@
       "perc": [[0, 100]]
     },
     "dev-vectorSet": {
+      "flag": false,
+      "perc": [[0, 100]]
+    },
+    "dev-array": {
       "flag": false,
       "perc": [[0, 100]]
     },

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.10,
+  "version": 3.91,
   "features": {
     "redisDataIntegration": {
       "flag": true,

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -37,6 +37,7 @@ export enum KnownFeatures {
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
   DevVectorSet = 'dev-vectorSet',
+  DevArray = 'dev-array',
   ProdMode = 'prodMode',
 }
 

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -87,6 +87,10 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevVectorSet,
     storage: FeatureStorage.Database,
   },
+  [KnownFeatures.DevArray]: {
+    name: KnownFeatures.DevArray,
+    storage: FeatureStorage.Database,
+  },
   [KnownFeatures.ProdMode]: {
     name: KnownFeatures.ProdMode,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -104,6 +104,10 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
+      KnownFeatures.DevArray,
+      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
+    );
+    this.strategies.set(
       KnownFeatures.ProdMode,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -13,6 +13,7 @@ export enum FeatureFlags {
   customTutorials = 'customTutorials',
   vectorSearchV2 = 'vectorSearchV2',
   devVectorSet = 'dev-vectorSet',
+  devArray = 'dev-array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
   prodMode = 'prodMode',

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -68,6 +68,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devVectorSet]: {
         flag: false,
       },
+      [FeatureFlags.devArray]: {
+        flag: false,
+      },
       [FeatureFlags.azureEntraId]: {
         flag: false,
       },
@@ -234,6 +237,15 @@ export const isDevVectorSetEnabledSelector = (state: RootState): boolean => {
 
   const features = state.app.features.featureFlags.features
   return features[FeatureFlags.devVectorSet]?.flag ?? false
+}
+
+export const isDevArrayEnabledSelector = (state: RootState): boolean => {
+  if (isDevelopment) {
+    return true
+  }
+
+  const features = state.app.features.featureFlags.features
+  return features[FeatureFlags.devArray]?.flag ?? false
 }
 
 export default appFeaturesSlice.reducer

--- a/redisinsight/ui/src/slices/tests/app/features.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/features.spec.ts
@@ -15,6 +15,7 @@ import reducer, {
   getFeatureFlagsFailure,
   fetchFeatureFlags,
   isAzureEntraIdEnabledSelector,
+  isDevArrayEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { FeatureFlags } from 'uiSrc/constants'
 import {
@@ -607,6 +608,44 @@ describe('slices', () => {
       })
 
       expect(isAzureEntraIdEnabledSelector(rootState)).toBe(false)
+    })
+  })
+
+  describe('isDevArrayEnabledSelector', () => {
+    const createRootState = (features: Record<string, { flag: boolean }>) => ({
+      ...initialStateDefault,
+      app: {
+        ...initialStateDefault.app,
+        features: {
+          ...initialState,
+          featureFlags: {
+            ...initialState.featureFlags,
+            features,
+          },
+        },
+      },
+    })
+
+    it('should return true when devArray flag is enabled', () => {
+      const rootState = createRootState({
+        [FeatureFlags.devArray]: { flag: true },
+      })
+
+      expect(isDevArrayEnabledSelector(rootState)).toBe(true)
+    })
+
+    it('should return false when devArray flag is disabled', () => {
+      const rootState = createRootState({
+        [FeatureFlags.devArray]: { flag: false },
+      })
+
+      expect(isDevArrayEnabledSelector(rootState)).toBe(false)
+    })
+
+    it('should return false when devArray flag is missing', () => {
+      const rootState = createRootState({})
+
+      expect(isDevArrayEnabledSelector(rootState)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
# What

Adds the `dev-array` feature flag as Foundation work for the Redis Array type initiative. Mirrors the existing `dev-vectorSet` plumbing 1:1:

- Backend: registers the flag with `CommonFlagStrategy` and `FeatureStorage.Database`; defaults to `false`.
- Frontend: adds the flag to the `FeatureFlags` enum and the initial Redux state, and exports `isDevArrayEnabledSelector` so the upcoming tasks can gate their UI surfaces behind it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive feature-flag registration with default false and no production UI wired yet; mirrors an existing dev-flag pattern.
> 
> **Overview**
> Introduces the **`dev-array`** feature flag (config version **3.9 → 3.91**) as foundation for upcoming Redis Array work, following the same pattern as **`dev-vectorSet`**.
> 
> **Backend** registers `KnownFeatures.DevArray` in known features and wires **`CommonFlagStrategy`** with database-backed storage; **`features-config.json`** defaults the flag to **off**.
> 
> **Frontend** adds `FeatureFlags.devArray`, default **`false`** in Redux initial state, and exports **`isDevArrayEnabledSelector`** (enabled in development, otherwise driven by fetched flags). Unit tests cover the selector for enabled, disabled, and missing flag cases.
> 
> No browser or API behavior is gated by this flag yet—only the toggle plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075ca21de61feb01cf9302a5f132e4d6329081e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->