### PR TITLE
RI-8284 Register Array key type in Add Key dialog + create-array backend

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Array/Create Array (Contiguous).bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Create Array (Contiguous).bru
@@ -1,0 +1,57 @@
+meta {
+  name: Create Array (Contiguous)
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "ar:readings",
+    "mode": "contiguous",
+    "startIndex": "0",
+    "values": ["20.1", "20.4", "20.9"],
+    "expire": 3600
+  }
+}
+
+docs {
+  # Create Array (Contiguous)
+
+  Creates a new Array key in contiguous mode. Uses the Redis `ARSET` command internally: `ARSET key startIndex value [value ...]` writes the provided values as a consecutive run starting at `startIndex`.
+
+  The example above creates the `ar:readings` array with three values at indexes `0`, `1`, and `2`, expiring after one hour.
+
+  Indexes are passed as numeric strings because the Array type supports the full unsigned 64-bit range, which exceeds JavaScript's safe integer range.
+
+  ## Request Body
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The key name for the new Array |
+  | `mode` | string | Must be `contiguous` for this request shape |
+  | `startIndex` | string | Start index as a numeric string (`0` to `18446744073709551615`) |
+  | `values` | string[] | Value(s) to write starting at `startIndex` |
+  | `expire` | number (optional) | TTL in seconds |
+
+  ## Response
+
+  Returns `201 Created` with no body on success.
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Validation failed, e.g. a non-canonical index: `startIndex must be an integer string between 0 and 18446744073709551615` |
+  | `403` | User has no permissions |
+  | `409` | Key with this name already exists |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Array/Create Array (Sparse).bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Create Array (Sparse).bru
@@ -1,0 +1,60 @@
+meta {
+  name: Create Array (Sparse)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "ar:readings:sparse",
+    "mode": "sparse",
+    "elements": [
+      { "index": "0", "value": "20.1" },
+      { "index": "5", "value": "21.4" },
+      { "index": "42", "value": "23.1" }
+    ]
+  }
+}
+
+docs {
+  # Create Array (Sparse)
+
+  Creates a new Array key in sparse mode. Uses the Redis `ARMSET` command internally: `ARMSET key index value [index value ...]` writes explicit index/value pairs, leaving the gaps between them unset.
+
+  The example above creates the `ar:readings:sparse` array with values at indexes `0`, `5`, and `42` only.
+
+  Indexes are passed as numeric strings because the Array type supports the full unsigned 64-bit range, which exceeds JavaScript's safe integer range.
+
+  ## Request Body
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The key name for the new Array |
+  | `mode` | string | Must be `sparse` for this request shape |
+  | `elements` | array | Index/value pairs to write |
+  | `elements[].index` | string | Element index as a numeric string (`0` to `18446744073709551615`) |
+  | `elements[].value` | string | Element value |
+  | `expire` | number (optional) | TTL in seconds |
+
+  ## Response
+
+  Returns `201 Created` with no body on success.
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Validation failed, e.g. a non-canonical index: `elements.0.index must be an integer string between 0 and 18446744073709551615` |
+  | `403` | User has no permissions |
+  | `409` | Key with this name already exists |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Array/folder.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Array
+}
+

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -1,0 +1,32 @@
+import { Factory } from 'fishery';
+import { faker } from '@faker-js/faker';
+import {
+  ArrayCreationMode,
+  ArrayElementDto,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
+
+const arrayKeyName = () => Buffer.from(`array:${faker.string.alphanumeric(6)}`);
+const arrayValue = () => Buffer.from(faker.string.alphanumeric(8));
+
+export const arrayElementFactory = Factory.define<ArrayElementDto>(
+  ({ sequence }) => ({
+    index: `${sequence}`,
+    value: arrayValue(),
+  }),
+);
+
+export const createContiguousArrayDtoFactory =
+  Factory.define<CreateArrayWithExpireDto>(() => ({
+    keyName: arrayKeyName(),
+    mode: ArrayCreationMode.Contiguous,
+    startIndex: '0',
+    values: [arrayValue(), arrayValue()],
+  }));
+
+export const createSparseArrayDtoFactory =
+  Factory.define<CreateArrayWithExpireDto>(() => ({
+    keyName: arrayKeyName(),
+    mode: ArrayCreationMode.Sparse,
+    elements: arrayElementFactory.buildList(2),
+  }));

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,13 +1,20 @@
 import {
+  Body,
   Controller,
+  Post,
   UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiRedisParams } from 'src/decorators/api-redis-params.decorator';
+import { ApiQueryRedisStringEncoding } from 'src/common/decorators';
+import { ClientMetadata } from 'src/common/models';
 import { BrowserSerializeInterceptor } from 'src/common/interceptors';
+import { BrowserClientMetadata } from 'src/modules/browser/decorators/browser-client-metadata.decorator';
 import { BrowserBaseController } from 'src/modules/browser/browser.base.controller';
 import { ArrayService } from 'src/modules/browser/array/array.service';
+import { CreateArrayWithExpireDto } from 'src/modules/browser/array/dto';
 
 @ApiTags('Browser: Array')
 @UseInterceptors(BrowserSerializeInterceptor)
@@ -16,5 +23,17 @@ import { ArrayService } from 'src/modules/browser/array/array.service';
 export class ArrayController extends BrowserBaseController {
   constructor(private arrayService: ArrayService) {
     super();
+  }
+
+  @Post('')
+  @ApiOperation({ description: 'Set key to hold Array data type' })
+  @ApiRedisParams()
+  @ApiBody({ type: CreateArrayWithExpireDto })
+  @ApiQueryRedisStringEncoding()
+  async createArray(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    return this.arrayService.createArray(clientMetadata, dto);
   }
 }

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -3,41 +3,22 @@ import { ConflictException, ForbiddenException } from '@nestjs/common';
 import { when } from 'jest-when';
 import { ReplyError } from 'src/models/redis-client';
 import { mockBrowserClientMetadata, mockRedisNoPermError } from 'src/__mocks__';
-import { mockKeyDto } from 'src/modules/browser/__mocks__';
 import {
   BrowserToolArrayCommands,
   BrowserToolKeysCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
 import {
-  ArrayCreationMode,
-  CreateArrayWithExpireDto,
-} from 'src/modules/browser/array/dto';
+  createContiguousArrayDtoFactory,
+  createSparseArrayDtoFactory,
+} from 'src/modules/browser/array/__tests__/array.factory';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { mockDatabaseClientFactory } from 'src/__mocks__/databases-client';
 import { mockStandaloneRedisClient } from 'src/__mocks__/redis-client';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ArrayService } from 'src/modules/browser/array/array.service';
 
-const mockArrayValue = Buffer.from('Lorem ipsum dolor sit amet.');
-const mockArrayValue2 = Buffer.from('Lorem ipsum dolor sit amet2.');
-
-const mockCreateContiguousArrayDto: CreateArrayWithExpireDto = {
-  keyName: mockKeyDto.keyName,
-  mode: ArrayCreationMode.Contiguous,
-  startIndex: '0',
-  values: [mockArrayValue, mockArrayValue2],
-};
-
-const mockCreateSparseArrayDto: CreateArrayWithExpireDto = {
-  keyName: mockKeyDto.keyName,
-  mode: ArrayCreationMode.Sparse,
-  elements: [
-    { index: '5', value: mockArrayValue },
-    { index: '17', value: mockArrayValue2 },
-  ],
-};
-
 describe('ArrayService', () => {
+  const client = mockStandaloneRedisClient;
   let service: ArrayService;
 
   beforeEach(async () => {
@@ -52,12 +33,8 @@ describe('ArrayService', () => {
     }).compile();
 
     service = module.get(ArrayService);
-    mockStandaloneRedisClient.sendCommand = jest
-      .fn()
-      .mockResolvedValue(undefined);
-    mockStandaloneRedisClient.sendPipeline = jest
-      .fn()
-      .mockResolvedValue(undefined);
+    client.sendCommand = jest.fn().mockResolvedValue(undefined);
+    client.sendPipeline = jest.fn().mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
@@ -65,58 +42,54 @@ describe('ArrayService', () => {
   });
 
   describe('createArray', () => {
-    beforeEach(() => {
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
-        .mockResolvedValue(false);
-    });
-
     it('create contiguous array without expiration', async () => {
+      const dto = createContiguousArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+      expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolArrayCommands.ArSet,
-        mockKeyDto.keyName,
-        '0',
-        mockArrayValue,
-        mockArrayValue2,
+        dto.keyName,
+        dto.startIndex,
+        ...(dto.values ?? []),
       ]);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it('create sparse array without expiration', async () => {
+      const dto = createSparseArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateSparseArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+      expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolArrayCommands.ArMSet,
-        mockKeyDto.keyName,
-        '5',
-        mockArrayValue,
-        '17',
-        mockArrayValue2,
+        dto.keyName,
+        ...(dto.elements ?? []).flatMap(({ index, value }) => [index, value]),
       ]);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it('create contiguous array with expiration', async () => {
-      const dto: CreateArrayWithExpireDto = {
-        keyName: mockKeyDto.keyName,
-        mode: ArrayCreationMode.Contiguous,
-        startIndex: '0',
-        values: [mockArrayValue],
-        expire: 1000,
-      };
-      when(mockStandaloneRedisClient.sendPipeline)
+      const dto = createContiguousArrayDtoFactory.build({ expire: 1000 });
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+      when(client.sendPipeline)
         .calledWith([
-          [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+          [
+            BrowserToolArrayCommands.ArSet,
+            dto.keyName,
+            dto.startIndex,
+            ...(dto.values ?? []),
+          ],
           [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
         ])
         .mockResolvedValue([
@@ -127,42 +100,43 @@ describe('ArrayService', () => {
       await expect(
         service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendPipeline).toHaveBeenCalledWith([
-        [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+      expect(client.sendPipeline).toHaveBeenCalledWith([
+        [
+          BrowserToolArrayCommands.ArSet,
+          dto.keyName,
+          dto.startIndex,
+          ...(dto.values ?? []),
+        ],
         [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
       ]);
     });
 
     it('key with this name exist', async () => {
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+      const dto = createContiguousArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
         .mockResolvedValue(true);
 
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(new ConflictException(ERROR_MESSAGES.KEY_NAME_EXIST));
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendCommand).toHaveBeenCalledTimes(1);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it("user don't have required permissions for createArray", async () => {
+      const dto = createContiguousArrayDtoFactory.build();
       const replyError: ReplyError = {
         ...mockRedisNoPermError,
         command: 'ARSET',
       };
-      mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
+      client.sendCommand.mockRejectedValue(replyError);
 
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(ForbiddenException);
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendCommand).toHaveBeenCalledTimes(1);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
   });
 });

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -1,7 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { mockDatabaseClientFactory } from 'src/__mocks__';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { when } from 'jest-when';
+import { ReplyError } from 'src/models/redis-client';
+import { mockBrowserClientMetadata, mockRedisNoPermError } from 'src/__mocks__';
+import { mockKeyDto } from 'src/modules/browser/__mocks__';
+import {
+  BrowserToolArrayCommands,
+  BrowserToolKeysCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
+import {
+  ArrayCreationMode,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { mockDatabaseClientFactory } from 'src/__mocks__/databases-client';
+import { mockStandaloneRedisClient } from 'src/__mocks__/redis-client';
+import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ArrayService } from 'src/modules/browser/array/array.service';
+
+const mockArrayValue = Buffer.from('Lorem ipsum dolor sit amet.');
+const mockArrayValue2 = Buffer.from('Lorem ipsum dolor sit amet2.');
+
+const mockCreateContiguousArrayDto: CreateArrayWithExpireDto = {
+  keyName: mockKeyDto.keyName,
+  mode: ArrayCreationMode.Contiguous,
+  startIndex: '0',
+  values: [mockArrayValue, mockArrayValue2],
+};
+
+const mockCreateSparseArrayDto: CreateArrayWithExpireDto = {
+  keyName: mockKeyDto.keyName,
+  mode: ArrayCreationMode.Sparse,
+  elements: [
+    { index: '5', value: mockArrayValue },
+    { index: '17', value: mockArrayValue2 },
+  ],
+};
 
 describe('ArrayService', () => {
   let service: ArrayService;
@@ -18,9 +52,117 @@ describe('ArrayService', () => {
     }).compile();
 
     service = module.get(ArrayService);
+    mockStandaloneRedisClient.sendCommand = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    mockStandaloneRedisClient.sendPipeline = jest
+      .fn()
+      .mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createArray', () => {
+    beforeEach(() => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(false);
+    });
+
+    it('create contiguous array without expiration', async () => {
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArSet,
+        mockKeyDto.keyName,
+        '0',
+        mockArrayValue,
+        mockArrayValue2,
+      ]);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('create sparse array without expiration', async () => {
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateSparseArrayDto,
+        ),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArMSet,
+        mockKeyDto.keyName,
+        '5',
+        mockArrayValue,
+        '17',
+        mockArrayValue2,
+      ]);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('create contiguous array with expiration', async () => {
+      const dto: CreateArrayWithExpireDto = {
+        keyName: mockKeyDto.keyName,
+        mode: ArrayCreationMode.Contiguous,
+        startIndex: '0',
+        values: [mockArrayValue],
+        expire: 1000,
+      };
+      when(mockStandaloneRedisClient.sendPipeline)
+        .calledWith([
+          [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+          [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
+        ])
+        .mockResolvedValue([
+          [null, 'OK'],
+          [null, 1],
+        ]);
+
+      await expect(
+        service.createArray(mockBrowserClientMetadata, dto),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendPipeline).toHaveBeenCalledWith([
+        [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+        [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
+      ]);
+    });
+
+    it('key with this name exist', async () => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(true);
+
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).rejects.toThrow(new ConflictException(ERROR_MESSAGES.KEY_NAME_EXIST));
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it("user don't have required permissions for createArray", async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARSET',
+      };
+      mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
+
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
   });
 });

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -1,7 +1,95 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { catchAclError, catchMultiTransactionError } from 'src/utils';
+import { ClientMetadata } from 'src/common/models';
+import {
+  ArrayCreationMode,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
+import {
+  BrowserToolArrayCommands,
+  BrowserToolKeysCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import {
+  RedisClient,
+  RedisClientCommand,
+  RedisClientCommandReply,
+} from 'src/modules/redis/client';
+import { checkIfKeyExists } from 'src/modules/browser/utils';
 
 @Injectable()
 export class ArrayService {
+  private logger = new Logger('ArrayService');
+
   constructor(private databaseClientFactory: DatabaseClientFactory) {}
+
+  public async createArray(
+    clientMetadata: ClientMetadata,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    try {
+      this.logger.debug('Creating array data type.', clientMetadata);
+      const { keyName, expire } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyExists(keyName, client);
+
+      if (expire) {
+        await this.createArrayWithExpiration(client, dto);
+      } else {
+        await this.createSimpleArray(client, dto);
+      }
+
+      this.logger.debug('Succeed to create array data type.', clientMetadata);
+    } catch (error) {
+      this.logger.error(
+        'Failed to create array data type.',
+        error,
+        clientMetadata,
+      );
+      throw catchAclError(error);
+    }
+  }
+
+  public async createSimpleArray(
+    client: RedisClient,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    await client.sendCommand(this.buildCreateCommand(dto));
+  }
+
+  public async createArrayWithExpiration(
+    client: RedisClient,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    const { keyName, expire } = dto;
+    const transactionResults = await client.sendPipeline([
+      this.buildCreateCommand(dto),
+      [BrowserToolKeysCommands.Expire, keyName, expire] as RedisClientCommand,
+    ]);
+    catchMultiTransactionError(
+      transactionResults as [Error, RedisClientCommandReply][],
+    );
+  }
+
+  private buildCreateCommand(
+    dto: CreateArrayWithExpireDto,
+  ): RedisClientCommand {
+    // DTO validation guarantees startIndex + values in contiguous mode
+    // and elements in sparse mode; defaults only satisfy strict null checks.
+    const { keyName, mode, startIndex = '0', values = [], elements = [] } = dto;
+
+    if (mode === ArrayCreationMode.Contiguous) {
+      // ARSET key startIndex value [value ...] — contiguous run from startIndex
+      return [BrowserToolArrayCommands.ArSet, keyName, startIndex, ...values];
+    }
+
+    // ARMSET key index value [index value ...] — sparse index/value pairs
+    return [
+      BrowserToolArrayCommands.ArMSet,
+      keyName,
+      ...elements.flatMap(({ index, value }) => [index, value]),
+    ];
+  }
 }

--- a/redisinsight/api/src/modules/browser/array/dto/create.array-with-expire.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/create.array-with-expire.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsDefined,
+  IsEnum,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ApiRedisString,
+  IsArrayIndex,
+  IsRedisString,
+  RedisStringType,
+} from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+import { KeyWithExpireDto } from 'src/modules/browser/keys/dto';
+
+export enum ArrayCreationMode {
+  Contiguous = 'contiguous',
+  Sparse = 'sparse',
+}
+
+export class ArrayElementDto {
+  @ApiProperty({
+    type: String,
+    description: 'Element index as a numeric string (unsigned 64-bit range)',
+  })
+  @IsDefined()
+  @IsArrayIndex()
+  index: string;
+
+  @ApiRedisString('Element value')
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  value: RedisString;
+}
+
+export class CreateArrayWithExpireDto extends KeyWithExpireDto {
+  @ApiProperty({
+    enum: ArrayCreationMode,
+    description:
+      'Contiguous mode writes values as a run starting at startIndex. ' +
+      'Sparse mode writes explicit index/value pairs.',
+  })
+  @IsDefined()
+  @IsEnum(ArrayCreationMode)
+  mode: ArrayCreationMode;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Start index as a numeric string (unsigned 64-bit range). ' +
+      'Required in contiguous mode.',
+  })
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Contiguous)
+  @IsDefined()
+  @IsArrayIndex()
+  startIndex?: string;
+
+  @ApiRedisString(
+    'Element value(s) to write starting at startIndex. Required in contiguous mode.',
+    true,
+    false,
+  )
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Contiguous)
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsRedisString({ each: true })
+  @RedisStringType({ each: true })
+  values?: RedisString[];
+
+  @ApiPropertyOptional({
+    type: ArrayElementDto,
+    isArray: true,
+    description: 'Index/value pairs to write. Required in sparse mode.',
+  })
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Sparse)
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => ArrayElementDto)
+  elements?: ArrayElementDto[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './create.array-with-expire.dto';

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -116,6 +116,8 @@ export enum BrowserToolVectorSetCommands {
 
 export enum BrowserToolArrayCommands {
   ARGet = 'arget',
+  ArSet = 'arset',
+  ArMSet = 'armset',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -10,6 +10,7 @@ import {
 import { RedisString } from 'src/common/constants';
 import { ClientMetadata } from 'src/common/models';
 import {
+  BrowserToolArrayCommands,
   BrowserToolHashCommands,
   BrowserToolVectorSetCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
@@ -45,6 +46,9 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSetAttr);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VRem);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSim);
+    // Array commands
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArSet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArMSet);
   }
 
   static prepareCommandOptions(options: IRedisClientCommandOptions): any {

--- a/redisinsight/api/test/api/array/POST-databases-id-array.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array.test.ts
@@ -1,0 +1,250 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+import { ArrayCreationMode } from 'src/modules/browser/array/dto';
+
+const { server, request, constants } = deps;
+// The harness types `deps.rte` as null until initRTE runs; tests access it
+// freely (the api test layer is untyped by design), so widen it here.
+const rte = deps.rte as any;
+
+// endpoint to test
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(`/${constants.API.DATABASES}/${instanceId}/array`);
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARSET/ARMSET are Redis 8.8 preview commands; rte.client has no typed method
+// for them, so assert array state through the generic `call`.
+const arlen = (key: string) => rte.client.call('ARLEN', key);
+const arcount = (key: string) => rte.client.call('ARCOUNT', key);
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+
+interface CreateArrayTestCase {
+  name: string;
+  data: { keyName: string } & Record<string, unknown>;
+  statusCode: number;
+  endpoint?: () => unknown;
+  responseBody?: object;
+  before?: () => Promise<unknown>;
+  after?: () => Promise<unknown>;
+}
+
+const createCheckFn = async (testCase: CreateArrayTestCase) => {
+  it(testCase.name, async () => {
+    if (testCase.before) {
+      await testCase.before();
+    } else if (testCase.statusCode === 201) {
+      expect(await rte.client.exists(testCase.data.keyName)).to.eql(0);
+    }
+
+    await validateApiCall({
+      endpoint,
+      ...testCase,
+    });
+
+    if (testCase.after) {
+      await testCase.after();
+    }
+  });
+};
+
+describe('POST /databases/:id/array', () => {
+  // Array is a Redis 8.8 preview type; skip where the server lacks ARSET.
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Contiguous (ARSET)', () => {
+    const contiguousKey = constants.getRandomString();
+    const nonZeroKey = constants.getRandomString();
+    const ttlKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should create a contiguous array',
+        data: {
+          keyName: contiguousKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['20.1', '20.4', '20.9'],
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await rte.client.exists(contiguousKey)).to.eql(1);
+          expect(await arlen(contiguousKey)).to.eql(3);
+          expect(await arget(contiguousKey, '0')).to.eql('20.1');
+          expect(await arget(contiguousKey, '2')).to.eql('20.9');
+          expect(await rte.client.ttl(contiguousKey)).to.eql(-1);
+        },
+      },
+      {
+        name: 'Should create a contiguous array starting at a non-zero index',
+        data: {
+          keyName: nonZeroKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '5',
+          values: ['a', 'b'],
+        },
+        statusCode: 201,
+        after: async () => {
+          // Length is highest set index + 1, so a run at 5..6 reports 7.
+          expect(await arlen(nonZeroKey)).to.eql(7);
+          expect(await arget(nonZeroKey, '5')).to.eql('a');
+        },
+      },
+      {
+        name: 'Should create a contiguous array with a TTL (pipeline path)',
+        data: {
+          keyName: ttlKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['x'],
+          expire: 100,
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await arlen(ttlKey)).to.eql(1);
+          expect(await rte.client.ttl(ttlKey)).to.gte(95);
+        },
+      },
+    ].map(createCheckFn);
+  });
+
+  describe('Sparse (ARMSET)', () => {
+    const sparseKey = constants.getRandomString();
+    const sparseTtlKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should create a sparse array with index gaps',
+        data: {
+          keyName: sparseKey,
+          mode: ArrayCreationMode.Sparse,
+          elements: [
+            { index: '5', value: 'v5' },
+            { index: '17', value: 'v17' },
+          ],
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await rte.client.exists(sparseKey)).to.eql(1);
+          // Length follows the highest index (17 + 1); count is the populated slots.
+          expect(await arlen(sparseKey)).to.eql(18);
+          expect(await arcount(sparseKey)).to.eql(2);
+          expect(await arget(sparseKey, '5')).to.eql('v5');
+          expect(await arget(sparseKey, '17')).to.eql('v17');
+          expect(await arget(sparseKey, '6')).to.eql(null);
+        },
+      },
+      {
+        name: 'Should create a sparse array with a TTL (pipeline path)',
+        data: {
+          keyName: sparseTtlKey,
+          mode: ArrayCreationMode.Sparse,
+          elements: [{ index: '0', value: 'only' }],
+          expire: 100,
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await arcount(sparseTtlKey)).to.eql(1);
+          expect(await rte.client.ttl(sparseTtlKey)).to.gte(95);
+        },
+      },
+    ].map(createCheckFn);
+  });
+
+  describe('Validation', () => {
+    [
+      {
+        name: 'Should reject a non-canonical index',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '007',
+          values: ['x'],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an out-of-range (> u64) index',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Sparse,
+          elements: [{ index: '18446744073709551616', value: 'x' }],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject contiguous mode with empty values',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: [],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an unknown mode',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: 'whatever',
+          values: ['x'],
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Errors', () => {
+    it('Should return conflict error if key already exists', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('ARSET', keyName, '0', 'existing');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['new'],
+        },
+        statusCode: 409,
+        responseBody: {
+          statusCode: 409,
+          error: 'Conflict',
+          message: 'This key name is already in use.',
+        },
+      });
+
+      // The existing value must not be overwritten.
+      expect(await arget(keyName, '0')).to.eql('existing');
+    });
+
+    [
+      {
+        name: 'Should return NotFound error if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['x'],
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -65,6 +65,8 @@ enum ApiEndpoints {
   REJSON_ARRAPPEND = 'rejson-rl/arrappend',
   REJSON_DOWNLOAD = 'rejson-rl/download-value',
 
+  ARRAY = 'array',
+
   VECTOR_SET = 'vector-set',
   VECTOR_SET_GET_ELEMENTS = 'vector-set/get-elements',
   VECTOR_SET_ELEMENTS = 'vector-set/elements',

--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -15,6 +15,6 @@ export const CommandsVersions = {
     since: '8.0',
   },
   ARRAY: {
-    since: '8.8',
+    since: '8.8.0',
   },
 }

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -193,6 +193,7 @@ export const ENDPOINT_BASED_ON_KEY_TYPE = Object.freeze({
   [KeyTypes.ReJSON]: ApiEndpoints.REJSON,
   [KeyTypes.Stream]: ApiEndpoints.STREAMS,
   [KeyTypes.VectorSet]: ApiEndpoints.VECTOR_SET,
+  [KeyTypes.Array]: ApiEndpoints.ARRAY,
 })
 
 export type EndpointBasedOnKeyType = keyof typeof ENDPOINT_BASED_ON_KEY_TYPE

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -46,6 +46,7 @@ import AddKeyList from './AddKeyList'
 import AddKeyReJSON from './AddKeyReJSON'
 import AddKeyStream from './AddKeyStream'
 import AddKeyVectorSet from './AddKeyVectorSet'
+import AddKeyArray from './AddKeyArray'
 import { ContentFields } from './AddKey.styles'
 
 import styles from './styles.module.scss'
@@ -235,6 +236,14 @@ const AddKey = (props: Props) => {
               )}
               {typeSelected === KeyTypes.VectorSet && (
                 <AddKeyVectorSet
+                  onCancel={closeAddKeyPanel}
+                  setKeyName={setKeyName}
+                  setKeyNameDisabled={setKeyNameDisabled}
+                  {...defaultFields}
+                />
+              )}
+              {typeSelected === KeyTypes.Array && (
+                <AddKeyArray
                   onCancel={closeAddKeyPanel}
                   setKeyName={setKeyName}
                   setKeyNameDisabled={setKeyNameDisabled}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { instance, mock } from 'ts-mockito'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import AddKeyArray, { Props } from './AddKeyArray'
+
+const mockedProps = mock<Props>()
+
+describe('AddKeyArray', () => {
+  beforeEach(() => {
+    // ActionFooter renders via a portal to #formFooterBar
+    const footer = document.createElement('div')
+    footer.setAttribute('id', 'formFooterBar')
+    document.body.appendChild(footer)
+  })
+
+  afterEach(() => {
+    document.getElementById('formFooterBar')?.remove()
+  })
+
+  it('should render', () => {
+    expect(render(<AddKeyArray {...instance(mockedProps)} />)).toBeTruthy()
+  })
+
+  it('should keep the submit button disabled', () => {
+    render(<AddKeyArray {...instance(mockedProps)} keyName="name" />)
+
+    expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import { render, screen } from 'uiSrc/utils/test-utils'
-import AddKeyArray, { Props } from './AddKeyArray'
+import AddKeyArray from './AddKeyArray'
+import { Props } from './AddKeyArray.types'
 
 const mockedProps = mock<Props>()
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { Maybe } from 'uiSrc/utils'
+import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
+import { Text } from 'uiSrc/components/base/text'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+  setKeyName?: (value: string) => void
+  setKeyNameDisabled?: (disabled: boolean) => void
+}
+
+// Creation forms land in follow-up PRs; submit stays disabled until then.
+const AddKeyArray = ({ onCancel }: Props) => (
+  <>
+    <Text size="M" color="secondary" data-testid="add-key-array-placeholder">
+      Array creation options are coming soon.
+    </Text>
+    <ActionFooter
+      onCancel={() => onCancel(true)}
+      onAction={() => undefined}
+      actionText="Add Key"
+      disabled
+      actionTestId="add-key-array-btn"
+    />
+  </>
+)
+
+export default AddKeyArray

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,16 +1,9 @@
 import React from 'react'
 
-import { Maybe } from 'uiSrc/utils'
 import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
 import { Text } from 'uiSrc/components/base/text'
 
-export interface Props {
-  keyName: string
-  keyTTL: Maybe<number>
-  onCancel: (isCancelled?: boolean) => void
-  setKeyName?: (value: string) => void
-  setKeyNameDisabled?: (disabled: boolean) => void
-}
+import { Props } from './AddKeyArray.types'
 
 // Creation forms land in follow-up PRs; submit stays disabled until then.
 const AddKeyArray = ({ onCancel }: Props) => (

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
@@ -1,0 +1,18 @@
+import { Maybe } from 'uiSrc/utils'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+  /**
+   * Setter for the parent-owned `keyName` field. Used by the sample-dataset
+   * mode to auto-populate the common key-name input with a bundled dataset's
+   * fixed key, and clear it again on switching back to manual entry.
+   */
+  setKeyName?: (value: string) => void
+  /**
+   * Setter for the parent-owned `keyName` input's `disabled` flag. Locked to
+   * `true` in sample-dataset mode (the key name is fixed) and `false` otherwise.
+   */
+  setKeyNameDisabled?: (disabled: boolean) => void
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
@@ -1,4 +1,4 @@
 import AddKeyArray from './AddKeyArray'
 
 export default AddKeyArray
-export type { Props } from './AddKeyArray'
+export type { Props } from './AddKeyArray.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
@@ -1,0 +1,4 @@
+import AddKeyArray from './AddKeyArray'
+
+export default AddKeyArray
+export type { Props } from './AddKeyArray'

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
@@ -125,6 +125,33 @@ export const AddJSONFormConfig: IAddJSONFormConfig = {
   },
 }
 
+interface IAddArrayFormConfig {
+  startIndex: IFormField
+  index: IFormField
+  value: IFormField
+}
+
+export const AddArrayFormConfig: IAddArrayFormConfig = {
+  startIndex: {
+    name: 'startIndex',
+    isRequire: true,
+    label: 'Start Index*',
+    placeholder: 'Enter Start Index',
+  },
+  index: {
+    name: 'index',
+    isRequire: true,
+    label: 'Index*',
+    placeholder: 'Enter Index',
+  },
+  value: {
+    name: 'value',
+    isRequire: true,
+    label: 'Value*',
+    placeholder: 'Enter Value',
+  },
+}
+
 interface IAddStreamFormConfig {
   entryId: IFormField
   name: IFormField

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,6 +1,9 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -13,6 +16,13 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     text: 'List',
     value: KeyTypes.List,
     color: GROUP_TYPES_COLORS[KeyTypes.List],
+  },
+  {
+    text: 'Array',
+    value: KeyTypes.Array,
+    color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    minVersion: CommandsVersions.ARRAY.since,
+    isEnabledSelector: isDevArrayEnabledSelector,
   },
   {
     text: 'Set',

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -102,6 +102,7 @@ import {
   CreateHashWithExpireDto,
   CreateRejsonRlWithExpireDto,
   CreateSetWithExpireDto,
+  CreateArrayWithExpireDto,
   GetKeyInfoResponse,
   GetKeysWithDetailsResponse,
   CreateStreamDto,
@@ -1040,6 +1041,15 @@ export function addListKey(
   onFailAction?: () => void,
 ) {
   return addTypedKey(data, KeyTypes.List, onSuccessAction, onFailAction)
+}
+
+// Asynchronous thunk action
+export function addArrayKey(
+  data: CreateArrayWithExpireDto,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return addTypedKey(data, KeyTypes.Array, onSuccessAction, onFailAction)
 }
 
 // Asynchronous thunk action

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { faker } from '@faker-js/faker'
 import { AxiosError } from 'axios'
 import { configureStore } from '@reduxjs/toolkit'
 import { getConfig } from 'uiSrc/config'
@@ -10,6 +11,7 @@ import {
 } from 'uiSrc/constants'
 import {
   ListElementDestination,
+  CreateArrayWithExpireDto,
   CreateHashWithExpireDto,
   CreateListWithExpireDto,
   CreateRejsonRlWithExpireDto,
@@ -52,6 +54,7 @@ import reducer, {
   addKey,
   addKeyFailure,
   addKeySuccess,
+  addArrayKey,
   addListKey,
   addReJSONKey,
   addSetKey,
@@ -1756,6 +1759,33 @@ describe('keys slice', () => {
           addKeySuccess(),
           updateKeyList({ keyName: data.keyName, keyType: 'list' }),
           addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('addArrayKey', () => {
+      it('success to add key', async () => {
+        // Arrange
+        const keyName = stringToBuffer(faker.string.alphanumeric(10))
+        const data = {
+          keyName,
+          mode: 'sparse',
+          elements: [{ index: '5', value: 'value' }],
+        } as unknown as CreateArrayWithExpireDto
+        const responsePayload = { data, status: 200 }
+
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        // Act
+        await store.dispatch<any>(addArrayKey(data, jest.fn()))
+
+        // Assert
+        const expectedActions = [
+          addKey(),
+          addKeySuccess(),
+          updateKeyList({ keyName: data.keyName, keyType: KeyTypes.Array }),
+          addMessageNotification(successMessages.ADDED_NEW_KEY(keyName)),
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })


### PR DESCRIPTION
# What

First slice of the Add/Create array key vertical (RI-8218). Stacked series: this PR → #RI-8285 (sample data) → #RI-8286 (manual modes).

- Full `POST /databases/:id/array` backend: mode-discriminated `CreateArrayWithExpireDto` (contiguous → `ARSET`, sparse → `ARMSET`), indexes validated canonical-only via `@IsArrayIndex()`, 409 on existing key, expire via pipeline. `BrowserToolArrayCommands` + Bruno coverage. **Shipped dark** — unreachable from the UI until the follow-up slices.
- "Array" registered in the Add Key type dropdown right after List (matching the key-type filter order), gated by the `dev-array` flag and server ≥ 8.8.0.
- `AddKeyArray` placeholder panel: Key Name + TTL work, submit disabled.

# Testing

- `yarn --cwd redisinsight/api test --testPathPattern "modules/browser/array"` — 6 tests (both modes, expire, conflict, ACL)
- Add Key UI suites green; lint + type-check green
- Manual: with `dev-array` on, the Array option appears after List; against servers < 8.8.0 or with the flag off it's hidden

## Manual testing screenshots

| Light | Dark |
|---|---|
| <img width="627" height="644" alt="image" src="https://github.com/user-attachments/assets/b68b1a53-755c-4ced-ad57-2d59f616feb9" /> | <img width="625" height="650" alt="image" src="https://github.com/user-attachments/assets/32c62f0c-a06f-4941-93d7-3c2e46fee71e" /> |
| <img width="617" height="641" alt="image" src="https://github.com/user-attachments/assets/17345452-cb3b-417b-88fa-e08fabc21a0c" /> | <img width="616" height="641" alt="image" src="https://github.com/user-attachments/assets/fa1075ce-3c24-48ca-8d94-c5fa0a3e6fc9" /> |

Not showing in DB with version lower than 8.8

<img width="615" height="645" alt="image" src="https://github.com/user-attachments/assets/ad917be2-4c83-4b73-8431-496fec2cc19b" />

---

Closes #RI-8284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Redis 8.8 preview commands and key-creation path on the server; UI submit is disabled so production users cannot create arrays from the dialog yet.
> 
> **Overview**
> Adds **`POST /databases/:id/array`** so Redis Insight can create Array keys via **`ARSET`** (contiguous) or **`ARMSET`** (sparse), with mode-specific **`CreateArrayWithExpireDto`** validation (canonical u64 index strings), optional TTL via pipeline, **409** when the key already exists, and ioredis builtins for the new commands.
> 
> On the UI, **Array** appears in the Add Key type list (after List), gated by **`dev-array`** and Redis **≥ 8.8.0**; **`AddKeyArray`** is a placeholder with submit disabled until follow-up work. **`addArrayKey`** and **`ApiEndpoints.ARRAY`** wire the client to the new route. Bruno requests and API/integration tests cover happy paths, validation, and conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96dde4c6367df1ba54b2343b47258db8703f75a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->