### PR TITLE
RI-7390 Promote dev-vectorSet flag to regular vectorSet flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.91,
+  "version": 3.92,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -139,7 +139,7 @@
       "flag": false,
       "perc": [[0, 100]]
     },
-    "dev-vectorSet": {
+    "vectorSet": {
       "flag": false,
       "perc": [[0, 100]]
     },

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.92,
+  "version": 3.93,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -140,16 +140,16 @@
       "perc": [[0, 100]]
     },
     "vectorSet": {
-      "flag": false,
-      "perc": [[0, 100]]
+      "flag": true,
+      "perc": [[0, 10]]
     },
     "dev-array": {
       "flag": false,
       "perc": [[0, 100]]
     },
     "prodMode": {
-      "flag": false,
-      "perc": [[0, 100]]
+      "flag": true,
+      "perc": [[0, 10]]
     }
   }
 }

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -36,7 +36,7 @@ export enum KnownFeatures {
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
-  DevVectorSet = 'dev-vectorSet',
+  VectorSet = 'vectorSet',
   DevArray = 'dev-array',
   ProdMode = 'prodMode',
 }

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -83,8 +83,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevBrowser,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.DevVectorSet]: {
-    name: KnownFeatures.DevVectorSet,
+  [KnownFeatures.VectorSet]: {
+    name: KnownFeatures.VectorSet,
     storage: FeatureStorage.Database,
   },
   [KnownFeatures.DevArray]: {

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -100,7 +100,7 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
-      KnownFeatures.DevVectorSet,
+      KnownFeatures.VectorSet,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -12,7 +12,7 @@ export enum FeatureFlags {
   databaseManagement = 'databaseManagement',
   customTutorials = 'customTutorials',
   vectorSearchV2 = 'vectorSearchV2',
-  devVectorSet = 'dev-vectorSet',
+  vectorSet = 'vectorSet',
   devArray = 'dev-array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -41,7 +41,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 }))
 
 /**
- * Build a fresh store with the `devVectorSet` feature flag pre-seeded so the
+ * Build a fresh store with the `vectorSet` feature flag pre-seeded so the
  * Vector Set option's `isEnabledSelector` (which reads the flag from the
  * features slice) resolves correctly. We seed the store rather than spying
  * on the selector because the option config holds an import-time reference
@@ -50,7 +50,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 const renderWithVectorSetFlag = (enabled: boolean) => {
   const storeState = set(
     cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+    `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
     { flag: enabled },
   )
   return render(

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,6 +1,6 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -44,6 +44,6 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isDevVectorSetEnabledSelector,
+    isEnabledSelector: isVectorSetEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -201,7 +201,7 @@ describe('FilterKeyType', () => {
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {
@@ -232,7 +232,7 @@ describe('FilterKeyType', () => {
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -7,7 +7,7 @@ import {
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 import {
   isDevArrayEnabledSelector,
-  isDevVectorSetEnabledSelector,
+  isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { FilterKeyTypeOption } from './FilterKeyType.types'
@@ -60,7 +60,7 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isDevVectorSetEnabledSelector,
+    isEnabledSelector: isVectorSetEnabledSelector,
   },
   {
     text: 'Graph',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -7,7 +7,7 @@ import {
 } from 'uiSrc/constants'
 import { KeyDetailsHeaderProps } from 'uiSrc/pages/browser/modules'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
 import { isTruncatedString } from 'uiSrc/utils'
 import TooLongKeyNameDetails from 'uiSrc/pages/browser/modules/key-details/components/too-long-key-name-details/TooLongKeyNameDetails'
 import ModulesTypeDetails from '../modules-type-details/ModulesTypeDetails'
@@ -30,7 +30,7 @@ export interface Props extends KeyDetailsHeaderProps {
 
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
-  const isDevVectorSet = useAppSelector(isDevVectorSetEnabledSelector)
+  const isVectorSet = useAppSelector(isVectorSetEnabledSelector)
 
   const TypeDetails: any = {
     [KeyTypes.ZSet]: <ZSetDetails {...props} />,
@@ -40,7 +40,7 @@ const DynamicTypeDetails = (props: Props) => {
     [KeyTypes.List]: <ListDetails {...props} />,
     [KeyTypes.ReJSON]: <RejsonDetailsWrapper {...props} />,
     [KeyTypes.Stream]: <StreamDetails {...props} />,
-    ...(isDevVectorSet && {
+    ...(isVectorSet && {
       [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
     }),
   }

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -65,7 +65,7 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.vectorSearchV2]: {
         flag: false,
       },
-      [FeatureFlags.devVectorSet]: {
+      [FeatureFlags.vectorSet]: {
         flag: false,
       },
       [FeatureFlags.devArray]: {
@@ -230,13 +230,13 @@ export const isAzureEntraIdEnabledSelector = (state: RootState): boolean => {
   return azureEntraIdEnabled && envDependentEnabled
 }
 
-export const isDevVectorSetEnabledSelector = (state: RootState): boolean => {
+export const isVectorSetEnabledSelector = (state: RootState): boolean => {
   if (isDevelopment) {
     return true
   }
 
   const features = state.app.features.featureFlags.features
-  return features[FeatureFlags.devVectorSet]?.flag ?? false
+  return features[FeatureFlags.vectorSet]?.flag ?? false
 }
 
 export const isDevArrayEnabledSelector = (state: RootState): boolean => {

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
@@ -5,7 +5,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory, toFp32EscapedString } from 'e2eSr
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Elements', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
@@ -3,7 +3,7 @@ import { StandaloneV880ConfigFactory } from 'e2eSrc/test-data/databases';
 import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Key (manual)', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
@@ -4,7 +4,7 @@ import { DatabaseInstance } from 'e2eSrc/types';
 
 const VEC2WORD_KEY = 'vec2word';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Key (sample data)', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
@@ -4,7 +4,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Element actions', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
@@ -4,7 +4,7 @@ import { DatabaseInstance } from 'e2eSrc/types';
 
 test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => {
   // V8 factory points at redis:8.0-M02, which reports redis_version:7.9.225.
-  test.use({ featureFlags: { 'dev-vectorSet': true } });
+  test.use({ featureFlags: { vectorSet: true } });
 
   let database: DatabaseInstance;
 
@@ -45,7 +45,7 @@ test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => 
 });
 
 test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
-  test.use({ featureFlags: { 'dev-vectorSet': false } });
+  test.use({ featureFlags: { vectorSet: false } });
 
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
@@ -4,7 +4,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Similarity search', () => {
   let database: DatabaseInstance;


### PR DESCRIPTION
# What

Promote the `dev-vectorSet` feature flag to a regular `vectorSet` flag and start a **10% rollout** for both `vectorSet` and `prodMode`.

- Renames the flag end-to-end: backend config (`features-config.json`, `KnownFeatures` enum, `known-features.ts` registry, `feature-flag.provider.ts` strategy registration), frontend enum (`FeatureFlags`) and slice selector (`isVectorSetEnabledSelector`), all UI consumers, and the E2E specs.
- Enables both `vectorSet` and `prodMode` for 10% of users — `{ "flag": true, "perc": [[0, 10]] }`.
- Bumps `features-config.json` version to `3.93`.
- E2E specs that exercise Vector Set UI keep their explicit `test.use({ featureFlags: { vectorSet: true } })` override so coverage is unaffected by the percentage gate.

Mirrors the prodMode promotion in [#5992](https://github.com/redis/RedisInsight/pull/5992).

# Testing

- `yarn lint:ui` and `yarn lint:api` pass.
- Unit tests for the affected UI specs pass (26 tests):
  - `FilterKeyType.spec.tsx`
  - `AddKey.spec.tsx`
- Manually verify the Vector Set UI (Add Key dialog, key type filter, key details panel) still gates on the renamed flag in both states (on and off).
- Manually verify the rollout percentage gates the flag for non-bucketed users.

---

Relates to RI-7390