### PR TITLE
RI-8213 Register array key type (UI + API)

### DIFF
--- a/redisinsight/api/src/modules/browser/keys/dto/key.dto.ts
+++ b/redisinsight/api/src/modules/browser/keys/dto/key.dto.ts
@@ -17,6 +17,7 @@ export enum RedisDataType {
   Graph = 'graphdata',
   TS = 'TSDB-TYPE',
   VectorSet = 'vectorset',
+  Array = 'array',
 }
 
 export class KeyDto {

--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -14,4 +14,7 @@ export const CommandsVersions = {
   VECTOR_SET: {
     since: '8.0',
   },
+  ARRAY: {
+    since: '8.8',
+  },
 }

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -12,6 +12,7 @@ export enum KeyTypes {
   JSON = 'json',
   Stream = 'stream',
   VectorSet = 'vectorset',
+  Array = 'array',
 }
 
 export const SEARCHABLE_KEY_TYPES: KeyTypes[] = [KeyTypes.Hash, KeyTypes.ReJSON]
@@ -31,6 +32,7 @@ export const GROUP_TYPES_DISPLAY = Object.freeze({
   [KeyTypes.JSON]: 'JSON',
   [KeyTypes.Stream]: 'Stream',
   [KeyTypes.VectorSet]: 'Vector Set',
+  [KeyTypes.Array]: 'Array',
   [ModulesKeyTypes.TimeSeries]: 'Time Series',
   [CommandGroup.Bitmap]: 'Bitmap',
   [CommandGroup.Cluster]: 'Cluster',
@@ -64,6 +66,7 @@ export const GROUP_TYPES_COLORS = Object.freeze({
   [KeyTypes.JSON]: 'var(--typeReJSONColor)',
   [KeyTypes.Stream]: 'var(--typeStreamColor)',
   [KeyTypes.VectorSet]: 'var(--typeVectorSetColor)',
+  [KeyTypes.Array]: 'var(--typeArrayColor)',
   [ModulesKeyTypes.Graph]: 'var(--typeGraphColor)',
   [ModulesKeyTypes.TimeSeries]: 'var(--typeTimeSeriesColor)',
   [CommandGroup.SortedSet]: 'var(--groupSortedSetColor)',

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -243,4 +243,53 @@ describe('FilterKeyType', () => {
 
     expect(queryByText('Vector Set')).not.toBeInTheDocument()
   })
+
+  it('should show Array when dev-array feature flag is enabled and redis version >= 8.8', async () => {
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '8.8.0',
+    }))
+    const initialStoreState = set(
+      cloneDeep(initialStateDefault),
+      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      { flag: true },
+    )
+    const { queryByText } = render(<FilterKeyType />, {
+      store: mockStore(initialStoreState),
+    })
+
+    await userEvent.click(screen.getByTestId(filterSelectId))
+
+    expect(queryByText('Array')).toBeInTheDocument()
+  })
+
+  it('should hide Array when dev-array feature flag is disabled', () => {
+    // Ensure the version gate is satisfied so the assertion truly
+    // exercises the feature-flag path and not the version path.
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '8.8.0',
+    }))
+    const { queryByText } = render(<FilterKeyType />)
+
+    fireEvent.click(screen.getByTestId(filterSelectId))
+
+    expect(queryByText('Array')).not.toBeInTheDocument()
+  })
+
+  it('should hide Array when redis version < 8.8 even if feature flag is enabled', async () => {
+    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
+      version: '8.0.0',
+    }))
+    const initialStoreState = set(
+      cloneDeep(initialStateDefault),
+      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      { flag: true },
+    )
+    const { queryByText } = render(<FilterKeyType />, {
+      store: mockStore(initialStoreState),
+    })
+
+    await userEvent.click(screen.getByTestId(filterSelectId))
+
+    expect(queryByText('Array')).not.toBeInTheDocument()
+  })
 })

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -5,7 +5,10 @@ import {
   FeatureFlags,
 } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isDevVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { FilterKeyTypeOption } from './FilterKeyType.types'
 
@@ -19,6 +22,13 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     text: 'List',
     value: KeyTypes.List,
     color: GROUP_TYPES_COLORS[KeyTypes.List],
+  },
+  {
+    text: 'Array',
+    value: KeyTypes.Array,
+    color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    minVersion: CommandsVersions.ARRAY.since,
+    isEnabledSelector: isDevArrayEnabledSelector,
   },
   {
     text: 'Set',

--- a/redisinsight/ui/src/pages/browser/components/key-row-type/KeyRowType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-row-type/KeyRowType.spec.tsx
@@ -35,4 +35,18 @@ describe('KeyRowType', () => {
     expect(queryByTestId(loadingTestId + nameString)).not.toBeInTheDocument()
     expect(queryByTestId(`badge-${type}_${nameString}`)).toBeInTheDocument()
   })
+
+  it('should render the Array badge for array keys', () => {
+    const type = KeyTypes.Array
+    const { queryByTestId, getByText } = render(
+      <KeyRowType
+        {...instance(mockedProps)}
+        nameString={nameString}
+        type={type}
+      />,
+    )
+
+    expect(queryByTestId(`badge-${type}_${nameString}`)).toBeInTheDocument()
+    expect(getByText('Array')).toBeInTheDocument()
+  })
 })

--- a/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
@@ -150,6 +150,7 @@ $typeStreamColor: #6a741b;
 $typeGraphColor: #14708d;
 $typeTimeSeriesColor: #6e6e6e;
 $typeVectorSetColor: #0284C7;
+$typeArrayColor: #db2777;
 $groupSortedSetColor: #a00a6b;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;

--- a/redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/darkTheme.scss
@@ -152,6 +152,7 @@
   --typeGraphColor: #{$typeGraphColor};
   --typeTimeSeriesColor: #{$typeTimeSeriesColor};
   --typeVectorSetColor: #{$typeVectorSetColor};
+  --typeArrayColor: #{$typeArrayColor};
   --groupSortedSetColor: #{$groupSortedSetColor};
   --groupBitmapColor: #{$groupBitmapColor};
   --groupClusterColor: #{$groupClusterColor};

--- a/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
@@ -115,6 +115,7 @@ $typeStreamColor: #c7cea8;
 $typeGraphColor: #acccd7;
 $typeTimeSeriesColor: #c7c7c7;
 $typeVectorSetColor: #0284C7;
+$typeArrayColor: #db2777;
 $groupSortedSetColor: #d9a0c6;
 $groupBitmapColor: #3f4b5f;
 $groupClusterColor: #6e6e6e;

--- a/redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/lightTheme.scss
@@ -147,6 +147,7 @@
   --typeGraphColor: #{$typeGraphColor};
   --typeTimeSeriesColor: #{$typeTimeSeriesColor};
   --typeVectorSetColor: #{$typeVectorSetColor};
+  --typeArrayColor: #{$typeArrayColor};
   --groupSortedSetColor: #{$groupSortedSetColor};
   --groupBitmapColor: #{$groupBitmapColor};
   --groupClusterColor: #{$groupClusterColor};


### PR DESCRIPTION
# What

Foundation work for the Redis array type initiative (epic RI-8174) — registers `array` as a recognized key type:

- `KeyTypes.Array` (UI) and `RedisDataType.Array` (API)
- Dedicated badge label + color (`--typeArrayColor`) in the light and dark themes
- Array option in the key-type filter dropdown, gated behind the `dev-array` flag (mirrors the VectorSet pattern)

Capability detection, the Add Key entry, and the details panel are out of scope (separate tickets).

# Testing

1. Run `yarn dev:desktop` (dev mode → `dev-array` flag is on).
2. On an array-capable Redis (8.8.0+), create a key: `ARSET myarray 0 "a" "b" "c"`.
3. In the Browser keys list, the key shows the **Array** badge.
4. Open the key-type filter dropdown → **Array** appears (after List) and filters to array keys.

Unit tests cover the keys-list badge rendering and the gated filter option (`yarn lint`, `yarn type-check`, `yarn test` all pass).

### Screenshots

|             | Light mode                       | Dark mode                       |
| ----------- | -------------------------------- | ------------------------------- |
| **Array badge** | <img width="338" height="197" alt="image" src="https://github.com/user-attachments/assets/0f6de6f4-aca3-48bf-8dc9-cc78a8933c37" /> | <img width="356" height="171" alt="image" src="https://github.com/user-attachments/assets/0cf703bc-80fc-46a6-8fb8-bcd0fffff3f1" /> |
| **Keys list**   | <img width="200" height="418" alt="image" src="https://github.com/user-attachments/assets/cd2da5b4-bb7b-4fd9-94c3-cb17aa3379c8" />  | <img width="190" height="414" alt="image" src="https://github.com/user-attachments/assets/15afde4a-5a97-4e46-a0c0-3418e0950815" />  |


- Older than 8.8 redis not showing the `arrays` label in the filter list
<img width="201" height="398" alt="image" src="https://github.com/user-attachments/assets/8b1c29b8-2aae-43cc-974b-33ba6e84cf9a" />

---

Closes #RI-8213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive type registration and UI gating behind a dev flag; no auth, data mutation, or new API endpoints in this diff.
> 
> **Overview**
> Registers Redis **`array`** as a first-class key type on the API (`RedisDataType.Array`) and UI (`KeyTypes.Array`), with display label **Array** and theme token **`--typeArrayColor`** in light and dark modes.
> 
> The browser key-type filter gains an **Array** option (after List), shown only when the **`dev-array`** feature flag is on and the connected instance is **Redis ≥ 8.8**—same gating pattern as Vector Set. Keys list rows can show an **Array** badge via existing `GROUP_TYPES_DISPLAY` / color mappings.
> 
> Unit tests cover filter visibility (flag + version) and **Array** badge rendering in `KeyRowType`. Add-key flow, capability detection, and the details panel are explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb8ffceba233d24dbbe78e6bb51397fd4e1789b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->