### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/.github/build/release-docker.sh
+++ b/.github/build/release-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 HELP="Args:
--v - Semver (3.4.2)
+-v - Semver (3.6.0)
 -d - Build image repository (Ex: -d redisinsight)
 -r - Target repository (Ex: -r redis/redisinsight)
 "

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -126,7 +126,7 @@ export default {
       : true,
     buildType: process.env.RI_BUILD_TYPE || 'DOCKER_ON_PREMISE',
     appType: process.env.RI_APP_TYPE,
-    appVersion: process.env.RI_APP_VERSION || '3.4.2',
+    appVersion: process.env.RI_APP_VERSION || '3.6.0',
     buildCommitSha: resolveBuildCommitSha(),
     requestTimeout: parseInt(process.env.RI_REQUEST_TIMEOUT, 10) || 25000,
     excludeRoutes: [],

--- a/redisinsight/api/config/swagger.ts
+++ b/redisinsight/api/config/swagger.ts
@@ -5,7 +5,7 @@ const SWAGGER_CONFIG: Omit<OpenAPIObject, 'paths'> = {
   info: {
     title: 'Redis Insight Backend API',
     description: 'Redis Insight Backend API',
-    version: '3.4.2',
+    version: '3.6.0',
   },
   tags: [],
 };

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redisinsight-api",
-  "version": "3.4.2",
+  "version": "3.6.0",
   "description": "Redis Insight API",
   "private": true,
   "author": {

--- a/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
+++ b/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
@@ -7,7 +7,7 @@ const ICON_PATH = app.isPackaged
   : path.join(__dirname, '../resources', 'icon.png')
 
 const appVersionPrefix = config.isEnterprise ? 'Enterprise - ' : ''
-const appVersion = app.getVersion() || '3.4.2'
+const appVersion = app.getVersion() || '3.6.0'
 const appVersionSuffix = !config.isProduction
   ? `-dev-${process.getCreationTime()}`
   : ''

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -3,7 +3,7 @@
   "appName": "Redis Insight",
   "productName": "RedisInsight",
   "private": true,
-  "version": "3.4.2",
+  "version": "3.6.0",
   "description": "Redis Insight",
   "main": "./dist/main/main.js",
   "author": {


### PR DESCRIPTION
## Summary
- Bumps RedisInsight version from `3.4.2` to `3.6.0` across all version-tracking files via `node scripts/update-version.js 3.6.0`.
- Files touched: `redisinsight/package.json`, `redisinsight/api/package.json`, `redisinsight/api/config/default.ts`, `redisinsight/api/config/swagger.ts`, `redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts`, `.github/build/release-docker.sh`.

## Test plan
- [x] `scripts/update-version.js` reported 6 files updated, 0 skipped, 0 errors.
- [ ] CI green.
- [x] Reviewer to confirm `3.6.0` is the intended target (skips `3.5.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string-only changes with no logic, security, or data-path modifications.
> 
> **Overview**
> Bumps the Redis Insight release version from **3.4.2** to **3.6.0** everywhere the product version is recorded.
> 
> **Root and API packages:** `redisinsight/package.json` and `redisinsight/api/package.json` `version` fields are updated to `3.6.0`.
> 
> **Runtime and docs defaults:** `redisinsight/api/config/default.ts` changes the `RI_APP_VERSION` fallback to `3.6.0`; `redisinsight/api/config/swagger.ts` OpenAPI `info.version` matches.
> 
> **Desktop and release tooling:** Electron About panel fallback in `aboutPanel.ts` and the semver example in `.github/build/release-docker.sh` help text are aligned to `3.6.0`.
> 
> No functional or behavioral code changes—only version strings for builds, UI, API metadata, and Docker release scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a2a4d823d0cd880f8361ed97d2a8b7340ec2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->