### PR TITLE
fix(desktop): inherit electron-builder default deb after-install (AppArmor, Ubuntu 24)

### DIFF
--- a/scripts/deb-after-install.sh
+++ b/scripts/deb-after-install.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
+# This hook has two parts:
+#   1. RedisInsight migration (below, wrapped in a subshell) — kills running instances
+#      and migrates the legacy "/opt/Redis Insight" install path to "/opt/redisinsight".
+#      The subshell is what lets us keep this logic untouched: its internal `exit 0`
+#      calls end only the subshell, so part 2 always runs afterwards.
+#   2. electron-builder's default after-install (appended at the bottom) — the /usr/bin
+#      symlink, the conditional chrome-sandbox chmod, the AppArmor profile install for
+#      Ubuntu 24+ (which fixes "No usable sandbox" on Ubuntu 23.10+/24.04), and the
+#      mime/desktop-database refresh. Setting deb.afterInstall makes electron-builder use
+#      THIS script instead of its default, so we have to carry the default ourselves.
+#      Part 2 is copied VERBATIM from app-builder-lib/templates/linux/after-install.tpl
+#      (electron-builder 26.15.2) — re-copy it from node_modules when bumping
+#      electron-builder. Its ${executable} / ${sanitizedProductName} placeholders are
+#      interpolated by electron-builder at build time.
+
+# ---------------------------------------------------------------------------
+# Part 1 — RedisInsight migration (unchanged; subshell isolates its `exit 0`)
+# ---------------------------------------------------------------------------
+(
 OLD_INSTALL_PATH="/opt/Redis Insight"
 NEW_INSTALL_PATH="/opt/redisinsight"
 DESKTOP_FILE="/usr/share/applications/redisinsight.desktop"
@@ -105,3 +124,65 @@ mkdir -p "$NEW_INSTALL_PATH" || true
 ln -sf "$NEW_INSTALL_PATH/redisinsight" "/usr/bin/redisinsight" || true
 
 echo "Post-installation completed with warnings"
+) || true
+
+# ---------------------------------------------------------------------------
+# Part 2 — electron-builder default after-install
+# Copied verbatim from app-builder-lib/templates/linux/after-install.tpl (26.15.2).
+# Keep in sync when bumping electron-builder.
+# ---------------------------------------------------------------------------
+if type update-alternatives >/dev/null 2>&1; then
+    # Remove previous link if it doesn't use update-alternatives
+    if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+else
+    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi
+
+# Install apparmor profile. (Ubuntu 24+)
+# First check if the version of AppArmor running on the device supports our profile.
+# This is in order to keep backwards compatibility with Ubuntu 22.04 which does not support abi/4.0.
+# In that case, we just skip installing the profile since the app runs fine without it on 22.04.
+#
+# Those apparmor_parser flags are akin to performing a dry run of loading a profile.
+# https://wiki.debian.org/AppArmor/HowToUse#Dumping_profiles
+#
+# Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
+# https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
+if apparmor_status --enabled > /dev/null 2>&1; then
+  APPARMOR_PROFILE_SOURCE='/opt/${sanitizedProductName}/resources/apparmor-profile'
+  APPARMOR_PROFILE_TARGET='/etc/apparmor.d/${executable}'
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
+
+    # Updating the current AppArmor profile is not possible and probably not meaningful in a chroot'ed environment.
+    # Use cases are for example environments where images for clients are maintained.
+    # There, AppArmor might correctly be installed, but live updating makes no sense.
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      # Extra flags taken from dh_apparmor:
+      # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+      # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET"
+    fi
+  else
+    echo "Skipping the installation of the AppArmor profile as this version of AppArmor does not seem to support the bundled profile"
+  fi
+fi


### PR DESCRIPTION
## Summary

Fixes the `.deb` package aborting at startup with **"No usable sandbox"** on Ubuntu 23.10+/24.04.

Those releases restrict unprivileged user namespaces via AppArmor, so Electron needs a bundled AppArmor profile installed at `/etc/apparmor.d/`. electron-builder's default `after-install.tpl` does exactly that — **but** because we set `deb.afterInstall`, electron-builder uses *our* script **instead of** its default, silently dropping the AppArmor install (along with the conditional `chrome-sandbox` chmod and mime/desktop-db refresh). electron-builder still bundles the profile at `/opt/redisinsight/resources/apparmor-profile`; our script just never deployed it.

## Change (one file)

`scripts/deb-after-install.sh`:
- **Our existing migration logic is kept byte-for-byte unchanged**, wrapped in a subshell `( … ) || true` so its internal `exit 0` calls end only the subshell and no longer terminate the postinst.
- electron-builder's default after-install block is **appended after it** (copied verbatim from `app-builder-lib/templates/linux/after-install.tpl` @ 26.15.2): `/usr/bin` symlink via `update-alternatives`, **conditional** `chrome-sandbox` chmod, AppArmor profile install **with its Ubuntu 22.04 `abi/4.0` backward-compat guard**, and mime/desktop-database refresh.

Diff is **+81 / -0** — no edits to the original logic.

### Interaction is benign
The default runs *second*: its conditional `chrome-sandbox` chmod supersedes our unconditional one (more correct), `update-alternatives` reconciles the symlink, and only the default installs the AppArmor profile. The 22.04 guard means nothing changes there.

> Note: the appended block is a copy of the upstream template, so re-copy it from `node_modules/app-builder-lib/templates/linux/after-install.tpl` when bumping electron-builder. A comment in the file flags this.

## Testing
- [ ] Build the `.deb`, install on **Ubuntu 24.04 (GNOME/Wayland)** → launches without "No usable sandbox"
- [ ] Confirm `/etc/apparmor.d/redisinsight` is created and loaded
- [ ] Install on **Ubuntu 22.04** → profile is skipped, app still launches (no regression)
- [ ] Upgrade from a legacy `/opt/Redis Insight` install → migration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Post-install runs as root and now installs AppArmor profiles and changes sandbox permissions; mistakes could affect launch on Linux upgrades, though logic is copied from upstream electron-builder.
> 
> **Overview**
> Fixes **`.deb` installs failing at launch with "No usable sandbox"** on Ubuntu 23.10+/24.04 by restoring electron-builder’s post-install steps that were dropped when `deb.afterInstall` pointed at a custom script only.
> 
> **`scripts/deb-after-install.sh`** is now a two-phase hook: existing Redis Insight path migration (kill instances, `/opt/Redis Insight` → `/opt/redisinsight`, desktop file updates) runs unchanged inside a **subshell** `( … ) || true`, so its `exit 0` paths no longer end the whole postinst before follow-up work runs. **Appended after that** is electron-builder’s default `after-install.tpl` (26.15.2): `/usr/bin` via `update-alternatives`, **conditional** `chrome-sandbox` permissions, **AppArmor profile** install to `/etc/apparmor.d/` (with the Ubuntu 22.04 profile-compat skip), and mime/desktop-database refresh.
> 
> Migration behavior is intentionally untouched; the new block runs second and is documented as needing a re-copy from `node_modules` when bumping electron-builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7229682f2020b0e192b90fb00321a4ef79cf390b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->