### PR TITLE
RI-8216 Establish BigInt-as-string index contract

### DIFF
--- a/redisinsight/api/src/common/decorators/array-index/array-index.decorator.spec.ts
+++ b/redisinsight/api/src/common/decorators/array-index/array-index.decorator.spec.ts
@@ -1,0 +1,65 @@
+import { validate } from 'class-validator';
+import { IsArrayIndex } from 'src/common/decorators';
+
+class SingleIndexDto {
+  @IsArrayIndex()
+  index: string;
+}
+
+class MultiIndexDto {
+  @IsArrayIndex({ each: true })
+  indexes: string[];
+}
+
+const validateSingle = async (index: any) => {
+  const dto = new SingleIndexDto();
+  dto.index = index;
+  return validate(dto);
+};
+
+describe('IsArrayIndex', () => {
+  it.each(['0', '42', '18446744073709551615'])(
+    'should pass for valid index %p',
+    async (input) => {
+      expect(await validateSingle(input)).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    '-1',
+    '1.5',
+    'abc',
+    '',
+    '18446744073709551616',
+    42,
+    undefined,
+    '007',
+    ' 42 ',
+  ])('should fail for %p', async (input) => {
+    const errors = await validateSingle(input);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('should fail with the documented (stable) message', async () => {
+    const errors = await validateSingle('-1');
+    // Consumers may match on this exact format — changing it is breaking.
+    expect(errors[0].constraints).toEqual({
+      ArrayIndexValidator:
+        'index must be an integer string between 0 and 18446744073709551615',
+    });
+  });
+
+  it('should fail with { each: true } when any element is invalid', async () => {
+    const dto = new MultiIndexDto();
+    dto.indexes = ['1', '-1', '3'];
+
+    expect(await validate(dto)).toHaveLength(1);
+  });
+
+  it('should pass with { each: true } when all elements are valid', async () => {
+    const dto = new MultiIndexDto();
+    dto.indexes = ['1', '2', '18446744073709551615'];
+
+    expect(await validate(dto)).toHaveLength(0);
+  });
+});

--- a/redisinsight/api/src/common/decorators/array-index/array-index.decorator.ts
+++ b/redisinsight/api/src/common/decorators/array-index/array-index.decorator.ts
@@ -1,0 +1,14 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { ArrayIndexValidator } from 'src/common/validators';
+
+export function IsArrayIndex(validationOptions?: ValidationOptions) {
+  return (object: any, propertyName: string) => {
+    registerDecorator({
+      name: 'isArrayIndex',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: ArrayIndexValidator,
+    });
+  };
+}

--- a/redisinsight/api/src/common/decorators/array-index/index.ts
+++ b/redisinsight/api/src/common/decorators/array-index/index.ts
@@ -1,0 +1,1 @@
+export * from './array-index.decorator';

--- a/redisinsight/api/src/common/decorators/index.ts
+++ b/redisinsight/api/src/common/decorators/index.ts
@@ -1,5 +1,6 @@
 export * from './redis-string';
 export * from './zset-score';
+export * from './array-index';
 export * from './default';
 export * from './data-as-json-string.decorator';
 export * from './session';

--- a/redisinsight/api/src/common/utils/array-index.helper.spec.ts
+++ b/redisinsight/api/src/common/utils/array-index.helper.spec.ts
@@ -1,0 +1,53 @@
+import {
+  ARRAY_INDEX_MAX,
+  isValidArrayIndex,
+  parseArrayIndex,
+} from 'src/common/utils';
+
+describe('array-index.helper', () => {
+  it('should expose max unsigned 64-bit value', () => {
+    expect(ARRAY_INDEX_MAX).toEqual(BigInt('18446744073709551615'));
+  });
+
+  describe('parseArrayIndex', () => {
+    it.each([
+      { input: '0', expected: '0' },
+      { input: '7', expected: '7' },
+      { input: '007', expected: '7' }, // leading zeros normalized
+      { input: ' 42 ', expected: '42' }, // outer whitespace trimmed
+      { input: '18446744073709551615', expected: '18446744073709551615' }, // max u64
+      { input: '18446744073709551616', expected: null }, // max + 1
+      { input: '184467440737095516150', expected: null }, // 21 digits — length guard
+      { input: '00000000000000000000042', expected: null }, // >20 chars — guard trumps normalization
+      { input: '-1', expected: null },
+      { input: '1.5', expected: null },
+      { input: '1e3', expected: null },
+      { input: '0x10', expected: null },
+      { input: 'abc', expected: null },
+      { input: '1 2', expected: null }, // internal whitespace
+      { input: '', expected: null },
+      { input: '   ', expected: null },
+    ])('should return $expected for $input', ({ input, expected }) => {
+      expect(parseArrayIndex(input)).toEqual(expected);
+    });
+
+    it.each([null, undefined, 7, BigInt(7), {}])(
+      'should return null for non-string %p',
+      (input) => {
+        expect(parseArrayIndex(input)).toEqual(null);
+      },
+    );
+  });
+
+  describe('isValidArrayIndex', () => {
+    it('should return true for a valid index', () => {
+      expect(isValidArrayIndex('123')).toEqual(true);
+    });
+    it('should return false for an invalid index', () => {
+      expect(isValidArrayIndex('-1')).toEqual(false);
+    });
+    it('should return false for non-string input', () => {
+      expect(isValidArrayIndex(42)).toEqual(false);
+    });
+  });
+});

--- a/redisinsight/api/src/common/utils/array-index.helper.ts
+++ b/redisinsight/api/src/common/utils/array-index.helper.ts
@@ -1,0 +1,43 @@
+/**
+ * Redis array indexes are unsigned 64-bit integers (0 … 2^64−1) and exceed
+ * Number.MAX_SAFE_INTEGER, so they travel as numeric strings end-to-end —
+ * never parseInt/Number, no JS-side arithmetic on indexes.
+ *
+ * Mirrored in redisinsight/ui/src/utils/arrayIndex.ts — keep semantics and
+ * tests in sync.
+ */
+// 2^64 - 1; BigInt() call (not a literal) — this tsconfig targets es2019,
+// where BigInt literals are a syntax error (TS2737).
+export const ARRAY_INDEX_MAX = BigInt('18446744073709551615');
+
+const ARRAY_INDEX_REGEX = /^\d+$/;
+
+// Max u64 is 20 digits; longer all-digit inputs can't be valid and a length
+// guard keeps BigInt() from parsing arbitrarily large request payloads.
+const ARRAY_INDEX_MAX_LENGTH = 20;
+
+/**
+ * Returns the canonical decimal string for a valid index ("007" → "7"),
+ * or null for anything else (empty or whitespace-only, negative,
+ * fractional, exponent, hex, > 2^64−1, non-string input).
+ */
+export const parseArrayIndex = (input: unknown): string | null => {
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const value = input.trim();
+  if (!ARRAY_INDEX_REGEX.test(value)) {
+    return null;
+  }
+
+  if (value.length > ARRAY_INDEX_MAX_LENGTH) {
+    return null;
+  }
+
+  const index = BigInt(value);
+  return index > ARRAY_INDEX_MAX ? null : index.toString();
+};
+
+export const isValidArrayIndex = (input: unknown): boolean =>
+  parseArrayIndex(input) !== null;

--- a/redisinsight/api/src/common/utils/index.ts
+++ b/redisinsight/api/src/common/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './array-index.helper';
 export * from './certificate-import.util';
 export * from './errors.util';
 export * from './merge.util';

--- a/redisinsight/api/src/common/validators/array-index.validator.ts
+++ b/redisinsight/api/src/common/validators/array-index.validator.ts
@@ -1,0 +1,23 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import {
+  ARRAY_INDEX_MAX,
+  parseArrayIndex,
+} from 'src/common/utils/array-index.helper';
+
+@ValidatorConstraint({ name: 'ArrayIndexValidator', async: false })
+export class ArrayIndexValidator implements ValidatorConstraintInterface {
+  validate(value: unknown) {
+    // Validators don't transform, so anything accepted reaches Redis verbatim;
+    // only the canonical form passes ('007' / ' 42 ' are rejected).
+    return typeof value === 'string' && parseArrayIndex(value) === value;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    // Stable message — consumers may match on it; changing it is breaking.
+    return `${args?.property || 'field'} must be an integer string between 0 and ${ARRAY_INDEX_MAX}`;
+  }
+}

--- a/redisinsight/api/src/common/validators/index.ts
+++ b/redisinsight/api/src/common/validators/index.ts
@@ -4,3 +4,4 @@ export * from './multi-number.validator';
 export * from './bigger-than.validator';
 export * from './github-link.validator';
 export * from './no-duplicates.validator';
+export * from './array-index.validator';

--- a/redisinsight/ui/src/utils/arrayIndex.ts
+++ b/redisinsight/ui/src/utils/arrayIndex.ts
@@ -1,0 +1,44 @@
+/**
+ * Redis array indexes are unsigned 64-bit integers (0 … 2^64−1) and exceed
+ * Number.MAX_SAFE_INTEGER, so they stay numeric strings end-to-end —
+ * never parseInt/Number, no JS-side arithmetic on indexes; Redux stores
+ * them as strings.
+ *
+ * Mirrored in redisinsight/api/src/common/utils/array-index.helper.ts —
+ * keep semantics and tests in sync.
+ */
+// 2^64 - 1; BigInt() call form (not a literal) for parity with the API
+// mirror, whose tsconfig targets es2019 (where BigInt literals are TS2737).
+export const ARRAY_INDEX_MAX = BigInt('18446744073709551615')
+
+const ARRAY_INDEX_REGEX = /^\d+$/
+
+// Max u64 is 20 digits; longer all-digit inputs can't be valid and a length
+// guard keeps BigInt() from parsing arbitrarily large request payloads.
+const ARRAY_INDEX_MAX_LENGTH = 20
+
+/**
+ * Returns the canonical decimal string for a valid index ("007" → "7"),
+ * or null for anything else (empty or whitespace-only, negative,
+ * fractional, exponent, hex, > 2^64−1, non-string input).
+ */
+export const parseArrayIndex = (input: unknown): string | null => {
+  if (typeof input !== 'string') {
+    return null
+  }
+
+  const value = input.trim()
+  if (!ARRAY_INDEX_REGEX.test(value)) {
+    return null
+  }
+
+  if (value.length > ARRAY_INDEX_MAX_LENGTH) {
+    return null
+  }
+
+  const index = BigInt(value)
+  return index > ARRAY_INDEX_MAX ? null : index.toString()
+}
+
+export const isValidArrayIndex = (input: unknown): boolean =>
+  parseArrayIndex(input) !== null

--- a/redisinsight/ui/src/utils/index.ts
+++ b/redisinsight/ui/src/utils/index.ts
@@ -4,6 +4,7 @@ import RouterWithSubRoutes from './routerWithSubRoutes'
 
 export * from './common'
 export * from './validations'
+export * from './arrayIndex'
 export * from './statuses'
 export * from './instance'
 export * from './apiResponse'

--- a/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
+++ b/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
@@ -1,0 +1,53 @@
+import {
+  ARRAY_INDEX_MAX,
+  isValidArrayIndex,
+  parseArrayIndex,
+} from 'uiSrc/utils'
+
+describe('arrayIndex', () => {
+  it('should expose max unsigned 64-bit value', () => {
+    expect(ARRAY_INDEX_MAX).toEqual(BigInt('18446744073709551615'))
+  })
+
+  describe('parseArrayIndex', () => {
+    it.each([
+      { input: '0', expected: '0' },
+      { input: '7', expected: '7' },
+      { input: '007', expected: '7' }, // leading zeros normalized
+      { input: ' 42 ', expected: '42' }, // outer whitespace trimmed
+      { input: '18446744073709551615', expected: '18446744073709551615' }, // max u64
+      { input: '18446744073709551616', expected: null }, // max + 1
+      { input: '184467440737095516150', expected: null }, // 21 digits — length guard
+      { input: '00000000000000000000042', expected: null }, // >20 chars — guard trumps normalization
+      { input: '-1', expected: null },
+      { input: '1.5', expected: null },
+      { input: '1e3', expected: null },
+      { input: '0x10', expected: null },
+      { input: 'abc', expected: null },
+      { input: '1 2', expected: null }, // internal whitespace
+      { input: '', expected: null },
+      { input: '   ', expected: null },
+    ])('should return $expected for $input', ({ input, expected }) => {
+      expect(parseArrayIndex(input)).toEqual(expected)
+    })
+
+    it.each([null, undefined, 7, BigInt(7), {}])(
+      'should return null for non-string %p',
+      (input) => {
+        expect(parseArrayIndex(input)).toEqual(null)
+      },
+    )
+  })
+
+  describe('isValidArrayIndex', () => {
+    it('should return true for a valid index', () => {
+      expect(isValidArrayIndex('123')).toEqual(true)
+    })
+    it('should return false for an invalid index', () => {
+      expect(isValidArrayIndex('-1')).toEqual(false)
+    })
+    it('should return false for non-string input', () => {
+      expect(isValidArrayIndex(42)).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
# What

Foundation for the Redis array type (epic RI-8174): array indexes are unsigned 64-bit integers and exceed `Number.MAX_SAFE_INTEGER`, so they must travel as numeric strings end-to-end.

- **Mirrored utilities** (this repo has no shared UI↔API code mechanism, so the contract is two modules with identical semantics and identical test tables): `api/src/common/utils/array-index.helper.ts` ↔ `ui/src/utils/arrayIndex.ts` — `parseArrayIndex` (canonical decimal string or `null`), `isValidArrayIndex`, `ARRAY_INDEX_MAX`.
- **`@IsArrayIndex()` DTO decorator** (mirrors the zset-score validator pattern): accepts the canonical form only — validators don't transform, so anything accepted reaches Redis verbatim. Fails with a stable message consumers can match on: `<field> must be an integer string between 0 and 18446744073709551615`. Supports `ValidationOptions` (`{ each: true }` for `string[]` fields).
- **Hardening**: a 20-digit length guard before the `BigInt()` call caps parse cost for request-sized payloads; `BigInt('…')` call form throughout (API tsconfig targets es2019, where BigInt literals are TS2737).
- **Convention documented** in `.ai/skills/backend/SKILL.md` and `.ai/skills/frontend/SKILL.md` so future array verticals (and agents) follow it.

No runtime consumers yet by design — the array feature verticals (view/search/add/delete) build on this.

# Testing

- `yarn --cwd redisinsight/api test --testPathPattern "array-index"` — 40 tests (helper + decorator, incl. the verbatim stable-message and `{ each: true }` cases)
- `node 'node_modules/.bin/jest' 'redisinsight/ui/src/utils/tests/arrayIndex.spec.ts' -c 'jest.config.cjs'` — 25 tests (mirror table, row-for-row identical to the API helper spec)
- `yarn lint` clean; `yarn type-check` unchanged vs main

---

Closes #RI-8216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New shared validation utilities and tests only; no existing routes or behavior are changed and nothing is consumed at runtime yet.
> 
> **Overview**
> Introduces a **shared contract** for Redis array indexes as **canonical numeric strings** (unsigned 64-bit, `0` … `18446744073709551615`), because indexes exceed `Number.MAX_SAFE_INTEGER`.
> 
> **API** adds `parseArrayIndex`, `isValidArrayIndex`, and `ARRAY_INDEX_MAX` in `array-index.helper.ts`, plus `@IsArrayIndex()` / `ArrayIndexValidator` for DTOs (same shape as existing zset-score validation). Validation accepts **only canonical strings**—no trimming or leading-zero normalization on the wire—so values that pass reach Redis unchanged. A **20-digit length guard** limits `BigInt()` parse cost on oversized inputs.
> 
> **UI** mirrors the same helpers in `arrayIndex.ts` with matching test tables. Both modules are exported from their package `utils` barrels.
> 
> No array endpoints or UI flows are wired in this PR; it is foundation-only for upcoming array work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d0d3d21ddd55aa31f348d67ee4c62c7bfff772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->