### PR TITLE
docs(release-notes): add New Contributors section to template

### DIFF
--- a/docs/release-notes/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/release-notes/RELEASE_NOTES_TEMPLATE.md
@@ -24,6 +24,14 @@
 
 ---
 
+### New Contributors
+
+* @[github-handle] made their first contribution in [PR link]
+
+(Include this section only when there is at least one new contributor since the previous release. Start from GitHub's auto-generated list via `gh api -X POST repos/redis/RedisInsight/releases/generate-notes -f tag_name=[VERSION] -f previous_tag_name=[LAST_RELEASED] -f target_commitish=main --jq '.body'`, but note it only catches authors whose commits land directly on `main` — external contributors whose work was merged through a feature branch (and then squashed) will be missed and must be added manually.)
+
+---
+
 **SHA-512 Checksums**
 
 [Link to checksums]


### PR DESCRIPTION
## Summary
- Adds a **New Contributors** section to `docs/release-notes/RELEASE_NOTES_TEMPLATE.md`.
- Includes a usage note that the section should only appear when there is at least one new contributor since the previous release, with guidance on seeding the list from GitHub's `generate-notes` API and manually adding contributors whose PRs were squash-merged from feature branches (which the API misses).

## Test plan
- [x] Verified the diff only touches `docs/release-notes/RELEASE_NOTES_TEMPLATE.md`.
- [ ] Reviewer to confirm the wording and placement of the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release notes template with no runtime or security impact.
> 
> **Overview**
> Extends **`docs/release-notes/RELEASE_NOTES_TEMPLATE.md`** with a **New Contributors** block (placeholder line for `@[github-handle]` and PR link), placed after the bug-only variant and before SHA-512 checksums.
> 
> The template also documents **when** to include the section (only if there is at least one new contributor since the last release) and **how** to build the list: seed from GitHub’s `generate-notes` API via `gh api`, then manually add contributors missed when work was squash-merged from feature branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc41e4af79fd42ee1ea61d8c49be6fe0245d97d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->