### PR TITLE
ci: disable node_modules cache for all app-building jobs

### DIFF
--- a/.github/workflows/pipeline-build-macos.yml
+++ b/.github/workflows/pipeline-build-macos.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics

--- a/.github/workflows/pipeline-build-windows.yml
+++ b/.github/workflows/pipeline-build-windows.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install all libs and dependencies
         uses: ./.github/actions/install-all-build-libs
+        with:
+          cache-node-modules: '0'
 
       - name: Setup certs
         uses: ./.github/actions/install-windows-certs


### PR DESCRIPTION
## Summary

Backports [redis/RedisInsight#6031](https://github.com/redis/RedisInsight/pull/6031) into `release/3.6.0` and extends it to **every** pipeline that builds the application. Specifically, this also adds `cache-node-modules: '0'` to the macOS and Windows build pipelines that were intentionally left untouched in the original PR.

Adds an opt-out `cache-node-modules` input (default `'1'`) to the `install-all-build-libs` composite action, and disables caching at all the call sites that actually build the application:

- `pipeline-build-linux.yml`
- `pipeline-build-docker.yml`
- `pipeline-build-macos.yml` *(new vs. #6031)*
- `pipeline-build-windows.yml` *(new vs. #6031)*
- `tests-e2e-playwright-chromium.yml`

All other consumers (`lint`, `type-check`, `tests-backend`, `tests-frontend`, `licenses-check`) fall through to the default `'1'` and keep caching unchanged.

## Why

Same reasoning as #6031: after the bump of `electron-builder` to `26.15.2`, builds in *E2E Playwright Tests (v2)* failed with `Cannot find module 'detect-libc'`, originating from a stale `node_modules/app-builder-lib/node_modules/@electron/rebuild@3.7.0` left behind by the restored cache. `yarn install --frozen-lockfile` does not delete orphaned nested `node_modules`, and the cache's `restore-keys` fallback silently brought the stale tree forward across the lockfile change.

For pipelines that build the app from scratch, a clean install is cheap insurance — these jobs already spend most of their time compiling and packaging, so the cache win was marginal anyway. Applying the same fix to macOS and Windows keeps behavior consistent across platforms and protects them from the same class of failure.

## Test plan

- [ ] CI runs on this PR pass on `release/3.6.0`
- [ ] `pipeline-build-linux.yml` runs without restoring node_modules
- [ ] `pipeline-build-docker.yml` runs without restoring node_modules
- [ ] `pipeline-build-macos.yml` runs without restoring node_modules
- [ ] `pipeline-build-windows.yml` runs without restoring node_modules
- [ ] `tests-e2e-playwright-chromium.yml` runs without restoring node_modules
- [ ] Lint / type-check / unit-test workflows still cache node_modules (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI caching behavior and release-note documentation; no runtime application code is affected.
> 
> **Overview**
> Adds an opt-out **`cache-node-modules`** input (default enabled) to **`install-all-build-libs`**, so the `node_modules` cache step is skipped when set to `'0'`.
> 
> **All application build and E2E web-build pipelines** now pass **`cache-node-modules: '0'`** (Linux, Docker, macOS, Windows, and Playwright Chromium E2E). That forces a fresh `yarn install` on those jobs to avoid stale nested dependencies after lockfile changes (e.g. missing `detect-libc` from restored cache). Lint, type-check, unit tests, and licenses workflows are unchanged and still use the default cache.
> 
> The **release notes template** gains an optional **New Contributors** section with guidance on generating and manually completing the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53640cd5d32c992bad3ad4ac4d0656238e67dfe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->