### PR TITLE
ci(e2e): disable node_modules cache for jobs that build the application

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -14,6 +14,11 @@ inputs:
     description: SQLite3 binary host mirror
     required: false
 
+  cache-node-modules:
+    description: Cache node_modules between runs ('1' enabled, '0' disabled). Disable for jobs that build the application to avoid stale nested deps surviving lockfile changes.
+    default: '1'
+    required: false
+
 runs:
   using: 'composite'
   steps:
@@ -24,6 +29,7 @@ runs:
 
     - name: Cache node_modules
       id: cache-node-modules
+      if: inputs.cache-node-modules != '0'
       uses: actions/cache@v5
       with:
         path: |

--- a/.github/workflows/pipeline-build-docker.yml
+++ b/.github/workflows/pipeline-build-docker.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Build sources
         run: ./.github/build/build.sh

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics

--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Install application dependencies
         uses: ./.github/actions/install-all-build-libs
+        with:
+          cache-node-modules: '0'
 
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e-playwright


### PR DESCRIPTION
# What

Add an opt-out `cache-node-modules` input (default `'1'`) to the
`install-all-build-libs` composite action and disable caching at the
three call sites that actually build the application:

- `pipeline-build-linux.yml`
- `pipeline-build-docker.yml`
- `tests-e2e-playwright-chromium.yml`

All other consumers (`lint`, `type-check`, `tests-backend`,
`tests-frontend`, `licenses-check`, `pipeline-build-macos`,
`pipeline-build-windows`) fall through to the default and keep
caching unchanged.

## Why

After PR #6026 bumped `electron-builder` to 26.15.2, the Linux build
in *E2E Playwright Tests (v2)* failed with
`Cannot find module 'detect-libc'`, originating from a stale
`node_modules/app-builder-lib/node_modules/@electron/rebuild@3.7.0`
left behind by the restored cache. `yarn install --frozen-lockfile`
does not delete orphaned nested `node_modules`, and the cache's
`restore-keys` fallback silently brought the stale tree forward across
the lockfile change.

For pipelines that build the app from scratch, a clean install is
cheap insurance — these jobs already spend most of their time
compiling and packaging, so the cache win was marginal anyway.

Note: this also disables `node_modules` caching for production release
flows that reuse `pipeline-build-{linux,docker}.yml` (e.g.
`manual-build.yml`, `aws-upload-prod.yml`). Intentional — same
correctness reasoning applies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with a safe default; only full app-build workflows opt out of caching, slightly increasing install time on those jobs.
> 
> **Overview**
> Adds an opt-out **`cache-node-modules`** input (default `'1'`) to **`install-all-build-libs`**, gating the `actions/cache` step on `inputs.cache-node-modules != '0'`.
> 
> **Linux**, **Docker**, and **E2E Playwright Chromium** workflows now pass **`cache-node-modules: '0'`** so app-build jobs always run a fresh `yarn install` instead of restoring `node_modules`. That avoids stale nested dependencies (e.g. after lockfile bumps) surviving cache `restore-keys` and breaking builds such as missing `detect-libc`.
> 
> Lint, tests, licenses, and macOS/Windows build pipelines are unchanged and keep the default cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e623bf3a4a5c742339cd56199427f42790fe05e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->