### PR TITLE
Use blueish readable Vector Set badge color on both themes

### DIFF
--- a/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
@@ -149,7 +149,7 @@ $typeReJSONColor: #3f4b5f;
 $typeStreamColor: #6a741b;
 $typeGraphColor: #14708d;
 $typeTimeSeriesColor: #6e6e6e;
-$typeVectorSetColor: #8A99A0;
+$typeVectorSetColor: #0284C7;
 $groupSortedSetColor: #a00a6b;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;

--- a/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
@@ -114,7 +114,7 @@ $typeReJSONColor: #b8c5db;
 $typeStreamColor: #c7cea8;
 $typeGraphColor: #acccd7;
 $typeTimeSeriesColor: #c7c7c7;
-$typeVectorSetColor: #8A99A0;
+$typeVectorSetColor: #0284C7;
 $groupSortedSetColor: #d9a0c6;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;


### PR DESCRIPTION
## Summary
- The Vector Set key-type badge used `secondary400` (`#8A99A0`) — a neutral gray that had poor contrast on both light and dark themes and made the badge blend into the row.
- Switch to `informative500` (`#0284C7`) from the redis-ui palette: a saturated sky/cyan blue that passes WCAG AA against both backgrounds and stays distinct from the other key-type colors (Hash is `primary` royal-blue, JSON is `secondary` muted gray-blue, etc.).
- Applied to both `light_theme/_theme_color.scss` and `dark_theme/_theme_color.scss` — same single-color approach as the previous value, so the filter dropdown swatch and the row badge in the key list both update.

## Before / After
| Before (`#8A99A0`) | After (`#0284C7`) |
|---|---|
| <img width="927" height="696" alt="image" src="https://github.com/user-attachments/assets/1946b3a8-67fb-4583-95ba-0cfaf45f2737" /> | <img width="927" height="696" alt="image" src="https://github.com/user-attachments/assets/1fff5486-d306-4c7f-b9bb-929390a2c460" /> |
| <img width="927" height="696" alt="image" src="https://github.com/user-attachments/assets/7476be88-29c0-4db8-bf4b-b8ba0b30fa53" /> | <img width="927" height="696" alt="image" src="https://github.com/user-attachments/assets/5af9d7fe-3518-4e4b-a731-123cca04b38c" /> |

## Test plan
- [ ] Open the Browser page in **light theme** and confirm the Vector Set row badges and the filter dropdown swatch render in the new blue and are easily distinguishable from Hash and JSON
- [ ] Switch to **dark theme** and confirm the same — the dot is clearly visible against the dark background
- [ ] Confirm no other key-type colors changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme-only SCSS token change for one key-type color; no logic, auth, or data handling.
> 
> **Overview**
> Updates the **Vector Set** key-type badge color from muted gray (`#8A99A0`) to sky blue (`#0284C7`) in both **light** and **dark** theme token files (`$typeVectorSetColor`). Browser list badges and the type filter swatch pick this up via `--typeVectorSetColor` / `GROUP_TYPES_COLORS` with no other key-type colors touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527b79a57be77f5c612927d3e6621a8778064ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->