### PR TITLE
[Vector Set] suggest element attributes in similarity-search filter

### DIFF
--- a/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-elements.response.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/get.vector-set-elements.response.ts
@@ -1,7 +1,7 @@
 import { KeyResponse } from 'src/modules/browser/keys/dto';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { RedisStringType } from 'src/common/decorators';
-import { RedisString } from 'src/common/constants';
+import { Type } from 'class-transformer';
+import { VectorSetElementListItemDto } from './vector-set-element-list-item.dto';
 
 export class GetVectorSetElementsResponse extends KeyResponse {
   @ApiProperty({
@@ -27,10 +27,10 @@ export class GetVectorSetElementsResponse extends KeyResponse {
   isPaginationSupported: boolean;
 
   @ApiProperty({
-    description: 'Array of vector set element names.',
+    description: 'Array of vector set elements with their attributes when set.',
     isArray: true,
-    type: String,
+    type: VectorSetElementListItemDto,
   })
-  @RedisStringType({ each: true })
-  elementNames: RedisString[];
+  @Type(() => VectorSetElementListItemDto)
+  elements: VectorSetElementListItemDto[];
 }

--- a/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/index.ts
@@ -1,5 +1,6 @@
 export * from './vector-set-element-details.dto';
 export * from './vector-set-element-key.dto';
+export * from './vector-set-element-list-item.dto';
 export * from './add.vector-set-element.dto';
 export * from './add.elements-to-vector-set.dto';
 export * from './create.vector-set.dto';

--- a/redisinsight/api/src/modules/browser/vector-set/dto/vector-set-element-list-item.dto.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/dto/vector-set-element-list-item.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RedisStringType } from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+export class VectorSetElementListItemDto {
+  @ApiProperty({
+    type: String,
+    description: 'Vector set element name.',
+  })
+  @RedisStringType()
+  name: RedisString;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Attributes string stored on the element (typically JSON). ' +
+      'Omitted when the element has no attributes.',
+  })
+  attributes?: string;
+}

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -320,6 +320,11 @@ describe('VectorSetService', () => {
   });
 
   describe('getElements', () => {
+    const mockAttributePipelineReply = mockElementNames.map((_, i) => [
+      null,
+      i === 0 ? '{"color":"red"}' : null,
+    ]);
+
     beforeEach(() => {
       client.isFeatureSupported = jest.fn().mockResolvedValue(true);
 
@@ -340,6 +345,10 @@ describe('VectorSetService', () => {
           mockDto.count,
         ])
         .mockResolvedValue(mockElementNames);
+
+      client.sendPipeline = jest
+        .fn()
+        .mockResolvedValue(mockAttributePipelineReply);
     });
 
     it('should get elements successfully', async () => {
@@ -358,9 +367,21 @@ describe('VectorSetService', () => {
         mockDto.end,
         mockDto.count,
       ]);
+      expect(client.sendPipeline).toHaveBeenCalledWith(
+        mockElementNames.map((name) => [
+          BrowserToolVectorSetCommands.VGetAttr,
+          mockDto.keyName,
+          name,
+        ]),
+      );
       expect(result.keyName).toEqual(mockDto.keyName);
       expect(result.total).toEqual(mockElements.length);
-      expect(result.elementNames).toHaveLength(mockElements.length);
+      expect(result.elements).toHaveLength(mockElements.length);
+      expect(Buffer.from(result.elements[0].name as any).toString()).toEqual(
+        mockElementNames[0],
+      );
+      expect(result.elements[0].attributes).toEqual('{"color":"red"}');
+      expect(result.elements[1].attributes).toBeUndefined();
       expect(result.isPaginationSupported).toBe(true);
     });
 
@@ -415,8 +436,9 @@ describe('VectorSetService', () => {
       );
 
       expect(result.total).toEqual(0);
-      expect(result.elementNames).toEqual([]);
+      expect(result.elements).toEqual([]);
       expect(result.nextCursor).toBeUndefined();
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException for wrong type error', async () => {
@@ -467,9 +489,27 @@ describe('VectorSetService', () => {
         mockDto.keyName,
         mockDto.count,
       ]);
-      expect(result.elementNames).toHaveLength(mockElements.length);
+      expect(result.elements).toHaveLength(mockElements.length);
       expect(result.nextCursor).toBeUndefined();
       expect(result.isPaginationSupported).toBe(false);
+    });
+
+    it('should keep attributes undefined when VGETATTR fails for an element', async () => {
+      client.sendPipeline = jest
+        .fn()
+        .mockResolvedValue(
+          mockElementNames.map(() => [new Error('boom'), null]),
+        );
+
+      const result = await service.getElements(
+        mockBrowserClientMetadata,
+        mockDto,
+      );
+
+      expect(result.elements).toHaveLength(mockElementNames.length);
+      result.elements.forEach((el) => {
+        expect(el.attributes).toBeUndefined();
+      });
     });
   });
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -173,6 +173,13 @@ export class VectorSetService {
         ])) as string[];
       }
 
+      const elements: { name: string | Buffer; attributes?: string }[] =
+        elementNames.map((name) => ({ name }));
+
+      if (elements.length > 0) {
+        await this.fetchAttributesForMatches(client, keyName, elements);
+      }
+
       this.logger.debug(
         'Succeed to get elements of the VectorSet data type.',
         clientMetadata,
@@ -182,7 +189,7 @@ export class VectorSetService {
         total,
         nextCursor,
         isPaginationSupported: isVRangeSupported,
-        elementNames,
+        elements,
       });
     } catch (error) {
       this.logger.error(
@@ -463,12 +470,13 @@ export class VectorSetService {
   }
 
   /**
-   * Back-fill the `attributes` field on each match by issuing one VGETATTR
-   * per element in a single pipeline. Used as the fallback path for Redis
-   * 8.0.0–8.0.2 where VSIM rejects the WITHATTRIBS option.
+   * Back-fill the `attributes` field on each item by issuing one VGETATTR
+   * per element in a single pipeline. Used by `getElements` (VRANGE /
+   * VRANDMEMBER don't return attributes) and as the fallback path of
+   * `similaritySearch` on Redis 8.0.0–8.0.2 where VSIM rejects WITHATTRIBS.
    *
    * Mutates `matches` in place. Per-element errors are swallowed (logged at
-   * debug) so a single failing VGETATTR cannot drop the whole search reply;
+   * debug) so a single failing VGETATTR cannot drop the whole reply;
    * elements without attributes simply keep `attributes` undefined.
    */
   private async fetchAttributesForMatches(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.spec.ts
@@ -262,7 +262,7 @@ describe('useSimilaritySearch', () => {
         })
 
         act(() => {
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).not.toHaveBeenCalled()
@@ -316,7 +316,7 @@ describe('useSimilaritySearch', () => {
         unmount()
 
         act(() => {
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).not.toHaveBeenCalled()
@@ -394,7 +394,7 @@ describe('useSimilaritySearch', () => {
         expect(fetchVectorSetSimilaritySearchPreview).not.toHaveBeenCalled()
 
         act(() => {
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).toHaveBeenCalledTimes(1)
@@ -414,7 +414,7 @@ describe('useSimilaritySearch', () => {
 
         act(() => {
           result.current.runSimilaritySearchPreview(baseState())
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).not.toHaveBeenCalled()
@@ -440,7 +440,7 @@ describe('useSimilaritySearch', () => {
             ...baseState(),
             vectorInput: '1, 2',
           })
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).not.toHaveBeenCalled()
@@ -460,7 +460,7 @@ describe('useSimilaritySearch', () => {
             mode: SimilaritySearchMode.Element,
             elementInput: 'book-1',
           })
-          jest.advanceTimersByTime(300)
+          jest.advanceTimersByTime(700)
         })
 
         expect(fetchVectorSetSimilaritySearchPreview).toHaveBeenCalledWith(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/hooks/useSimilaritySearch/useSimilaritySearch.ts
@@ -32,7 +32,7 @@ import { areKeysEqual } from './useSimilaritySearch.utils'
  * Tuned to feel responsive without spamming the BE during fast typing — the
  * preview is best-effort, not a hot path.
  */
-const PREVIEW_DEBOUNCE_MS = 250
+const PREVIEW_DEBOUNCE_MS = 600
 
 export const useSimilaritySearch = (): UseSimilaritySearchResult => {
   const dispatch = useAppDispatch()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/command-preview/CommandPreview.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/command-preview/CommandPreview.tsx
@@ -13,13 +13,11 @@ export const CommandPreview = ({
   loading = false,
 }: CommandPreviewProps) => {
   const isEmpty = command.length === 0
-  // Keep showing the previous command while a refresh is in flight so the
-  // preview doesn't flicker between the old text and a placeholder on every
-  // keystroke. Only fall back to the placeholder on the very first load,
-  // when there's nothing to show yet.
   let displayText = command
-  if (isEmpty) {
-    displayText = loading ? COMMAND_PREVIEW_LOADING_PLACEHOLDER : ''
+  if (loading) {
+    displayText = COMMAND_PREVIEW_LOADING_PLACEHOLDER
+  } else if (isEmpty) {
+    displayText = ''
   }
 
   return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/command-preview/CommandPreview.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/command-preview/CommandPreview.tsx
@@ -13,11 +13,13 @@ export const CommandPreview = ({
   loading = false,
 }: CommandPreviewProps) => {
   const isEmpty = command.length === 0
+  // Keep showing the previous command while a refresh is in flight so the
+  // preview doesn't flicker between the old text and a placeholder on every
+  // keystroke. Only fall back to the placeholder on the very first load,
+  // when there's nothing to show yet.
   let displayText = command
-  if (loading) {
-    displayText = COMMAND_PREVIEW_LOADING_PLACEHOLDER
-  } else if (isEmpty) {
-    displayText = ''
+  if (isEmpty) {
+    displayText = loading ? COMMAND_PREVIEW_LOADING_PLACEHOLDER : ''
   }
 
   return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { render } from 'uiSrc/utils/test-utils'
+
+import {
+  FilterInputWithSuggestions,
+  findActiveDotToken,
+  findUsedAttributeKeys,
+} from './FilterInputWithSuggestions'
+
+const TEST_ID = 'filter'
+
+const renderForm = (
+  props: Partial<{
+    value: string
+    suggestions: string[]
+  }> = {},
+) => {
+  const onChange = jest.fn()
+  const utils = render(
+    <FilterInputWithSuggestions
+      value={props.value ?? ''}
+      onChange={onChange}
+      suggestions={props.suggestions ?? ['price', 'category', 'color']}
+      data-testid={TEST_ID}
+    />,
+  )
+  return { ...utils, onChange }
+}
+
+describe('findActiveDotToken', () => {
+  it('returns null when caret is at 0', () => {
+    expect(findActiveDotToken('.price', 0)).toBeNull()
+  })
+
+  it('detects a token right after a leading dot', () => {
+    expect(findActiveDotToken('.pri', 4)).toEqual({
+      dotIndex: 0,
+      prefix: 'pri',
+    })
+  })
+
+  it('detects an empty prefix when caret is right after the dot', () => {
+    expect(findActiveDotToken('.', 1)).toEqual({ dotIndex: 0, prefix: '' })
+  })
+
+  it('detects a token after whitespace', () => {
+    expect(findActiveDotToken('a == 1 and .pr', 14)).toEqual({
+      dotIndex: 11,
+      prefix: 'pr',
+    })
+  })
+
+  it('returns null when the dot is preceded by a word char (decimal numbers)', () => {
+    expect(findActiveDotToken('3.14', 4)).toBeNull()
+  })
+
+  it('returns null when there is no dot before caret', () => {
+    expect(findActiveDotToken('price > 5', 9)).toBeNull()
+  })
+
+  it('returns null when a non-word char sits between the dot and caret', () => {
+    expect(findActiveDotToken('.price > 5', 10)).toBeNull()
+  })
+})
+
+describe('findUsedAttributeKeys', () => {
+  it('returns an empty set when there are no dot tokens', () => {
+    expect(findUsedAttributeKeys('price > 5')).toEqual(new Set())
+  })
+
+  it('collects every fully-typed .attribute token', () => {
+    expect(
+      findUsedAttributeKeys('.price > 5 and .category == "books"'),
+    ).toEqual(new Set(['price', 'category']))
+  })
+
+  it('skips decimal numbers (.dot preceded by a word char)', () => {
+    expect(findUsedAttributeKeys('rating > 3.14')).toEqual(new Set())
+  })
+
+  it('excludes the token at excludeDotIndex (the one being typed)', () => {
+    // ".price > 5 and .pr" — active token starts at the second dot (index 15)
+    expect(findUsedAttributeKeys('.price > 5 and .pr', 15)).toEqual(
+      new Set(['price']),
+    )
+  })
+})
+
+describe('FilterInputWithSuggestions', () => {
+  it('does not render the dropdown until the user focuses and types a dot', () => {
+    renderForm()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-suggestions`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the dropdown filtered by prefix when the user types a dot', () => {
+    renderForm({ value: '.c' })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    fireEvent.focus(input)
+    input.setSelectionRange(2, 2)
+    fireEvent.keyUp(input, { key: 'c' })
+
+    expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-category`),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-color`),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-suggestion-price`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('inserts a suggestion on click and emits onChange', () => {
+    const { onChange } = renderForm({ value: '.c' })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    fireEvent.focus(input)
+    input.setSelectionRange(2, 2)
+    fireEvent.keyUp(input, { key: 'c' })
+
+    fireEvent.mouseDown(screen.getByTestId(`${TEST_ID}-suggestion-category`))
+    expect(onChange).toHaveBeenCalledWith('.category')
+  })
+
+  it('omits attributes already used elsewhere in the expression', () => {
+    // `.price > 5 and .` — caret at the trailing dot, `price` already used
+    const value = '.price > 5 and .'
+    renderForm({ value })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    fireEvent.focus(input)
+    input.setSelectionRange(value.length, value.length)
+    fireEvent.keyUp(input, { key: '.' })
+
+    expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-category`),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-color`),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-suggestion-price`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not hide an attribute while the user is editing it in place', () => {
+    // `.pri` — caret inside the only token. The token at dotIndex 0 is the
+    // active one, so it should not be counted as "used" and `price` must
+    // remain visible while the user finishes typing.
+    const value = '.pri'
+    renderForm({ value })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    fireEvent.focus(input)
+    input.setSelectionRange(value.length, value.length)
+    fireEvent.keyUp(input, { key: 'i' })
+
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-price`),
+    ).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -161,4 +161,97 @@ describe('FilterInputWithSuggestions', () => {
       screen.getByTestId(`${TEST_ID}-suggestion-price`),
     ).toBeInTheDocument()
   })
+
+  it('replaces the whole word-token when the caret is mid-token', () => {
+    // `.ca|t` — caret at index 2, the `t` after the caret is still part of
+    // the token. Picking `category` must produce `.category`, not
+    // `.categoryt` (regression test for the half-token replacement bug).
+    const value = '.cat'
+    const { onChange } = renderForm({ value })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    fireEvent.focus(input)
+    input.setSelectionRange(2, 2)
+    fireEvent.keyUp(input, { key: 'ArrowLeft' })
+
+    fireEvent.mouseDown(screen.getByTestId(`${TEST_ID}-suggestion-category`))
+    expect(onChange).toHaveBeenCalledWith('.category')
+  })
+
+  describe('keyboard navigation', () => {
+    const openDropdown = () => {
+      const utils = renderForm({ value: '.' })
+      const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+      fireEvent.focus(input)
+      input.setSelectionRange(1, 1)
+      fireEvent.keyUp(input, { key: '.' })
+      return { ...utils, input }
+    }
+
+    it('ArrowDown wraps through the suggestion list', () => {
+      const { input } = openDropdown()
+      // 3 suggestions: price, category, color (order = order of `suggestions`
+      // prop). activeIndex starts at 0.
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      expect(
+        screen.getByTestId(`${TEST_ID}-suggestion-category`),
+      ).toHaveAttribute('aria-selected', 'true')
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      // wrapped back to index 0
+      expect(screen.getByTestId(`${TEST_ID}-suggestion-price`)).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+    })
+
+    it('ArrowUp wraps to the last item from index 0', () => {
+      const { input } = openDropdown()
+      fireEvent.keyDown(input, { key: 'ArrowUp' })
+      expect(screen.getByTestId(`${TEST_ID}-suggestion-color`)).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+    })
+
+    it('Enter picks the highlighted suggestion', () => {
+      const { input, onChange } = openDropdown()
+      fireEvent.keyDown(input, { key: 'ArrowDown' }) // category
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(onChange).toHaveBeenCalledWith('.category')
+    })
+
+    it('Tab picks the highlighted suggestion (and preventDefault keeps focus)', () => {
+      const { input, onChange } = openDropdown()
+      fireEvent.keyDown(input, { key: 'Tab' })
+      expect(onChange).toHaveBeenCalledWith('.price')
+    })
+
+    it('Escape closes the dropdown', () => {
+      const { input } = openDropdown()
+      expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(
+        screen.queryByTestId(`${TEST_ID}-suggestions`),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('exposes ARIA combobox wiring on the wrapper and aria-activedescendant on the input', () => {
+    renderForm({ value: '.' })
+    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
+    const wrapper = screen.getByTestId(`${TEST_ID}-wrapper`)
+    fireEvent.focus(input)
+    input.setSelectionRange(1, 1)
+    fireEvent.keyUp(input, { key: '.' })
+
+    expect(wrapper).toHaveAttribute('role', 'combobox')
+    expect(wrapper).toHaveAttribute('aria-expanded', 'true')
+    expect(wrapper).toHaveAttribute('aria-haspopup', 'listbox')
+    expect(wrapper).toHaveAttribute('aria-controls', `${TEST_ID}-suggestions`)
+    expect(input).toHaveAttribute('aria-autocomplete', 'list')
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      `${TEST_ID}-suggestions-option-0`,
+    )
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -154,6 +154,31 @@ describe('FilterInputWithSuggestions', () => {
         screen.queryByTestId(`${TEST_ID}-suggestions`),
       ).not.toBeInTheDocument()
     })
+
+    it('Escape suppression releases when the caret moves to a later token', () => {
+      // Open at `.` (dotIndex 0), press Escape, then move the caret to a new
+      // `.` further in the expression — the dropdown should reappear.
+      const { input, rerender, onChange } = openDropdown()
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(
+        screen.queryByTestId(`${TEST_ID}-suggestions`),
+      ).not.toBeInTheDocument()
+
+      // Simulate the user typing past the first dot and adding ` and .`
+      // with the new dot at index 5.
+      rerender(
+        <FilterInputWithSuggestions
+          value=". and ."
+          onChange={onChange}
+          suggestions={['price', 'category', 'color']}
+          testId={TEST_ID}
+        />,
+      )
+      const refreshed = screen.getByTestId(TEST_ID) as HTMLInputElement
+      focusAt(refreshed, 7, '.')
+
+      expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
+    })
   })
 
   it('exposes ARIA combobox wiring on the wrapper and aria-activedescendant on the input', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { render } from 'uiSrc/utils/test-utils'
 
 import { FilterInputWithSuggestions } from './FilterInputWithSuggestions'
+import { SUGGESTIONS_HINT } from './constants'
 
 const TEST_ID = 'filter'
 
@@ -52,6 +53,15 @@ describe('FilterInputWithSuggestions', () => {
     expect(
       screen.queryByTestId(`${TEST_ID}-suggestion-price`),
     ).not.toBeInTheDocument()
+  })
+
+  it('renders the muted hint above the suggestion list', () => {
+    renderForm({ value: '.' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, 1, '.')
+
+    expect(screen.getByTestId(`${TEST_ID}-suggestions-hint`)).toHaveTextContent(
+      SUGGESTIONS_HINT,
+    )
   })
 
   it('inserts a suggestion on click and emits onChange', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -18,7 +18,7 @@ const renderForm = (
       value={props.value ?? ''}
       onChange={onChange}
       suggestions={props.suggestions ?? ['price', 'category', 'color']}
-      data-testid={TEST_ID}
+      testId={TEST_ID}
     />,
   )
   return { ...utils, onChange }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.spec.tsx
@@ -2,11 +2,7 @@ import React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 import { render } from 'uiSrc/utils/test-utils'
 
-import {
-  FilterInputWithSuggestions,
-  findActiveDotToken,
-  findUsedAttributeKeys,
-} from './FilterInputWithSuggestions'
+import { FilterInputWithSuggestions } from './FilterInputWithSuggestions'
 
 const TEST_ID = 'filter'
 
@@ -28,64 +24,11 @@ const renderForm = (
   return { ...utils, onChange }
 }
 
-describe('findActiveDotToken', () => {
-  it('returns null when caret is at 0', () => {
-    expect(findActiveDotToken('.price', 0)).toBeNull()
-  })
-
-  it('detects a token right after a leading dot', () => {
-    expect(findActiveDotToken('.pri', 4)).toEqual({
-      dotIndex: 0,
-      prefix: 'pri',
-    })
-  })
-
-  it('detects an empty prefix when caret is right after the dot', () => {
-    expect(findActiveDotToken('.', 1)).toEqual({ dotIndex: 0, prefix: '' })
-  })
-
-  it('detects a token after whitespace', () => {
-    expect(findActiveDotToken('a == 1 and .pr', 14)).toEqual({
-      dotIndex: 11,
-      prefix: 'pr',
-    })
-  })
-
-  it('returns null when the dot is preceded by a word char (decimal numbers)', () => {
-    expect(findActiveDotToken('3.14', 4)).toBeNull()
-  })
-
-  it('returns null when there is no dot before caret', () => {
-    expect(findActiveDotToken('price > 5', 9)).toBeNull()
-  })
-
-  it('returns null when a non-word char sits between the dot and caret', () => {
-    expect(findActiveDotToken('.price > 5', 10)).toBeNull()
-  })
-})
-
-describe('findUsedAttributeKeys', () => {
-  it('returns an empty set when there are no dot tokens', () => {
-    expect(findUsedAttributeKeys('price > 5')).toEqual(new Set())
-  })
-
-  it('collects every fully-typed .attribute token', () => {
-    expect(
-      findUsedAttributeKeys('.price > 5 and .category == "books"'),
-    ).toEqual(new Set(['price', 'category']))
-  })
-
-  it('skips decimal numbers (.dot preceded by a word char)', () => {
-    expect(findUsedAttributeKeys('rating > 3.14')).toEqual(new Set())
-  })
-
-  it('excludes the token at excludeDotIndex (the one being typed)', () => {
-    // ".price > 5 and .pr" — active token starts at the second dot (index 15)
-    expect(findUsedAttributeKeys('.price > 5 and .pr', 15)).toEqual(
-      new Set(['price']),
-    )
-  })
-})
+const focusAt = (input: HTMLInputElement, caret: number, lastKey: string) => {
+  fireEvent.focus(input)
+  input.setSelectionRange(caret, caret)
+  fireEvent.keyUp(input, { key: lastKey })
+}
 
 describe('FilterInputWithSuggestions', () => {
   it('does not render the dropdown until the user focuses and types a dot', () => {
@@ -97,10 +40,7 @@ describe('FilterInputWithSuggestions', () => {
 
   it('renders the dropdown filtered by prefix when the user types a dot', () => {
     renderForm({ value: '.c' })
-    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-    fireEvent.focus(input)
-    input.setSelectionRange(2, 2)
-    fireEvent.keyUp(input, { key: 'c' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, 2, 'c')
 
     expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
     expect(
@@ -116,46 +56,29 @@ describe('FilterInputWithSuggestions', () => {
 
   it('inserts a suggestion on click and emits onChange', () => {
     const { onChange } = renderForm({ value: '.c' })
-    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-    fireEvent.focus(input)
-    input.setSelectionRange(2, 2)
-    fireEvent.keyUp(input, { key: 'c' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, 2, 'c')
 
     fireEvent.mouseDown(screen.getByTestId(`${TEST_ID}-suggestion-category`))
     expect(onChange).toHaveBeenCalledWith('.category')
   })
 
   it('omits attributes already used elsewhere in the expression', () => {
-    // `.price > 5 and .` — caret at the trailing dot, `price` already used
     const value = '.price > 5 and .'
     renderForm({ value })
-    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-    fireEvent.focus(input)
-    input.setSelectionRange(value.length, value.length)
-    fireEvent.keyUp(input, { key: '.' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, value.length, '.')
 
-    expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
-    expect(
-      screen.getByTestId(`${TEST_ID}-suggestion-category`),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId(`${TEST_ID}-suggestion-color`),
-    ).toBeInTheDocument()
     expect(
       screen.queryByTestId(`${TEST_ID}-suggestion-price`),
     ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${TEST_ID}-suggestion-category`),
+    ).toBeInTheDocument()
   })
 
   it('does not hide an attribute while the user is editing it in place', () => {
-    // `.pri` — caret inside the only token. The token at dotIndex 0 is the
-    // active one, so it should not be counted as "used" and `price` must
-    // remain visible while the user finishes typing.
     const value = '.pri'
     renderForm({ value })
-    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-    fireEvent.focus(input)
-    input.setSelectionRange(value.length, value.length)
-    fireEvent.keyUp(input, { key: 'i' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, value.length, 'i')
 
     expect(
       screen.getByTestId(`${TEST_ID}-suggestion-price`),
@@ -163,15 +86,8 @@ describe('FilterInputWithSuggestions', () => {
   })
 
   it('replaces the whole word-token when the caret is mid-token', () => {
-    // `.ca|t` — caret at index 2, the `t` after the caret is still part of
-    // the token. Picking `category` must produce `.category`, not
-    // `.categoryt` (regression test for the half-token replacement bug).
-    const value = '.cat'
-    const { onChange } = renderForm({ value })
-    const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-    fireEvent.focus(input)
-    input.setSelectionRange(2, 2)
-    fireEvent.keyUp(input, { key: 'ArrowLeft' })
+    const { onChange } = renderForm({ value: '.cat' })
+    focusAt(screen.getByTestId(TEST_ID) as HTMLInputElement, 2, 'ArrowLeft')
 
     fireEvent.mouseDown(screen.getByTestId(`${TEST_ID}-suggestion-category`))
     expect(onChange).toHaveBeenCalledWith('.category')
@@ -181,23 +97,18 @@ describe('FilterInputWithSuggestions', () => {
     const openDropdown = () => {
       const utils = renderForm({ value: '.' })
       const input = screen.getByTestId(TEST_ID) as HTMLInputElement
-      fireEvent.focus(input)
-      input.setSelectionRange(1, 1)
-      fireEvent.keyUp(input, { key: '.' })
+      focusAt(input, 1, '.')
       return { ...utils, input }
     }
 
     it('ArrowDown wraps through the suggestion list', () => {
       const { input } = openDropdown()
-      // 3 suggestions: price, category, color (order = order of `suggestions`
-      // prop). activeIndex starts at 0.
       fireEvent.keyDown(input, { key: 'ArrowDown' })
       expect(
         screen.getByTestId(`${TEST_ID}-suggestion-category`),
       ).toHaveAttribute('aria-selected', 'true')
       fireEvent.keyDown(input, { key: 'ArrowDown' })
       fireEvent.keyDown(input, { key: 'ArrowDown' })
-      // wrapped back to index 0
       expect(screen.getByTestId(`${TEST_ID}-suggestion-price`)).toHaveAttribute(
         'aria-selected',
         'true',
@@ -215,12 +126,12 @@ describe('FilterInputWithSuggestions', () => {
 
     it('Enter picks the highlighted suggestion', () => {
       const { input, onChange } = openDropdown()
-      fireEvent.keyDown(input, { key: 'ArrowDown' }) // category
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
       fireEvent.keyDown(input, { key: 'Enter' })
       expect(onChange).toHaveBeenCalledWith('.category')
     })
 
-    it('Tab picks the highlighted suggestion (and preventDefault keeps focus)', () => {
+    it('Tab picks the highlighted suggestion', () => {
       const { input, onChange } = openDropdown()
       fireEvent.keyDown(input, { key: 'Tab' })
       expect(onChange).toHaveBeenCalledWith('.price')
@@ -228,7 +139,6 @@ describe('FilterInputWithSuggestions', () => {
 
     it('Escape closes the dropdown', () => {
       const { input } = openDropdown()
-      expect(screen.getByTestId(`${TEST_ID}-suggestions`)).toBeInTheDocument()
       fireEvent.keyDown(input, { key: 'Escape' })
       expect(
         screen.queryByTestId(`${TEST_ID}-suggestions`),
@@ -240,9 +150,7 @@ describe('FilterInputWithSuggestions', () => {
     renderForm({ value: '.' })
     const input = screen.getByTestId(TEST_ID) as HTMLInputElement
     const wrapper = screen.getByTestId(`${TEST_ID}-wrapper`)
-    fireEvent.focus(input)
-    input.setSelectionRange(1, 1)
-    fireEvent.keyUp(input, { key: '.' })
+    focusAt(input, 1, '.')
 
     expect(wrapper).toHaveAttribute('role', 'combobox')
     expect(wrapper).toHaveAttribute('aria-expanded', 'true')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.styles.ts
@@ -6,21 +6,34 @@ export const Wrapper = styled.div<HTMLAttributes<HTMLDivElement>>`
   width: 100%;
 `
 
-export const SuggestionsList = styled.ul<HTMLAttributes<HTMLUListElement>>`
+export const SuggestionsPanel = styled.div<HTMLAttributes<HTMLDivElement>>`
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
   right: 0;
   z-index: 10;
+  background: ${({ theme }) => theme.semantic.color.background.neutral100};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+  border-radius: ${({ theme }) => theme.core.space.space050};
+  box-shadow: ${({ theme }) => theme.core.shadow.shadow700};
+  overflow: hidden;
+`
+
+export const SuggestionsHint = styled.div<HTMLAttributes<HTMLDivElement>>`
+  padding: ${({ theme }) =>
+    `${theme.core.space.space050} ${theme.core.space.space100}`};
+  color: ${({ theme }) => theme.semantic.color.text.neutral500};
+  font-size: 12px;
+  border-bottom: 1px solid
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
+export const SuggestionsList = styled.ul<HTMLAttributes<HTMLUListElement>>`
   margin: 0;
   padding: 4px 0;
   list-style: none;
   max-height: 200px;
   overflow-y: auto;
-  background: ${({ theme }) => theme.semantic.color.background.neutral100};
-  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
-  border-radius: ${({ theme }) => theme.core.space.space050};
-  box-shadow: ${({ theme }) => theme.core.shadow.shadow700};
 `
 
 export const SuggestionItem = styled.li<

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.styles.ts
@@ -1,0 +1,39 @@
+import { HTMLAttributes } from 'react'
+import styled from 'styled-components'
+
+export const Wrapper = styled.div<HTMLAttributes<HTMLDivElement>>`
+  position: relative;
+  width: 100%;
+`
+
+export const SuggestionsList = styled.ul<HTMLAttributes<HTMLUListElement>>`
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+  background: ${({ theme }) => theme.semantic.color.background.neutral100};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+  border-radius: ${({ theme }) => theme.core.space.space050};
+  box-shadow: ${({ theme }) => theme.core.shadow.shadow700};
+`
+
+export const SuggestionItem = styled.li<
+  HTMLAttributes<HTMLLIElement> & { $active: boolean }
+>`
+  padding: ${({ theme }) =>
+    `${theme.core.space.space050} ${theme.core.space.space100}`};
+  cursor: pointer;
+  color: ${({ theme }) => theme.semantic.color.text.neutral800};
+  background: ${({ theme, $active }) =>
+    $active ? theme.semantic.color.background.neutral400 : 'transparent'};
+
+  &:hover {
+    background: ${({ theme }) => theme.semantic.color.background.neutral400};
+  }
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -10,6 +10,7 @@ import React, {
 import { TextInput } from 'uiSrc/components/base/inputs'
 import * as keys from 'uiSrc/constants/keys'
 
+import { SUGGESTIONS_HINT } from './constants'
 import * as S from './FilterInputWithSuggestions.styles'
 import { FilterInputWithSuggestionsProps } from './FilterInputWithSuggestions.types'
 import {
@@ -151,34 +152,41 @@ export const FilterInputWithSuggestions = ({
         data-testid={testId}
       />
       {showDropdown && (
-        <S.SuggestionsList
-          id={listboxId}
-          data-testid={listboxId ?? 'filter-suggestions'}
-          role="listbox"
-        >
-          {filteredSuggestions.map((key, index) => (
-            <S.SuggestionItem
-              key={key}
-              id={listboxId ? `${listboxId}-option-${index}` : undefined}
-              $active={index === activeIndex}
-              role="option"
-              aria-selected={index === activeIndex}
-              data-testid={
-                testId
-                  ? `${testId}-suggestion-${key}`
-                  : `filter-suggestion-${key}`
-              }
-              onMouseDown={(event) => {
-                event.preventDefault()
-                applySuggestion(key)
-                inputRef.current?.focus()
-              }}
-              onMouseEnter={() => setActiveIndex(index)}
-            >
-              {key}
-            </S.SuggestionItem>
-          ))}
-        </S.SuggestionsList>
+        <S.SuggestionsPanel>
+          <S.SuggestionsHint
+            data-testid={testId ? `${testId}-suggestions-hint` : undefined}
+          >
+            {SUGGESTIONS_HINT}
+          </S.SuggestionsHint>
+          <S.SuggestionsList
+            id={listboxId}
+            data-testid={listboxId ?? 'filter-suggestions'}
+            role="listbox"
+          >
+            {filteredSuggestions.map((key, index) => (
+              <S.SuggestionItem
+                key={key}
+                id={listboxId ? `${listboxId}-option-${index}` : undefined}
+                $active={index === activeIndex}
+                role="option"
+                aria-selected={index === activeIndex}
+                data-testid={
+                  testId
+                    ? `${testId}-suggestion-${key}`
+                    : `filter-suggestion-${key}`
+                }
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                  applySuggestion(key)
+                  inputRef.current?.focus()
+                }}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                {key}
+              </S.SuggestionItem>
+            ))}
+          </S.SuggestionsList>
+        </S.SuggestionsPanel>
       )}
     </S.Wrapper>
   )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -1,0 +1,254 @@
+import React, {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+import { TextInput } from 'uiSrc/components/base/inputs'
+
+import * as S from './FilterInputWithSuggestions.styles'
+
+export interface FilterInputWithSuggestionsProps {
+  value: string
+  onChange: (value: string) => void
+  suggestions: string[]
+  placeholder?: string
+  disabled?: boolean
+  'data-testid'?: string
+}
+
+/**
+ * Resolve the attribute-name token actively being typed before the caret.
+ *
+ * VSIM filter syntax uses `.attribute` to reference attribute fields, so we
+ * scan back from the caret for a `.` that is preceded by either nothing or a
+ * non-word character (so `3.14` and a trailing decimal don't trigger). Any
+ * non-word character between the dot and the caret cancels the token, which
+ * lets the user keep typing free-form filter expressions without spurious
+ * dropdowns popping up mid-comparison.
+ *
+ * Returns `null` when there is no active token at the caret.
+ */
+const DOT_TOKEN_BODY = /^[A-Za-z0-9_]*$/
+const isWordChar = (ch: string): boolean => /[A-Za-z0-9_]/.test(ch)
+
+export interface ActiveDotToken {
+  dotIndex: number
+  prefix: string
+}
+
+export const findActiveDotToken = (
+  value: string,
+  caret: number,
+): ActiveDotToken | null => {
+  if (caret <= 0) return null
+  let i = caret - 1
+  while (i >= 0) {
+    const ch = value[i]
+    if (ch === '.') {
+      const before = i === 0 ? '' : value[i - 1]
+      if (before !== '' && isWordChar(before)) return null
+      const prefix = value.substring(i + 1, caret)
+      if (!DOT_TOKEN_BODY.test(prefix)) return null
+      return { dotIndex: i, prefix }
+    }
+    if (!isWordChar(ch)) return null
+    i -= 1
+  }
+  return null
+}
+
+/**
+ * Collect every fully-typed `.attribute` token in `value`. Used to hide
+ * already-referenced attributes from the dropdown so the user can't pick the
+ * same one twice. The token currently being typed (its dot at
+ * `excludeDotIndex`) is skipped so editing it doesn't make its own suggestion
+ * disappear.
+ */
+const USED_DOT_TOKEN_RE = /(^|[^A-Za-z0-9_])\.([A-Za-z0-9_]+)/g
+
+export const findUsedAttributeKeys = (
+  value: string,
+  excludeDotIndex?: number,
+): Set<string> => {
+  const used = new Set<string>()
+  USED_DOT_TOKEN_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = USED_DOT_TOKEN_RE.exec(value)) !== null) {
+    const dotIndex = match.index + match[1].length
+    if (dotIndex === excludeDotIndex) continue
+    used.add(match[2])
+  }
+  return used
+}
+
+const KEY_ARROW_DOWN = 'ArrowDown'
+const KEY_ARROW_UP = 'ArrowUp'
+const KEY_ENTER = 'Enter'
+const KEY_TAB = 'Tab'
+const KEY_ESCAPE = 'Escape'
+
+export const FilterInputWithSuggestions = ({
+  value,
+  onChange,
+  suggestions,
+  placeholder,
+  disabled,
+  'data-testid': dataTestId,
+}: FilterInputWithSuggestionsProps) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [caret, setCaret] = useState<number>(value.length)
+  const [isFocused, setIsFocused] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  // Caret pending after `onChange` so we can restore selection imperatively
+  // once React has flushed the controlled value back into the input.
+  const pendingCaretRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (pendingCaretRef.current == null) return
+    const pos = pendingCaretRef.current
+    pendingCaretRef.current = null
+    const el = inputRef.current
+    if (!el) return
+    el.setSelectionRange(pos, pos)
+    setCaret(pos)
+  }, [value])
+
+  const activeToken = useMemo(
+    () => (isFocused ? findActiveDotToken(value, caret) : null),
+    [isFocused, value, caret],
+  )
+
+  const filteredSuggestions = useMemo(() => {
+    if (!activeToken) return []
+    const prefix = activeToken.prefix.toLowerCase()
+    const usedKeys = findUsedAttributeKeys(value, activeToken.dotIndex)
+    return suggestions.filter(
+      (key) => !usedKeys.has(key) && key.toLowerCase().startsWith(prefix),
+    )
+  }, [activeToken, suggestions, value])
+
+  useEffect(() => {
+    if (activeIndex >= filteredSuggestions.length) {
+      setActiveIndex(0)
+    }
+  }, [filteredSuggestions, activeIndex])
+
+  const showDropdown = activeToken != null && filteredSuggestions.length > 0
+
+  const syncCaret = useCallback(() => {
+    const el = inputRef.current
+    if (!el) return
+    const pos = el.selectionStart ?? value.length
+    setCaret(pos)
+  }, [value.length])
+
+  const applySuggestion = useCallback(
+    (key: string) => {
+      if (!activeToken) return
+      const before = value.substring(0, activeToken.dotIndex + 1)
+      const after = value.substring(caret)
+      const nextValue = `${before}${key}${after}`
+      const nextCaret = before.length + key.length
+      pendingCaretRef.current = nextCaret
+      onChange(nextValue)
+    },
+    [activeToken, caret, onChange, value],
+  )
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (!showDropdown) return
+      if (event.key === KEY_ARROW_DOWN) {
+        event.preventDefault()
+        setActiveIndex((i) => (i + 1) % filteredSuggestions.length)
+      } else if (event.key === KEY_ARROW_UP) {
+        event.preventDefault()
+        setActiveIndex(
+          (i) =>
+            (i - 1 + filteredSuggestions.length) % filteredSuggestions.length,
+        )
+      } else if (event.key === KEY_ENTER || event.key === KEY_TAB) {
+        event.preventDefault()
+        applySuggestion(filteredSuggestions[activeIndex])
+      } else if (event.key === KEY_ESCAPE) {
+        event.preventDefault()
+        setIsFocused(false)
+      }
+    },
+    [activeIndex, applySuggestion, filteredSuggestions, showDropdown],
+  )
+
+  const handleChange = useCallback(
+    (next: string) => {
+      onChange(next)
+      // Defer to next tick so the input has applied the new value before we
+      // read its caret position back.
+      setTimeout(() => {
+        const el = inputRef.current
+        if (!el) return
+        setCaret(el.selectionStart ?? next.length)
+      }, 0)
+    },
+    [onChange],
+  )
+
+  return (
+    <S.Wrapper data-testid={dataTestId ? `${dataTestId}-wrapper` : undefined}>
+      <TextInput
+        ref={inputRef}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        onKeyDown={handleKeyDown}
+        onKeyUp={syncCaret}
+        onClick={syncCaret}
+        onFocus={() => {
+          setIsFocused(true)
+          syncCaret()
+        }}
+        onBlur={() => {
+          // Defer so a mousedown on a suggestion item can fire first; the
+          // suggestion handler re-focuses the input itself.
+          setTimeout(() => setIsFocused(false), 100)
+        }}
+        data-testid={dataTestId}
+      />
+      {showDropdown && (
+        <S.SuggestionsList
+          data-testid={
+            dataTestId ? `${dataTestId}-suggestions` : 'filter-suggestions'
+          }
+          role="listbox"
+        >
+          {filteredSuggestions.map((key, index) => (
+            <S.SuggestionItem
+              key={key}
+              $active={index === activeIndex}
+              role="option"
+              aria-selected={index === activeIndex}
+              data-testid={
+                dataTestId
+                  ? `${dataTestId}-suggestion-${key}`
+                  : `filter-suggestion-${key}`
+              }
+              onMouseDown={(event) => {
+                event.preventDefault()
+                applySuggestion(key)
+                inputRef.current?.focus()
+              }}
+              onMouseEnter={() => setActiveIndex(index)}
+            >
+              {key}
+            </S.SuggestionItem>
+          ))}
+        </S.SuggestionsList>
+      )}
+    </S.Wrapper>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -24,7 +24,7 @@ export const FilterInputWithSuggestions = ({
   suggestions,
   placeholder,
   disabled,
-  'data-testid': dataTestId,
+  testId,
 }: FilterInputWithSuggestionsProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [caret, setCaret] = useState<number>(value.length)
@@ -120,7 +120,7 @@ export const FilterInputWithSuggestions = ({
     [onChange],
   )
 
-  const listboxId = dataTestId ? `${dataTestId}-suggestions` : undefined
+  const listboxId = testId ? `${testId}-suggestions` : undefined
   const activeOptionId =
     showDropdown && listboxId ? `${listboxId}-option-${activeIndex}` : undefined
 
@@ -130,7 +130,7 @@ export const FilterInputWithSuggestions = ({
       aria-expanded={showDropdown}
       aria-haspopup="listbox"
       aria-controls={listboxId}
-      data-testid={dataTestId ? `${dataTestId}-wrapper` : undefined}
+      data-testid={testId ? `${testId}-wrapper` : undefined}
     >
       <TextInput
         ref={inputRef}
@@ -148,7 +148,7 @@ export const FilterInputWithSuggestions = ({
         onBlur={() => setIsFocused(false)}
         aria-autocomplete="list"
         aria-activedescendant={activeOptionId}
-        data-testid={dataTestId}
+        data-testid={testId}
       />
       {showDropdown && (
         <S.SuggestionsList
@@ -164,8 +164,8 @@ export const FilterInputWithSuggestions = ({
               role="option"
               aria-selected={index === activeIndex}
               data-testid={
-                dataTestId
-                  ? `${dataTestId}-suggestion-${key}`
+                testId
+                  ? `${testId}-suggestion-${key}`
                   : `filter-suggestion-${key}`
               }
               onMouseDown={(event) => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -31,6 +31,12 @@ export const FilterInputWithSuggestions = ({
   const [caret, setCaret] = useState<number>(value.length)
   const [isFocused, setIsFocused] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
+  // `dotIndex` of the token that was dismissed via Escape. Suppresses the
+  // dropdown while the caret stays on the same token; cleared as soon as the
+  // active token changes so later `.tokens` still get suggestions.
+  const [dismissedDotIndex, setDismissedDotIndex] = useState<number | null>(
+    null,
+  )
   const pendingCaretRef = useRef<number | null>(null)
 
   // Restore caret after `applySuggestion` once React has flushed the new value.
@@ -64,7 +70,21 @@ export const FilterInputWithSuggestions = ({
     }
   }, [filteredSuggestions, activeIndex])
 
-  const showDropdown = activeToken != null && filteredSuggestions.length > 0
+  // Clear Escape suppression once the caret leaves the dismissed token so a
+  // later `.attribute` (or a return to this one) gets suggestions again.
+  useEffect(() => {
+    if (
+      dismissedDotIndex != null &&
+      activeToken?.dotIndex !== dismissedDotIndex
+    ) {
+      setDismissedDotIndex(null)
+    }
+  }, [activeToken, dismissedDotIndex])
+
+  const showDropdown =
+    activeToken != null &&
+    filteredSuggestions.length > 0 &&
+    activeToken.dotIndex !== dismissedDotIndex
 
   const syncCaret = useCallback(() => {
     const el = inputRef.current
@@ -106,10 +126,16 @@ export const FilterInputWithSuggestions = ({
         applySuggestion(filteredSuggestions[activeIndex])
       } else if (event.key === keys.ESCAPE) {
         event.preventDefault()
-        setIsFocused(false)
+        if (activeToken) setDismissedDotIndex(activeToken.dotIndex)
       }
     },
-    [activeIndex, applySuggestion, filteredSuggestions, showDropdown],
+    [
+      activeIndex,
+      activeToken,
+      applySuggestion,
+      filteredSuggestions,
+      showDropdown,
+    ],
   )
 
   const handleChange = useCallback(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -8,87 +8,15 @@ import React, {
 } from 'react'
 
 import { TextInput } from 'uiSrc/components/base/inputs'
+import * as keys from 'uiSrc/constants/keys'
 
 import * as S from './FilterInputWithSuggestions.styles'
-
-export interface FilterInputWithSuggestionsProps {
-  value: string
-  onChange: (value: string) => void
-  suggestions: string[]
-  placeholder?: string
-  disabled?: boolean
-  'data-testid'?: string
-}
-
-/**
- * Resolve the attribute-name token actively being typed before the caret.
- *
- * VSIM filter syntax uses `.attribute` to reference attribute fields, so we
- * scan back from the caret for a `.` that is preceded by either nothing or a
- * non-word character (so `3.14` and a trailing decimal don't trigger). Any
- * non-word character between the dot and the caret cancels the token, which
- * lets the user keep typing free-form filter expressions without spurious
- * dropdowns popping up mid-comparison.
- *
- * Returns `null` when there is no active token at the caret.
- */
-const DOT_TOKEN_BODY = /^[A-Za-z0-9_]*$/
-const isWordChar = (ch: string): boolean => /[A-Za-z0-9_]/.test(ch)
-
-export interface ActiveDotToken {
-  dotIndex: number
-  prefix: string
-}
-
-export const findActiveDotToken = (
-  value: string,
-  caret: number,
-): ActiveDotToken | null => {
-  if (caret <= 0) return null
-  let i = caret - 1
-  while (i >= 0) {
-    const ch = value[i]
-    if (ch === '.') {
-      const before = i === 0 ? '' : value[i - 1]
-      if (before !== '' && isWordChar(before)) return null
-      const prefix = value.substring(i + 1, caret)
-      if (!DOT_TOKEN_BODY.test(prefix)) return null
-      return { dotIndex: i, prefix }
-    }
-    if (!isWordChar(ch)) return null
-    i -= 1
-  }
-  return null
-}
-
-/**
- * Collect every fully-typed `.attribute` token in `value`. Used to hide
- * already-referenced attributes from the dropdown so the user can't pick the
- * same one twice. The token currently being typed (its dot at
- * `excludeDotIndex`) is skipped so editing it doesn't make its own suggestion
- * disappear.
- *
- * The regex is created per-call rather than hoisted so we never have to worry
- * about a stale `lastIndex` from an earlier invocation leaking across calls.
- */
-export const findUsedAttributeKeys = (
-  value: string,
-  excludeDotIndex?: number,
-): Set<string> => {
-  const used = new Set<string>()
-  for (const match of value.matchAll(/(^|[^A-Za-z0-9_])\.([A-Za-z0-9_]+)/g)) {
-    const dotIndex = (match.index ?? 0) + match[1].length
-    if (dotIndex === excludeDotIndex) continue
-    used.add(match[2])
-  }
-  return used
-}
-
-const KEY_ARROW_DOWN = 'ArrowDown'
-const KEY_ARROW_UP = 'ArrowUp'
-const KEY_ENTER = 'Enter'
-const KEY_TAB = 'Tab'
-const KEY_ESCAPE = 'Escape'
+import { FilterInputWithSuggestionsProps } from './FilterInputWithSuggestions.types'
+import {
+  findActiveDotToken,
+  findUsedAttributeKeys,
+  isWordChar,
+} from './FilterInputWithSuggestions.utils'
 
 export const FilterInputWithSuggestions = ({
   value,
@@ -102,10 +30,9 @@ export const FilterInputWithSuggestions = ({
   const [caret, setCaret] = useState<number>(value.length)
   const [isFocused, setIsFocused] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
-  // Caret pending after `onChange` so we can restore selection imperatively
-  // once React has flushed the controlled value back into the input.
   const pendingCaretRef = useRef<number | null>(null)
 
+  // Restore caret after `applySuggestion` once React has flushed the new value.
   useEffect(() => {
     if (pendingCaretRef.current == null) return
     const pos = pendingCaretRef.current
@@ -141,27 +68,22 @@ export const FilterInputWithSuggestions = ({
   const syncCaret = useCallback(() => {
     const el = inputRef.current
     if (!el) return
-    const pos = el.selectionStart ?? value.length
-    setCaret(pos)
+    setCaret(el.selectionStart ?? value.length)
   }, [value.length])
 
   const applySuggestion = useCallback(
     (key: string) => {
       if (!activeToken) return
       const before = value.substring(0, activeToken.dotIndex + 1)
-      // Scan forward from the caret while we're still inside a word so the
-      // suggestion replaces the WHOLE token, not just the chars typed so far —
-      // otherwise editing `.ca|t` and accepting `category` produces
-      // `.categoryt` with the trailing `t` left dangling.
+      // Replace the whole word-token under the caret, not just up to the caret,
+      // so accepting `category` while editing `.ca|t` yields `.category`.
       let tokenEnd = caret
       while (tokenEnd < value.length && isWordChar(value[tokenEnd])) {
         tokenEnd += 1
       }
       const after = value.substring(tokenEnd)
-      const nextValue = `${before}${key}${after}`
-      const nextCaret = before.length + key.length
-      pendingCaretRef.current = nextCaret
-      onChange(nextValue)
+      pendingCaretRef.current = before.length + key.length
+      onChange(`${before}${key}${after}`)
     },
     [activeToken, caret, onChange, value],
   )
@@ -169,19 +91,19 @@ export const FilterInputWithSuggestions = ({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
       if (!showDropdown) return
-      if (event.key === KEY_ARROW_DOWN) {
+      if (event.key === keys.ARROW_DOWN) {
         event.preventDefault()
         setActiveIndex((i) => (i + 1) % filteredSuggestions.length)
-      } else if (event.key === KEY_ARROW_UP) {
+      } else if (event.key === keys.ARROW_UP) {
         event.preventDefault()
         setActiveIndex(
           (i) =>
             (i - 1 + filteredSuggestions.length) % filteredSuggestions.length,
         )
-      } else if (event.key === KEY_ENTER || event.key === KEY_TAB) {
+      } else if (event.key === keys.ENTER || event.key === keys.TAB) {
         event.preventDefault()
         applySuggestion(filteredSuggestions[activeIndex])
-      } else if (event.key === KEY_ESCAPE) {
+      } else if (event.key === keys.ESCAPE) {
         event.preventDefault()
         setIsFocused(false)
       }
@@ -192,26 +114,17 @@ export const FilterInputWithSuggestions = ({
   const handleChange = useCallback(
     (next: string) => {
       onChange(next)
-      // React's synthetic `onChange` fires after the DOM input has flushed its
-      // value and selection, so we can read `selectionStart` synchronously.
       const el = inputRef.current
       setCaret(el?.selectionStart ?? next.length)
     },
     [onChange],
   )
 
-  // Stable IDs for ARIA wiring so the input can advertise the listbox and the
-  // currently-highlighted option to assistive tech.
   const listboxId = dataTestId ? `${dataTestId}-suggestions` : undefined
   const activeOptionId =
     showDropdown && listboxId ? `${listboxId}-option-${activeIndex}` : undefined
 
   return (
-    // ARIA 1.2 combobox pattern: the wrapper takes the combobox role +
-    // expanded/haspopup/controls so the relationship is announced regardless
-    // of which inner element ends up focused. `aria-activedescendant`
-    // / `aria-autocomplete` go on the input itself since they describe the
-    // textbox behaviour.
     <S.Wrapper
       role="combobox"
       aria-expanded={showDropdown}
@@ -232,10 +145,6 @@ export const FilterInputWithSuggestions = ({
           setIsFocused(true)
           syncCaret()
         }}
-        // `onMouseDown` on suggestion items calls `preventDefault`, which keeps
-        // focus on the input, so the dropdown stays open during a click. A
-        // genuine blur (Tab away, outside click) closes the dropdown
-        // immediately — no timeout needed.
         onBlur={() => setIsFocused(false)}
         aria-autocomplete="list"
         aria-activedescendant={activeOptionId}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.tsx
@@ -67,19 +67,17 @@ export const findActiveDotToken = (
  * same one twice. The token currently being typed (its dot at
  * `excludeDotIndex`) is skipped so editing it doesn't make its own suggestion
  * disappear.
+ *
+ * The regex is created per-call rather than hoisted so we never have to worry
+ * about a stale `lastIndex` from an earlier invocation leaking across calls.
  */
-const USED_DOT_TOKEN_RE = /(^|[^A-Za-z0-9_])\.([A-Za-z0-9_]+)/g
-
 export const findUsedAttributeKeys = (
   value: string,
   excludeDotIndex?: number,
 ): Set<string> => {
   const used = new Set<string>()
-  USED_DOT_TOKEN_RE.lastIndex = 0
-  let match: RegExpExecArray | null
-  // eslint-disable-next-line no-cond-assign
-  while ((match = USED_DOT_TOKEN_RE.exec(value)) !== null) {
-    const dotIndex = match.index + match[1].length
+  for (const match of value.matchAll(/(^|[^A-Za-z0-9_])\.([A-Za-z0-9_]+)/g)) {
+    const dotIndex = (match.index ?? 0) + match[1].length
     if (dotIndex === excludeDotIndex) continue
     used.add(match[2])
   }
@@ -151,7 +149,15 @@ export const FilterInputWithSuggestions = ({
     (key: string) => {
       if (!activeToken) return
       const before = value.substring(0, activeToken.dotIndex + 1)
-      const after = value.substring(caret)
+      // Scan forward from the caret while we're still inside a word so the
+      // suggestion replaces the WHOLE token, not just the chars typed so far —
+      // otherwise editing `.ca|t` and accepting `category` produces
+      // `.categoryt` with the trailing `t` left dangling.
+      let tokenEnd = caret
+      while (tokenEnd < value.length && isWordChar(value[tokenEnd])) {
+        tokenEnd += 1
+      }
+      const after = value.substring(tokenEnd)
       const nextValue = `${before}${key}${after}`
       const nextCaret = before.length + key.length
       pendingCaretRef.current = nextCaret
@@ -186,19 +192,33 @@ export const FilterInputWithSuggestions = ({
   const handleChange = useCallback(
     (next: string) => {
       onChange(next)
-      // Defer to next tick so the input has applied the new value before we
-      // read its caret position back.
-      setTimeout(() => {
-        const el = inputRef.current
-        if (!el) return
-        setCaret(el.selectionStart ?? next.length)
-      }, 0)
+      // React's synthetic `onChange` fires after the DOM input has flushed its
+      // value and selection, so we can read `selectionStart` synchronously.
+      const el = inputRef.current
+      setCaret(el?.selectionStart ?? next.length)
     },
     [onChange],
   )
 
+  // Stable IDs for ARIA wiring so the input can advertise the listbox and the
+  // currently-highlighted option to assistive tech.
+  const listboxId = dataTestId ? `${dataTestId}-suggestions` : undefined
+  const activeOptionId =
+    showDropdown && listboxId ? `${listboxId}-option-${activeIndex}` : undefined
+
   return (
-    <S.Wrapper data-testid={dataTestId ? `${dataTestId}-wrapper` : undefined}>
+    // ARIA 1.2 combobox pattern: the wrapper takes the combobox role +
+    // expanded/haspopup/controls so the relationship is announced regardless
+    // of which inner element ends up focused. `aria-activedescendant`
+    // / `aria-autocomplete` go on the input itself since they describe the
+    // textbox behaviour.
+    <S.Wrapper
+      role="combobox"
+      aria-expanded={showDropdown}
+      aria-haspopup="listbox"
+      aria-controls={listboxId}
+      data-testid={dataTestId ? `${dataTestId}-wrapper` : undefined}
+    >
       <TextInput
         ref={inputRef}
         placeholder={placeholder}
@@ -212,23 +232,25 @@ export const FilterInputWithSuggestions = ({
           setIsFocused(true)
           syncCaret()
         }}
-        onBlur={() => {
-          // Defer so a mousedown on a suggestion item can fire first; the
-          // suggestion handler re-focuses the input itself.
-          setTimeout(() => setIsFocused(false), 100)
-        }}
+        // `onMouseDown` on suggestion items calls `preventDefault`, which keeps
+        // focus on the input, so the dropdown stays open during a click. A
+        // genuine blur (Tab away, outside click) closes the dropdown
+        // immediately — no timeout needed.
+        onBlur={() => setIsFocused(false)}
+        aria-autocomplete="list"
+        aria-activedescendant={activeOptionId}
         data-testid={dataTestId}
       />
       {showDropdown && (
         <S.SuggestionsList
-          data-testid={
-            dataTestId ? `${dataTestId}-suggestions` : 'filter-suggestions'
-          }
+          id={listboxId}
+          data-testid={listboxId ?? 'filter-suggestions'}
           role="listbox"
         >
           {filteredSuggestions.map((key, index) => (
             <S.SuggestionItem
               key={key}
+              id={listboxId ? `${listboxId}-option-${index}` : undefined}
               $active={index === activeIndex}
               role="option"
               aria-selected={index === activeIndex}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.types.ts
@@ -4,7 +4,7 @@ export interface FilterInputWithSuggestionsProps {
   suggestions: string[]
   placeholder?: string
   disabled?: boolean
-  'data-testid'?: string
+  testId?: string
 }
 
 export interface ActiveDotToken {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.types.ts
@@ -1,0 +1,13 @@
+export interface FilterInputWithSuggestionsProps {
+  value: string
+  onChange: (value: string) => void
+  suggestions: string[]
+  placeholder?: string
+  disabled?: boolean
+  'data-testid'?: string
+}
+
+export interface ActiveDotToken {
+  dotIndex: number
+  prefix: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.utils.spec.ts
@@ -1,0 +1,62 @@
+import {
+  findActiveDotToken,
+  findUsedAttributeKeys,
+} from './FilterInputWithSuggestions.utils'
+
+describe('findActiveDotToken', () => {
+  it('returns null when caret is at 0', () => {
+    expect(findActiveDotToken('.price', 0)).toBeNull()
+  })
+
+  it('detects a token right after a leading dot', () => {
+    expect(findActiveDotToken('.pri', 4)).toEqual({
+      dotIndex: 0,
+      prefix: 'pri',
+    })
+  })
+
+  it('detects an empty prefix when caret is right after the dot', () => {
+    expect(findActiveDotToken('.', 1)).toEqual({ dotIndex: 0, prefix: '' })
+  })
+
+  it('detects a token after whitespace', () => {
+    expect(findActiveDotToken('a == 1 and .pr', 14)).toEqual({
+      dotIndex: 11,
+      prefix: 'pr',
+    })
+  })
+
+  it('returns null when the dot is preceded by a word char (decimal numbers)', () => {
+    expect(findActiveDotToken('3.14', 4)).toBeNull()
+  })
+
+  it('returns null when there is no dot before caret', () => {
+    expect(findActiveDotToken('price > 5', 9)).toBeNull()
+  })
+
+  it('returns null when a non-word char sits between the dot and caret', () => {
+    expect(findActiveDotToken('.price > 5', 10)).toBeNull()
+  })
+})
+
+describe('findUsedAttributeKeys', () => {
+  it('returns an empty set when there are no dot tokens', () => {
+    expect(findUsedAttributeKeys('price > 5')).toEqual(new Set())
+  })
+
+  it('collects every fully-typed .attribute token', () => {
+    expect(
+      findUsedAttributeKeys('.price > 5 and .category == "books"'),
+    ).toEqual(new Set(['price', 'category']))
+  })
+
+  it('skips decimal numbers (.dot preceded by a word char)', () => {
+    expect(findUsedAttributeKeys('rating > 3.14')).toEqual(new Set())
+  })
+
+  it('excludes the token at excludeDotIndex', () => {
+    expect(findUsedAttributeKeys('.price > 5 and .pr', 15)).toEqual(
+      new Set(['price']),
+    )
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/FilterInputWithSuggestions.utils.ts
@@ -1,0 +1,49 @@
+import { ActiveDotToken } from './FilterInputWithSuggestions.types'
+
+const WORD_CHAR = /[A-Za-z0-9_]/
+const DOT_TOKEN_BODY = /^[A-Za-z0-9_]*$/
+
+export const isWordChar = (ch: string): boolean => WORD_CHAR.test(ch)
+
+/**
+ * Resolve the `.attribute` token actively being typed before the caret, or
+ * `null` if none. Decimal numbers like `3.14` and tokens broken by non-word
+ * characters do not match.
+ */
+export const findActiveDotToken = (
+  value: string,
+  caret: number,
+): ActiveDotToken | null => {
+  if (caret <= 0) return null
+  let i = caret - 1
+  while (i >= 0) {
+    const ch = value[i]
+    if (ch === '.') {
+      const before = i === 0 ? '' : value[i - 1]
+      if (before !== '' && isWordChar(before)) return null
+      const prefix = value.substring(i + 1, caret)
+      if (!DOT_TOKEN_BODY.test(prefix)) return null
+      return { dotIndex: i, prefix }
+    }
+    if (!isWordChar(ch)) return null
+    i -= 1
+  }
+  return null
+}
+
+/**
+ * Collect every fully-typed `.attribute` token in `value`. The token whose dot
+ * sits at `excludeDotIndex` (the one currently being edited) is skipped.
+ */
+export const findUsedAttributeKeys = (
+  value: string,
+  excludeDotIndex?: number,
+): Set<string> => {
+  const used = new Set<string>()
+  for (const match of value.matchAll(/(^|[^A-Za-z0-9_])\.([A-Za-z0-9_]+)/g)) {
+    const dotIndex = (match.index ?? 0) + match[1].length
+    if (dotIndex === excludeDotIndex) continue
+    used.add(match[2])
+  }
+  return used
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/constants.ts
@@ -1,0 +1,1 @@
+export const SUGGESTIONS_HINT = 'List based on partial scan of data.'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterInputWithSuggestions'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/filter-input-with-suggestions/index.ts
@@ -1,1 +1,5 @@
-export * from './FilterInputWithSuggestions'
+export { FilterInputWithSuggestions } from './FilterInputWithSuggestions'
+export type {
+  ActiveDotToken,
+  FilterInputWithSuggestionsProps,
+} from './FilterInputWithSuggestions.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
@@ -119,7 +119,7 @@ describe('SimilaritySearchForm', () => {
     ).toBeDisabled()
   })
 
-  it('shows a loading placeholder while the preview is being fetched', () => {
+  it('shows the loading placeholder while the preview is being fetched', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({ previewLoading: true }),
     )
@@ -132,7 +132,7 @@ describe('SimilaritySearchForm', () => {
     ).toHaveTextContent('command is loading...')
   })
 
-  it('keeps the previous command visible while a refresh is in flight (no flicker)', () => {
+  it('shows the loading placeholder even when a previous command exists', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({
         previewLoading: true,
@@ -143,13 +143,9 @@ describe('SimilaritySearchForm', () => {
     fillValidVector()
     fireEvent.click(screen.getByTestId(`${TEST_ID}-preview-toggle`))
 
-    const previewText = screen.getByTestId(
-      'similarity-search-command-preview-text',
-    )
-    expect(previewText).toHaveTextContent(
-      'VSIM mykey ELE seed WITHSCORES WITHATTRIBS',
-    )
-    expect(previewText).not.toHaveTextContent('command is loading...')
+    expect(
+      screen.getByTestId('similarity-search-command-preview-text'),
+    ).toHaveTextContent('command is loading...')
   })
 
   it('renders the hook-supplied preview verbatim once toggled on', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.spec.tsx
@@ -132,6 +132,26 @@ describe('SimilaritySearchForm', () => {
     ).toHaveTextContent('command is loading...')
   })
 
+  it('keeps the previous command visible while a refresh is in flight (no flicker)', () => {
+    mockedUseSimilaritySearch.mockReturnValue(
+      useSimilaritySearchResultFactory.build({
+        previewLoading: true,
+        preview: 'VSIM mykey ELE seed WITHSCORES WITHATTRIBS',
+      }),
+    )
+    renderComponent()
+    fillValidVector()
+    fireEvent.click(screen.getByTestId(`${TEST_ID}-preview-toggle`))
+
+    const previewText = screen.getByTestId(
+      'similarity-search-command-preview-text',
+    )
+    expect(previewText).toHaveTextContent(
+      'VSIM mykey ELE seed WITHSCORES WITHATTRIBS',
+    )
+    expect(previewText).not.toHaveTextContent('command is loading...')
+  })
+
   it('renders the hook-supplied preview verbatim once toggled on', () => {
     mockedUseSimilaritySearch.mockReturnValue(
       useSimilaritySearchResultFactory.build({

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -245,7 +245,7 @@ export const SimilaritySearchForm = ({
                   onChange={(value) => setField('filter', value)}
                   disabled={loading}
                   suggestions={attributeKeys}
-                  data-testid={`${TEST_ID}-filter-input`}
+                  testId={`${TEST_ID}-filter-input`}
                 />
               </FlexItem>
             </Row>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -302,7 +302,6 @@ export const SimilaritySearchForm = ({
             <PrimaryButton
               onClick={handleSubmit}
               disabled={submitDisabled}
-              loading={isLoading}
               data-testid={`${TEST_ID}-submit`}
             >
               Find similar items

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/similarity-search-form/similarity-search-form/SimilaritySearchForm.tsx
@@ -9,6 +9,7 @@ import { InfoIcon, ResetIcon, RiIcon } from 'uiSrc/components/base/icons'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput, QuantityCounter } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
+import { vectorSetAttributeKeysSelector } from 'uiSrc/slices/browser/vectorSet'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 
@@ -17,6 +18,7 @@ import { getVectorFieldInfo } from '../../vector-set-element-form/utils'
 import { useSimilaritySearch } from '../../hooks/useSimilaritySearch'
 
 import { CommandPreview } from '../command-preview'
+import { FilterInputWithSuggestions } from '../filter-input-with-suggestions'
 import { FilterSyntaxHelpPopover } from '../filter-syntax-help-popover'
 import * as S from './SimilaritySearchForm.styles'
 import {
@@ -62,6 +64,7 @@ export const SimilaritySearchForm = ({
   const [previewVisible, setPreviewVisible] = useState(false)
 
   const { id: databaseId } = useAppSelector(connectedInstanceSelector)
+  const attributeKeys = useAppSelector(vectorSetAttributeKeysSelector)
 
   // React to external prefill requests: switch to Element mode and seed the
   // element input. Keyed on `nonce` so re-requesting the same value still
@@ -236,11 +239,12 @@ export const SimilaritySearchForm = ({
                 <FilterSyntaxHelpPopover />
               </S.FilterLabel>
               <FlexItem grow>
-                <TextInput
+                <FilterInputWithSuggestions
                   placeholder={FILTER_PLACEHOLDER}
                   value={state.filter}
                   onChange={(value) => setField('filter', value)}
                   disabled={loading}
+                  suggestions={attributeKeys}
                   data-testid={`${TEST_ID}-filter-input`}
                 />
               </FlexItem>

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -11,6 +11,7 @@ import {
   isEqualBuffers,
   isStatusSuccessful,
   Maybe,
+  mergeAttributeKeys,
   stringToBuffer,
 } from 'uiSrc/utils'
 import successMessages from 'uiSrc/components/notifications/success-messages'
@@ -59,6 +60,7 @@ export const initialState: InitialStateVectorSet = {
     keyName: '',
     nextCursor: undefined,
     elements: [],
+    attributeKeys: [],
   },
   adding: {
     loading: false,
@@ -93,11 +95,14 @@ const vectorSetSlice = createSlice({
     },
     loadVectorSetElementsSuccess: (
       state,
-      { payload }: PayloadAction<VectorSetData>,
+      { payload }: PayloadAction<Omit<VectorSetData, 'attributeKeys'>>,
     ) => {
+      const elements = payload.elements ?? []
       state.data = {
         ...state.data,
         ...payload,
+        elements,
+        attributeKeys: mergeAttributeKeys([], elements),
       }
       state.loading = false
     },
@@ -114,14 +119,19 @@ const vectorSetSlice = createSlice({
       state,
       {
         payload: { elements, nextCursor, ...rest },
-      }: PayloadAction<VectorSetData>,
+      }: PayloadAction<Omit<VectorSetData, 'attributeKeys'>>,
     ) => {
       state.loading = false
+      const incoming = elements ?? []
       state.data = {
         ...state.data,
         ...rest,
         nextCursor,
-        elements: (state.data?.elements ?? []).concat(elements),
+        elements: (state.data?.elements ?? []).concat(incoming),
+        attributeKeys: mergeAttributeKeys(
+          state.data?.attributeKeys ?? [],
+          incoming,
+        ),
       }
     },
     loadMoreVectorSetElementsFailure: (state, { payload }) => {
@@ -177,6 +187,10 @@ const vectorSetSlice = createSlice({
       )
       if (el) {
         el.attributes = payload.attributes
+        state.data.attributeKeys = mergeAttributeKeys(
+          state.data.attributeKeys ?? [],
+          [{ attributes: payload.attributes }],
+        )
       }
     },
 
@@ -313,6 +327,8 @@ export const {
 export const vectorSetSelector = (state: RootState) => state.browser.vectorSet
 export const vectorSetDataSelector = (state: RootState) =>
   state.browser.vectorSet?.data
+export const vectorSetAttributeKeysSelector = (state: RootState): string[] =>
+  state.browser.vectorSet?.data?.attributeKeys ?? []
 export const addVectorSetElementsStateSelector = (
   state: RootState,
 ): AddVectorSetElementsState => state.browser.vectorSet?.adding
@@ -351,13 +367,7 @@ export function fetchVectorSetElements({
         )
 
       if (isStatusSuccessful(status)) {
-        const { elementNames, ...rest } = data
-        dispatch(
-          loadVectorSetElementsSuccess({
-            ...rest,
-            elements: elementNames.map((name) => ({ name })),
-          }),
-        )
+        dispatch(loadVectorSetElementsSuccess(data))
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       } else {
         dispatch(loadVectorSetElementsFailure(DEFAULT_ERROR_MESSAGE))
@@ -397,13 +407,7 @@ export function fetchMoreVectorSetElements({
         )
 
       if (isStatusSuccessful(status)) {
-        const { elementNames, ...rest } = data
-        dispatch(
-          loadMoreVectorSetElementsSuccess({
-            ...rest,
-            elements: elementNames.map((name) => ({ name })),
-          }),
-        )
+        dispatch(loadMoreVectorSetElementsSuccess(data))
       } else {
         dispatch(loadMoreVectorSetElementsFailure(DEFAULT_ERROR_MESSAGE))
       }

--- a/redisinsight/ui/src/slices/browser/vectorSet.ts
+++ b/redisinsight/ui/src/slices/browser/vectorSet.ts
@@ -33,7 +33,6 @@ import {
   FetchVectorSetElementsParams,
   GetVectorSetElementsResponse,
   InitialStateVectorSet,
-  VectorSetData,
   VectorSetElement,
   VectorSetSimilaritySearchPayload,
   VectorSetSimilaritySearchPreviewPayload,
@@ -95,7 +94,7 @@ const vectorSetSlice = createSlice({
     },
     loadVectorSetElementsSuccess: (
       state,
-      { payload }: PayloadAction<Omit<VectorSetData, 'attributeKeys'>>,
+      { payload }: PayloadAction<GetVectorSetElementsResponse>,
     ) => {
       const elements = payload.elements ?? []
       state.data = {
@@ -119,7 +118,7 @@ const vectorSetSlice = createSlice({
       state,
       {
         payload: { elements, nextCursor, ...rest },
-      }: PayloadAction<Omit<VectorSetData, 'attributeKeys'>>,
+      }: PayloadAction<GetVectorSetElementsResponse>,
     ) => {
       state.loading = false
       const incoming = elements ?? []

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -14,16 +14,7 @@ export interface VectorSetData {
   /** From API: whether cursor-based pagination is supported for listing elements. */
   isPaginationSupported?: boolean
   elements: VectorSetElement[]
-  /**
-   * Union of top-level JSON attribute keys collected from `elements.attributes`,
-   * alphabetically sorted. Grows monotonically across pagination so the similarity
-   * search filter can suggest attribute names the user has already seen.
-   *
-   * Keys are never pruned: removing an attribute from a single element via the
-   * attribute editor does not retract its key from the dropdown. We trade some
-   * staleness for a referentially stable array that memoized selectors can
-   * depend on.
-   */
+  /** Top-level JSON attribute keys seen so far. Monotonic — never pruned. */
   attributeKeys: string[]
 }
 

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -14,6 +14,17 @@ export interface VectorSetData {
   /** From API: whether cursor-based pagination is supported for listing elements. */
   isPaginationSupported?: boolean
   elements: VectorSetElement[]
+  /**
+   * Union of top-level JSON attribute keys collected from `elements.attributes`,
+   * alphabetically sorted. Grows monotonically across pagination so the similarity
+   * search filter can suggest attribute names the user has already seen.
+   */
+  attributeKeys: string[]
+}
+
+export interface VectorSetElementListItem {
+  name: RedisResponseBuffer
+  attributes?: string
 }
 
 export interface GetVectorSetElementsResponse {
@@ -21,7 +32,7 @@ export interface GetVectorSetElementsResponse {
   keyName: RedisString
   nextCursor?: string
   isPaginationSupported?: boolean
-  elementNames: RedisResponseBuffer[]
+  elements: VectorSetElementListItem[]
 }
 
 export interface AddVectorSetElementsState {

--- a/redisinsight/ui/src/slices/interfaces/vectorSet.ts
+++ b/redisinsight/ui/src/slices/interfaces/vectorSet.ts
@@ -18,6 +18,11 @@ export interface VectorSetData {
    * Union of top-level JSON attribute keys collected from `elements.attributes`,
    * alphabetically sorted. Grows monotonically across pagination so the similarity
    * search filter can suggest attribute names the user has already seen.
+   *
+   * Keys are never pruned: removing an attribute from a single element via the
+   * attribute editor does not retract its key from the dropdown. We trade some
+   * staleness for a referentially stable array that memoized selectors can
+   * depend on.
    */
   attributeKeys: string[]
 }

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -143,6 +143,7 @@ describe('vectorSet slice', () => {
         similaritySearchPreview: initialState.similaritySearchPreview,
         data: {
           ...data,
+          attributeKeys: [],
         },
       }
 
@@ -208,6 +209,7 @@ describe('vectorSet slice', () => {
         similaritySearchPreview: initialState.similaritySearchPreview,
         data: {
           ...data,
+          attributeKeys: [],
         },
       }
 
@@ -245,6 +247,7 @@ describe('vectorSet slice', () => {
         similaritySearchPreview: initialState.similaritySearchPreview,
         data: {
           ...data,
+          attributeKeys: [],
         },
       }
 
@@ -556,7 +559,7 @@ describe('vectorSet slice', () => {
           thunkElements[thunkElements.length - 1],
         ),
         isPaginationSupported: true,
-        elementNames: thunkElements.map((el) => el.name),
+        elements: thunkElements.map((el) => ({ name: el.name })),
       }
 
       it('call fetchVectorSetElements, loadVectorSetElementsSuccess when fetch is successful', async () => {
@@ -570,13 +573,9 @@ describe('vectorSet slice', () => {
           }),
         )
 
-        const { elementNames, ...rest } = apiResponse
         const expectedActions = [
           loadVectorSetElements(undefined),
-          loadVectorSetElementsSuccess({
-            ...rest,
-            elements: elementNames.map((name) => ({ name })),
-          }),
+          loadVectorSetElementsSuccess(apiResponse as any),
           updateSelectedKeyRefreshTime(Date.now()),
         ]
 
@@ -619,7 +618,7 @@ describe('vectorSet slice', () => {
           moreElements[moreElements.length - 1],
         ),
         isPaginationSupported: true,
-        elementNames: moreElements.map((el) => el.name),
+        elements: moreElements.map((el) => ({ name: el.name })),
       }
       const requestCursor = vectorSetPaginationCursorAfter(
         vectorSetElementFactory.build(),
@@ -637,13 +636,9 @@ describe('vectorSet slice', () => {
           }),
         )
 
-        const { elementNames: moreElementNames, ...moreRest } = moreApiResponse
         const expectedActions = [
           loadMoreVectorSetElements(),
-          loadMoreVectorSetElementsSuccess({
-            ...moreRest,
-            elements: moreElementNames.map((name) => ({ name })),
-          }),
+          loadMoreVectorSetElementsSuccess(moreApiResponse as any),
         ]
 
         expect(mockedStore.getActions()).toEqual(expectedActions)

--- a/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/vectorSet.spec.ts
@@ -13,6 +13,10 @@ import {
   addMessageNotification,
   IAddInstanceErrorPayload,
 } from 'uiSrc/slices/app/notifications'
+import {
+  GetVectorSetElementsResponse,
+  RedisResponseBuffer,
+} from 'uiSrc/slices/interfaces'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 import {
@@ -552,7 +556,7 @@ describe('vectorSet slice', () => {
   describe('thunks', () => {
     describe('fetchVectorSetElements', () => {
       const thunkElements = vectorSetElementFactory.buildList(3)
-      const apiResponse = {
+      const apiResponse: GetVectorSetElementsResponse = {
         keyName: vectorSetTestKeyName(),
         total: thunkElements.length,
         nextCursor: vectorSetPaginationCursorAfter(
@@ -568,14 +572,14 @@ describe('vectorSet slice', () => {
 
         await store.dispatch<any>(
           fetchVectorSetElements({
-            key: apiResponse.keyName as any,
+            key: apiResponse.keyName as RedisResponseBuffer,
             count: 10,
           }),
         )
 
         const expectedActions = [
           loadVectorSetElements(undefined),
-          loadVectorSetElementsSuccess(apiResponse as any),
+          loadVectorSetElementsSuccess(apiResponse),
           updateSelectedKeyRefreshTime(Date.now()),
         ]
 
@@ -611,7 +615,7 @@ describe('vectorSet slice', () => {
 
     describe('fetchMoreVectorSetElements', () => {
       const moreElements = vectorSetElementFactory.buildList(3)
-      const moreApiResponse = {
+      const moreApiResponse: GetVectorSetElementsResponse = {
         keyName: vectorSetTestKeyName(),
         total: faker.number.int({ min: moreElements.length + 1, max: 100 }),
         nextCursor: vectorSetPaginationCursorAfter(
@@ -630,7 +634,7 @@ describe('vectorSet slice', () => {
 
         await store.dispatch<any>(
           fetchMoreVectorSetElements({
-            key: moreApiResponse.keyName as any,
+            key: moreApiResponse.keyName as RedisResponseBuffer,
             nextCursor: requestCursor,
             count: 10,
           }),
@@ -638,7 +642,7 @@ describe('vectorSet slice', () => {
 
         const expectedActions = [
           loadMoreVectorSetElements(),
-          loadMoreVectorSetElementsSuccess(moreApiResponse as any),
+          loadMoreVectorSetElementsSuccess(moreApiResponse),
         ]
 
         expect(mockedStore.getActions()).toEqual(expectedActions)

--- a/redisinsight/ui/src/utils/index.ts
+++ b/redisinsight/ui/src/utils/index.ts
@@ -32,5 +32,6 @@ export * from './redisearch'
 export * from './capability'
 export * from './rdi'
 export * from './bigString'
+export * from './vectorSet'
 
 export { Maybe, Nullable, RouterWithSubRoutes, getLetterByIndex }

--- a/redisinsight/ui/src/utils/vectorSet/attributeKeys.spec.ts
+++ b/redisinsight/ui/src/utils/vectorSet/attributeKeys.spec.ts
@@ -1,0 +1,61 @@
+import {
+  extractAttributeKeys,
+  mergeAttributeKeys,
+} from 'uiSrc/utils/vectorSet/attributeKeys'
+
+describe('extractAttributeKeys', () => {
+  it('returns top-level keys from a JSON object', () => {
+    expect(extractAttributeKeys('{"a":1,"b":2}')).toEqual(['a', 'b'])
+  })
+
+  it('returns [] for empty / null / undefined', () => {
+    expect(extractAttributeKeys('')).toEqual([])
+    expect(extractAttributeKeys(null)).toEqual([])
+    expect(extractAttributeKeys(undefined)).toEqual([])
+  })
+
+  it('returns [] for non-object JSON', () => {
+    expect(extractAttributeKeys('"foo"')).toEqual([])
+    expect(extractAttributeKeys('42')).toEqual([])
+    expect(extractAttributeKeys('true')).toEqual([])
+    expect(extractAttributeKeys('null')).toEqual([])
+    expect(extractAttributeKeys('[1,2,3]')).toEqual([])
+  })
+
+  it('returns [] for invalid JSON', () => {
+    expect(extractAttributeKeys('not-json')).toEqual([])
+    expect(extractAttributeKeys('{a:1}')).toEqual([])
+  })
+})
+
+describe('mergeAttributeKeys', () => {
+  it('unions existing and discovered keys alphabetically', () => {
+    const result = mergeAttributeKeys(
+      ['color'],
+      [
+        { attributes: '{"price":10,"category":"books"}' },
+        { attributes: '{"color":"red"}' },
+      ],
+    )
+    expect(result).toEqual(['category', 'color', 'price'])
+  })
+
+  it('returns same reference when no new keys appear', () => {
+    const existing = ['a', 'b']
+    const result = mergeAttributeKeys(existing, [
+      { attributes: '{"a":1,"b":2}' },
+    ])
+    expect(result).toBe(existing)
+  })
+
+  it('handles items without attributes', () => {
+    expect(mergeAttributeKeys(['x'], [{}, { attributes: undefined }])).toEqual([
+      'x',
+    ])
+  })
+
+  it('returns existing when items is empty', () => {
+    const existing = ['x']
+    expect(mergeAttributeKeys(existing, [])).toBe(existing)
+  })
+})

--- a/redisinsight/ui/src/utils/vectorSet/attributeKeys.ts
+++ b/redisinsight/ui/src/utils/vectorSet/attributeKeys.ts
@@ -1,8 +1,3 @@
-/**
- * Parse a vector set element's `attributes` JSON string and return its
- * top-level keys. Returns `[]` for any non-JSON, non-object, or array value
- * so callers can union safely without guarding for malformed payloads.
- */
 export const extractAttributeKeys = (
   raw: string | undefined | null,
 ): string[] => {
@@ -17,12 +12,8 @@ export const extractAttributeKeys = (
   }
 }
 
-/**
- * Union the alphabetically-sorted top-level attribute keys across `existing`
- * and the keys discovered in `items`. Stable order keeps memoized consumers
- * (e.g. the similarity-search filter dropdown) referentially stable when no
- * new keys appear.
- */
+// Returns the same reference when no new keys are added so memoized consumers
+// stay stable across paginated loads.
 export const mergeAttributeKeys = (
   existing: string[],
   items: { attributes?: string }[],

--- a/redisinsight/ui/src/utils/vectorSet/attributeKeys.ts
+++ b/redisinsight/ui/src/utils/vectorSet/attributeKeys.ts
@@ -1,0 +1,38 @@
+/**
+ * Parse a vector set element's `attributes` JSON string and return its
+ * top-level keys. Returns `[]` for any non-JSON, non-object, or array value
+ * so callers can union safely without guarding for malformed payloads.
+ */
+export const extractAttributeKeys = (
+  raw: string | undefined | null,
+): string[] => {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed))
+      return []
+    return Object.keys(parsed as Record<string, unknown>)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Union the alphabetically-sorted top-level attribute keys across `existing`
+ * and the keys discovered in `items`. Stable order keeps memoized consumers
+ * (e.g. the similarity-search filter dropdown) referentially stable when no
+ * new keys appear.
+ */
+export const mergeAttributeKeys = (
+  existing: string[],
+  items: { attributes?: string }[],
+): string[] => {
+  const set = new Set(existing)
+  for (const item of items) {
+    for (const key of extractAttributeKeys(item.attributes)) {
+      set.add(key)
+    }
+  }
+  if (set.size === existing.length) return existing
+  return Array.from(set).sort()
+}

--- a/redisinsight/ui/src/utils/vectorSet/index.ts
+++ b/redisinsight/ui/src/utils/vectorSet/index.ts
@@ -1,0 +1,1 @@
+export * from './attributeKeys'


### PR DESCRIPTION
## Summary

- Backend `getElements` now back-fills each element's `attributes` via a VGETATTR pipeline, and the list-response shape becomes `elements: VectorSetElementListItemDto[]` so attributes travel with each element.
- Redux state accumulates a `VectorSetData.attributeKeys` set across pagination — keys discovered on later pages are appended, never replaced.
- The similarity-search filter input now opens a `.`-triggered dropdown of those attribute keys: prefix-filtered, keyboard-navigable, ARIA-wired, and keys already referenced in the expression are hidden so they can't be picked twice.
- The dropdown shows a muted "List based on partial scan of data." hint above the suggestions so users understand the list grows with pagination and isn't a complete index.

https://github.com/user-attachments/assets/c4836aa1-36fb-4d7b-b9ad-e8b16cbd1429

## Test plan

- [ ] Open a vector-set key with JSON attributes set on some elements; paginate and confirm the filter dropdown's suggestions grow as new attribute names appear.
- [ ] In the filter field type `.` — dropdown should appear with all known attribute keys and the "List based on partial scan of data." hint at the top.
- [ ] Type `.p` — dropdown should filter to keys starting with `p`.
- [ ] Use ArrowDown/ArrowUp/Enter/Tab to pick; Escape to dismiss.
- [ ] After picking `.price`, type ` and .` — `price` should not appear in the second suggestion list.
- [ ] Edit an existing `.price` token in place: `price` should still be suggested while the caret sits inside it.
- [ ] Verify decimal numbers like `3.14` do not trigger the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The get-elements API response shape changes (`elementNames` → `elements`), which is a contract break for any external API consumers; list calls also add a VGETATTR pipeline per page, increasing Redis load on large element counts.
> 
> **Overview**
> Vector set **list elements** responses now return `elements` (name + optional `attributes`) instead of `elementNames`, with the backend issuing a **VGETATTR** pipeline after VRANGE/VRANDMEMBER so attribute JSON is available without a per-row details call.
> 
> The UI **merges top-level JSON keys** from loaded elements into monotonic `attributeKeys` in Redux (growing as pages load). The similarity-search **filter** field uses a new **dot-triggered autocomplete** (`FilterInputWithSuggestions`): prefix filtering, keyboard/ARIA behavior, hiding keys already used in the expression, and a hint that suggestions come from a partial scan.
> 
> Smaller tweaks: similarity-search **preview debounce** increases to 600ms; command preview shows **loading** even when a stale preview string exists; submit stays disabled during preview fetch without tying the primary button’s loading spinner to the main search request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bf9780e99b7c5351acdaa142f86ae61723b1a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->