### PR TITLE
ci(install): fail on yarn.lock drift and document the contract for agents

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -67,8 +67,12 @@ runs:
       with:
         dir-path: './redisinsight/api'
 
+    # Deliberately not gated on cache hit — the root `postinstall` runs
+    # `yarn-deduplicate yarn.lock`, which is what the lockfile-drift
+    # check below relies on to detect non-dedup-clean lockfiles. With
+    # node_modules restored from cache, this step is fast (mostly just
+    # postinstall).
     - name: Install dependencies for root package.js
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       uses: ./.github/actions/install-deps
       with:
         dir-path: './'
@@ -87,22 +91,16 @@ runs:
           yarn --cwd redisinsight/api generate:api-client
         fi
 
-    # Verifies the root yarn.lock is dedup-clean by running yarn-deduplicate
-    # in read-only check mode (`--list --fail`). This is the property the
-    # root `postinstall` enforces locally (via `yarn-deduplicate yarn.lock`)
-    # but that `--frozen-lockfile` does not. Runs unconditionally so an
-    # exact node_modules cache hit (which skips the install steps above)
-    # does not bypass the check, and so pre-existing lockfile drift is
-    # caught on code-only PRs too.
-    #
-    # Scoped to the root lockfile only — the non-root lockfiles
-    # (redisinsight/yarn.lock, redisinsight/api/yarn.lock) have never had
-    # dedup enforcement and currently contain duplicates; enabling the
-    # check there is a separate follow-up.
-    - name: Verify root yarn.lock is dedup-clean
+    # The root install above always runs, so its postinstall
+    # (`yarn-deduplicate yarn.lock`) always runs. If the committed
+    # lockfile is non-dedup-clean, postinstall rewrote it in place and
+    # this diff fails. `--frozen-lockfile` already catches the case where
+    # the lockfile disagrees with package.json.
+    - name: Verify root yarn.lock is unchanged after install
       shell: bash
       run: |
-        if ! ./node_modules/.bin/yarn-deduplicate --list --fail yarn.lock; then
-          echo "::error file=yarn.lock::Root yarn.lock is not dedup-clean. The root 'postinstall' (yarn-deduplicate yarn.lock) would rewrite it during 'yarn install'. Run 'yarn install' at the repo root locally and commit the updated yarn.lock."
+        if ! git diff --exit-code --quiet -- yarn.lock; then
+          echo "::error file=yarn.lock::yarn.lock was modified by 'yarn install' (postinstall ran yarn-deduplicate). The committed lockfile is not dedup-clean. Run 'yarn install' at the repo root locally and commit the updated yarn.lock."
+          git --no-pager diff --stat -- yarn.lock
           exit 1
         fi

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -87,22 +87,22 @@ runs:
           yarn --cwd redisinsight/api generate:api-client
         fi
 
-    # Detects lockfile drift caused by `yarn install` running the root
-    # `postinstall` (which executes `yarn-deduplicate yarn.lock`). A PR may
-    # pass `--frozen-lockfile` yet still ship a non-dedup-clean lockfile,
-    # which dirties every local install. Runs unconditionally so an exact
-    # node_modules cache hit (which skips the install steps above) does
-    # not bypass the check.
-    - name: Verify yarn.lock files are unchanged after install
+    # Verifies the root yarn.lock is dedup-clean by running yarn-deduplicate
+    # in read-only check mode (`--list --fail`). This is the property the
+    # root `postinstall` enforces locally (via `yarn-deduplicate yarn.lock`)
+    # but that `--frozen-lockfile` does not. Runs unconditionally so an
+    # exact node_modules cache hit (which skips the install steps above)
+    # does not bypass the check, and so pre-existing lockfile drift is
+    # caught on code-only PRs too.
+    #
+    # Scoped to the root lockfile only — the non-root lockfiles
+    # (redisinsight/yarn.lock, redisinsight/api/yarn.lock) have never had
+    # dedup enforcement and currently contain duplicates; enabling the
+    # check there is a separate follow-up.
+    - name: Verify root yarn.lock is dedup-clean
       shell: bash
       run: |
-        fail=0
-        for lock in yarn.lock redisinsight/yarn.lock redisinsight/api/yarn.lock; do
-          if [ -f "$lock" ] && ! git diff --exit-code --quiet -- "$lock"; then
-            dir=$(dirname "$lock")
-            echo "::error file=$lock::$lock was modified by 'yarn install'. The committed lockfile is not dedup-clean. Run 'yarn install' in $dir locally and commit the updated lockfile."
-            git --no-pager diff --stat -- "$lock"
-            fail=1
-          fi
-        done
-        exit $fail
+        if ! ./node_modules/.bin/yarn-deduplicate --list --fail yarn.lock; then
+          echo "::error file=yarn.lock::Root yarn.lock is not dedup-clean. The root 'postinstall' (yarn-deduplicate yarn.lock) would rewrite it during 'yarn install'. Run 'yarn install' at the repo root locally and commit the updated yarn.lock."
+          exit 1
+        fi

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -30,7 +30,12 @@ runs:
           node_modules
           redisinsight/node_modules
           redisinsight/api/node_modules
-        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', 'redisinsight/yarn.lock', 'redisinsight/api/yarn.lock') }}
+        # Hash both package.json and yarn.lock for every workspace so a
+        # change to either invalidates the cache. Hashing only yarn.lock
+        # let package.json edits without `yarn install` cache-hit, which
+        # skipped `yarn install --frozen-lockfile` and hid the resulting
+        # package.json / yarn.lock mismatch.
+        key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package.json', 'yarn.lock', 'redisinsight/package.json', 'redisinsight/yarn.lock', 'redisinsight/api/package.json', 'redisinsight/api/yarn.lock') }}
         restore-keys: |
           node-modules-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -104,3 +104,4 @@ runs:
           git --no-pager diff --stat -- yarn.lock
           exit 1
         fi
+        echo "yarn.lock is unchanged after install — dedup-clean ✅"

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -67,13 +67,19 @@ runs:
       with:
         dir-path: './redisinsight/api'
 
+    - name: Install dependencies for root package.js
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      uses: ./.github/actions/install-deps
+      with:
+        dir-path: './'
+        keytar-host-mirror: ${{ inputs.keytar-host-mirror }}
+        sqlite3-host-mirror: ${{ inputs.sqlite3-host-mirror }}
+
     # The OpenAPI client (`redisinsight/api-client/`) is gitignored and produced
     # by the `postinstall` hook in `redisinsight/api`. When the node_modules
-    # cache is restored, that postinstall is skipped, so the directory ends up
-    # missing and any subsequent step that imports `apiClient` fails — in
-    # particular the root postinstall below, which runs `vite optimize` and
-    # resolves the `apiClient` alias during dep scanning. Generate it here
-    # when it isn't present, before the root install runs.
+    # cache is restored, postinstall is skipped, so the directory ends up
+    # missing and the UI workspace fails to resolve `from 'apiClient'`.
+    # Generate it here when it isn't present.
     - name: Generate OpenAPI client (if missing)
       shell: bash
       run: |
@@ -81,23 +87,11 @@ runs:
           yarn --cwd redisinsight/api generate:api-client
         fi
 
-    # Deliberately not gated on cache hit — the root `postinstall` runs
-    # `yarn-deduplicate yarn.lock`, which is what the lockfile-drift
-    # check below relies on to detect non-dedup-clean lockfiles. With
-    # node_modules restored from cache, this step is fast (mostly just
-    # postinstall).
-    - name: Install dependencies for root package.js
-      uses: ./.github/actions/install-deps
-      with:
-        dir-path: './'
-        keytar-host-mirror: ${{ inputs.keytar-host-mirror }}
-        sqlite3-host-mirror: ${{ inputs.sqlite3-host-mirror }}
-
-    # The root install above always runs, so its postinstall
-    # (`yarn-deduplicate yarn.lock`) always runs. If the committed
-    # lockfile is non-dedup-clean, postinstall rewrote it in place and
-    # this diff fails. `--frozen-lockfile` already catches the case where
-    # the lockfile disagrees with package.json.
+    # When install ran (cache miss), its postinstall executed
+    # `yarn-deduplicate yarn.lock`. If the committed lockfile was not
+    # dedup-clean, postinstall rewrote it in place and this diff fails.
+    # On cache hit install was skipped — the lockfile is byte-identical
+    # to a previously verified state, so the diff is a no-op.
     - name: Verify root yarn.lock is unchanged after install
       shell: bash
       run: |

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -67,6 +67,20 @@ runs:
       with:
         dir-path: './redisinsight/api'
 
+    # The OpenAPI client (`redisinsight/api-client/`) is gitignored and produced
+    # by the `postinstall` hook in `redisinsight/api`. When the node_modules
+    # cache is restored, that postinstall is skipped, so the directory ends up
+    # missing and any subsequent step that imports `apiClient` fails — in
+    # particular the root postinstall below, which runs `vite optimize` and
+    # resolves the `apiClient` alias during dep scanning. Generate it here
+    # when it isn't present, before the root install runs.
+    - name: Generate OpenAPI client (if missing)
+      shell: bash
+      run: |
+        if [ ! -f redisinsight/api-client/index.ts ]; then
+          yarn --cwd redisinsight/api generate:api-client
+        fi
+
     # Deliberately not gated on cache hit — the root `postinstall` runs
     # `yarn-deduplicate yarn.lock`, which is what the lockfile-drift
     # check below relies on to detect non-dedup-clean lockfiles. With
@@ -78,18 +92,6 @@ runs:
         dir-path: './'
         keytar-host-mirror: ${{ inputs.keytar-host-mirror }}
         sqlite3-host-mirror: ${{ inputs.sqlite3-host-mirror }}
-
-    # The OpenAPI client (`redisinsight/api-client/`) is gitignored and produced
-    # by the `postinstall` hook in `redisinsight/api`. When the node_modules
-    # cache is restored, postinstall is skipped, so the directory ends up
-    # missing and the UI workspace fails to resolve `from 'apiClient'`.
-    # Generate it here when it isn't present.
-    - name: Generate OpenAPI client (if missing)
-      shell: bash
-      run: |
-        if [ ! -f redisinsight/api-client/index.ts ]; then
-          yarn --cwd redisinsight/api generate:api-client
-        fi
 
     # The root install above always runs, so its postinstall
     # (`yarn-deduplicate yarn.lock`) always runs. If the committed

--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -86,3 +86,23 @@ runs:
         if [ ! -f redisinsight/api-client/index.ts ]; then
           yarn --cwd redisinsight/api generate:api-client
         fi
+
+    # Detects lockfile drift caused by `yarn install` running the root
+    # `postinstall` (which executes `yarn-deduplicate yarn.lock`). A PR may
+    # pass `--frozen-lockfile` yet still ship a non-dedup-clean lockfile,
+    # which dirties every local install. Runs unconditionally so an exact
+    # node_modules cache hit (which skips the install steps above) does
+    # not bypass the check.
+    - name: Verify yarn.lock files are unchanged after install
+      shell: bash
+      run: |
+        fail=0
+        for lock in yarn.lock redisinsight/yarn.lock redisinsight/api/yarn.lock; do
+          if [ -f "$lock" ] && ! git diff --exit-code --quiet -- "$lock"; then
+            dir=$(dirname "$lock")
+            echo "::error file=$lock::$lock was modified by 'yarn install'. The committed lockfile is not dedup-clean. Run 'yarn install' in $dir locally and commit the updated lockfile."
+            git --no-pager diff --stat -- "$lock"
+            fail=1
+          fi
+        done
+        exit $fail

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -31,3 +31,19 @@ runs:
         # export npm_config_node_sqlite3_binary_host_mirror=${{ inputs.sqlite3-host-mirror }}
 
         yarn install --frozen-lockfile --network-timeout 1000000
+
+    # Detects lockfile drift caused by `yarn install` running the root
+    # `postinstall` (which executes `yarn-deduplicate yarn.lock`). A PR may
+    # pass `--frozen-lockfile` yet still ship a non-dedup-clean lockfile,
+    # which dirties every local install. Fail fast here so authors re-run
+    # `yarn install` locally and commit the deduped lockfile.
+    - name: Verify yarn.lock is unchanged after install
+      if: hashFiles(format('{0}/yarn.lock', inputs.dir-path)) != ''
+      working-directory: ${{ inputs.dir-path }}
+      shell: bash
+      run: |
+        if ! git diff --exit-code --quiet -- yarn.lock; then
+          echo "::error file=${{ inputs.dir-path }}/yarn.lock::yarn.lock was modified by 'yarn install' in ${{ inputs.dir-path }}. The committed lockfile is not dedup-clean. Run 'yarn install' locally in ${{ inputs.dir-path }} and commit the updated yarn.lock."
+          git --no-pager diff --stat -- yarn.lock
+          exit 1
+        fi

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -31,19 +31,3 @@ runs:
         # export npm_config_node_sqlite3_binary_host_mirror=${{ inputs.sqlite3-host-mirror }}
 
         yarn install --frozen-lockfile --network-timeout 1000000
-
-    # Detects lockfile drift caused by `yarn install` running the root
-    # `postinstall` (which executes `yarn-deduplicate yarn.lock`). A PR may
-    # pass `--frozen-lockfile` yet still ship a non-dedup-clean lockfile,
-    # which dirties every local install. Fail fast here so authors re-run
-    # `yarn install` locally and commit the deduped lockfile.
-    - name: Verify yarn.lock is unchanged after install
-      if: hashFiles(format('{0}/yarn.lock', inputs.dir-path)) != ''
-      working-directory: ${{ inputs.dir-path }}
-      shell: bash
-      run: |
-        if ! git diff --exit-code --quiet -- yarn.lock; then
-          echo "::error file=${{ inputs.dir-path }}/yarn.lock::yarn.lock was modified by 'yarn install' in ${{ inputs.dir-path }}. The committed lockfile is not dedup-clean. Run 'yarn install' locally in ${{ inputs.dir-path }} and commit the updated yarn.lock."
-          git --no-pager diff --stat -- yarn.lock
-          exit 1
-        fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,13 @@ These apply to every change in the repo. Skill files contain the full detail; th
 - Verify current branch with `git branch --show-current` before any push.
 - All changes go through pull requests.
 
+### Dependency / lockfile management (always)
+
+- The root `postinstall` runs `yarn-deduplicate yarn.lock`, so `yarn install` rewrites the lockfile whenever it isn't dedup-clean. After modifying any `package.json` (root, `redisinsight/`, or `redisinsight/api/`), run `yarn install` from that directory and commit the resulting lockfile changes.
+- Never edit `yarn.lock` files by hand and never run `yarn install --ignore-scripts` (or otherwise skip `postinstall`) when preparing a commit — the lockfile shipped to CI must match what `yarn install` produces locally.
+- CI runs `yarn install --frozen-lockfile` and then fails if `yarn.lock` is modified by the install. A green local install in every changed package's directory is required before pushing.
+- Use the right package manager for the change: `yarn add` / `yarn remove` (or `yarn upgrade`) for dependency changes, never manual edits to `package.json` versions without re-running install.
+
 ## Skills
 
 All detailed development standards are exposed as skills under `.ai/skills/`. Claude Code auto-discovers them; each skill triggers when its description matches the task.
@@ -160,6 +167,7 @@ All detailed development standards are exposed as skills under `.ai/skills/`. Cl
 
 - Commit secrets or API keys
 - Edit `node_modules/` or `vendor/` directories
+- Edit `yarn.lock` by hand or commit a lockfile produced with `--ignore-scripts` / a skipped `postinstall`
 - Use fixed time waits in tests (use `waitFor` instead)
 - Use `!important` in styled-components
 - Import directly from `@redis-ui/*` (use internal wrappers from `uiSrc/components/ui`)


### PR DESCRIPTION
# What

Closes the gap where a PR can ship a `yarn.lock` that gets silently
rewritten the first time a developer (or CI on the next run) executes
`yarn install`. Three small changes:

1. **CI guard against lockfile drift** — new `Verify root yarn.lock is
   unchanged after install` step in `install-all-build-libs`. After
   `yarn install` runs, it does a `git diff --exit-code -- yarn.lock`.
   If the root `postinstall` (which runs `yarn-deduplicate yarn.lock`)
   mutated the file, CI fails with an inline error annotation pointing
   at `yarn.lock` and a short remediation message.
2. **Cache key now includes `package.json`** — the `node_modules` cache
   used to be keyed only on `hash(yarn.lock files)`, which meant a
   `package.json` edit without a matching `yarn install` would still
   cache-hit, skip install entirely, and slip past
   `yarn install --frozen-lockfile`. Hashing both files for every
   workspace forces a cache miss → install → frozen-lockfile check on
   any dep change, intended or not.
3. **AGENTS.md rule** — new "Dependency / lockfile management
   (always)" subsection under *Always-On Rules*, plus a `🚫 Never Do`
   bullet, documenting that:
   - any `package.json` edit must be followed by `yarn install` from
     that directory, with the resulting lockfile changes committed;
   - `yarn.lock` files are never edited by hand and never produced
     with `--ignore-scripts` / a skipped `postinstall`;
   - CI now enforces the dedup-clean lockfile contract.

# Why

`yarn install --frozen-lockfile` only checks that `package.json` and
`yarn.lock` agree — it does not check whether `postinstall` mutates the
lockfile. The root `postinstall` runs `yarn-deduplicate yarn.lock`, so a
PR that ships a non-dedup-clean lockfile (typical of installs done with
`--ignore-scripts` or by agents that skip `postinstall`) passes CI but
dirties every subsequent local `yarn install`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI guardrails and documentation; the electron-builder patch bump is a minor devDependency change with limited runtime impact.
> 
> **Overview**
> Tightens CI and agent docs so **non-dedup-clean** root `yarn.lock` files cannot merge unnoticed after `postinstall` runs `yarn-deduplicate`.
> 
> In **`install-all-build-libs`**, the `node_modules` cache key now hashes **`package.json` and `yarn.lock` for root and both workspaces**, so a `package.json`-only change forces a fresh install instead of a cache hit that skips `--frozen-lockfile`. A new step **`Verify root yarn.lock is unchanged after install`** fails the job with a `yarn.lock` annotation if install mutates the committed lockfile.
> 
> **`AGENTS.md`** adds an always-on **dependency / lockfile management** section and a **Never Do** bullet: run `yarn install` after dep edits, never hand-edit lockfiles or skip `postinstall`, and expect CI to enforce the contract.
> 
> Also bumps root devDependency **`electron-builder`** from `^26.0.12` to `^26.15.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f401ea1364c1d008084e8a055efa6d8d780a7838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->