### PR TITLE
RI-8214 Scaffold array NestJS module

### DIFF
--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,0 +1,20 @@
+import {
+  Controller,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { BrowserSerializeInterceptor } from 'src/common/interceptors';
+import { BrowserBaseController } from 'src/modules/browser/browser.base.controller';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+
+@ApiTags('Browser: Array')
+@UseInterceptors(BrowserSerializeInterceptor)
+@Controller('array')
+@UsePipes(new ValidationPipe({ transform: true }))
+export class ArrayController extends BrowserBaseController {
+  constructor(private arrayService: ArrayService) {
+    super();
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.module.ts
+++ b/redisinsight/api/src/modules/browser/array/array.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+import { ArrayController } from 'src/modules/browser/array/array.controller';
+
+@Module({})
+export class ArrayModule {
+  static register({ route }: { route: string }): DynamicModule {
+    return {
+      module: ArrayModule,
+      imports: [
+        RouterModule.register([
+          {
+            path: route,
+            module: ArrayModule,
+          },
+        ]),
+      ],
+      controllers: [ArrayController],
+      providers: [ArrayService],
+    };
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDatabaseClientFactory } from 'src/__mocks__';
+import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+
+describe('ArrayService', () => {
+  let service: ArrayService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArrayService,
+        {
+          provide: DatabaseClientFactory,
+          useFactory: mockDatabaseClientFactory,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ArrayService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+
+@Injectable()
+export class ArrayService {
+  constructor(private databaseClientFactory: DatabaseClientFactory) {}
+}

--- a/redisinsight/api/src/modules/browser/browser.module.ts
+++ b/redisinsight/api/src/modules/browser/browser.module.ts
@@ -10,6 +10,7 @@ import { StreamModule } from 'src/modules/browser/stream/stream.module';
 import { RedisearchModule } from 'src/modules/browser/redisearch/redisearch.module';
 import { KeysModule } from 'src/modules/browser/keys/keys.module';
 import { VectorSetModule } from 'src/modules/browser/vector-set/vector-set.module';
+import { ArrayModule } from 'src/modules/browser/array/array.module';
 import { BrowserHistoryRepository } from './browser-history/repositories/browser-history.repository';
 import { LocalBrowserHistoryRepository } from './browser-history/repositories/local.browser-history.repository';
 
@@ -34,6 +35,7 @@ export class BrowserModule {
         RedisearchModule.register({ route }),
         KeysModule.register({ route }),
         VectorSetModule.register({ route }),
+        ArrayModule.register({ route }),
       ],
       exports: [BrowserHistoryModule],
     };


### PR DESCRIPTION
# What

Foundation slice for the Redis Array type initiative ([RI-8174](https://redislabs.atlassian.net/browse/RI-8174), §6.1 Task 1).

Scaffolds an empty `array/` NestJS module under `redisinsight/api/src/modules/browser/`, mirroring the existing per-type modules (`list`, `hash`, `vector-set`), and registers it in the browser module graph. No endpoints yet — the feature verticals add them as they land.

- `array.module.ts` — `DynamicModule` with `RouterModule` wiring
- `array.controller.ts` — empty controller extending `BrowserBaseController` (no routes yet)
- `array.service.ts` — empty `@Injectable` pre-wired with `DatabaseClientFactory`
- `array.service.spec.ts` — smoke test

One small deviation from the siblings: the `register({ route }: { route: string })` param is typed. The siblings' untyped `{ route }` is a TS7031 implicit-`any` already grandfathered into the type-check baseline; typing the new file keeps `yarn type-check` green without growing the baseline. No runtime difference.

# Testing

- `yarn lint:api` — clean
- API `type-check` baseline compare — no new errors
- Browser module test suite — 551 passing (incl. new `ArrayService` spec)

---

Closes #RI-8214

[RI-8174]: https://redislabs.atlassian.net/browse/RI-8174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive module wiring only; no routes, data access, or behavior changes.
> 
> **Overview**
> Adds a **scaffold NestJS `array` browser module** for the Redis Array type workstream: empty controller (no routes), service wired with `DatabaseClientFactory`, dynamic `register({ route })` routing, and a smoke unit test.
> 
> **`BrowserModule`** now imports `ArrayModule.register({ route })` alongside the other per-type browser modules. The new module’s `register` argument is explicitly typed as `{ route: string }` (siblings still use untyped `route`); behavior is unchanged.
> 
> No API endpoints or Redis Array logic yet—follow-up PRs are expected to add them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1b051b45a6a3953a5794a9aa731a94ee837f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->