### PR TITLE
RI-8181 Change dev environment badge variant

### DIFF
--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.constants.ts
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.constants.ts
@@ -18,7 +18,7 @@ export const BADGE_CONFIG: Partial<
   },
   [Environment.Development]: {
     label: 'DEV',
-    variant: 'default',
+    variant: 'informative',
     tooltip: DEVELOPMENT_TOOLTIP,
   },
 }


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

| Before | After |
| --- | --- |
| <img width="253" height="215" alt="Screenshot 2026-06-03 at 12 03 13" src="https://github.com/user-attachments/assets/f8b04b86-1623-4a1b-801b-2d9d3da51cc5" /> | <img width="251" height="208" alt="Screenshot 2026-06-03 at 12 03 58" src="https://github.com/user-attachments/assets/dc138678-27d5-4f9b-88e8-4c711da0c78f" /> |
| <img width="260" height="211" alt="Screenshot 2026-06-03 at 12 03 45" src="https://github.com/user-attachments/assets/af932b6a-4554-4e96-92f6-684b0e7a1808" /> | <img width="262" height="216" alt="Screenshot 2026-06-03 at 12 04 11" src="https://github.com/user-attachments/assets/22f6d03b-a3fe-418d-9b22-debdbb562aac" /> |

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change to badge styling with no logic, API, or security impact.
> 
> **Overview**
> Updates the **Development** environment badge styling by changing its `RiBadge` variant from **`default`** to **`informative`** in `BADGE_CONFIG`, so DEV is visually distinct from the default badge treatment (aligned with the PR screenshots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7660bd2c968ccee6d4ce63843f5b0dfad11004d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->