### PR TITLE
Fix Electron postinstall on Node 24+ (pin yauzl)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "react-router-dom/react-router/path-to-regexp": "^1.9.0",
     "**/form-data": "^4.0.4",
     "@types/react": "18.2.1",
-    "@types/react-dom": "18.2.1"
+    "@types/react-dom": "18.2.1",
+    "yauzl": "^3.3.1"
   },
   "devDependencies": {
     "@aivenio/tsc-output-parser": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5444,11 +5444,6 @@ buffer-builder@^0.2.0:
   resolved "https://registry.yarnpkg.com/buffer-builder/-/buffer-builder-0.2.0.tgz#3322cd307d8296dab1f604618593b261a3fade8f"
   integrity sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
-
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -8225,13 +8220,6 @@ fb-watchman@^2.0.0:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
-  dependencies:
-    pend "~1.2.0"
 
 fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
@@ -16271,13 +16259,12 @@ yarn-deduplicate@^6.0.2:
     semver "^7.5.0"
     tslib "^2.5.0"
 
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+yauzl@^2.10.0, yauzl@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
+  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
   dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
+    pend "~1.2.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Pin `yauzl` to `^3.3.1` via yarn resolutions. `yauzl@2` (transitively via
`extract-zip` in electron's `install.js`) silently extracts only the first
zip entry on Node ≥ 24.16, leaving `node_modules/electron/dist` incomplete
and breaking `yarn dev:desktop` after a fresh `yarn install`.

Remove this resolution once upstream drops `extract-zip`
(electron/electron#51619) - a.k.a. we bump Electron to a release that includes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency resolution-only change with no application code; low risk aside from verifying Electron install still works across Node versions.
> 
> **Overview**
> Adds a **yarn resolution** pinning **`yauzl`** to **`^3.3.1`**, so installs resolve **`yauzl@3.4.0`** instead of **`yauzl@2`** pulled transitively (e.g. via **`extract-zip`** during Electron’s postinstall).
> 
> This works around **`yauzl@2`** extracting only the first zip entry on **Node ≥ 24.16**, which left **`node_modules/electron/dist`** incomplete and broke **`yarn dev:desktop`** after a fresh install. The lockfile update drops older **`yauzl@2`**-related entries (**`buffer-crc32`**, **`fd-slicer`**) in favor of the **`yauzl@3`** tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2ae2a45296a9ce9fbc8c01f6c20134ca7ad880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->