### PR TITLE
RI-8215: Detect @array command group support

### DIFF
--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -114,6 +114,10 @@ export enum BrowserToolVectorSetCommands {
   VSim = 'VSIM',
 }
 
+export enum BrowserToolArrayCommands {
+  ARGet = 'arget',
+}
+
 export type BrowserToolCommands =
   | BrowserToolKeysCommands
   | BrowserToolStringCommands
@@ -125,4 +129,5 @@ export type BrowserToolCommands =
   | BrowserToolStreamCommands
   | BrowserToolGraphCommands
   | BrowserToolTSCommands
-  | BrowserToolVectorSetCommands;
+  | BrowserToolVectorSetCommands
+  | BrowserToolArrayCommands;

--- a/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
@@ -1,0 +1,123 @@
+import { mockCommonClientMetadata } from 'src/__mocks__/common';
+import { MockRedisClient } from 'src/__mocks__/redis-client';
+import { BrowserToolArrayCommands } from 'src/modules/browser/constants/browser-tool-commands';
+import { RedisClient, RedisFeature } from './redis.client';
+
+// Bypass MockRedisClient's per-instance jest.fn() override and invoke the
+// real RedisClient.isFeatureSupported implementation.
+const callRealIsFeatureSupported = (
+  client: MockRedisClient,
+  feature: RedisFeature,
+): Promise<boolean> =>
+  RedisClient.prototype.isFeatureSupported.call(client, feature);
+
+describe('RedisClient', () => {
+  let client: MockRedisClient;
+
+  beforeEach(() => {
+    client = new MockRedisClient(mockCommonClientMetadata);
+  });
+
+  describe('isFeatureSupported(ArrayCommands)', () => {
+    it('returns true when COMMAND INFO reports the probe command', async () => {
+      client.call = jest
+        .fn()
+        .mockResolvedValue([
+          ['arget', 2, ['readonly', 'fast'], 1, 1, 1, [], [], [], []],
+        ]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(true);
+      expect(client.call).toHaveBeenCalledWith(
+        ['command', 'info', BrowserToolArrayCommands.ARGet],
+        { replyEncoding: 'utf8' },
+      );
+    });
+
+    it('returns false when COMMAND INFO returns a nil entry (unknown command)', async () => {
+      client.call = jest.fn().mockResolvedValue([null]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO returns an empty array', async () => {
+      client.call = jest.fn().mockResolvedValue([]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO returns a non-array reply', async () => {
+      client.call = jest.fn().mockResolvedValue(null);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO throws (e.g., ACL-restricted)', async () => {
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('caches the probe result across repeated invocations', async () => {
+      client.call = jest
+        .fn()
+        .mockResolvedValue([
+          ['arget', 2, ['readonly', 'fast'], 1, 1, 1, [], [], [], []],
+        ]);
+
+      const first = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+      const second = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a negative probe result across repeated invocations', async () => {
+      client.call = jest.fn().mockResolvedValue([null]);
+
+      const first = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+      const second = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(first).toBe(false);
+      expect(second).toBe(false);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
@@ -71,8 +71,40 @@ describe('RedisClient', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false when COMMAND INFO throws (e.g., ACL-restricted)', async () => {
+    it('falls back to a version check when COMMAND INFO throws on a 8.8+ server', async () => {
+      // Reproduces the ACL-restricted user case: COMMAND INFO is forbidden
+      // (@slow / @connection) but @array data commands are permitted.
       client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      client.getInfo = jest
+        .fn()
+        .mockResolvedValue({ server: { redis_version: '8.8.0' } });
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when COMMAND INFO throws on a pre-8.8 server', async () => {
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      client.getInfo = jest
+        .fn()
+        .mockResolvedValue({ server: { redis_version: '8.4.0' } });
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO throws and the server version is unknown', async () => {
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      // Default MockRedisClient.getInfo resolves to undefined, leaving the
+      // probe with no fallback signal.
 
       const result = await callRealIsFeatureSupported(
         client,

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -9,6 +9,7 @@ import * as semverCompare from 'node-version-compare';
 import { RedisDatabaseHelloResponse } from 'src/modules/database/dto/redis-info.dto';
 import { plainToClass } from 'class-transformer';
 import { Database } from 'src/modules/database/models/database';
+import { BrowserToolArrayCommands } from 'src/modules/browser/constants/browser-tool-commands';
 
 const REDIS_CLIENTS_CONFIG = apiConfig.get('redis_clients');
 
@@ -58,6 +59,7 @@ export enum RedisFeature {
   UnlinkCommand = 'UnlinkCommand',
   VRangeCommand = 'VRangeCommand',
   VsimWithAttribs = 'VsimWithAttribs',
+  ArrayCommands = 'ArrayCommands',
 }
 
 const CLIENT_DATABASE_FIELDS: (keyof Database)[] = ['providerDetails'];
@@ -70,6 +72,8 @@ export abstract class RedisClient extends EventEmitter2 {
   protected _redisVersion: string | undefined;
 
   protected _isInfoCommandDisabled: boolean | undefined;
+
+  protected _arrayCommandGroupSupported: boolean | undefined;
 
   protected lastTimeUsed: number;
 
@@ -187,9 +191,34 @@ export abstract class RedisClient extends EventEmitter2 {
       case RedisFeature.VsimWithAttribs:
         // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
         return this.isRedisVersionAtLeast('8.0.3');
+      case RedisFeature.ArrayCommands:
+        // @array command group is preview-status in Redis 8.8+. Some 8.8.0+
+        // builds may omit it, so probe via COMMAND INFO rather than relying on
+        // the version string alone.
+        return this.isArrayCommandGroupSupported();
       default:
         return false;
     }
+  }
+
+  private async isArrayCommandGroupSupported(): Promise<boolean> {
+    if (this._arrayCommandGroupSupported !== undefined) {
+      return this._arrayCommandGroupSupported;
+    }
+
+    try {
+      const reply = (await this.call(
+        ['command', 'info', BrowserToolArrayCommands.ARGet],
+        { replyEncoding: 'utf8' },
+      )) as RedisClientCommandReply[];
+
+      this._arrayCommandGroupSupported =
+        Array.isArray(reply) && reply.some((info) => info != null);
+    } catch (e) {
+      this._arrayCommandGroupSupported = false;
+    }
+
+    return this._arrayCommandGroupSupported;
   }
 
   private async isRedisVersionAtLeast(minVersion: string): Promise<boolean> {

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -192,9 +192,9 @@ export abstract class RedisClient extends EventEmitter2 {
         // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
         return this.isRedisVersionAtLeast('8.0.3');
       case RedisFeature.ArrayCommands:
-        // @array command group is preview-status in Redis 8.8+. Some 8.8.0+
-        // builds may omit it, so probe via COMMAND INFO rather than relying on
-        // the version string alone.
+        // @array command group is preview-status in Redis 8.8+. Probe via
+        // COMMAND INFO because some 8.8.0+ builds may omit the group; fall
+        // back to a version check if the probe itself is not allowed.
         return this.isArrayCommandGroupSupported();
       default:
         return false;
@@ -215,7 +215,14 @@ export abstract class RedisClient extends EventEmitter2 {
       this._arrayCommandGroupSupported =
         Array.isArray(reply) && reply.some((info) => info != null);
     } catch (e) {
-      this._arrayCommandGroupSupported = false;
+      // COMMAND INFO is categorised under @slow / @connection in Redis ACL,
+      // so a least-privilege user with only data-command access can still
+      // run @array commands but cannot run the probe. Fall back to a
+      // version check so we don't misclassify supported servers as
+      // unsupported; this matches how every other RedisFeature case resolves
+      // support today.
+      this._arrayCommandGroupSupported =
+        await this.isRedisVersionAtLeast('8.8');
     }
 
     return this._arrayCommandGroupSupported;

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -14,6 +14,8 @@ import {
   CustomErrorCodes,
   DatabaseListColumn,
 } from 'uiSrc/constants'
+import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
+import { isVersionHigherOrEquals } from 'uiSrc/utils/comparisons/compareVersions'
 import { setAppContextInitialState } from 'uiSrc/slices/app/context'
 import { resetKeys } from 'uiSrc/slices/browser/keys'
 import successMessages from 'uiSrc/components/notifications/success-messages'
@@ -390,6 +392,13 @@ export const connectedInstanceOverviewSelector = (state: RootState) =>
   state.connections.instances.instanceOverview
 export const importInstancesSelector = (state: RootState) =>
   state.connections.instances.importInstances
+
+export const isArraySupportedSelector = (state: RootState): boolean => {
+  const { version } = state.connections.instances.instanceOverview
+  return (
+    !!version && isVersionHigherOrEquals(version, CommandsVersions.ARRAY.since)
+  )
+}
 
 // The reducer
 export default instancesSlice.reducer

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -71,6 +71,7 @@ import reducer, {
   resetConnectedInstanceDangerousCommands,
   fetchConnectedInstanceDangerousCommandsAction,
   connectedInstanceDangerousCommandsSelector,
+  isArraySupportedSelector,
 } from '../../instances/instances'
 import { Environment } from 'apiClient'
 import {
@@ -2092,6 +2093,38 @@ describe('instances slice', () => {
         // Assert
         expect(store.getActions()).toEqual([])
         expect(onFail).toHaveBeenCalled()
+      })
+    })
+
+    describe('isArraySupportedSelector', () => {
+      const buildRootState = (version: string) =>
+        Object.assign(cloneDeep(initialStateDefault), {
+          connections: {
+            instances: {
+              ...initialState,
+              instanceOverview: {
+                ...initialState.instanceOverview,
+                version,
+              },
+            },
+          },
+        })
+
+      it('returns false when version is empty', () => {
+        expect(isArraySupportedSelector(buildRootState(''))).toBe(false)
+      })
+
+      it('returns false for versions below 8.8', () => {
+        expect(isArraySupportedSelector(buildRootState('7.4.0'))).toBe(false)
+        expect(isArraySupportedSelector(buildRootState('8.0.0'))).toBe(false)
+        expect(isArraySupportedSelector(buildRootState('8.7.99'))).toBe(false)
+      })
+
+      it('returns true for 8.8.0 and above', () => {
+        expect(isArraySupportedSelector(buildRootState('8.8'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('8.8.0'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('8.8.5'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('9.0.0'))).toBe(true)
       })
     })
   })


### PR DESCRIPTION
Adds the backend capability probe and the UI selector that answer "does this server support the @array command group?"

**Consumers are intentionally not wired in this PR**, per the ticket scope:
- The backend probe will be invoked by `ArrayService` preflight checks introduced in follow up tasks, mirroring how `VectorSetService.getElements()` invokes `isFeatureSupported(VRangeCommand)`.
- The UI selector will be consumed by the specific task to gate the Add Key dialog entry and to render the "this server does not support the array type" message in the details panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive capability detection and selectors with no production call sites wired yet; limited blast radius beyond future array features.
> 
> **Overview**
> Adds **@array command group** detection on the API and a matching UI capability flag, without wiring browser UI or `ArrayService` yet.
> 
> **API:** Introduces `BrowserToolArrayCommands` (probe via `arget`) and `RedisFeature.ArrayCommands`. `RedisClient.isFeatureSupported` probes with `COMMAND INFO`; results are cached. If the probe fails (e.g. ACL forbids `@slow` / `@connection`), it falls back to Redis **≥ 8.8**. New unit tests cover success, failure, ACL fallback, and caching.
> 
> **UI:** Adds `isArraySupportedSelector`, true when `instanceOverview.version` is at least `CommandsVersions.ARRAY.since` (8.8), plus selector tests.
> 
> Follow-ups will call the API probe from array preflights and use the selector for Add Key / details messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338ebfe9c6880137ad14ba196a5d36561f4c26da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->