### PR TITLE
build(desktop): bump Electron to 41.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
     "react-router-dom/react-router/path-to-regexp": "^1.9.0",
     "**/form-data": "^4.0.4",
     "@types/react": "18.2.1",
-    "@types/react-dom": "18.2.1",
-    "yauzl": "^3.3.1"
+    "@types/react-dom": "18.2.1"
   },
   "devDependencies": {
     "@aivenio/tsc-output-parser": "2.1.1",
@@ -173,7 +172,7 @@
     "csv-stringify": "^6.4.0",
     "deep-object-diff": "^1.1.9",
     "dotenv": "^16.4.5",
-    "electron": "^40.10.2",
+    "electron": "^41.7.2",
     "electron-builder": "26.14.0",
     "electron-builder-notarize": "^1.5.2",
     "electron-debug": "^3.2.0",

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -77,7 +77,7 @@
     "@types/json-bigint": "^1.0.4",
     "adm-zip": "^0.5.9",
     "axios": "^1.16.0",
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.10.1",
     "body-parser": "^1.20.3",
     "busboy": "^1.6.0",
     "class-transformer": "^0.5.1",

--- a/redisinsight/api/yarn.lock
+++ b/redisinsight/api/yarn.lock
@@ -3314,10 +3314,10 @@ bcrypt-pbkdf@^1.0.2:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@^12.8.0:
-  version "12.8.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.8.0.tgz#ec9ccd4a426a35f3b9355c147af6c92a6ddd6862"
-  integrity sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==
+better-sqlite3@^12.10.1:
+  version "12.10.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.10.1.tgz#1fedf77460210c83d5140fb700c81700964a1a24"
+  integrity sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
@@ -6776,9 +6776,9 @@ nock@^13.3.0:
     propagate "^2.0.0"
 
 node-abi@^3.3.0:
-  version "3.40.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.40.0.tgz#51d8ed44534f70ff1357dfbc3a89717b1ceac1b4"
-  integrity sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==
+  version "3.92.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.92.0.tgz#18e2214677499b8dda81ffcd095afc763d5a9802"
+  integrity sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==
   dependencies:
     semver "^7.3.5"
 

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -19,7 +19,7 @@
     "**/cpu-features": "file:./api/stubs/cpu-features"
   },
   "dependencies": {
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.10.1",
     "keytar": "^7.9.0",
     "tunnel-ssh": "^5.1.2"
   }

--- a/redisinsight/yarn.lock
+++ b/redisinsight/yarn.lock
@@ -21,10 +21,10 @@ bcrypt-pbkdf@^1.0.2:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@^12.8.0:
-  version "12.8.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.8.0.tgz#ec9ccd4a426a35f3b9355c147af6c92a6ddd6862"
-  integrity sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==
+better-sqlite3@^12.10.1:
+  version "12.10.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.10.1.tgz#1fedf77460210c83d5140fb700c81700964a1a24"
+  integrity sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
@@ -161,9 +161,9 @@ napi-build-utils@^1.0.1:
   integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
 node-abi@^3.3.0:
-  version "3.45.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.45.0.tgz#f568f163a3bfca5aacfce1fbeee1fa2cc98441f5"
-  integrity sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==
+  version "3.92.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.92.0.tgz#18e2214677499b8dda81ffcd095afc763d5a9802"
+  integrity sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==
   dependencies:
     semver "^7.3.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,6 +1191,11 @@
     uuid "^8.3.0"
     vfile "^4.2.0"
 
+"@electron-internal/extract-zip@^1.0.1":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz#debf68f415ed7a8416d568cd03cda98109c0eab4"
+  integrity sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==
+
 "@electron/asar@3.4.1", "@electron/asar@^3.3.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.4.1.tgz#4e9196a4b54fba18c56cd8d5cac67c5bdc588065"
@@ -1209,21 +1214,6 @@
     fs-extra "^9.0.1"
     minimist "^1.2.5"
 
-"@electron/get@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.3.tgz#fba552683d387aebd9f3fcadbcafc8e12ee4f960"
-  integrity sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==
-  dependencies:
-    debug "^4.1.1"
-    env-paths "^2.2.0"
-    fs-extra "^8.1.0"
-    got "^11.8.5"
-    progress "^2.0.3"
-    semver "^6.2.0"
-    sumchecker "^3.0.1"
-  optionalDependencies:
-    global-agent "^3.0.0"
-
 "@electron/get@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-3.1.0.tgz#22c5a0bd917ab201badeb77bc4ad18cba54cb4ec"
@@ -1238,6 +1228,20 @@
     sumchecker "^3.0.1"
   optionalDependencies:
     global-agent "^3.0.0"
+
+"@electron/get@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-5.0.0.tgz#3c7ec0e26480ce51a487d54c8a10233460531021"
+  integrity sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^3.0.0"
+    graceful-fs "^4.2.11"
+    progress "^2.0.3"
+    semver "^7.6.3"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    undici "^7.24.4"
 
 "@electron/notarize@2.3.2", "@electron/notarize@2.5.0":
   version "2.3.2"
@@ -4247,13 +4251,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yauzl@^2.9.1":
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
-  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
-  dependencies:
-    "@types/node" "*"
-
 "@typescript-eslint/eslint-plugin@7.16.1":
   version "7.16.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.1.tgz#f5f5da52db674b1f2cdb9d5f3644e5b2ec750465"
@@ -7194,14 +7191,14 @@ electron-updater@^6.6.2:
     semver "^7.6.3"
     tiny-typed-emitter "^2.1.0"
 
-electron@^40.10.2:
-  version "40.10.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-40.10.2.tgz#78d09d50ff3c24feebe98be9ccefb789de31ce89"
-  integrity sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==
+electron@^41.7.2:
+  version "41.7.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.7.2.tgz#5f8fb6c657b86b89b7e21d65b6cf07a7ff74d6fc"
+  integrity sha512-oYbZNimoMlAy6Fp/o5x2vTggptuPsIbnPKCb6jGf1PJStXH7Gkw0MUQrBliHmDqKLW7yeE+SPsvFNILVN0ORMQ==
   dependencies:
-    "@electron/get" "^2.0.0"
+    "@electron-internal/extract-zip" "^1.0.1"
+    "@electron/get" "^5.0.0"
     "@types/node" "^24.9.0"
-    extract-zip "^2.0.1"
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -7299,6 +7296,11 @@ env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+env-paths@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
+  integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
 
 envinfo@^7.7.3:
   version "7.8.1"
@@ -8098,17 +8100,6 @@ extend@^3.0.0, extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extract-zip@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
-  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
-  dependencies:
-    debug "^4.1.1"
-    get-stream "^5.1.0"
-    yauzl "^2.10.0"
-  optionalDependencies:
-    "@types/yauzl" "^2.9.1"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -12081,11 +12072,6 @@ pe-library@^0.4.1:
   resolved "https://registry.yarnpkg.com/pe-library/-/pe-library-0.4.1.tgz#e269be0340dcb13aa6949d743da7d658c3e2fbea"
   integrity sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-
 php-serialize@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/php-serialize/-/php-serialize-5.1.3.tgz#95b6e1d9195bd9959a180b2870cccd72ef3ee105"
@@ -15135,6 +15121,11 @@ undici@^6.25.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.26.0.tgz#333a35b7f519c48d2dc6aeb38e4e91d9274e0652"
   integrity sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==
 
+undici@^7.24.4:
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.27.2.tgz#f8fae968ee68377cfc61713d9cd152773716804f"
+  integrity sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==
+
 unherit@^1.0.4:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
@@ -16116,13 +16107,6 @@ yarn-deduplicate@^6.0.2:
     commander "^10.0.1"
     semver "^7.5.0"
     tslib "^2.5.0"
-
-yauzl@^2.10.0, yauzl@^3.3.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
-  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
-  dependencies:
-    pend "~1.2.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
# What

Bumps Electron from **40.10.2 → 41.7.2** and refreshes the native-module toolchain so the build still uses **prebuilt `better-sqlite3` binaries**. Resolves the **EOL** concern raised in #5991 - Electron 40 is approaching end-of-life on the [Electron support schedule](https://endoflife.date/electron), which also blocks downstream redistributors (e.g. NixOS packaging) from shipping up-to-date builds.

# Why **41** and not **42**

Electron 42 ships **ABI 146**. `better-sqlite3@12.10.1` fixed the *code* paths for Electron 42, but the WiseLibs release does **not** yet publish prebuilt `.node` assets for ABI 146 — only ABI 145 (Electron 41) and below. Targeting 42 today would silently force every dev install and CI job into a local C++ build (`node-gyp`), which is exactly what the prebuilt pipeline is here to avoid.

Electron 41 is the **highest version with verified prebuilt `better-sqlite3` coverage** for all our targets (macOS x64/arm64, Linux x64/arm64 glibc + musl, Windows x64). Once WiseLibs publishes the ABI 146 assets, the follow-up to 42 is a one-line bump.

# Dependency summary

| Package                 | From       | To         |
| ----------------------- | ---------- | ---------- |
| `electron`              | `^40.10.2` | `^41.7.2`  |
| `better-sqlite3`        | `^12.8.0`  | `^12.10.1` |
| `node-abi` (transitive) | `3.45.0`   | `3.92.0`   |

Removed: `resolutions.yauzl: ^3.3.1` from root `package.json` (obsolete after Electron 41 dropped `extract-zip`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Electron major bumps affect the desktop runtime and native module ABI; risk is moderated by staying on 41 for prebuilt better-sqlite3 and lockfile-only dependency churn.
> 
> **Overview**
> Moves the desktop stack from **Electron 40.10.2** to **41.7.2** and aligns **better-sqlite3** from **12.8.0** to **12.10.1** in the root, API, and `redisinsight` package manifests so native SQLite keeps working on the new Electron ABI.
> 
> Lockfiles pick up the Electron 41 download path: **@electron/get** v5, **@electron-internal/extract-zip**, and dropped **extract-zip** / **yauzl** / **@types/yauzl** entries. **node-abi** moves to **3.92.0** as a transitive dependency of **better-sqlite3**.
> 
> Root **package.json** removes the obsolete **`resolutions.yauzl`** pin that was only needed for the old Electron zip stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ad6848acc003121685bd1ed8ecb7c7144ad09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->