### PR TITLE
fix(desktop): patch app-builder-lib to stage snap desktop-init scripts

### DIFF
--- a/patches/app-builder-lib+26.15.2.patch
+++ b/patches/app-builder-lib+26.15.2.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/app-builder-lib/out/targets/snap/coreLegacy.js b/node_modules/app-builder-lib/out/targets/snap/coreLegacy.js
+index 63dc31f..e74038f 100644
+--- a/node_modules/app-builder-lib/out/targets/snap/coreLegacy.js
++++ b/node_modules/app-builder-lib/out/targets/snap/coreLegacy.js
+@@ -321,6 +321,19 @@ class SnapCoreLegacy extends SnapTarget_1.SnapCore {
+         const commandContent = buildCommandShContent({ isTemplate, executableName: this.packager.executableName, extraAppArgs });
+         await (0, promises_1.writeFile)(commandWrapperPath, commandContent, { mode: 0o755 });
+         await (0, promises_1.chmod)(commandWrapperPath, 0o755);
++        // Template builds (mksquashfs, no snapcraft) assume the prebuilt snap template tarball ships
++        // the desktop-integration scripts at the snap root, but it does not — so command.sh fails at
++        // runtime with "$SNAP/desktop-init.sh: No such file or directory". Stage them next to command.sh
++        // at the stage root. No-template builds already copy these into scripts/ in buildWithoutTemplate.
++        if (isTemplate) {
++            const snapTemplateDir = (0, pathManager_1.getTemplatePath)("snap");
++            for (const script of ["desktop-init.sh", "desktop-common.sh", "desktop-gnome-specific.sh"]) {
++                const dest = path.join(stageDir, script);
++                await (0, promises_1.copyFile)(path.join(snapTemplateDir, script), dest);
++                // copyFile doesn't preserve mode; chmod 755 explicitly
++                await (0, promises_1.chmod)(dest, 0o755);
++            }
++        }
+     }
+     normalizePlugConfiguration(raw) {
+         if (raw == null) {


### PR DESCRIPTION
## Summary

Fixes the broken snap bundle introduced by the electron-builder `26.0.12` → `26.15.2` bump (#6026, for the snap Wayland fix). Installing and launching the snap fails immediately with:

```
/snap/redisinsight/x1/command.sh: line 2: /snap/redisinsight/x1/desktop-init.sh: No such file or directory
```

## Root cause

electron-builder `26.15.2` ships a rewritten TypeScript snap target. The generated `command.sh` now launches the app through three desktop-integration scripts:

```sh
exec "$SNAP/desktop-init.sh" "$SNAP/desktop-common.sh" "$SNAP/desktop-gnome-specific.sh" "$SNAP/<app>"
```

There are two build paths in `app-builder-lib/out/targets/snap/coreLegacy.js`:

- **No-template path** (`buildWithoutTemplate`, uses `snapcraft`): copies the three scripts into `scripts/`, staged to the snap root. ✅ Works.
- **Template path** (`buildWithTemplate`, uses `mksquashfs`, no `snapcraft`): writes `command.sh` to the stage root but **never stages the three desktop scripts** — it wrongly assumes the prebuilt `snap-template-electron-4.0-2` tarball ships them. ❌ Broken.

RedisInsight's x64 build hits the **template path** (`isUseTemplateApp = true`), and CI builds the snap via electron-builder with **no `snapcraft` installed**, so the produced snap has a `command.sh` pointing at a `desktop-init.sh` that was never packaged.

`26.15.3` (the only newer 26.x) has the **identical bug**, so a version bump does not fix it.

## Fix

A `patch-package` patch (the repo already uses patch-package) that makes `stageSnapFiles` copy `desktop-init.sh`, `desktop-common.sh`, and `desktop-gnome-specific.sh` to the snap stage root for template builds — mirroring what `buildWithoutTemplate` already does. No CI changes, keeps the Wayland fix.

## Testing

- Patch verified to reverse and re-apply cleanly via `patch-package`.
- ⚠️ Not yet runtime-verified — a snap build requires Linux/`mksquashfs`. Needs a CI Linux snap build → install → confirm launch. **Reviewer: please validate the built snap manually.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change applied via patch-package at install time; no app runtime or auth/data logic touched, though snap CI validation is still needed.
> 
> **Overview**
> Adds a **patch-package** patch for `app-builder-lib@26.15.2` so Linux **template** snap builds (mksquashfs, no snapcraft) copy `desktop-init.sh`, `desktop-common.sh`, and `desktop-gnome-specific.sh` into the snap stage root after `command.sh` is written.
> 
> That aligns template packaging with what the non-template path already does, fixing immediate launch failure when `command.sh` references scripts that were never included in the snap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d700461ae6cfd9f4303894395bfdf56ff3d0c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->