### PR TITLE
RI-8286 Add manual creation modes (contiguous/sparse) to the Array Add Key panel

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -144,7 +144,7 @@ describe('AddKeyArray', () => {
       ).toBeInTheDocument()
       expect(screen.getByTestId('start-index')).toHaveValue('0')
       expect(screen.getByTestId(valueFindingRegex)).toBeInTheDocument()
-      expect(screen.queryByTestId('sparse-index')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('sparse-index-0')).not.toBeInTheDocument()
     })
 
     it('should show paired index and value inputs after switching to sparse mode', async () => {
@@ -152,8 +152,8 @@ describe('AddKeyArray', () => {
 
       await selectSparseMode()
 
-      expect(screen.getByTestId('sparse-index')).toBeInTheDocument()
-      expect(screen.getByTestId('sparse-value')).toBeInTheDocument()
+      expect(screen.getByTestId('sparse-index-0')).toBeInTheDocument()
+      expect(screen.getByTestId('sparse-value-0')).toBeInTheDocument()
       expect(screen.queryByTestId('start-index')).not.toBeInTheDocument()
     })
 
@@ -196,7 +196,7 @@ describe('AddKeyArray', () => {
 
       expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
 
-      fireEvent.change(screen.getByTestId('sparse-index'), {
+      fireEvent.change(screen.getByTestId('sparse-index-0'), {
         target: { value: '5' },
       })
 
@@ -230,10 +230,10 @@ describe('AddKeyArray', () => {
 
       await selectSparseMode()
 
-      fireEvent.change(screen.getByTestId('sparse-index'), {
+      fireEvent.change(screen.getByTestId('sparse-index-0'), {
         target: { value: '0042' },
       })
-      fireEvent.change(screen.getByTestId('sparse-value'), {
+      fireEvent.change(screen.getByTestId('sparse-value-0'), {
         target: { value: 'answer' },
       })
       fireEvent.click(screen.getByTestId('add-key-array-btn'))

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -8,7 +8,7 @@ import {
   userEvent,
   waitFor,
 } from 'uiSrc/utils/test-utils'
-import { addKeyIntoList } from 'uiSrc/slices/browser/keys'
+import { addArrayKey, addKeyIntoList } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
 import { Environment } from 'apiClient'
 import {
@@ -17,6 +17,11 @@ import {
 } from 'uiSrc/mocks/factories/browser/bulkActions/bulkActionOverview.factory'
 import AddKeyArray from './AddKeyArray'
 import { Props } from './AddKeyArray.types'
+import {
+  CONTIGUOUS_MODE,
+  CREATION_MODE_OPTIONS,
+  SPARSE_MODE,
+} from './constants'
 import { DEFAULT_SAMPLE_DATASET, SAMPLE_DATASETS } from './LoadSampleDataset'
 
 const defaultProps: Props = {
@@ -28,6 +33,7 @@ const defaultProps: Props = {
 jest.mock('uiSrc/slices/browser/keys', () => ({
   ...jest.requireActual('uiSrc/slices/browser/keys'),
   addKeyIntoList: jest.fn(() => ({ type: 'keys/addKeyIntoList' })),
+  addArrayKey: jest.fn(() => ({ type: 'keys/addArrayKey' })),
 }))
 
 const mockLoad = jest.fn()
@@ -69,10 +75,21 @@ const contiguousDataset = SAMPLE_DATASETS.find(
   ({ collectionName }) => collectionName === 'readme-document',
 )!
 
+const valueFindingRegex = /^value-\d+$/
+
+const getModeOptionLabel = (mode: string) =>
+  CREATION_MODE_OPTIONS.find(({ value }) => value === mode)?.label ?? ''
+
 const selectSampleMode = () =>
   fireEvent.click(screen.getByTestId('add-key-array-populate-sample'))
 const selectManualMode = () =>
   fireEvent.click(screen.getByTestId('add-key-array-populate-manual'))
+const selectSparseMode = async () => {
+  await userEvent.click(screen.getByTestId('creation-mode-select'))
+  await userEvent.click(
+    await screen.findByText(getModeOptionLabel(SPARSE_MODE)),
+  )
+}
 const selectDataset = async (label: string) => {
   await userEvent.click(screen.getByTestId('sample-dataset-select'))
   await userEvent.click(await screen.findByText(label))
@@ -118,11 +135,129 @@ describe('AddKeyArray', () => {
     expect(renderComponent()).toBeTruthy()
   })
 
-  it('should keep the manual side as a placeholder with a disabled submit button', () => {
-    renderComponent({ keyName: 'name' })
+  describe('manual mode', () => {
+    it('should render contiguous mode with default start index by default', () => {
+      renderComponent()
 
-    expect(screen.getByTestId('add-key-array-placeholder')).toBeInTheDocument()
-    expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+      expect(
+        screen.getByText(getModeOptionLabel(CONTIGUOUS_MODE)),
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('start-index')).toHaveValue('0')
+      expect(screen.getByTestId(valueFindingRegex)).toBeInTheDocument()
+      expect(screen.queryByTestId('sparse-index')).not.toBeInTheDocument()
+    })
+
+    it('should show paired index and value inputs after switching to sparse mode', async () => {
+      renderComponent()
+
+      await selectSparseMode()
+
+      expect(screen.getByTestId('sparse-index')).toBeInTheDocument()
+      expect(screen.getByTestId('sparse-value')).toBeInTheDocument()
+      expect(screen.queryByTestId('start-index')).not.toBeInTheDocument()
+    })
+
+    it('should disable the submit button with empty keyName', () => {
+      renderComponent({ keyName: '' })
+
+      expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+    })
+
+    it('should disable the submit button when the start index is cleared', () => {
+      renderComponent({ keyName: 'name' })
+
+      expect(screen.getByTestId('add-key-array-btn')).not.toBeDisabled()
+
+      fireEvent.change(screen.getByTestId('start-index'), {
+        target: { value: '' },
+      })
+
+      expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+    })
+
+    it('should disable submit when a contiguous range would exceed the u64 max', () => {
+      renderComponent({ keyName: 'name' })
+
+      fireEvent.change(screen.getByTestId('start-index'), {
+        target: { value: '18446744073709551615' },
+      })
+      // a single value at the max index is still in range
+      expect(screen.getByTestId('add-key-array-btn')).not.toBeDisabled()
+
+      // a second value would land one past the u64 range
+      fireEvent.click(screen.getByTestId('add-item'))
+      expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+    })
+
+    it('should disable the submit button in sparse mode until every index is filled', async () => {
+      renderComponent({ keyName: 'name' })
+
+      await selectSparseMode()
+
+      expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+
+      fireEvent.change(screen.getByTestId('sparse-index'), {
+        target: { value: '5' },
+      })
+
+      expect(screen.getByTestId('add-key-array-btn')).not.toBeDisabled()
+    })
+
+    it('should dispatch addArrayKey with a canonical start index on contiguous submit', () => {
+      renderComponent({ keyName: 'name', onCancel: jest.fn() })
+
+      fireEvent.change(screen.getByTestId('start-index'), {
+        target: { value: '007' },
+      })
+      fireEvent.change(screen.getByTestId('value-0'), {
+        target: { value: 'first' },
+      })
+      fireEvent.click(screen.getByTestId('add-key-array-btn'))
+
+      expect(addArrayKey).toHaveBeenCalledWith(
+        {
+          keyName: stringToBuffer('name'),
+          mode: CONTIGUOUS_MODE,
+          startIndex: '7',
+          values: [stringToBuffer('first')],
+        },
+        expect.any(Function),
+      )
+    })
+
+    it('should dispatch addArrayKey with canonical element indexes on sparse submit', async () => {
+      renderComponent({ keyName: 'name', onCancel: jest.fn() })
+
+      await selectSparseMode()
+
+      fireEvent.change(screen.getByTestId('sparse-index'), {
+        target: { value: '0042' },
+      })
+      fireEvent.change(screen.getByTestId('sparse-value'), {
+        target: { value: 'answer' },
+      })
+      fireEvent.click(screen.getByTestId('add-key-array-btn'))
+
+      expect(addArrayKey).toHaveBeenCalledWith(
+        {
+          keyName: stringToBuffer('name'),
+          mode: SPARSE_MODE,
+          elements: [{ index: '42', value: stringToBuffer('answer') }],
+        },
+        expect.any(Function),
+      )
+    })
+
+    it('should include expire in payload when keyTTL is provided', () => {
+      renderComponent({ keyName: 'name', keyTTL: 60, onCancel: jest.fn() })
+
+      fireEvent.click(screen.getByTestId('add-key-array-btn'))
+
+      expect(addArrayKey).toHaveBeenCalledWith(
+        expect.objectContaining({ expire: 60 }),
+        expect.any(Function),
+      )
+    })
   })
 
   describe('sample data mode', () => {
@@ -140,7 +275,7 @@ describe('AddKeyArray', () => {
         screen.getByTestId('add-key-array-load-sample-dataset'),
       ).toBeInTheDocument()
       expect(
-        screen.queryByTestId('add-key-array-placeholder'),
+        screen.queryByTestId('creation-mode-select'),
       ).not.toBeInTheDocument()
       expect(setKeyName).toHaveBeenLastCalledWith(
         DEFAULT_SAMPLE_DATASET.keyName,
@@ -148,9 +283,7 @@ describe('AddKeyArray', () => {
       expect(setKeyNameDisabled).toHaveBeenLastCalledWith(true)
 
       selectManualMode()
-      expect(
-        screen.getByTestId('add-key-array-placeholder'),
-      ).toBeInTheDocument()
+      expect(screen.getByTestId('creation-mode-select')).toBeInTheDocument()
       expect(setKeyName).toHaveBeenLastCalledWith('')
       expect(setKeyNameDisabled).toHaveBeenLastCalledWith(false)
     })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.transforms.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.transforms.spec.ts
@@ -1,0 +1,46 @@
+import { stringToBuffer } from 'uiSrc/utils'
+import {
+  transformToContiguousMode,
+  transformToSparseMode,
+} from './AddKeyArray.transforms'
+import { CONTIGUOUS_MODE, SPARSE_MODE } from './constants'
+
+describe('AddKeyArray.transforms', () => {
+  describe('transformToContiguousMode', () => {
+    it('should build an ARSET payload with a canonical start index and buffered values', () => {
+      const result = transformToContiguousMode({
+        keyName: 'name',
+        startIndex: '007',
+        values: ['first', 'second'],
+      })
+
+      expect(result).toEqual({
+        keyName: stringToBuffer('name'),
+        mode: CONTIGUOUS_MODE,
+        startIndex: '7',
+        values: [stringToBuffer('first'), stringToBuffer('second')],
+      })
+    })
+  })
+
+  describe('transformToSparseMode', () => {
+    it('should build an ARMSET payload with canonical element indexes and buffered values', () => {
+      const result = transformToSparseMode({
+        keyName: 'name',
+        elements: [
+          { id: 0, index: '0042', value: 'answer' },
+          { id: 1, index: '5', value: 'five' },
+        ],
+      })
+
+      expect(result).toEqual({
+        keyName: stringToBuffer('name'),
+        mode: SPARSE_MODE,
+        elements: [
+          { index: '42', value: stringToBuffer('answer') },
+          { index: '5', value: stringToBuffer('five') },
+        ],
+      })
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.transforms.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.transforms.ts
@@ -1,0 +1,45 @@
+import { CreateArrayWithExpireDto } from 'apiClient'
+
+import { parseArrayIndex, stringToBuffer } from 'uiSrc/utils'
+
+import { CONTIGUOUS_MODE, SPARSE_MODE } from './constants'
+import { IArraySparseElement } from './AddKeyArray.types'
+
+// RedisResponseBuffer and the generated apiClient buffer shape are
+// structurally equal at runtime but typed differently, so cast at the boundary.
+const toApiBuffer = (value: string) =>
+  stringToBuffer(value) as unknown as CreateArrayWithExpireDto['keyName']
+
+export interface ContiguousPayloadInput {
+  keyName: string
+  startIndex: string
+  values: string[]
+}
+
+export interface SparsePayloadInput {
+  keyName: string
+  elements: IArraySparseElement[]
+}
+
+export const transformToContiguousMode = ({
+  keyName,
+  startIndex,
+  values,
+}: ContiguousPayloadInput): CreateArrayWithExpireDto => ({
+  keyName: toApiBuffer(keyName),
+  mode: CONTIGUOUS_MODE,
+  startIndex: parseArrayIndex(startIndex)!,
+  values: values.map((value) => toApiBuffer(value)),
+})
+
+export const transformToSparseMode = ({
+  keyName,
+  elements,
+}: SparsePayloadInput): CreateArrayWithExpireDto => ({
+  keyName: toApiBuffer(keyName),
+  mode: SPARSE_MODE,
+  elements: elements.map((item) => ({
+    index: parseArrayIndex(item.index)!,
+    value: toApiBuffer(item.value),
+  })),
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,13 +1,23 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
-import { stringToBuffer } from 'uiSrc/utils'
-import { addKeyIntoList, addKeyStateSelector } from 'uiSrc/slices/browser/keys'
+import {
+  ARRAY_INDEX_MAX,
+  isValidArrayIndex,
+  parseArrayIndex,
+  stringToBuffer,
+} from 'uiSrc/utils'
+import {
+  addArrayKey,
+  addKeyIntoList,
+  addKeyStateSelector,
+} from 'uiSrc/slices/browser/keys'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
 import { useLoadData } from 'uiSrc/services/hooks'
 import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
+import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import {
   RiRadioGroupItemIndicator,
   RiRadioGroupItemRoot,
@@ -18,7 +28,7 @@ import { Col } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { useDatabaseEnvironment } from 'uiSrc/components/hooks/useDatabaseEnvironment'
-import { Environment } from 'apiClient'
+import { CreateArrayWithExpireDto, Environment } from 'apiClient'
 
 import LoadSampleDataset, {
   DEFAULT_SAMPLE_DATASET,
@@ -30,13 +40,46 @@ import LoadSampleDataset, {
   sampleDatasetLoadedNotification,
   sampleDatasetTtlFailedNotification,
 } from './LoadSampleDataset'
-import { POPULATE_LABEL, POPULATE_OPTIONS, PopulateMode } from './constants'
+import {
+  ArrayCreationMode,
+  CONTIGUOUS_MODE,
+  CREATION_MODE_OPTIONS,
+  DEFAULT_START_INDEX,
+  POPULATE_LABEL,
+  POPULATE_OPTIONS,
+  PopulateMode,
+} from './constants'
+import {
+  transformToContiguousMode,
+  transformToSparseMode,
+} from './AddKeyArray.transforms'
+import AddKeyArrayContiguous from './AddKeyArrayContiguous'
+import AddKeyArraySparse from './AddKeyArraySparse'
 import * as S from './AddKeyArray.styles'
 
-import { Props } from './AddKeyArray.types'
+import {
+  ContiguousValue,
+  INITIAL_SPARSE_ELEMENT,
+  Props,
+  SparseValue,
+} from './AddKeyArray.types'
+
+// Contiguous mode writes values to consecutive indexes, so the last one
+// (start + count - 1) must also stay within the u64 range.
+const isValidContiguousRange = (startIndex: string, count: number): boolean => {
+  const start = parseArrayIndex(startIndex)
+  if (start === null) return false
+  return BigInt(start) + BigInt(Math.max(count - 1, 0)) <= ARRAY_INDEX_MAX
+}
 
 const AddKeyArray = (props: Props) => {
-  const { keyTTL, onCancel, setKeyName, setKeyNameDisabled } = props
+  const {
+    keyName = '',
+    keyTTL,
+    onCancel,
+    setKeyName,
+    setKeyNameDisabled,
+  } = props
   const [populateMode, setPopulateMode] = useState<PopulateMode>(
     PopulateMode.Manual,
   )
@@ -44,6 +87,15 @@ const AddKeyArray = (props: Props) => {
   const [dataset, setDataset] = useState<SampleArrayDataset>(
     DEFAULT_SAMPLE_DATASET,
   )
+
+  const [mode, setMode] = useState<ArrayCreationMode>(CONTIGUOUS_MODE)
+  const [contiguous, setContiguous] = useState<ContiguousValue>({
+    startIndex: DEFAULT_START_INDEX,
+    values: [''],
+  })
+  const [sparse, setSparse] = useState<SparseValue>({
+    elements: [{ ...INITIAL_SPARSE_ELEMENT }],
+  })
 
   const { loading } = useAppSelector(addKeyStateSelector)
   const { id: instanceId } = useAppSelector(connectedInstanceSelector)
@@ -53,6 +105,14 @@ const AddKeyArray = (props: Props) => {
   const isProductionDatabase = environment === Environment.Production
 
   const dispatch = useAppDispatch()
+
+  // Mirror AddKeyList: values may stay empty strings — only the key name and
+  // the indexes gate submission.
+  const isManualFormValid =
+    keyName.length > 0 &&
+    (mode === CONTIGUOUS_MODE
+      ? isValidContiguousRange(contiguous.startIndex, contiguous.values.length)
+      : sparse.elements.every(({ index }) => isValidArrayIndex(index)))
 
   // The ref short-circuits synchronous double-clicks before React flushes the
   // state update; the state drives the button's disabled/loading.
@@ -133,9 +193,26 @@ const AddKeyArray = (props: Props) => {
     }
   }
 
+  const submitManualData = (): void => {
+    const data: CreateArrayWithExpireDto =
+      mode === CONTIGUOUS_MODE
+        ? transformToContiguousMode({
+            keyName,
+            startIndex: contiguous.startIndex,
+            values: contiguous.values,
+          })
+        : transformToSparseMode({ keyName, elements: sparse.elements })
+    if (keyTTL !== undefined && keyTTL !== null) {
+      data.expire = keyTTL
+    }
+    dispatch(addArrayKey(data, onCancel))
+  }
+
   const onClickAction = () => {
     if (isSampleMode) {
       submitSampleDataset()
+    } else if (isManualFormValid) {
+      submitManualData()
     }
   }
 
@@ -204,13 +281,28 @@ const AddKeyArray = (props: Props) => {
           )}
         </>
       ) : (
-        <Text
-          size="M"
-          color="secondary"
-          data-testid="add-key-array-placeholder"
-        >
-          Array creation options are coming soon.
-        </Text>
+        <>
+          <RiSelect
+            value={mode}
+            options={CREATION_MODE_OPTIONS}
+            onChange={(value) => setMode(value as ArrayCreationMode)}
+            data-testid="creation-mode-select"
+          />
+          <Spacer size="m" />
+          {mode === CONTIGUOUS_MODE ? (
+            <AddKeyArrayContiguous
+              disabled={loading}
+              value={contiguous}
+              onChange={setContiguous}
+            />
+          ) : (
+            <AddKeyArraySparse
+              disabled={loading}
+              value={sparse}
+              onChange={setSparse}
+            />
+          )}
+        </>
       )}
       <ActionFooter
         onCancel={() => onCancel(true)}
@@ -218,7 +310,9 @@ const AddKeyArray = (props: Props) => {
         actionText="Add Key"
         loading={loading || isSubmittingSampleDataset}
         disabled={
-          !isSampleMode || isSubmittingSampleDataset || isProductionDatabase
+          isSampleMode
+            ? isSubmittingSampleDataset || isProductionDatabase
+            : !isManualFormValid
         }
         actionTestId="add-key-array-btn"
       />

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
@@ -10,6 +10,27 @@ export interface PopulateOption {
   id: string
 }
 
+export interface IArraySparseElement {
+  id: number
+  index: string
+  value: string
+}
+
+export const INITIAL_SPARSE_ELEMENT: IArraySparseElement = {
+  id: 0,
+  index: '',
+  value: '',
+}
+
+export interface ContiguousValue {
+  startIndex: string
+  values: string[]
+}
+
+export interface SparseValue {
+  elements: IArraySparseElement[]
+}
+
 export interface Props {
   keyName: string
   keyTTL: Maybe<number>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.spec.tsx
@@ -1,78 +1,81 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
-import { ContiguousValue } from '../AddKeyArray.types'
 import AddKeyArrayContiguous from './AddKeyArrayContiguous'
-import { Props } from './AddKeyArrayContiguous.types'
+import { AddKeyArrayContiguousProps } from './AddKeyArrayContiguous.types'
 
-const INITIAL_VALUE: ContiguousValue = { startIndex: '0', values: [''] }
+const defaultProps: AddKeyArrayContiguousProps = {
+  value: { startIndex: '0', values: [''] },
+  onChange: jest.fn(),
+}
+
+const renderComponent = (propsOverride?: Partial<AddKeyArrayContiguousProps>) =>
+  render(<AddKeyArrayContiguous {...defaultProps} {...propsOverride} />)
 
 const valueFindingRegex = /^value-\d+$/
 
 describe('AddKeyArrayContiguous', () => {
-  // Controlled component: a small stateful harness mirrors the parent so edits
-  // round-trip through `value`, and the spy records every reported change.
-  const renderComponent = (propsOverride?: Partial<Props>) => {
-    const onChange = propsOverride?.onChange ?? jest.fn()
-    const Harness = () => {
-      const [value, setValue] = useState<ContiguousValue>(
-        propsOverride?.value ?? INITIAL_VALUE,
-      )
-      return (
-        <AddKeyArrayContiguous
-          disabled={propsOverride?.disabled}
-          value={value}
-          onChange={(next) => {
-            setValue(next)
-            onChange(next)
-          }}
-        />
-      )
-    }
-    return { onChange, ...render(<Harness />) }
-  }
-
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('should render with the default start index and a single value row', () => {
+  it('should render the provided start index and value row', () => {
     renderComponent()
 
     expect(screen.getByTestId('start-index')).toHaveValue('0')
     expect(screen.getByTestId(valueFindingRegex)).toBeInTheDocument()
   })
 
-  it('should keep only digits when typing into the start index input', () => {
-    renderComponent()
-
-    const startIndex = screen.getByTestId('start-index')
-    fireEvent.change(startIndex, { target: { value: '1a2b3c' } })
-
-    expect(startIndex).toHaveValue('123')
-  })
-
-  it('should allow adding and removing value rows', () => {
-    renderComponent()
-
-    fireEvent.click(screen.getByTestId('add-item'))
-    expect(screen.getAllByTestId(valueFindingRegex)).toHaveLength(2)
-
-    fireEvent.click(screen.getAllByTestId('remove-item')[1])
-    expect(screen.getAllByTestId(valueFindingRegex)).toHaveLength(1)
-  })
-
-  it('should report updated start index and values on change', () => {
-    const { onChange } = renderComponent()
+  it('should report the digit-stripped start index on change', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
 
     fireEvent.change(screen.getByTestId('start-index'), {
-      target: { value: '5' },
+      target: { value: '1a2b3c' },
     })
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      startIndex: '123',
+      values: [''],
+    })
+  })
+
+  it('should report a new empty row when a value is added', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
+
+    fireEvent.click(screen.getByTestId('add-item'))
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      startIndex: '0',
+      values: ['', ''],
+    })
+  })
+
+  it('should report the remaining rows when a value is removed', () => {
+    const onChange = jest.fn()
+    renderComponent({
+      value: { startIndex: '0', values: ['a', 'b'] },
+      onChange,
+    })
+
+    fireEvent.click(screen.getAllByTestId('remove-item')[1])
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      startIndex: '0',
+      values: ['a'],
+    })
+  })
+
+  it('should report an updated value on change', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
+
     fireEvent.change(screen.getByTestId('value-0'), {
       target: { value: 'first' },
     })
 
     expect(onChange).toHaveBeenLastCalledWith({
-      startIndex: '5',
+      startIndex: '0',
       values: ['first'],
     })
   })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.spec.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { ContiguousValue } from '../AddKeyArray.types'
+import AddKeyArrayContiguous from './AddKeyArrayContiguous'
+import { Props } from './AddKeyArrayContiguous.types'
+
+const INITIAL_VALUE: ContiguousValue = { startIndex: '0', values: [''] }
+
+const valueFindingRegex = /^value-\d+$/
+
+describe('AddKeyArrayContiguous', () => {
+  // Controlled component: a small stateful harness mirrors the parent so edits
+  // round-trip through `value`, and the spy records every reported change.
+  const renderComponent = (propsOverride?: Partial<Props>) => {
+    const onChange = propsOverride?.onChange ?? jest.fn()
+    const Harness = () => {
+      const [value, setValue] = useState<ContiguousValue>(
+        propsOverride?.value ?? INITIAL_VALUE,
+      )
+      return (
+        <AddKeyArrayContiguous
+          disabled={propsOverride?.disabled}
+          value={value}
+          onChange={(next) => {
+            setValue(next)
+            onChange(next)
+          }}
+        />
+      )
+    }
+    return { onChange, ...render(<Harness />) }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render with the default start index and a single value row', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('start-index')).toHaveValue('0')
+    expect(screen.getByTestId(valueFindingRegex)).toBeInTheDocument()
+  })
+
+  it('should keep only digits when typing into the start index input', () => {
+    renderComponent()
+
+    const startIndex = screen.getByTestId('start-index')
+    fireEvent.change(startIndex, { target: { value: '1a2b3c' } })
+
+    expect(startIndex).toHaveValue('123')
+  })
+
+  it('should allow adding and removing value rows', () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByTestId('add-item'))
+    expect(screen.getAllByTestId(valueFindingRegex)).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByTestId('remove-item')[1])
+    expect(screen.getAllByTestId(valueFindingRegex)).toHaveLength(1)
+  })
+
+  it('should report updated start index and values on change', () => {
+    const { onChange } = renderComponent()
+
+    fireEvent.change(screen.getByTestId('start-index'), {
+      target: { value: '5' },
+    })
+    fireEvent.change(screen.getByTestId('value-0'), {
+      target: { value: 'first' },
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      startIndex: '5',
+      values: ['first'],
+    })
+  })
+
+  it('should disable inputs when the disabled prop is set', () => {
+    renderComponent({ disabled: true })
+
+    expect(screen.getByTestId('start-index')).toBeDisabled()
+    expect(screen.getByTestId('value-0')).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
@@ -7,9 +7,9 @@ import { FormField } from 'uiSrc/components/base/forms/FormField'
 
 import { AddArrayFormConfig as config } from '../../constants/fields-config'
 import AddMultipleFields from '../../../add-multiple-fields'
-import { Props } from './AddKeyArrayContiguous.types'
+import { AddKeyArrayContiguousProps } from './AddKeyArrayContiguous.types'
 
-const AddKeyArrayContiguous = (props: Props) => {
+const AddKeyArrayContiguous = (props: AddKeyArrayContiguousProps) => {
   const { disabled, value, onChange } = props
   const { startIndex, values } = value
 
@@ -41,7 +41,6 @@ const AddKeyArrayContiguous = (props: Props) => {
     <>
       <FormField label={config.startIndex.label}>
         <TextInput
-          name={config.startIndex.name}
           id={config.startIndex.name}
           placeholder={config.startIndex.placeholder}
           value={startIndex}
@@ -59,8 +58,6 @@ const AddKeyArrayContiguous = (props: Props) => {
       >
         {(item, index) => (
           <TextInput
-            name={`value-${index}`}
-            id={`value-${index}`}
             placeholder={config.value.placeholder}
             value={item}
             disabled={disabled}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+
+import { validateListIndex } from 'uiSrc/utils'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Spacer } from 'uiSrc/components/base/layout'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+
+import { AddArrayFormConfig as config } from '../../constants/fields-config'
+import AddMultipleFields from '../../../add-multiple-fields'
+import { Props } from './AddKeyArrayContiguous.types'
+
+const AddKeyArrayContiguous = (props: Props) => {
+  const { disabled, value, onChange } = props
+  const { startIndex, values } = value
+
+  const setStartIndex = (next: string) => onChange({ startIndex: next, values })
+  const setValues = (next: string[]) => onChange({ startIndex, values: next })
+
+  const addValueField = () => {
+    setValues([...values, ''])
+  }
+
+  const onClickRemoveValue = (_item: string, index?: number) => {
+    if (values.length === 1) {
+      setValues([''])
+    } else {
+      setValues(values.filter((_el, i) => i !== index))
+    }
+  }
+
+  const isClearValueDisabled = (item: string) =>
+    values.length === 1 && !item.length
+
+  const handleValueChange = (next: string, index: number) => {
+    const newValues = [...values]
+    newValues[index] = next
+    setValues(newValues)
+  }
+
+  return (
+    <>
+      <FormField label={config.startIndex.label}>
+        <TextInput
+          name={config.startIndex.name}
+          id={config.startIndex.name}
+          placeholder={config.startIndex.placeholder}
+          value={startIndex}
+          disabled={disabled}
+          onChange={(next) => setStartIndex(validateListIndex(next))}
+          data-testid="start-index"
+        />
+      </FormField>
+      <Spacer size="m" />
+      <AddMultipleFields
+        items={values}
+        onClickRemove={onClickRemoveValue}
+        onClickAdd={addValueField}
+        isClearDisabled={isClearValueDisabled}
+      >
+        {(item, index) => (
+          <TextInput
+            name={`value-${index}`}
+            id={`value-${index}`}
+            placeholder={config.value.placeholder}
+            value={item}
+            disabled={disabled}
+            onChange={(next) => handleValueChange(next, index)}
+            data-testid={`value-${index}`}
+          />
+        )}
+      </AddMultipleFields>
+    </>
+  )
+}
+
+export default AddKeyArrayContiguous

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.types.ts
@@ -1,0 +1,7 @@
+import type { ContiguousValue } from '../AddKeyArray.types'
+
+export interface Props {
+  disabled?: boolean
+  value: ContiguousValue
+  onChange: (value: ContiguousValue) => void
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.types.ts
@@ -1,6 +1,6 @@
 import type { ContiguousValue } from '../AddKeyArray.types'
 
-export interface Props {
+export interface AddKeyArrayContiguousProps {
   disabled?: boolean
   value: ContiguousValue
   onChange: (value: ContiguousValue) => void

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/index.ts
@@ -1,4 +1,3 @@
 import AddKeyArrayContiguous from './AddKeyArrayContiguous'
 
 export default AddKeyArrayContiguous
-export type { Props } from './AddKeyArrayContiguous.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/index.ts
@@ -1,0 +1,4 @@
+import AddKeyArrayContiguous from './AddKeyArrayContiguous'
+
+export default AddKeyArrayContiguous
+export type { Props } from './AddKeyArrayContiguous.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.spec.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { SparseValue } from '../AddKeyArray.types'
+import AddKeyArraySparse from './AddKeyArraySparse'
+import { Props } from './AddKeyArraySparse.types'
+
+const INITIAL_VALUE: SparseValue = {
+  elements: [{ id: 0, index: '', value: '' }],
+}
+
+describe('AddKeyArraySparse', () => {
+  // Controlled component: a small stateful harness mirrors the parent so edits
+  // round-trip through `value`, and the spy records every reported change.
+  const renderComponent = (propsOverride?: Partial<Props>) => {
+    const onChange = propsOverride?.onChange ?? jest.fn()
+    const Harness = () => {
+      const [value, setValue] = useState<SparseValue>(
+        propsOverride?.value ?? INITIAL_VALUE,
+      )
+      return (
+        <AddKeyArraySparse
+          disabled={propsOverride?.disabled}
+          value={value}
+          onChange={(next) => {
+            setValue(next)
+            onChange(next)
+          }}
+        />
+      )
+    }
+    return { onChange, ...render(<Harness />) }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render with a single index/value row', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('sparse-index')).toBeInTheDocument()
+    expect(screen.getByTestId('sparse-value')).toBeInTheDocument()
+  })
+
+  it('should keep only digits when typing into the index input', () => {
+    renderComponent()
+
+    const sparseIndex = screen.getByTestId('sparse-index')
+    fireEvent.change(sparseIndex, { target: { value: 'abc12def' } })
+
+    expect(sparseIndex).toHaveValue('12')
+  })
+
+  it('should allow adding and removing element rows', () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByTestId('add-item'))
+    expect(screen.getAllByTestId('sparse-index')).toHaveLength(2)
+    expect(screen.getAllByTestId('sparse-value')).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByTestId('remove-item')[1])
+    expect(screen.getAllByTestId('sparse-index')).toHaveLength(1)
+  })
+
+  it('should report updated elements on change', () => {
+    const { onChange } = renderComponent()
+
+    fireEvent.change(screen.getByTestId('sparse-index'), {
+      target: { value: '42' },
+    })
+    fireEvent.change(screen.getByTestId('sparse-value'), {
+      target: { value: 'answer' },
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      elements: [{ id: 0, index: '42', value: 'answer' }],
+    })
+  })
+
+  it('should disable inputs when the disabled prop is set', () => {
+    renderComponent({ disabled: true })
+
+    expect(screen.getByTestId('sparse-index')).toBeDisabled()
+    expect(screen.getByTestId('sparse-value')).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.spec.tsx
@@ -1,86 +1,91 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
-import { SparseValue } from '../AddKeyArray.types'
 import AddKeyArraySparse from './AddKeyArraySparse'
-import { Props } from './AddKeyArraySparse.types'
+import { AddKeyArraySparseProps } from './AddKeyArraySparse.types'
 
-const INITIAL_VALUE: SparseValue = {
-  elements: [{ id: 0, index: '', value: '' }],
+const defaultProps: AddKeyArraySparseProps = {
+  value: { elements: [{ id: 0, index: '', value: '' }] },
+  onChange: jest.fn(),
 }
 
-describe('AddKeyArraySparse', () => {
-  // Controlled component: a small stateful harness mirrors the parent so edits
-  // round-trip through `value`, and the spy records every reported change.
-  const renderComponent = (propsOverride?: Partial<Props>) => {
-    const onChange = propsOverride?.onChange ?? jest.fn()
-    const Harness = () => {
-      const [value, setValue] = useState<SparseValue>(
-        propsOverride?.value ?? INITIAL_VALUE,
-      )
-      return (
-        <AddKeyArraySparse
-          disabled={propsOverride?.disabled}
-          value={value}
-          onChange={(next) => {
-            setValue(next)
-            onChange(next)
-          }}
-        />
-      )
-    }
-    return { onChange, ...render(<Harness />) }
-  }
+const renderComponent = (propsOverride?: Partial<AddKeyArraySparseProps>) =>
+  render(<AddKeyArraySparse {...defaultProps} {...propsOverride} />)
 
+describe('AddKeyArraySparse', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('should render with a single index/value row', () => {
+  it('should render a single index/value row', () => {
     renderComponent()
 
-    expect(screen.getByTestId('sparse-index')).toBeInTheDocument()
-    expect(screen.getByTestId('sparse-value')).toBeInTheDocument()
+    expect(screen.getByTestId('sparse-index-0')).toBeInTheDocument()
+    expect(screen.getByTestId('sparse-value-0')).toBeInTheDocument()
   })
 
-  it('should keep only digits when typing into the index input', () => {
-    renderComponent()
+  it('should report the digit-stripped index on change', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
 
-    const sparseIndex = screen.getByTestId('sparse-index')
-    fireEvent.change(sparseIndex, { target: { value: 'abc12def' } })
+    fireEvent.change(screen.getByTestId('sparse-index-0'), {
+      target: { value: 'abc12def' },
+    })
 
-    expect(sparseIndex).toHaveValue('12')
+    expect(onChange).toHaveBeenLastCalledWith({
+      elements: [{ id: 0, index: '12', value: '' }],
+    })
   })
 
-  it('should allow adding and removing element rows', () => {
-    renderComponent()
+  it('should report a new element when a row is added', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
 
     fireEvent.click(screen.getByTestId('add-item'))
-    expect(screen.getAllByTestId('sparse-index')).toHaveLength(2)
-    expect(screen.getAllByTestId('sparse-value')).toHaveLength(2)
 
-    fireEvent.click(screen.getAllByTestId('remove-item')[1])
-    expect(screen.getAllByTestId('sparse-index')).toHaveLength(1)
+    expect(onChange).toHaveBeenLastCalledWith({
+      elements: [
+        { id: 0, index: '', value: '' },
+        { id: 1, index: '', value: '' },
+      ],
+    })
   })
 
-  it('should report updated elements on change', () => {
-    const { onChange } = renderComponent()
-
-    fireEvent.change(screen.getByTestId('sparse-index'), {
-      target: { value: '42' },
+  it('should report the remaining elements when a row is removed', () => {
+    const onChange = jest.fn()
+    renderComponent({
+      value: {
+        elements: [
+          { id: 0, index: '0', value: 'a' },
+          { id: 1, index: '5', value: 'b' },
+        ],
+      },
+      onChange,
     })
-    fireEvent.change(screen.getByTestId('sparse-value'), {
+
+    fireEvent.click(screen.getAllByTestId('remove-item')[1])
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      elements: [{ id: 0, index: '0', value: 'a' }],
+    })
+  })
+
+  it('should report an updated value on change', () => {
+    const onChange = jest.fn()
+    renderComponent({ onChange })
+
+    fireEvent.change(screen.getByTestId('sparse-value-0'), {
       target: { value: 'answer' },
     })
 
     expect(onChange).toHaveBeenLastCalledWith({
-      elements: [{ id: 0, index: '42', value: 'answer' }],
+      elements: [{ id: 0, index: '', value: 'answer' }],
     })
   })
 
   it('should disable inputs when the disabled prop is set', () => {
     renderComponent({ disabled: true })
 
-    expect(screen.getByTestId('sparse-index')).toBeDisabled()
-    expect(screen.getByTestId('sparse-value')).toBeDisabled()
+    expect(screen.getByTestId('sparse-index-0')).toBeDisabled()
+    expect(screen.getByTestId('sparse-value-0')).toBeDisabled()
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.tsx
@@ -11,9 +11,9 @@ import {
   IArraySparseElement,
   INITIAL_SPARSE_ELEMENT,
 } from '../AddKeyArray.types'
-import { Props } from './AddKeyArraySparse.types'
+import { AddKeyArraySparseProps } from './AddKeyArraySparse.types'
 
-const AddKeyArraySparse = (props: Props) => {
+const AddKeyArraySparse = (props: AddKeyArraySparseProps) => {
   const { disabled, value, onChange } = props
   const { elements } = value
 
@@ -75,28 +75,24 @@ const AddKeyArraySparse = (props: Props) => {
           <FlexItem grow={1}>
             <FormField>
               <TextInput
-                name={`index-${item.id}`}
-                id={`index-${item.id}`}
                 placeholder={config.index.placeholder}
                 value={item.index}
                 disabled={disabled}
                 onChange={(next) =>
                   handleElementChange('index', item.id, validateListIndex(next))
                 }
-                data-testid="sparse-index"
+                data-testid={`sparse-index-${item.id}`}
               />
             </FormField>
           </FlexItem>
           <FlexItem grow={2}>
             <FormField>
               <TextInput
-                name={`elementValue-${item.id}`}
-                id={`elementValue-${item.id}`}
                 placeholder={config.value.placeholder}
                 value={item.value}
                 disabled={disabled}
                 onChange={(next) => handleElementChange('value', item.id, next)}
-                data-testid="sparse-value"
+                data-testid={`sparse-value-${item.id}`}
               />
             </FormField>
           </FlexItem>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+
+import { validateListIndex } from 'uiSrc/utils'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+
+import { AddArrayFormConfig as config } from '../../constants/fields-config'
+import AddMultipleFields from '../../../add-multiple-fields'
+import {
+  IArraySparseElement,
+  INITIAL_SPARSE_ELEMENT,
+} from '../AddKeyArray.types'
+import { Props } from './AddKeyArraySparse.types'
+
+const AddKeyArraySparse = (props: Props) => {
+  const { disabled, value, onChange } = props
+  const { elements } = value
+
+  const setElements = (next: IArraySparseElement[]) =>
+    onChange({ elements: next })
+
+  const addElementField = () => {
+    const lastElement = elements[elements.length - 1]
+    setElements([
+      ...elements,
+      {
+        ...INITIAL_SPARSE_ELEMENT,
+        id: lastElement.id + 1,
+      },
+    ])
+  }
+
+  const clearElementValues = (id: number) => {
+    setElements(
+      elements.map((item) =>
+        item.id === id ? { ...item, index: '', value: '' } : item,
+      ),
+    )
+  }
+
+  const onClickRemoveElement = ({ id }: IArraySparseElement) => {
+    if (elements.length === 1) {
+      clearElementValues(id)
+      return
+    }
+
+    setElements(elements.filter((item) => item.id !== id))
+  }
+
+  const isClearElementDisabled = (item: IArraySparseElement): boolean =>
+    elements.length === 1 && !(item.index.length || item.value.length)
+
+  const handleElementChange = (
+    formField: 'index' | 'value',
+    id: number,
+    next: string,
+  ) => {
+    setElements(
+      elements.map((item) =>
+        item.id === id ? { ...item, [formField]: next } : item,
+      ),
+    )
+  }
+
+  return (
+    <AddMultipleFields
+      items={elements}
+      isClearDisabled={isClearElementDisabled}
+      onClickRemove={onClickRemoveElement}
+      onClickAdd={addElementField}
+    >
+      {(item) => (
+        <Row align="center" gap="m">
+          <FlexItem grow={1}>
+            <FormField>
+              <TextInput
+                name={`index-${item.id}`}
+                id={`index-${item.id}`}
+                placeholder={config.index.placeholder}
+                value={item.index}
+                disabled={disabled}
+                onChange={(next) =>
+                  handleElementChange('index', item.id, validateListIndex(next))
+                }
+                data-testid="sparse-index"
+              />
+            </FormField>
+          </FlexItem>
+          <FlexItem grow={2}>
+            <FormField>
+              <TextInput
+                name={`elementValue-${item.id}`}
+                id={`elementValue-${item.id}`}
+                placeholder={config.value.placeholder}
+                value={item.value}
+                disabled={disabled}
+                onChange={(next) => handleElementChange('value', item.id, next)}
+                data-testid="sparse-value"
+              />
+            </FormField>
+          </FlexItem>
+        </Row>
+      )}
+    </AddMultipleFields>
+  )
+}
+
+export default AddKeyArraySparse

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.types.ts
@@ -1,0 +1,7 @@
+import type { SparseValue } from '../AddKeyArray.types'
+
+export interface Props {
+  disabled?: boolean
+  value: SparseValue
+  onChange: (value: SparseValue) => void
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/AddKeyArraySparse.types.ts
@@ -1,6 +1,6 @@
 import type { SparseValue } from '../AddKeyArray.types'
 
-export interface Props {
+export interface AddKeyArraySparseProps {
   disabled?: boolean
   value: SparseValue
   onChange: (value: SparseValue) => void

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/index.ts
@@ -1,0 +1,4 @@
+import AddKeyArraySparse from './AddKeyArraySparse'
+
+export default AddKeyArraySparse
+export type { Props } from './AddKeyArraySparse.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArraySparse/index.ts
@@ -1,4 +1,3 @@
 import AddKeyArraySparse from './AddKeyArraySparse'
 
 export default AddKeyArraySparse
-export type { Props } from './AddKeyArraySparse.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/constants.ts
@@ -1,4 +1,26 @@
+import { CreateArrayWithExpireDto } from 'apiClient'
+
 import type { PopulateOption } from './AddKeyArray.types'
+
+export type ArrayCreationMode = CreateArrayWithExpireDto['mode']
+
+export const CONTIGUOUS_MODE: ArrayCreationMode = 'contiguous'
+export const SPARSE_MODE: ArrayCreationMode = 'sparse'
+
+export const CREATION_MODE_OPTIONS = [
+  {
+    value: CONTIGUOUS_MODE,
+    inputDisplay: 'Contiguous (sequential indexes)',
+    label: 'Contiguous (sequential indexes)',
+  },
+  {
+    value: SPARSE_MODE,
+    inputDisplay: 'Sparse (explicit indexes)',
+    label: 'Sparse (explicit indexes)',
+  },
+]
+
+export const DEFAULT_START_INDEX = '0'
 
 export enum PopulateMode {
   Sample = 'sample',

--- a/redisinsight/ui/src/telemetry/telemetryUtils.ts
+++ b/redisinsight/ui/src/telemetry/telemetryUtils.ts
@@ -198,6 +198,12 @@ const getAdditionalAddedEventData = (endpoint: ApiEndpoints, data: any) => {
         length: data.elements?.length,
         TTL: data.expire || -1,
       }
+    case ApiEndpoints.ARRAY:
+      return {
+        keyType: KeyTypes.Array,
+        length: data.values?.length ?? data.elements?.length,
+        TTL: data.expire || -1,
+      }
     default:
       return {}
   }

--- a/redisinsight/ui/src/telemetry/tests/telemetryUtils.spec.ts
+++ b/redisinsight/ui/src/telemetry/tests/telemetryUtils.spec.ts
@@ -1,9 +1,11 @@
 import { RootState, store } from 'uiSrc/slices/store'
+import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
 import { TelemetryEvent } from '../events'
 import {
   getRedisModulesSummary,
   getFreeDbFlag,
   getJsonPathLevel,
+  getAdditionalAddedEventData,
 } from '../telemetryUtils'
 
 const DEFAULT_SUMMARY = Object.freeze({
@@ -199,5 +201,27 @@ describe('getJsonPathLevel', () => {
     expect(getJsonPathLevel(undefined)).toBe(0)
     // @ts-expect-error testing runtime failure
     expect(getJsonPathLevel({})).toBe(0)
+  })
+})
+
+describe('getAdditionalAddedEventData', () => {
+  it('includes array metadata for a contiguous create (values length + TTL)', () => {
+    expect(
+      getAdditionalAddedEventData(ApiEndpoints.ARRAY, {
+        values: ['a', 'b', 'c'],
+        expire: 3600,
+      }),
+    ).toEqual({ keyType: KeyTypes.Array, length: 3, TTL: 3600 })
+  })
+
+  it('includes array metadata for a sparse create (elements length, default TTL)', () => {
+    expect(
+      getAdditionalAddedEventData(ApiEndpoints.ARRAY, {
+        elements: [
+          { index: '0', value: 'a' },
+          { index: '5', value: 'b' },
+        ],
+      }),
+    ).toEqual({ keyType: KeyTypes.Array, length: 2, TTL: -1 })
   })
 })


### PR DESCRIPTION
# What

Final slice of the Add/Create array key vertical (RI-8218). Stacked on the RI-8285 PR — **retarget as predecessors merge**; only the last commit is this PR's diff.

- Creation-mode select in Manual mode: Contiguous (default) and Sparse.
- Contiguous: start-index input (default `0`) + ordered value rows → `ARSET`.
- Sparse: index/value paired rows → `ARMSET`.
- Index inputs accept digits only and submit the canonical form (matching the API's strict index validation); submit disabled until key name and all indexes are valid.

# Testing

- 22 `AddKeyArray` jest tests (both modes: rows add/remove, digit-stripping, validation gating, canonical-index submits, TTL)
- Manual: create contiguous and sparse keys against Redis 8.8.0+, verify with `ARGETRANGE`/`ARSCAN`; try invalid indexes ('007' is normalized client-side, out-of-range u64 disables submit)

## Manual testing screenshots

| Light | Dark |
|---|---|
| <img width="769" height="771" alt="image" src="https://github.com/user-attachments/assets/34e90109-bbb7-403f-8a40-691dcd865fda" /> | <img width="772" height="778" alt="image" src="https://github.com/user-attachments/assets/ce9afb41-f3e3-4b3c-bdf5-0f156a2811d9" /> |
| <img width="770" height="778" alt="image" src="https://github.com/user-attachments/assets/221f9156-cef5-4bb3-8041-cc408c50f395" /> | <img width="771" height="778" alt="image" src="https://github.com/user-attachments/assets/4ff400d9-d835-42ab-b5a3-f8ee161cab80" />|

---

<img width="752" height="318" alt="image" src="https://github.com/user-attachments/assets/f5375a23-7cf6-4b07-bed8-4d6390fc23db" />

Analytics event 

<img width="849" height="252" alt="image" src="https://github.com/user-attachments/assets/18a1a17a-563a-4f5c-899a-80f4c17d8d08" />


Closes #RI-8286



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New write path to Redis via `addArrayKey` with index validation and range checks; mistakes could create wrong array keys but are gated client-side and mirror existing add-key patterns.
> 
> **Overview**
> Replaces the manual **“coming soon”** placeholder in **Add Key → Array** with real creation flows, while **Load sample data** behavior stays the same.
> 
> In **Create manually**, users pick **Contiguous** (default) or **Sparse** via `creation-mode-select`. **Contiguous** uses a start index (default `0`) and repeatable value rows; **Sparse** uses paired index/value rows. Index fields strip non-digits and submit **canonical** indexes via `parseArrayIndex` in `AddKeyArray.transforms` before `addArrayKey` (`CreateArrayWithExpireDto`). Submit stays disabled until the key name is set and indexes validate—including blocking contiguous ranges that would exceed the u64 max.
> 
> Telemetry adds `ApiEndpoints.ARRAY` handling in `getAdditionalAddedEventData` (length from `values` or `elements`, TTL). Coverage expands across `AddKeyArray`, contiguous/sparse subcomponents, transforms, and telemetry tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 272ee4755953fc57c6671953ba39621293c5f37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->