### PR TITLE
RI-8219: Add Array Browse (Redux slice + View tab + key-info count)

### DIFF
--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -81,9 +81,6 @@ enum ApiEndpoints {
   ARRAY_SCAN = 'array/scan',
   ARRAY_GET_LENGTH = 'array/get-length',
   ARRAY_GET_COUNT = 'array/get-count',
-  ARRAY_GET_NEXT_INDEX = 'array/get-next-index',
-  ARRAY_GET_ELEMENT = 'array/get-element',
-  ARRAY_GET_ELEMENTS = 'array/get-elements',
 
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -77,6 +77,14 @@ enum ApiEndpoints {
   VECTOR_SET_SIMILARITY_SEARCH = 'vector-set/similarity-search',
   VECTOR_SET_SIMILARITY_SEARCH_PREVIEW = 'vector-set/similarity-search/preview',
 
+  ARRAY_GET_RANGE = 'array/get-range',
+  ARRAY_SCAN = 'array/scan',
+  ARRAY_GET_LENGTH = 'array/get-length',
+  ARRAY_GET_COUNT = 'array/get-count',
+  ARRAY_GET_NEXT_INDEX = 'array/get-next-index',
+  ARRAY_GET_ELEMENT = 'array/get-element',
+  ARRAY_GET_ELEMENTS = 'array/get-elements',
+
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',
   STREAMS_ENTRIES_GET = 'streams/entries/get',

--- a/redisinsight/ui/src/constants/prop-types/keys.ts
+++ b/redisinsight/ui/src/constants/prop-types/keys.ts
@@ -10,6 +10,7 @@ export interface IKeyPropTypes {
   length: number
   quantType?: string
   vectorDim?: number
+  count?: number
 }
 
 export interface IFetchKeyArgs {

--- a/redisinsight/ui/src/constants/prop-types/keys.ts
+++ b/redisinsight/ui/src/constants/prop-types/keys.ts
@@ -10,7 +10,8 @@ export interface IKeyPropTypes {
   length: number
   quantType?: string
   vectorDim?: number
-  count?: number
+  // Decimal string — u64 ARCOUNT exceeds `Number.MAX_SAFE_INTEGER`.
+  count?: string
 }
 
 export interface IFetchKeyArgs {

--- a/redisinsight/ui/src/mocks/factories/browser/array/arrayElement.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/array/arrayElement.factory.ts
@@ -1,0 +1,51 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import { KeyTypes } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { IKeyPropTypes } from 'uiSrc/constants/prop-types/keys'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+/** Random shared array key buffer name (stable per import). */
+export const mockArrayKeyBuffer = stringToBuffer(
+  `arr:${faker.string.alphanumeric(10)}`,
+)
+
+/**
+ * `ArrayDataElement` factory. `index` follows the fishery sequence as a
+ * decimal string so consecutive `.build()` calls produce '0', '1', '2'… —
+ * pin specific positions (BigInt-as-string boundary, sparse gaps, etc.)
+ * via `.build({ index })` overrides. Defaults to an empty slot since most
+ * tests assert gap rendering; use `arrayElementWithValueFactory` when you
+ * need a populated value.
+ */
+export const arrayElementFactory = Factory.define<ArrayDataElement>(
+  ({ sequence }) => ({
+    index: String(sequence - 1),
+    value: null,
+  }),
+)
+
+/** Variant that fills the slot with a buffered random string. */
+export const arrayElementWithValueFactory = Factory.define<ArrayDataElement>(
+  ({ sequence }) => ({
+    index: String(sequence - 1),
+    value: stringToBuffer(faker.word.noun()) as unknown as RedisResponseBuffer,
+  }),
+)
+
+/**
+ * Selected-key info shape used by the key-details header when an Array key
+ * is open. Mirrors `GetArrayKeyInfoResponse`: `length` and `count` are
+ * decimal strings since u64 indexes exceed `Number.MAX_SAFE_INTEGER`.
+ * Returned as `Partial<IKeyPropTypes>` so tests only need to override the
+ * fields they assert on.
+ */
+export const selectedArrayKeyInfoFactory = Factory.define<
+  Partial<IKeyPropTypes>
+>(() => ({
+  type: KeyTypes.Array,
+  size: faker.number.int({ min: 1, max: 4096 }),
+  length: faker.number.int({ min: 1, max: 1000 }),
+  count: String(faker.number.int({ min: 0, max: 1000 })),
+}))

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
@@ -162,4 +162,48 @@ describe('KeyDetailsHeaderSizeLength', () => {
       'Vector dim: 0',
     )
   })
+
+  it('should render count when provided (Array key type)', () => {
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
+      type: KeyTypes.Array,
+      size: 1024,
+      length: 10,
+      count: 7,
+    })
+
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
+
+    expect(screen.getByTestId('key-count-text')).toHaveTextContent('Count: 7')
+  })
+
+  it('should not render count when not provided', () => {
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
+      type: KeyTypes.Array,
+      size: 1024,
+      length: 10,
+    })
+
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
+
+    expect(screen.queryByTestId('key-count-text')).not.toBeInTheDocument()
+  })
+
+  it('should render count when value is 0', () => {
+    mockSelectedKeyDataSelector.mockReturnValueOnce({
+      type: KeyTypes.Array,
+      size: 1024,
+      length: 10,
+      count: 0,
+    })
+
+    render(
+      <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
+    )
+
+    expect(screen.getByTestId('key-count-text')).toHaveTextContent('Count: 0')
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from 'uiSrc/utils/test-utils'
 import * as keysSlice from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
+import { selectedArrayKeyInfoFactory } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
 import { Props, KeyDetailsHeaderSizeLength } from './KeyDetailsHeaderSizeLength'
 
 let store: typeof mockedStore
@@ -164,12 +165,9 @@ describe('KeyDetailsHeaderSizeLength', () => {
   })
 
   it('should render count when provided (Array key type)', () => {
-    mockSelectedKeyDataSelector.mockReturnValueOnce({
-      type: KeyTypes.Array,
-      size: 1024,
-      length: 10,
-      count: '7',
-    })
+    mockSelectedKeyDataSelector.mockReturnValueOnce(
+      selectedArrayKeyInfoFactory.build({ count: '7' }),
+    )
 
     render(
       <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
@@ -179,11 +177,9 @@ describe('KeyDetailsHeaderSizeLength', () => {
   })
 
   it('should not render count when not provided', () => {
-    mockSelectedKeyDataSelector.mockReturnValueOnce({
-      type: KeyTypes.Array,
-      size: 1024,
-      length: 10,
-    })
+    mockSelectedKeyDataSelector.mockReturnValueOnce(
+      selectedArrayKeyInfoFactory.build({ count: undefined }),
+    )
 
     render(
       <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,
@@ -193,12 +189,9 @@ describe('KeyDetailsHeaderSizeLength', () => {
   })
 
   it('should render count when value is 0', () => {
-    mockSelectedKeyDataSelector.mockReturnValueOnce({
-      type: KeyTypes.Array,
-      size: 1024,
-      length: 10,
-      count: '0',
-    })
+    mockSelectedKeyDataSelector.mockReturnValueOnce(
+      selectedArrayKeyInfoFactory.build({ count: '0' }),
+    )
 
     render(
       <KeyDetailsHeaderSizeLength {...instance(mockedProps)} width={1920} />,

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.spec.tsx
@@ -168,7 +168,7 @@ describe('KeyDetailsHeaderSizeLength', () => {
       type: KeyTypes.Array,
       size: 1024,
       length: 10,
-      count: 7,
+      count: '7',
     })
 
     render(
@@ -197,7 +197,7 @@ describe('KeyDetailsHeaderSizeLength', () => {
       type: KeyTypes.Array,
       size: 1024,
       length: 10,
-      count: 0,
+      count: '0',
     })
 
     render(

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-size-length/KeyDetailsHeaderSizeLength.tsx
@@ -22,7 +22,7 @@ export interface Props {
 }
 
 const KeyDetailsHeaderSizeLength = ({ width }: Props) => {
-  const { type, size, length, quantType, vectorDim } =
+  const { type, size, length, quantType, vectorDim, count } =
     useAppSelector(selectedKeyDataSelector) ?? initialKeyInfo
 
   const isSizeTooLarge = size === -1
@@ -99,6 +99,18 @@ const KeyDetailsHeaderSizeLength = ({ width }: Props) => {
           >
             {width > MIDDLE_SCREEN_RESOLUTION ? 'Vector dim: ' : 'Dim: '}
             {vectorDim}
+          </Text>
+        </FlexItem>
+      )}
+      {count !== undefined && (
+        <FlexItem>
+          <Text
+            size="s"
+            className={styles.subtitleText}
+            data-testid="key-count-text"
+          >
+            {width > MIDDLE_SCREEN_RESOLUTION ? 'Count: ' : 'Cnt: '}
+            {count}
           </Text>
         </FlexItem>
       )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -30,6 +30,7 @@ jest.mock('./hooks', () => ({
     setShowEmpty: jest.fn(),
     runQuery: jest.fn(),
     resetQuery: jest.fn(),
+    isArrayKeyReady: true,
     elements: [],
     loading: false,
   }),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { instance, mock } from 'ts-mockito'
+import { render, screen } from 'uiSrc/utils/test-utils'
+
+import { ArrayDetails, Props } from './ArrayDetails'
+
+// Stub out the child components so this spec covers only the composition
+// surface — the children have their own focused specs.
+const stubChild = (testId: string) => () => {
+  const ReactLib = require('react')
+  return ReactLib.createElement('div', { 'data-testid': testId })
+}
+
+jest.mock('./array-details-table', () => ({
+  ArrayDetailsTable: stubChild('array-details-table-mock'),
+}))
+jest.mock('./array-range-form', () => ({
+  ArrayRangeForm: stubChild('array-range-form-mock'),
+}))
+jest.mock('uiSrc/pages/browser/modules', () => ({
+  KeyDetailsHeader: stubChild('key-details-header-mock'),
+}))
+jest.mock('./hooks', () => ({
+  useArrayRangeQuery: () => ({
+    start: '0',
+    end: '9',
+    showEmpty: true,
+    setStart: jest.fn(),
+    setEnd: jest.fn(),
+    setShowEmpty: jest.fn(),
+    runQuery: jest.fn(),
+    resetQuery: jest.fn(),
+    elements: [],
+    loading: false,
+  }),
+}))
+
+const mockedProps = mock<Props>()
+
+describe('ArrayDetails', () => {
+  it('renders the header, range form, and table', () => {
+    render(<ArrayDetails {...instance(mockedProps)} />)
+
+    expect(screen.getByTestId('array-details')).toBeInTheDocument()
+    expect(screen.getByTestId('key-details-header-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('array-range-form-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('array-details-table-mock')).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+export const Container = styled(Col)`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`
+
+export const DetailsBody = styled(Col)`
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`
+
+export const TableWrapper = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import { useAppSelector } from 'uiSrc/slices/hooks'
 
-import {
-  selectedKeyDataSelector,
-  selectedKeySelector,
-} from 'uiSrc/slices/browser/keys'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
@@ -17,7 +14,9 @@ import { ArrayRangeForm } from './array-range-form'
 import { useArrayRangeQuery } from './hooks'
 import * as S from './ArrayDetails.styles'
 
-export interface Props extends KeyDetailsHeaderProps {}
+export interface Props extends KeyDetailsHeaderProps {
+  keyProp: RedisResponseBuffer | null
+}
 
 /**
  * View / Browse vertical container for the array key type. Composes the
@@ -28,11 +27,13 @@ export interface Props extends KeyDetailsHeaderProps {}
  * docs/redis-array-type-initiative.md §6 Tasks 2,4-7).
  */
 const ArrayDetails = (props: Props) => {
+  const { keyProp } = props
   const { loading } = useAppSelector(selectedKeySelector)
-  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
-  const keyName = selectedKeyData?.name
-    ? bufferToString(selectedKeyData.name as RedisResponseBuffer)
-    : ''
+  // Render the form's CLI preview off `keyProp` rather than the cached
+  // `selectedKeyData?.name` so the displayed key matches the one the
+  // form will actually query — avoids a one-fetch lag while
+  // `fetchKeyInfo` populates the selected-key slice.
+  const keyName = keyProp ? bufferToString(keyProp) : ''
 
   const {
     start,
@@ -45,7 +46,7 @@ const ArrayDetails = (props: Props) => {
     resetQuery,
     elements,
     loading: rangeLoading,
-  } = useArrayRangeQuery()
+  } = useArrayRangeQuery(keyProp)
 
   return (
     <S.Container data-testid="array-details">

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -44,6 +44,7 @@ const ArrayDetails = (props: Props) => {
     setShowEmpty,
     runQuery,
     resetQuery,
+    isArrayKeyReady,
     elements,
     loading: rangeLoading,
   } = useArrayRangeQuery(keyProp)
@@ -62,6 +63,11 @@ const ArrayDetails = (props: Props) => {
         onToggleShowEmpty={setShowEmpty}
         onRun={runQuery}
         onReset={resetQuery}
+        // While the selected-key slice hasn't caught up with `keyProp`
+        // (or the resolved type isn't Array), disable manual actions —
+        // the hook also guards internally but this gives the user
+        // immediate feedback rather than a no-op click.
+        disabled={!isArrayKeyReady}
       />
       <S.DetailsBody>
         {!loading && (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { useAppSelector } from 'uiSrc/slices/hooks'
+
+import {
+  selectedKeyDataSelector,
+  selectedKeySelector,
+} from 'uiSrc/slices/browser/keys'
+import {
+  KeyDetailsHeader,
+  KeyDetailsHeaderProps,
+} from 'uiSrc/pages/browser/modules'
+import { bufferToString } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+import { ArrayDetailsTable } from './array-details-table'
+import { ArrayRangeForm } from './array-range-form'
+import { useArrayRangeQuery } from './hooks'
+import * as S from './ArrayDetails.styles'
+
+export interface Props extends KeyDetailsHeaderProps {}
+
+/**
+ * View / Browse vertical container for the array key type. Composes the
+ * standard `KeyDetailsHeader` (length + count surfaced via the array
+ * key-info strategy), a range/scan query form, and the virtualized
+ * result table. Editing, deleting, and the Aggregate / Search / Add
+ * tabs live in their own verticals (see
+ * docs/redis-array-type-initiative.md §6 Tasks 2,4-7).
+ */
+const ArrayDetails = (props: Props) => {
+  const { loading } = useAppSelector(selectedKeySelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+  const keyName = selectedKeyData?.name
+    ? bufferToString(selectedKeyData.name as RedisResponseBuffer)
+    : ''
+
+  const {
+    start,
+    end,
+    showEmpty,
+    setStart,
+    setEnd,
+    setShowEmpty,
+    runQuery,
+    resetQuery,
+    elements,
+    loading: rangeLoading,
+  } = useArrayRangeQuery()
+
+  return (
+    <S.Container data-testid="array-details">
+      <KeyDetailsHeader {...props} key="key-details-header" />
+      <ArrayRangeForm
+        keyName={keyName}
+        start={start}
+        end={end}
+        showEmpty={showEmpty}
+        loading={rangeLoading}
+        onChangeStart={setStart}
+        onChangeEnd={setEnd}
+        onToggleShowEmpty={setShowEmpty}
+        onRun={runQuery}
+        onReset={resetQuery}
+      />
+      <S.DetailsBody>
+        {!loading && (
+          <S.TableWrapper>
+            <ArrayDetailsTable elements={elements} loading={rangeLoading} />
+          </S.TableWrapper>
+        )}
+      </S.DetailsBody>
+    </S.Container>
+  )
+}
+
+export { ArrayDetails }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -47,6 +47,7 @@ const ArrayDetails = (props: Props) => {
     isArrayKeyReady,
     elements,
     loading: rangeLoading,
+    error: rangeError,
   } = useArrayRangeQuery(keyProp)
 
   return (
@@ -72,7 +73,11 @@ const ArrayDetails = (props: Props) => {
       <S.DetailsBody>
         {!loading && (
           <S.TableWrapper>
-            <ArrayDetailsTable elements={elements} loading={rangeLoading} />
+            <ArrayDetailsTable
+              elements={elements}
+              loading={rangeLoading}
+              error={rangeError}
+            />
           </S.TableWrapper>
         )}
       </S.DetailsBody>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { CellContext, ColumnDef } from 'uiSrc/components/base/layout/table'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+
+import { ArrayIndexCell } from './components/ArrayIndexCell'
+import { ArrayValueCell } from './components/ArrayValueCell'
+import { ArrayTableConfig } from './ArrayDetailsTable.types'
+
+export const TEST_ID = 'array-details-table'
+
+const indexColumn: ColumnDef<ArrayDataElement> = {
+  id: 'index',
+  accessorKey: 'index',
+  header: 'Index',
+  enableSorting: false,
+  enableResizing: true,
+  cell: ({ row }: CellContext<ArrayDataElement, unknown>) => (
+    <ArrayIndexCell index={row.original.index} />
+  ),
+}
+
+const valueColumn: ColumnDef<ArrayDataElement> = {
+  id: 'value',
+  accessorKey: 'value',
+  header: 'Value',
+  enableSorting: false,
+  enableResizing: true,
+  cell: ({ row, table }: CellContext<ArrayDataElement, unknown>) => {
+    const { compressor, viewFormat } = table.options.meta as ArrayTableConfig
+    return (
+      <ArrayValueCell
+        index={row.original.index}
+        value={row.original.value}
+        compressor={compressor}
+        viewFormat={viewFormat}
+      />
+    )
+  },
+}
+
+/**
+ * Static column definitions for the array table. Cells read shared config
+ * (`compressor`, `viewFormat`) from `table.options.meta` at render time,
+ * so this array itself doesn't need to be rebuilt when the config changes.
+ */
+export const arrayColumns: ColumnDef<ArrayDataElement>[] = [
+  indexColumn,
+  valueColumn,
+]
+
+const MIN_COLUMN_WIDTH = 160
+export const TABLE_MIN_WIDTH = `${arrayColumns.length * MIN_COLUMN_WIDTH}px`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+
+import { ArrayDetailsTable } from './ArrayDetailsTable'
+
+const renderComponent = (
+  elements: ArrayDataElement[],
+  loading: boolean = false,
+) => render(<ArrayDetailsTable elements={elements} loading={loading} />)
+
+describe('ArrayDetailsTable', () => {
+  it('renders an index cell for each element', () => {
+    renderComponent([
+      { index: '0', value: null },
+      { index: '7', value: null },
+      { index: '18446744073709551610', value: null },
+    ])
+
+    expect(screen.getByTestId('array-details-table-index-0')).toHaveTextContent(
+      '0',
+    )
+    expect(screen.getByTestId('array-details-table-index-7')).toHaveTextContent(
+      '7',
+    )
+    expect(
+      screen.getByTestId('array-details-table-index-18446744073709551610'),
+    ).toHaveTextContent('18446744073709551610')
+  })
+
+  it('shows "(empty)" for null values (gap-preserving range)', () => {
+    renderComponent([{ index: '3', value: null }])
+
+    expect(screen.getByTestId('array-details-table-empty-3')).toHaveTextContent(
+      '(empty)',
+    )
+  })
+
+  it('shows "(empty)" when value is undefined (JSON-dropped key edge case)', () => {
+    renderComponent([
+      { index: '4', value: undefined } as unknown as ArrayDataElement,
+    ])
+
+    expect(screen.getByTestId('array-details-table-empty-4')).toHaveTextContent(
+      '(empty)',
+    )
+  })
+
+  it('renders a value cell for populated rows', () => {
+    const value = {
+      type: 'Buffer',
+      data: [104, 105],
+    } as unknown as ArrayDataElement['value']
+    renderComponent([{ index: '1', value }])
+
+    expect(
+      screen.getByTestId('array-details-table-value-1'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('array-details-table-empty-1'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('smoke-renders without crashing when there are no elements', () => {
+    const { container } = renderComponent([])
+    expect(container).toBeTruthy()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { render, screen } from 'uiSrc/utils/test-utils'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+import {
+  arrayElementFactory,
+  arrayElementWithValueFactory,
+} from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
 
 import { ArrayDetailsTable } from './ArrayDetailsTable'
 
@@ -15,10 +19,12 @@ const renderComponent = (
 
 describe('ArrayDetailsTable', () => {
   it('renders an index cell for each element', () => {
+    // Pin the indexes the assertions look for — including the u64 boundary
+    // case (2^64 - 6) — instead of relying on the factory sequence.
     renderComponent([
-      { index: '0', value: null },
-      { index: '7', value: null },
-      { index: '18446744073709551610', value: null },
+      arrayElementFactory.build({ index: '0' }),
+      arrayElementFactory.build({ index: '7' }),
+      arrayElementFactory.build({ index: '18446744073709551610' }),
     ])
 
     expect(screen.getByTestId('array-details-table-index-0')).toHaveTextContent(
@@ -33,7 +39,7 @@ describe('ArrayDetailsTable', () => {
   })
 
   it('shows "(empty)" for null values (gap-preserving range)', () => {
-    renderComponent([{ index: '3', value: null }])
+    renderComponent([arrayElementFactory.build({ index: '3' })])
 
     expect(screen.getByTestId('array-details-table-empty-3')).toHaveTextContent(
       '(empty)',
@@ -42,7 +48,10 @@ describe('ArrayDetailsTable', () => {
 
   it('shows "(empty)" when value is undefined (JSON-dropped key edge case)', () => {
     renderComponent([
-      { index: '4', value: undefined } as unknown as ArrayDataElement,
+      arrayElementFactory.build({
+        index: '4',
+        value: undefined,
+      } as unknown as Partial<ArrayDataElement>),
     ])
 
     expect(screen.getByTestId('array-details-table-empty-4')).toHaveTextContent(
@@ -51,11 +60,7 @@ describe('ArrayDetailsTable', () => {
   })
 
   it('renders a value cell for populated rows', () => {
-    const value = {
-      type: 'Buffer',
-      data: [104, 105],
-    } as unknown as ArrayDataElement['value']
-    renderComponent([{ index: '1', value }])
+    renderComponent([arrayElementWithValueFactory.build({ index: '1' })])
 
     expect(
       screen.getByTestId('array-details-table-value-1'),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -7,7 +7,11 @@ import { ArrayDetailsTable } from './ArrayDetailsTable'
 const renderComponent = (
   elements: ArrayDataElement[],
   loading: boolean = false,
-) => render(<ArrayDetailsTable elements={elements} loading={loading} />)
+  error?: string,
+) =>
+  render(
+    <ArrayDetailsTable elements={elements} loading={loading} error={error} />,
+  )
 
 describe('ArrayDetailsTable', () => {
   it('renders an index cell for each element', () => {
@@ -64,5 +68,16 @@ describe('ArrayDetailsTable', () => {
   it('smoke-renders without crashing when there are no elements', () => {
     const { container } = renderComponent([])
     expect(container).toBeTruthy()
+  })
+
+  it('shows the error message in the empty state when the fetch failed', () => {
+    renderComponent([], false, 'Network unreachable')
+    expect(screen.getByText('Network unreachable')).toBeInTheDocument()
+  })
+
+  it('prefers the loading message over the error while a retry is in flight', () => {
+    renderComponent([], true, 'Network unreachable')
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.queryByText('Network unreachable')).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -80,4 +80,11 @@ describe('ArrayDetailsTable', () => {
     expect(screen.getByText('Loading…')).toBeInTheDocument()
     expect(screen.queryByText('Network unreachable')).not.toBeInTheDocument()
   })
+
+  it('falls back to the default empty message when error is an empty string', () => {
+    // The array slice resets `error` to `''` after a successful request, so
+    // a nullish-only fallback would leave the table blank on an empty range.
+    renderComponent([], false, '')
+    expect(screen.getByText('No elements in range')).toBeInTheDocument()
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+import { FlexItem } from 'uiSrc/components/base/layout/flex'
+import { Table } from 'uiSrc/components/base/layout/table'
+
+export const Container = styled(FlexItem)`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.core?.space.space200};
+`
+
+export const StyledTable = styled(Table)`
+  scrollbar-width: thin;
+  max-height: 100%;
+  box-shadow: 0px 0px 0px 1px
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+
+  [data-role='table-scroller'] {
+    scrollbar-width: thin;
+  }
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -1,0 +1,65 @@
+import React, { memo, useMemo } from 'react'
+import { useAppSelector } from 'uiSrc/slices/hooks'
+
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { KeyValueCompressor } from 'uiSrc/constants'
+import { Nullable } from 'uiSrc/utils'
+
+import {
+  ARRAY_TABLE_EMPTY_MESSAGE,
+  ARRAY_TABLE_LOADING_MESSAGE,
+} from './constants'
+import {
+  arrayColumns,
+  TABLE_MIN_WIDTH,
+  TEST_ID,
+} from './ArrayDetailsTable.config'
+import {
+  ArrayDetailsTableProps,
+  ArrayTableConfig,
+} from './ArrayDetailsTable.types'
+import * as S from './ArrayDetailsTable.styles'
+
+/**
+ * Renders the array slice's currently-loaded `elements` through the
+ * redis-ui `Table` (`@redis-ui/table`). Stays read-only in this vertical;
+ * row-level edit/delete affordances ship with the Modify / Delete
+ * verticals (see docs/redis-array-type-initiative.md §6 Tasks 6-7).
+ */
+const ArrayDetailsTable = memo(
+  ({ elements, loading }: ArrayDetailsTableProps) => {
+    const { compressor = null } = useAppSelector(
+      connectedInstanceSelector,
+    ) as unknown as { compressor: Nullable<KeyValueCompressor> }
+    const { viewFormat } = useAppSelector(selectedKeySelector)
+
+    // Pass shared per-cell config via the table's `meta` so the static
+    // column defs in `ArrayDetailsTable.config` don't need to close over
+    // them and can be rebuilt only when `compressor` / `viewFormat` change.
+    const meta = useMemo<ArrayTableConfig>(
+      () => ({ compressor, viewFormat }),
+      [compressor, viewFormat],
+    )
+
+    const emptyState = loading
+      ? ARRAY_TABLE_LOADING_MESSAGE
+      : ARRAY_TABLE_EMPTY_MESSAGE
+
+    return (
+      <S.Container data-testid={TEST_ID}>
+        <S.StyledTable
+          columns={arrayColumns}
+          data={elements}
+          meta={meta}
+          stripedRows
+          minWidth={TABLE_MIN_WIDTH}
+          emptyState={emptyState}
+          data-testid={`${TEST_ID}-table`}
+        />
+      </S.Container>
+    )
+  },
+)
+
+export { ArrayDetailsTable }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -28,7 +28,7 @@ import * as S from './ArrayDetailsTable.styles'
  * verticals (see docs/redis-array-type-initiative.md §6 Tasks 6-7).
  */
 const ArrayDetailsTable = memo(
-  ({ elements, loading }: ArrayDetailsTableProps) => {
+  ({ elements, loading, error }: ArrayDetailsTableProps) => {
     const { compressor = null } = useAppSelector(
       connectedInstanceSelector,
     ) as unknown as { compressor: Nullable<KeyValueCompressor> }
@@ -44,7 +44,7 @@ const ArrayDetailsTable = memo(
 
     const emptyState = loading
       ? ARRAY_TABLE_LOADING_MESSAGE
-      : ARRAY_TABLE_EMPTY_MESSAGE
+      : (error ?? ARRAY_TABLE_EMPTY_MESSAGE)
 
     return (
       <S.Container data-testid={TEST_ID}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -42,9 +42,13 @@ const ArrayDetailsTable = memo(
       [compressor, viewFormat],
     )
 
+    // Use `||` rather than `??` here: the array slice clears `error` to `''`
+    // after a successful request, and `''` is not nullish, so `??` would
+    // surface the empty string and the table would render with no text on
+    // an empty-but-successful range/scan.
     const emptyState = loading
       ? ARRAY_TABLE_LOADING_MESSAGE
-      : (error ?? ARRAY_TABLE_EMPTY_MESSAGE)
+      : error || ARRAY_TABLE_EMPTY_MESSAGE
 
     return (
       <S.Container data-testid={TEST_ID}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
@@ -1,0 +1,18 @@
+import { KeyValueCompressor, KeyValueFormat } from 'uiSrc/constants'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+import { Nullable } from 'uiSrc/utils'
+
+export interface ArrayDetailsTableProps {
+  elements: ArrayDataElement[]
+  loading: boolean
+}
+
+/**
+ * Shared cell config passed to the redis-ui table via `meta`. Lets the
+ * static column definitions read `compressor`/`viewFormat` at render time
+ * without each cell having to close over them via the parent component.
+ */
+export interface ArrayTableConfig {
+  compressor: Nullable<KeyValueCompressor>
+  viewFormat: KeyValueFormat
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
@@ -5,6 +5,10 @@ import { Nullable } from 'uiSrc/utils'
 export interface ArrayDetailsTableProps {
   elements: ArrayDataElement[]
   loading: boolean
+  /** Surfaces a failed ARGETRANGE/ARSCAN in the empty state so the table
+   *  doesn't misleadingly read "No elements in range" when the request
+   *  errored. The slice still also raises a toast via `addErrorNotification`. */
+  error?: string
 }
 
 /**

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
+import { Text } from 'uiSrc/components/base/text'
+import { formatLongName } from 'uiSrc/utils'
+
+interface ArrayIndexCellProps {
+  /** Decimal-string index (BigInt-as-string contract). */
+  index: string
+}
+
+const TEST_ID_PREFIX = 'array-details-table-index'
+
+/**
+ * Renders an array slot's index with a tooltip showing the full value —
+ * indexes can be up to 20 digits (2^64-1), which need truncation in the
+ * cell but should remain copyable from the tooltip.
+ */
+export const ArrayIndexCell = ({ index }: ArrayIndexCellProps) => (
+  <Text
+    component="div"
+    color="secondary"
+    style={{ maxWidth: '100%' }}
+    data-testid={`${TEST_ID_PREFIX}-${index}`}
+  >
+    <RiTooltip
+      title="Index"
+      position="bottom"
+      anchorClassName="truncateText"
+      content={formatLongName(index)}
+    >
+      <span className="truncateText">{index}</span>
+    </RiTooltip>
+  </Text>
+)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
@@ -4,10 +4,7 @@ import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
 import { Text } from 'uiSrc/components/base/text'
 import { formatLongName } from 'uiSrc/utils'
 
-interface ArrayIndexCellProps {
-  /** Decimal-string index (BigInt-as-string contract). */
-  index: string
-}
+import { ArrayIndexCellProps } from './ArrayIndexCell.types'
 
 const TEST_ID_PREFIX = 'array-details-table-index'
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.types.ts
@@ -1,0 +1,4 @@
+export interface ArrayIndexCellProps {
+  /** Decimal-string index (BigInt-as-string contract). */
+  index: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+
+import { Text } from 'uiSrc/components/base/text'
+import {
+  KeyValueCompressor,
+  KeyValueFormat,
+  TEXT_FAILED_CONVENT_FORMATTER,
+} from 'uiSrc/constants'
+import { createTooltipContent, formattingBuffer, Nullable } from 'uiSrc/utils'
+import { decompressingBuffer } from 'uiSrc/utils/decompressors'
+import { FormattedValue } from 'uiSrc/pages/browser/modules/key-details/shared'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+
+interface ArrayValueCellProps {
+  index: string
+  value: ArrayDataElement['value']
+  compressor: Nullable<KeyValueCompressor>
+  viewFormat: KeyValueFormat
+}
+
+const TEST_ID_PREFIX = 'array-details-table'
+
+/**
+ * Renders a populated array slot's value through the standard buffer →
+ * decompress → format pipeline. For empty slots (null from ARGETRANGE,
+ * or an absent `value` field from a serialization edge case) renders a
+ * muted "(empty)" marker instead of running it through the formatter
+ * chain.
+ */
+export const ArrayValueCell = ({
+  index,
+  value,
+  compressor,
+  viewFormat,
+}: ArrayValueCellProps) => {
+  // Treat null and undefined identically — `JSON.stringify` drops keys
+  // whose values are undefined, so an undefined `value` here means the
+  // slot arrived without a buffer payload.
+  if (value == null) {
+    return (
+      <Text color="subdued" data-testid={`${TEST_ID_PREFIX}-empty-${index}`}>
+        (empty)
+      </Text>
+    )
+  }
+
+  // Values flow through the API in `encoding=buffer` mode, so we narrow
+  // RedisString to RedisResponseBuffer at the rendering boundary.
+  const buffer = value as RedisResponseBuffer
+  const { value: decompressed } = decompressingBuffer(buffer, compressor)
+  const decompressedBuffer = decompressed as RedisResponseBuffer
+  const { value: formatted, isValid } = formattingBuffer(
+    decompressedBuffer,
+    viewFormat,
+    { expanded: false },
+  )
+  const tooltipContent = createTooltipContent(
+    formatted,
+    decompressedBuffer,
+    viewFormat,
+  )
+
+  return (
+    <div
+      className="innerCellAsCell"
+      data-testid={`${TEST_ID_PREFIX}-value-${index}`}
+    >
+      <FormattedValue
+        value={formatted}
+        expanded={false}
+        title={isValid ? 'Value' : TEXT_FAILED_CONVENT_FORMATTER(viewFormat)}
+        tooltipContent={tooltipContent}
+        position="bottom"
+      />
+    </div>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -1,23 +1,13 @@
 import React from 'react'
 
 import { Text } from 'uiSrc/components/base/text'
-import {
-  KeyValueCompressor,
-  KeyValueFormat,
-  TEXT_FAILED_CONVENT_FORMATTER,
-} from 'uiSrc/constants'
-import { createTooltipContent, formattingBuffer, Nullable } from 'uiSrc/utils'
+import { TEXT_FAILED_CONVENT_FORMATTER } from 'uiSrc/constants'
+import { createTooltipContent, formattingBuffer } from 'uiSrc/utils'
 import { decompressingBuffer } from 'uiSrc/utils/decompressors'
 import { FormattedValue } from 'uiSrc/pages/browser/modules/key-details/shared'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 
-interface ArrayValueCellProps {
-  index: string
-  value: ArrayDataElement['value']
-  compressor: Nullable<KeyValueCompressor>
-  viewFormat: KeyValueFormat
-}
+import { ArrayValueCellProps } from './ArrayValueCell.types'
 
 const TEST_ID_PREFIX = 'array-details-table'
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.types.ts
@@ -1,0 +1,10 @@
+import { KeyValueCompressor, KeyValueFormat } from 'uiSrc/constants'
+import { Nullable } from 'uiSrc/utils'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+
+export interface ArrayValueCellProps {
+  index: string
+  value: ArrayDataElement['value']
+  compressor: Nullable<KeyValueCompressor>
+  viewFormat: KeyValueFormat
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/index.ts
@@ -1,0 +1,2 @@
+export { ArrayIndexCell } from './ArrayIndexCell'
+export { ArrayValueCell } from './ArrayValueCell'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -1,0 +1,2 @@
+export const ARRAY_TABLE_EMPTY_MESSAGE = 'No elements in range'
+export const ARRAY_TABLE_LOADING_MESSAGE = 'Loading…'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/index.ts
@@ -1,0 +1,2 @@
+export { ArrayDetailsTable } from './ArrayDetailsTable'
+export type { ArrayDetailsTableProps } from './ArrayDetailsTable.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
@@ -1,0 +1,14 @@
+export const ARRAY_RANGE_FORM_TEST_ID = 'array-range-form'
+
+export const PREVIEW_TOGGLE_LABEL = 'Show preview'
+export const PREVIEW_TOGGLE_ARIA_LABEL = 'Toggle command preview'
+export const PREVIEW_TOGGLE_SHOW_TOOLTIP =
+  'Show the Redis command that will run'
+export const PREVIEW_TOGGLE_HIDE_TOOLTIP = 'Hide the command preview'
+
+export const RUN_BUTTON_LABEL = 'Run'
+export const RESET_TOOLTIP = 'Reset to defaults'
+export const INVALID_INDEX_MESSAGE =
+  'Index must be a valid 64-bit unsigned integer'
+export const INVALID_ORDER_MESSAGE =
+  'End must be greater than or equal to start'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
@@ -12,3 +12,13 @@ export const INVALID_INDEX_MESSAGE =
   'Index must be a valid 64-bit unsigned integer'
 export const INVALID_ORDER_MESSAGE =
   'End must be greater than or equal to start'
+
+/**
+ * Mirror of the backend's `ARRAY_RANGE_MAX_ELEMENTS` cap used by
+ * `ArrayService.assertValidRange` (a span greater than this is rejected
+ * with a 400). Kept in BigInt to compose with the BigInt index math the
+ * form already does without any precision-losing Number conversions.
+ */
+export const ARRAY_RANGE_MAX_SPAN = 1_000_000n
+export const INVALID_RANGE_TOO_LARGE_MESSAGE =
+  'Range too large — request at most 1,000,000 indexes per query'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.constants.ts
@@ -10,8 +10,6 @@ export const RUN_BUTTON_LABEL = 'Run'
 export const RESET_TOOLTIP = 'Reset to defaults'
 export const INVALID_INDEX_MESSAGE =
   'Index must be a valid 64-bit unsigned integer'
-export const INVALID_ORDER_MESSAGE =
-  'End must be greater than or equal to start'
 
 /**
  * Mirror of the backend's `ARRAY_RANGE_MAX_ELEMENTS` cap used by

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -89,6 +89,17 @@ describe('ArrayRangeForm', () => {
     expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
   })
 
+  it('disables Run and Reset when the disabled prop is set', () => {
+    // Container passes disabled=true while the selected-key slice has
+    // not confirmed the new key is an array, so manual clicks during a
+    // key switch can't dispatch ARGETRANGE/ARSCAN at a non-array key.
+    const onReset = jest.fn()
+    renderComponent({ onReset, disabled: true })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+    expect(screen.getByTestId('array-range-form-reset')).toBeDisabled()
+  })
+
   it('quotes key names containing whitespace in the command preview', () => {
     renderComponent({ keyName: 'a b' })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -60,10 +60,39 @@ describe('ArrayRangeForm', () => {
     expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
   })
 
-  it('disables Run when end < start', () => {
+  it.each(['007', ' 7 ', '7.0', '1e3'])(
+    'disables Run for non-canonical index input %p (matches backend @IsArrayIndex)',
+    (input) => {
+      renderComponent({ start: input })
+
+      expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+    },
+  )
+
+  it('disables Run when end < start (backend rejects reversed ranges)', () => {
     renderComponent({ start: '500', end: '100' })
 
     expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('quotes key names containing whitespace in the command preview', () => {
+    renderComponent({ keyName: 'a b' })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      /ARGETRANGE\s+"a b"\s+0\s+9/,
+    )
+  })
+
+  it('escapes embedded quotes/backslashes in keys for the command preview', () => {
+    renderComponent({ keyName: 'a"b\\c' })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      /ARGETRANGE\s+"a\\"b\\\\c"\s+0\s+9/,
+    )
   })
 
   it('calls onRun when Run is clicked with a valid range', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -75,6 +75,20 @@ describe('ArrayRangeForm', () => {
     expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
   })
 
+  it('disables Run when the span exceeds the backend cap (1,000,000)', () => {
+    // span = end - start + 1 = 1_000_001, one past the cap
+    renderComponent({ start: '0', end: '1000000' })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('allows Run when the span equals the backend cap (1,000,000)', () => {
+    // span = end - start + 1 = 1_000_000, exactly at the cap
+    renderComponent({ start: '0', end: '999999' })
+
+    expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
+  })
+
   it('quotes key names containing whitespace in the command preview', () => {
     renderComponent({ keyName: 'a b' })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { ArrayRangeForm } from './ArrayRangeForm'
+import { ArrayRangeFormProps } from './ArrayRangeForm.types'
+
+const defaultProps: ArrayRangeFormProps = {
+  start: '0',
+  end: '9',
+  showEmpty: true,
+  loading: false,
+  onChangeStart: jest.fn(),
+  onChangeEnd: jest.fn(),
+  onToggleShowEmpty: jest.fn(),
+  onRun: jest.fn(),
+}
+
+const renderComponent = (props: Partial<ArrayRangeFormProps> = {}) =>
+  render(<ArrayRangeForm {...defaultProps} {...props} />)
+
+const PREVIEW_TEXT_TESTID = 'array-range-form-command-preview-text'
+const PREVIEW_TOGGLE_TESTID = 'array-range-form-preview-toggle'
+
+describe('ArrayRangeForm', () => {
+  it('hides the command preview by default', () => {
+    renderComponent()
+
+    expect(screen.queryByTestId(PREVIEW_TEXT_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('reveals the ARGETRANGE preview when the toggle is pressed (showEmpty=true)', () => {
+    renderComponent({ showEmpty: true })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      /ARGETRANGE\s+\S+\s+0\s+9/,
+    )
+  })
+
+  it('reveals the ARSCAN preview when the toggle is pressed (showEmpty=false)', () => {
+    renderComponent({ showEmpty: false })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      /ARSCAN\s+\S+\s+0\s+9/,
+    )
+  })
+
+  it('disables Run while loading', () => {
+    renderComponent({ loading: true })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('disables Run when start index is not a valid BigInt-string', () => {
+    renderComponent({ start: '-1' })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('disables Run when end < start', () => {
+    renderComponent({ start: '500', end: '100' })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('calls onRun when Run is clicked with a valid range', () => {
+    const onRun = jest.fn()
+    renderComponent({ onRun })
+
+    fireEvent.click(screen.getByTestId('array-range-form-run'))
+    expect(onRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the reset button only when onReset is provided', () => {
+    const { rerender } = renderComponent()
+    expect(
+      screen.queryByTestId('array-range-form-reset'),
+    ).not.toBeInTheDocument()
+
+    const onReset = jest.fn()
+    rerender(<ArrayRangeForm {...defaultProps} onReset={onReset} />)
+
+    fireEvent.click(screen.getByTestId('array-range-form-reset'))
+    expect(onReset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -107,15 +107,19 @@ describe('ArrayRangeForm', () => {
     expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
   })
 
-  it('disables Run and Reset when the disabled prop is set', () => {
+  it('disables Run, Reset, inputs and checkbox when the disabled prop is set', () => {
     // Container passes disabled=true while the selected-key slice has
-    // not confirmed the new key is an array, so manual clicks during a
-    // key switch can't dispatch ARGETRANGE/ARSCAN at a non-array key.
+    // not confirmed the new key is an array. Inputs/checkbox are also
+    // disabled so the auto-fetch effect can't pick up half-typed or
+    // over-cap drafts that bypass the form's rangeInvalid guard.
     const onReset = jest.fn()
     renderComponent({ onReset, disabled: true })
 
     expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
     expect(screen.getByTestId('array-range-form-reset')).toBeDisabled()
+    expect(screen.getByTestId('array-range-form-start')).toBeDisabled()
+    expect(screen.getByTestId('array-range-form-end')).toBeDisabled()
+    expect(screen.getByTestId('array-range-form-show-empty')).toBeDisabled()
   })
 
   it('quotes key names containing whitespace in the command preview', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -96,6 +96,14 @@ describe('ArrayRangeForm', () => {
     expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
   })
 
+  it('allows Run for an over-cap span when ARSCAN is selected (showEmpty=false)', () => {
+    // ARSCAN has no span cap on the backend — sparse arrays are routinely
+    // browsed with ranges far larger than 1M; LIMIT is the backpressure.
+    renderComponent({ start: '0', end: '10000000', showEmpty: false })
+
+    expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
+  })
+
   it('disables Run and Reset when the disabled prop is set', () => {
     // Container passes disabled=true while the selected-key slice has
     // not confirmed the new key is an array, so manual clicks during a

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -69,15 +69,22 @@ describe('ArrayRangeForm', () => {
     },
   )
 
-  it('disables Run when end < start (backend rejects reversed ranges)', () => {
+  it('allows Run when end < start (backend returns reverse-order results)', () => {
     renderComponent({ start: '500', end: '100' })
 
-    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+    expect(screen.getByTestId('array-range-form-run')).not.toBeDisabled()
   })
 
   it('disables Run when the span exceeds the backend cap (1,000,000)', () => {
     // span = end - start + 1 = 1_000_001, one past the cap
     renderComponent({ start: '0', end: '1000000' })
+
+    expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
+  })
+
+  it('disables Run when a reversed range exceeds the backend cap', () => {
+    // span = |end - start| + 1 = 1_000_001, one past the cap
+    renderComponent({ start: '1000000', end: '0' })
 
     expect(screen.getByTestId('array-range-form-run')).toBeDisabled()
   })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.spec.tsx
@@ -38,13 +38,16 @@ describe('ArrayRangeForm', () => {
     )
   })
 
-  it('reveals the ARSCAN preview when the toggle is pressed (showEmpty=false)', () => {
+  it('reveals the ARSCAN preview with the matching LIMIT when toggled (showEmpty=false)', () => {
+    // The preview must mirror what `scanArrayRange` actually sends — the
+    // slice always pins LIMIT to DEFAULT_SCAN_LIMIT — so copying the
+    // preview into CLI/Workbench can't issue an unbounded ARSCAN.
     renderComponent({ showEmpty: false })
 
     fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
 
     expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
-      /ARSCAN\s+\S+\s+0\s+9/,
+      /ARSCAN\s+\S+\s+0\s+9\s+LIMIT\s+1000000/,
     )
   })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.styles.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components'
+import { ToggleButton } from 'uiSrc/components/base/forms/buttons'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+
+/**
+ * Height of the action row, sized to fit the expanded `CommandPreview` bar
+ * so toggling the preview on/off doesn't reflow the surrounding layout.
+ * Mirrors `SimilaritySearchForm`'s ACTION_ROW_HEIGHT.
+ */
+const ACTION_ROW_HEIGHT = '40px'
+
+/**
+ * Height of a TextInput in the Redis UI default size. The inputs row uses
+ * `align="end"` so labels stay anchored to the top — this box matches the
+ * input element's height so its content (the checkbox) sits at the input's
+ * vertical midline rather than dropping to its baseline.
+ */
+const INPUT_HEIGHT = '36px'
+
+export const FormContainer = styled(Col)`
+  width: 100%;
+  padding: ${({ theme }) => theme.core.space.space150};
+  background: ${({ theme }) => theme.semantic.color.background.neutral300};
+  border-bottom: 1px solid
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
+export const ActionRow = styled(Row)`
+  min-height: ${ACTION_ROW_HEIGHT};
+`
+
+export const InputAlignedBox = styled.div`
+  display: flex;
+  align-items: center;
+  height: ${INPUT_HEIGHT};
+`
+
+export const PreviewToggleButton = styled(ToggleButton)`
+  ${({ theme, pressed }) =>
+    !pressed && `border-color: ${theme.semantic.color.border.neutral600};`}
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.styles.ts
@@ -29,9 +29,11 @@ export const ActionRow = styled(Row)`
   min-height: ${ACTION_ROW_HEIGHT};
 `
 
-export const InputAlignedBox = styled.div`
-  display: flex;
-  align-items: center;
+// `Row` (`FlexGroup direction="row"`) supplies the flex container; only
+// the fixed height needs to live in the styles file so the checkbox lines
+// up with the adjacent TextInput's vertical midline. The consuming JSX
+// passes `align="center"` as a prop rather than hardcoding it here.
+export const InputAlignedBox = styled(Row)`
   height: ${INPUT_HEIGHT};
 `
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -8,7 +8,7 @@ import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { Text } from 'uiSrc/components/base/text'
-import { isValidArrayIndex } from 'uiSrc/utils/arrayIndex'
+import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 
 import { CommandPreview } from '../command-preview'
 import {
@@ -24,6 +24,16 @@ import {
 } from './ArrayRangeForm.constants'
 import { ArrayRangeFormProps } from './ArrayRangeForm.types'
 import * as S from './ArrayRangeForm.styles'
+
+// Wraps a Redis argument that may contain whitespace or quotes so the
+// preview text stays runnable when copied into CLI / Workbench. Mirrors
+// the same escaping rules the redis-cli parser applies to double-quoted
+// strings: backslash and double-quote get backslash-escaped.
+const quoteRedisArgument = (value: string): string => {
+  if (value.length === 0) return '""'
+  if (!/[\s"\\]/.test(value)) return value
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
 
 /**
  * Range/scan query form for the array View tab. Lays out inputs above a
@@ -49,8 +59,14 @@ export const ArrayRangeForm = ({
 }: ArrayRangeFormProps) => {
   const [previewVisible, setPreviewVisible] = useState(false)
 
-  const startInvalid = !isValidArrayIndex(start)
-  const endInvalid = !isValidArrayIndex(end)
+  // Match the backend's @IsArrayIndex validator exactly: accept only
+  // canonical decimal strings (no leading zeros, no whitespace, etc.).
+  // Loose-acceptance values like "007" or " 7 " would pass `parseArrayIndex`
+  // but be rejected with a 400 once the request reaches the API.
+  const startInvalid = parseArrayIndex(start) !== start
+  const endInvalid = parseArrayIndex(end) !== end
+  // Reversed ranges (start > end) are rejected by the backend (matches
+  // every Redis range command). Surface the constraint inline.
   const orderInvalid =
     !startInvalid && !endInvalid && BigInt(start) > BigInt(end)
   const rangeInvalid = startInvalid || endInvalid || orderInvalid
@@ -65,7 +81,9 @@ export const ArrayRangeForm = ({
   const command = useMemo(() => {
     // Always surface the command verb so the preview is meaningful even
     // before a key is selected; substitute a placeholder for the key.
-    const name = keyName || '<key>'
+    // Quote the key so binary-unsafe names (whitespace, quotes) stay
+    // runnable when copied into CLI / Workbench.
+    const name = keyName ? quoteRedisArgument(keyName) : '<key>'
     const verb = showEmpty ? 'ARGETRANGE' : 'ARSCAN'
     return `${verb} ${name} ${start} ${end}`
   }, [keyName, start, end, showEmpty])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -58,6 +58,7 @@ export const ArrayRangeForm = ({
   onToggleShowEmpty,
   onRun,
   onReset,
+  disabled = false,
 }: ArrayRangeFormProps) => {
   const [previewVisible, setPreviewVisible] = useState(false)
 
@@ -167,7 +168,7 @@ export const ArrayRangeForm = ({
                 size="M"
                 icon={ResetIcon}
                 onClick={onReset}
-                disabled={loading}
+                disabled={loading || disabled}
                 aria-label="Reset array range form"
                 data-testid={`${TEST_ID}-reset`}
               />
@@ -177,7 +178,7 @@ export const ArrayRangeForm = ({
         <FlexItem grow={false}>
           <PrimaryButton
             onClick={() => onRun()}
-            disabled={rangeInvalid || loading}
+            disabled={rangeInvalid || loading || disabled}
             data-testid={`${TEST_ID}-run`}
           >
             {RUN_BUTTON_LABEL}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -13,8 +13,10 @@ import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import { CommandPreview } from '../command-preview'
 import {
   ARRAY_RANGE_FORM_TEST_ID as TEST_ID,
+  ARRAY_RANGE_MAX_SPAN,
   INVALID_INDEX_MESSAGE,
   INVALID_ORDER_MESSAGE,
+  INVALID_RANGE_TOO_LARGE_MESSAGE,
   PREVIEW_TOGGLE_ARIA_LABEL,
   PREVIEW_TOGGLE_HIDE_TOOLTIP,
   PREVIEW_TOGGLE_LABEL,
@@ -69,14 +71,24 @@ export const ArrayRangeForm = ({
   // every Redis range command). Surface the constraint inline.
   const orderInvalid =
     !startInvalid && !endInvalid && BigInt(start) > BigInt(end)
-  const rangeInvalid = startInvalid || endInvalid || orderInvalid
+  // Mirror the backend's ARRAY_RANGE_MAX_ELEMENTS cap so we fail fast
+  // instead of round-tripping a request that will 400. Span is
+  // (end - start + 1) per the inclusive-bounds contract.
+  const spanInvalid =
+    !startInvalid &&
+    !endInvalid &&
+    !orderInvalid &&
+    BigInt(end) - BigInt(start) + 1n > ARRAY_RANGE_MAX_SPAN
+  const rangeInvalid = startInvalid || endInvalid || orderInvalid || spanInvalid
 
   const startError = startInvalid ? INVALID_INDEX_MESSAGE : undefined
   const endError = endInvalid
     ? INVALID_INDEX_MESSAGE
     : orderInvalid
       ? INVALID_ORDER_MESSAGE
-      : undefined
+      : spanInvalid
+        ? INVALID_RANGE_TOO_LARGE_MESSAGE
+        : undefined
 
   const command = useMemo(() => {
     // Always surface the command verb so the preview is meaningful even

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo, useState } from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { IconButton, PrimaryButton } from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { ResetIcon, RiIcon } from 'uiSrc/components/base/icons'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
+import { Text } from 'uiSrc/components/base/text'
+import { isValidArrayIndex } from 'uiSrc/utils/arrayIndex'
+
+import { CommandPreview } from '../command-preview'
+import {
+  ARRAY_RANGE_FORM_TEST_ID as TEST_ID,
+  INVALID_INDEX_MESSAGE,
+  INVALID_ORDER_MESSAGE,
+  PREVIEW_TOGGLE_ARIA_LABEL,
+  PREVIEW_TOGGLE_HIDE_TOOLTIP,
+  PREVIEW_TOGGLE_LABEL,
+  PREVIEW_TOGGLE_SHOW_TOOLTIP,
+  RESET_TOOLTIP,
+  RUN_BUTTON_LABEL,
+} from './ArrayRangeForm.constants'
+import { ArrayRangeFormProps } from './ArrayRangeForm.types'
+import * as S from './ArrayRangeForm.styles'
+
+/**
+ * Range/scan query form for the array View tab. Lays out inputs above a
+ * single action row containing a toggleable command preview, an optional
+ * reset, and the primary Run button — matching the Vector Set similarity-
+ * search form pattern so the two verticals feel like siblings.
+ *
+ * - `Start` / `End` are decimal-string indexes (BigInt-as-string contract).
+ * - `Show empty indexes` ON  → ARGETRANGE (returns `null` for gaps).
+ * - `Show empty indexes` OFF → ARSCAN (skips gaps; `Limit` caps result size).
+ */
+export const ArrayRangeForm = ({
+  keyName,
+  start,
+  end,
+  showEmpty,
+  loading,
+  onChangeStart,
+  onChangeEnd,
+  onToggleShowEmpty,
+  onRun,
+  onReset,
+}: ArrayRangeFormProps) => {
+  const [previewVisible, setPreviewVisible] = useState(false)
+
+  const startInvalid = !isValidArrayIndex(start)
+  const endInvalid = !isValidArrayIndex(end)
+  const orderInvalid =
+    !startInvalid && !endInvalid && BigInt(start) > BigInt(end)
+  const rangeInvalid = startInvalid || endInvalid || orderInvalid
+
+  const startError = startInvalid ? INVALID_INDEX_MESSAGE : undefined
+  const endError = endInvalid
+    ? INVALID_INDEX_MESSAGE
+    : orderInvalid
+      ? INVALID_ORDER_MESSAGE
+      : undefined
+
+  const command = useMemo(() => {
+    // Always surface the command verb so the preview is meaningful even
+    // before a key is selected; substitute a placeholder for the key.
+    const name = keyName || '<key>'
+    const verb = showEmpty ? 'ARGETRANGE' : 'ARSCAN'
+    return `${verb} ${name} ${start} ${end}`
+  }, [keyName, start, end, showEmpty])
+
+  const previewTooltip = previewVisible
+    ? PREVIEW_TOGGLE_HIDE_TOOLTIP
+    : PREVIEW_TOGGLE_SHOW_TOOLTIP
+
+  return (
+    <S.FormContainer data-testid={TEST_ID} gap="m" grow={false}>
+      <Row align="end" gap="m">
+        <FlexItem>
+          <FormField label="Start index">
+            <TextInput
+              value={start}
+              onChange={onChangeStart}
+              data-testid={`${TEST_ID}-start`}
+              error={startError}
+              placeholder="0"
+            />
+          </FormField>
+        </FlexItem>
+        <FlexItem>
+          <FormField label="End index">
+            <TextInput
+              value={end}
+              onChange={onChangeEnd}
+              data-testid={`${TEST_ID}-end`}
+              error={endError}
+              placeholder="9"
+            />
+          </FormField>
+        </FlexItem>
+        <FlexItem grow={false}>
+          <S.InputAlignedBox>
+            <Checkbox
+              id={`${TEST_ID}-show-empty`}
+              name="show-empty-indexes"
+              label="Show empty indexes"
+              checked={showEmpty}
+              onChange={(e) => onToggleShowEmpty(e.target.checked)}
+              data-testid={`${TEST_ID}-show-empty`}
+            />
+          </S.InputAlignedBox>
+        </FlexItem>
+      </Row>
+
+      <S.ActionRow align="center" gap="m">
+        <FlexItem grow={false}>
+          <RiTooltip content={previewTooltip} position="top">
+            <S.PreviewToggleButton
+              pressed={previewVisible}
+              onPressedChange={setPreviewVisible}
+              aria-label={PREVIEW_TOGGLE_ARIA_LABEL}
+              data-testid={`${TEST_ID}-preview-toggle`}
+            >
+              <RiIcon size="m" type="CliIcon" />
+              <Text size="s">{PREVIEW_TOGGLE_LABEL}</Text>
+            </S.PreviewToggleButton>
+          </RiTooltip>
+        </FlexItem>
+        <FlexItem grow>
+          {previewVisible && <CommandPreview command={command} />}
+        </FlexItem>
+        {onReset && (
+          <FlexItem grow={false}>
+            <RiTooltip content={RESET_TOOLTIP} position="top">
+              <IconButton
+                size="M"
+                icon={ResetIcon}
+                onClick={onReset}
+                disabled={loading}
+                aria-label="Reset array range form"
+                data-testid={`${TEST_ID}-reset`}
+              />
+            </RiTooltip>
+          </FlexItem>
+        )}
+        <FlexItem grow={false}>
+          <PrimaryButton
+            onClick={() => onRun()}
+            disabled={rangeInvalid || loading}
+            data-testid={`${TEST_ID}-run`}
+          >
+            {RUN_BUTTON_LABEL}
+          </PrimaryButton>
+        </FlexItem>
+      </S.ActionRow>
+    </S.FormContainer>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -9,6 +9,7 @@ import { TextInput } from 'uiSrc/components/base/inputs'
 import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { Text } from 'uiSrc/components/base/text'
 import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
+import { DEFAULT_SCAN_LIMIT } from 'uiSrc/slices/browser/array'
 
 import { CommandPreview } from '../command-preview'
 import {
@@ -99,9 +100,14 @@ export const ArrayRangeForm = ({
     // before a key is selected; substitute a placeholder for the key.
     // Quote the key so binary-unsafe names (whitespace, quotes) stay
     // runnable when copied into CLI / Workbench.
+    //
+    // ARSCAN includes the same `LIMIT` the slice thunk pins to every
+    // request — without it, the copied command would issue an unbounded
+    // ARSCAN against CLI/Workbench and return far more rows than what
+    // Run actually executes.
     const name = keyName ? quoteRedisArgument(keyName) : '<key>'
-    const verb = showEmpty ? 'ARGETRANGE' : 'ARSCAN'
-    return `${verb} ${name} ${start} ${end}`
+    if (showEmpty) return `ARGETRANGE ${name} ${start} ${end}`
+    return `ARSCAN ${name} ${start} ${end} LIMIT ${DEFAULT_SCAN_LIMIT}`
   }, [keyName, start, end, showEmpty])
 
   const previewTooltip = previewVisible

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -71,7 +71,13 @@ export const ArrayRangeForm = ({
   // instead of round-tripping a request that will 400. Span is
   // (|end - start| + 1) per the inclusive-bounds contract — reversed
   // ranges (start > end) are valid and return elements in reverse order.
+  //
+  // Only applied to ARGETRANGE (`showEmpty: true`). ARSCAN skips empty
+  // slots server-side and intentionally has no span cap — sparse arrays
+  // are routinely browsed with ranges far larger than 1M; LIMIT is the
+  // natural backpressure there.
   const spanInvalid =
+    showEmpty &&
     !startInvalid &&
     !endInvalid &&
     (BigInt(start) > BigInt(end)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -15,7 +15,6 @@ import {
   ARRAY_RANGE_FORM_TEST_ID as TEST_ID,
   ARRAY_RANGE_MAX_SPAN,
   INVALID_INDEX_MESSAGE,
-  INVALID_ORDER_MESSAGE,
   INVALID_RANGE_TOO_LARGE_MESSAGE,
   PREVIEW_TOGGLE_ARIA_LABEL,
   PREVIEW_TOGGLE_HIDE_TOOLTIP,
@@ -68,28 +67,26 @@ export const ArrayRangeForm = ({
   // but be rejected with a 400 once the request reaches the API.
   const startInvalid = parseArrayIndex(start) !== start
   const endInvalid = parseArrayIndex(end) !== end
-  // Reversed ranges (start > end) are rejected by the backend (matches
-  // every Redis range command). Surface the constraint inline.
-  const orderInvalid =
-    !startInvalid && !endInvalid && BigInt(start) > BigInt(end)
   // Mirror the backend's ARRAY_RANGE_MAX_ELEMENTS cap so we fail fast
   // instead of round-tripping a request that will 400. Span is
-  // (end - start + 1) per the inclusive-bounds contract.
+  // (|end - start| + 1) per the inclusive-bounds contract — reversed
+  // ranges (start > end) are valid and return elements in reverse order.
   const spanInvalid =
     !startInvalid &&
     !endInvalid &&
-    !orderInvalid &&
-    BigInt(end) - BigInt(start) + 1n > ARRAY_RANGE_MAX_SPAN
-  const rangeInvalid = startInvalid || endInvalid || orderInvalid || spanInvalid
+    (BigInt(start) > BigInt(end)
+      ? BigInt(start) - BigInt(end)
+      : BigInt(end) - BigInt(start)) +
+      1n >
+      ARRAY_RANGE_MAX_SPAN
+  const rangeInvalid = startInvalid || endInvalid || spanInvalid
 
   const startError = startInvalid ? INVALID_INDEX_MESSAGE : undefined
   const endError = endInvalid
     ? INVALID_INDEX_MESSAGE
-    : orderInvalid
-      ? INVALID_ORDER_MESSAGE
-      : spanInvalid
-        ? INVALID_RANGE_TOO_LARGE_MESSAGE
-        : undefined
+    : spanInvalid
+      ? INVALID_RANGE_TOO_LARGE_MESSAGE
+      : undefined
 
   const command = useMemo(() => {
     // Always surface the command verb so the preview is meaningful even

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -125,6 +125,7 @@ export const ArrayRangeForm = ({
               data-testid={`${TEST_ID}-start`}
               error={startError}
               placeholder="0"
+              disabled={disabled}
             />
           </FormField>
         </FlexItem>
@@ -136,6 +137,7 @@ export const ArrayRangeForm = ({
               data-testid={`${TEST_ID}-end`}
               error={endError}
               placeholder="9"
+              disabled={disabled}
             />
           </FormField>
         </FlexItem>
@@ -148,6 +150,7 @@ export const ArrayRangeForm = ({
               checked={showEmpty}
               onChange={(e) => onToggleShowEmpty(e.target.checked)}
               data-testid={`${TEST_ID}-show-empty`}
+              disabled={disabled}
             />
           </S.InputAlignedBox>
         </FlexItem>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -140,7 +140,7 @@ export const ArrayRangeForm = ({
           </FormField>
         </FlexItem>
         <FlexItem grow={false}>
-          <S.InputAlignedBox>
+          <S.InputAlignedBox align="center">
             <Checkbox
               id={`${TEST_ID}-show-empty`}
               name="show-empty-indexes"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.types.ts
@@ -18,4 +18,11 @@ export interface ArrayRangeFormProps {
    * actual reset semantics (resetting Redux state alongside form state).
    */
   onReset?: () => void
+  /**
+   * Disables the Run / Reset actions in addition to the form's internal
+   * range validation. Container passes `true` while the selected key's
+   * confirmed type/name has not caught up with the clicked key yet so a
+   * quick click cannot dispatch a query against a non-array key.
+   */
+  disabled?: boolean
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.types.ts
@@ -1,0 +1,21 @@
+export interface ArrayRangeFormProps {
+  /**
+   * Key name rendered in the preview command. Optional so the form can be
+   * rendered in isolation (tests, Storybook); in the live composition the
+   * container always passes the selected key.
+   */
+  keyName?: string
+  start: string
+  end: string
+  showEmpty: boolean
+  loading: boolean
+  onChangeStart: (value: string) => void
+  onChangeEnd: (value: string) => void
+  onToggleShowEmpty: (value: boolean) => void
+  onRun: () => void
+  /**
+   * Optional reset hook — restores form defaults. The container owns the
+   * actual reset semantics (resetting Redux state alongside form state).
+   */
+  onReset?: () => void
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/index.ts
@@ -1,0 +1,2 @@
+export { ArrayRangeForm } from './ArrayRangeForm'
+export type { ArrayRangeFormProps } from './ArrayRangeForm.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.styles.ts
@@ -1,0 +1,23 @@
+import { HTMLAttributes } from 'react'
+import styled from 'styled-components'
+import { Row } from 'uiSrc/components/base/layout/flex'
+
+export const PreviewBar = styled(Row)`
+  width: 100%;
+  padding: ${({ theme }) =>
+    `${theme.core.space.space100} ${theme.core.space.space200}`};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral600};
+  border-radius: 4px;
+  background: ${({ theme }) => theme.semantic.color.background.neutral100};
+`
+
+export const PreviewText = styled.code<HTMLAttributes<HTMLElement>>`
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Source Code Pro', Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: ${({ theme }) => theme.semantic.color.text.neutral800};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import { CopyButton } from 'uiSrc/components/copy-button'
+
+import { PreviewBar, PreviewText } from './CommandPreview.styles'
+import { CommandPreviewProps } from './CommandPreview.types'
+
+const TEST_ID = 'array-range-form-command-preview'
+const LOADING_PLACEHOLDER = 'Building command…'
+
+/**
+ * Inline single-line preview of the Redis command that the current form
+ * state will dispatch. Mirrors the pattern established by Vector Set's
+ * similarity-search form so the look-and-feel is consistent across
+ * verticals. Will be promoted to `key-details/shared/` once the Aggregate
+ * and Search verticals (Tasks 4 / 5) start needing it.
+ */
+export const CommandPreview = ({
+  command,
+  loading = false,
+}: CommandPreviewProps) => {
+  const isEmpty = command.length === 0
+  let displayText = command
+  if (loading) {
+    displayText = LOADING_PLACEHOLDER
+  } else if (isEmpty) {
+    displayText = ''
+  }
+
+  return (
+    <PreviewBar data-testid={TEST_ID} gap="m" align="center">
+      <PreviewText title={command} data-testid={`${TEST_ID}-text`}>
+        {displayText}
+      </PreviewText>
+      <CopyButton
+        copy={command}
+        disabled={isEmpty}
+        data-testid={`${TEST_ID}-copy`}
+        aria-label="Copy command"
+      />
+    </PreviewBar>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/CommandPreview.types.ts
@@ -1,0 +1,4 @@
+export interface CommandPreviewProps {
+  command: string
+  loading?: boolean
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/command-preview/index.ts
@@ -1,0 +1,2 @@
+export { CommandPreview } from './CommandPreview'
+export type { CommandPreviewProps } from './CommandPreview.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Defaults for the array View / Browse vertical (see
+ * `docs/redis-array-type-initiative.md` §6 Task 3). All indexes are decimal
+ * strings to preserve the BigInt-as-string contract (§8.1) — never numbers.
+ */
+
+/** Inclusive lower bound for the initial range query. */
+export const DEFAULT_RANGE_START = '0'
+
+/**
+ * Inclusive upper bound for the initial range query. ARGETRANGE is hard-
+ * capped at 1,000,000 elements server-side; 9 gives a 10-element preview
+ * so the table comfortably fits without scrolling on first load.
+ */
+export const DEFAULT_RANGE_END = '9'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useArrayRangeQuery } from './useArrayRangeQuery'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
@@ -107,7 +107,12 @@ describe('useArrayRangeQuery', () => {
     const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
       url.includes('array/scan'),
     )
-    expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '99' })
+    expect(call?.[1]).toEqual({
+      keyName: keyBuffer,
+      start: '0',
+      end: '99',
+      limit: 1_000_000,
+    })
   })
 
   it('runQuery is a no-op while isArrayKeyReady=false', async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
@@ -37,11 +37,8 @@ const renderWithStore = (
 ) => {
   const store = mockStore(state)
   store.clearActions()
-  const { result, rerender } = renderHook(
-    ({ key }: { key: typeof prop }) => useArrayRangeQuery(key),
-    { store, initialProps: { key: prop } } as any,
-  )
-  return { result, rerender, store }
+  const { result } = renderHook(() => useArrayRangeQuery(prop), { store })
+  return { result, store }
 }
 
 describe('useArrayRangeQuery', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.ts
@@ -1,0 +1,161 @@
+import { cloneDeep } from 'lodash'
+import {
+  act,
+  initialStateDefault,
+  mockStore,
+  renderHook,
+} from 'uiSrc/utils/test-utils'
+import { apiService } from 'uiSrc/services'
+import { KeyTypes } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
+import { useArrayRangeQuery } from './useArrayRangeQuery'
+
+const KEY = 'readings'
+const keyBuffer = stringToBuffer(KEY)
+
+const buildState = (
+  overrides: {
+    selectedKeyType?: KeyTypes
+    selectedKeyName?: ReturnType<typeof stringToBuffer> | null
+  } = {},
+) => {
+  const next = cloneDeep(initialStateDefault)
+  next.browser.array = cloneDeep(initialStateArray)
+  next.browser.keys.selectedKey.data = overrides.selectedKeyName
+    ? ({
+        type: overrides.selectedKeyType ?? KeyTypes.Array,
+        name: overrides.selectedKeyName,
+      } as any)
+    : null
+  return next
+}
+
+const renderWithStore = (
+  prop: ReturnType<typeof stringToBuffer> | null,
+  state = buildState({ selectedKeyName: keyBuffer }),
+) => {
+  const store = mockStore(state)
+  store.clearActions()
+  const { result, rerender } = renderHook(
+    ({ key }: { key: typeof prop }) => useArrayRangeQuery(key),
+    { store, initialProps: { key: prop } } as any,
+  )
+  return { result, rerender, store }
+}
+
+describe('useArrayRangeQuery', () => {
+  beforeEach(() => {
+    apiService.post = jest
+      .fn()
+      .mockResolvedValue({ status: 200, data: { keyName: KEY, elements: [] } })
+  })
+
+  it('initialises form defaults and isArrayKeyReady=true for a matching Array key', () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    expect(result.current.start).toBe('0')
+    expect(result.current.end).toBe('9')
+    expect(result.current.showEmpty).toBe(true)
+    expect(result.current.isArrayKeyReady).toBe(true)
+  })
+
+  it('isArrayKeyReady=false until selectedKeyData catches up with keyProp', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('isArrayKeyReady=false when selected key type is not Array', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({
+        selectedKeyName: keyBuffer,
+        selectedKeyType: KeyTypes.String,
+      }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('runQuery dispatches ARGETRANGE when showEmpty=true', async () => {
+    const { result } = renderWithStore(keyBuffer)
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery('2', '8')
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/get-range'),
+    )
+    expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '2', end: '8' })
+  })
+
+  it('runQuery dispatches ARSCAN when showEmpty=false', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setShowEmpty(false)
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery('0', '99')
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/scan'),
+    )
+    expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '99' })
+  })
+
+  it('runQuery is a no-op while isArrayKeyReady=false', async () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery('0', '9')
+    })
+
+    expect(apiService.post as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('auto-fires the default ARGETRANGE on first ready render for a key', () => {
+    renderWithStore(keyBuffer)
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/get-range'),
+    )
+    expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '9' })
+  })
+
+  it('resetQuery restores defaults and refires the default range', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setStart('42')
+      result.current.setEnd('100')
+      result.current.setShowEmpty(false)
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.resetQuery()
+    })
+
+    expect(result.current.start).toBe('0')
+    expect(result.current.end).toBe('9')
+    expect(result.current.showEmpty).toBe(true)
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/get-range'),
+    )
+    expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '9' })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react'
+import { Provider } from 'react-redux'
 import { cloneDeep } from 'lodash'
 import {
   act,
@@ -136,6 +138,50 @@ describe('useArrayRangeQuery', () => {
       url.includes('array/get-range'),
     )
     expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '9' })
+  })
+
+  it('honors pre-ready form edits when isArrayKeyReady flips to true', async () => {
+    const notReadyStore = mockStore(buildState({ selectedKeyName: null }))
+    const readyStore = mockStore(buildState({ selectedKeyName: keyBuffer }))
+
+    let swapStore: React.Dispatch<React.SetStateAction<any>> = () => {}
+    const SwappableProvider = ({ children }: { children: React.ReactNode }) => {
+      const [store, setStore] = useState<any>(notReadyStore)
+      swapStore = setStore
+      return <Provider store={store}>{children}</Provider>
+    }
+
+    const { result } = renderHook(() => useArrayRangeQuery(keyBuffer), {
+      wrapper: SwappableProvider,
+    } as any)
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+
+    act(() => {
+      result.current.setShowEmpty(false)
+      result.current.setStart('5')
+      result.current.setEnd('15')
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    act(() => {
+      swapStore(readyStore)
+    })
+
+    const scanCall = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/scan'),
+    )
+    expect(scanCall?.[1]).toEqual({
+      keyName: keyBuffer,
+      start: '5',
+      end: '15',
+      limit: 1_000_000,
+    })
+
+    const rangeCall = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/get-range'),
+    )
+    expect(rangeCall).toBeUndefined()
   })
 
   it('resetQuery restores defaults and refires the default range', async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -39,9 +39,21 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
   const [showEmpty, setShowEmpty] = useState<boolean>(true)
 
+  // True only once `fetchKeyInfo` has resolved and the resulting
+  // `selectedKeyData` matches the currently selected `keyProp` AND has
+  // type Array. Manual user actions (Run / Reset) are gated on this so a
+  // quick click during the key-switch window can't dispatch ARGETRANGE /
+  // ARSCAN against a non-array key (which the API rejects with a
+  // WrongType 400). The auto-fetch effect uses the same condition.
+  const isArrayKeyReady =
+    !!keyProp &&
+    selectedKeyData?.type === KeyTypes.Array &&
+    !!selectedKeyData?.name &&
+    isEqualBuffers(selectedKeyData.name, keyProp)
+
   const runQuery = useCallback(
     (nextStart: string = start, nextEnd: string = end) => {
-      if (!keyProp) return
+      if (!isArrayKeyReady || !keyProp) return
       if (showEmpty) {
         dispatch(
           fetchArrayRange({
@@ -60,7 +72,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         )
       }
     },
-    [dispatch, keyProp, showEmpty, start, end],
+    [dispatch, isArrayKeyReady, keyProp, showEmpty, start, end],
   )
 
   // Detect key switches by raw-buffer byte equality so two binary-distinct
@@ -102,20 +114,13 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   }, [dispatch, keyProp])
 
   useEffect(() => {
-    if (!keyProp) return
     // Gate on confirmed type from the selected-key slice: until
     // `fetchKeyInfo` resolves with `type === Array` and a `name` that
     // matches our `keyProp`, dispatching ARGETRANGE would hit the API
     // with a key of unknown / mismatched type and surface a WrongType
     // 400. Skip silently — this effect refires when the slice catches
     // up.
-    if (
-      selectedKeyData?.type !== KeyTypes.Array ||
-      !selectedKeyData?.name ||
-      !isEqualBuffers(selectedKeyData.name, keyProp)
-    ) {
-      return
-    }
+    if (!isArrayKeyReady || !keyProp) return
     // Fire only once per key switch; subsequent renders for the same
     // confirmed selection (e.g. unrelated slice updates) must not refire.
     if (
@@ -132,7 +137,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         end: DEFAULT_RANGE_END,
       }),
     )
-  }, [dispatch, keyProp, selectedKeyData?.type, selectedKeyData?.name])
+  }, [dispatch, isArrayKeyReady, keyProp])
 
   // On unmount (e.g. user navigates away from an array key), cancel any
   // in-flight range/scan so its late response can't land into a stale
@@ -143,11 +148,13 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   // Restore form defaults and refire the default-range query. The slice
   // is intentionally NOT wiped — keeping the current data prevents a
   // visible "blank" flicker between reset and the fresh ARGETRANGE.
+  // Same readiness gate as `runQuery` so a Reset click during a key
+  // switch can't dispatch against a non-array key either.
   const resetQuery = useCallback(() => {
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)
     setShowEmpty(true)
-    if (!keyProp) return
+    if (!isArrayKeyReady || !keyProp) return
     dispatch(
       fetchArrayRange({
         key: keyProp,
@@ -155,7 +162,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         end: DEFAULT_RANGE_END,
       }),
     )
-  }, [dispatch, keyProp])
+  }, [dispatch, isArrayKeyReady, keyProp])
 
   return {
     start,
@@ -166,6 +173,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     setShowEmpty,
     runQuery,
     resetQuery,
+    isArrayKeyReady,
     elements: data?.elements ?? [],
     loading,
     error,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
   arrayDataSelector,
@@ -7,8 +7,8 @@ import {
   scanArrayRange,
   setArrayInitialState,
 } from 'uiSrc/slices/browser/array'
-import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
-import { bufferToString } from 'uiSrc/utils'
+import { isEqualBuffers } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
 
 /**
@@ -19,10 +19,15 @@ import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
  * want narrower or wider slices change the bounds directly. Auto-fires
  * the initial query when a new key is selected and on user-triggered
  * refresh.
+ *
+ * Takes the raw `keyProp` buffer (the same identity threaded through
+ * `KeyDetails` → `DynamicTypeDetails`) rather than reading
+ * `selectedKeyData?.name`. The selector lags behind selection by one
+ * `fetchKeyInfo` round-trip, which would render the previous key's
+ * data until that completes; `keyProp` updates synchronously on click.
  */
-export const useArrayRangeQuery = () => {
+export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const dispatch = useAppDispatch()
-  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
   const { loading, error } = useAppSelector(arraySelector)
   const data = useAppSelector(arrayDataSelector)
 
@@ -30,16 +35,13 @@ export const useArrayRangeQuery = () => {
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
   const [showEmpty, setShowEmpty] = useState<boolean>(true)
 
-  const keyBuffer = selectedKeyData?.name
-  const keyName = keyBuffer ? bufferToString(keyBuffer) : ''
-
   const runQuery = useCallback(
     (nextStart: string = start, nextEnd: string = end) => {
-      if (!keyBuffer) return
+      if (!keyProp) return
       if (showEmpty) {
         dispatch(
           fetchArrayRange({
-            key: keyBuffer,
+            key: keyProp,
             start: nextStart,
             end: nextEnd,
           }),
@@ -47,36 +49,48 @@ export const useArrayRangeQuery = () => {
       } else {
         dispatch(
           scanArrayRange({
-            key: keyBuffer,
+            key: keyProp,
             start: nextStart,
             end: nextEnd,
           }),
         )
       }
     },
-    [dispatch, keyBuffer, showEmpty, start, end],
+    [dispatch, keyProp, showEmpty, start, end],
   )
 
-  // Reset slice + fire the default-range query whenever the user switches
-  // keys. Refresh is owned by `refreshKey` (in `slices/browser/keys`) so
-  // this effect intentionally does NOT depend on `lastRefreshTime` — the
-  // range thunks update `lastRefreshTime` themselves on success, which
-  // would otherwise create a fetch-update-fetch loop.
+  // Detect key switches by raw-buffer byte equality so two binary-distinct
+  // keys whose lossy `bufferToString` forms collide (e.g. invalid UTF-8
+  // decoded with the U+FFFD replacement character) still trigger a
+  // refetch. Stored in a ref because two buffer references with the same
+  // bytes should be treated as the same key — React's default referential
+  // equality on the dep array would otherwise refire on every render that
+  // produces a fresh buffer instance for the same logical key.
+  //
+  // Refresh is owned by `refreshKey` (in `slices/browser/keys`) so this
+  // effect intentionally does NOT depend on `lastRefreshTime` — the range
+  // thunks update `lastRefreshTime` themselves on success, which would
+  // otherwise create a fetch-update-fetch loop.
+  const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
   useEffect(() => {
-    if (!keyBuffer) return
+    if (!keyProp) return
+    if (lastKeyRef.current && isEqualBuffers(lastKeyRef.current, keyProp)) {
+      return
+    }
+    lastKeyRef.current = keyProp
+
     dispatch(setArrayInitialState())
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)
     setShowEmpty(true)
     dispatch(
       fetchArrayRange({
-        key: keyBuffer,
+        key: keyProp,
         start: DEFAULT_RANGE_START,
         end: DEFAULT_RANGE_END,
       }),
     )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, keyName])
+  }, [dispatch, keyProp])
 
   // Restore form defaults and refire the default-range query. The slice
   // is intentionally NOT wiped — keeping the current data prevents a
@@ -85,15 +99,15 @@ export const useArrayRangeQuery = () => {
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)
     setShowEmpty(true)
-    if (!keyBuffer) return
+    if (!keyProp) return
     dispatch(
       fetchArrayRange({
-        key: keyBuffer,
+        key: keyProp,
         start: DEFAULT_RANGE_START,
         end: DEFAULT_RANGE_END,
       }),
     )
-  }, [dispatch, keyBuffer])
+  }, [dispatch, keyProp])
 
   return {
     start,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import {
+  arrayDataSelector,
+  arraySelector,
+  fetchArrayRange,
+  scanArrayRange,
+  setArrayInitialState,
+} from 'uiSrc/slices/browser/array'
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { bufferToString } from 'uiSrc/utils'
+import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
+
+/**
+ * Owns the View / Browse tab query state for an array key. Holds the
+ * inclusive range (`start`/`end`) and the "show empty indexes" toggle
+ * that switches between ARGETRANGE (gap-preserving) and ARSCAN
+ * (populated-only). The range bounds alone size the result — users who
+ * want narrower or wider slices change the bounds directly. Auto-fires
+ * the initial query when a new key is selected and on user-triggered
+ * refresh.
+ */
+export const useArrayRangeQuery = () => {
+  const dispatch = useAppDispatch()
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+  const { loading, error } = useAppSelector(arraySelector)
+  const data = useAppSelector(arrayDataSelector)
+
+  const [start, setStart] = useState<string>(DEFAULT_RANGE_START)
+  const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
+  const [showEmpty, setShowEmpty] = useState<boolean>(true)
+
+  const keyBuffer = selectedKeyData?.name
+  const keyName = keyBuffer ? bufferToString(keyBuffer) : ''
+
+  const runQuery = useCallback(
+    (nextStart: string = start, nextEnd: string = end) => {
+      if (!keyBuffer) return
+      if (showEmpty) {
+        dispatch(
+          fetchArrayRange({
+            key: keyBuffer,
+            start: nextStart,
+            end: nextEnd,
+          }),
+        )
+      } else {
+        dispatch(
+          scanArrayRange({
+            key: keyBuffer,
+            start: nextStart,
+            end: nextEnd,
+          }),
+        )
+      }
+    },
+    [dispatch, keyBuffer, showEmpty, start, end],
+  )
+
+  // Reset slice + fire the default-range query whenever the user switches
+  // keys. Refresh is owned by `refreshKey` (in `slices/browser/keys`) so
+  // this effect intentionally does NOT depend on `lastRefreshTime` — the
+  // range thunks update `lastRefreshTime` themselves on success, which
+  // would otherwise create a fetch-update-fetch loop.
+  useEffect(() => {
+    if (!keyBuffer) return
+    dispatch(setArrayInitialState())
+    setStart(DEFAULT_RANGE_START)
+    setEnd(DEFAULT_RANGE_END)
+    setShowEmpty(true)
+    dispatch(
+      fetchArrayRange({
+        key: keyBuffer,
+        start: DEFAULT_RANGE_START,
+        end: DEFAULT_RANGE_END,
+      }),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, keyName])
+
+  // Restore form defaults and refire the default-range query. The slice
+  // is intentionally NOT wiped — keeping the current data prevents a
+  // visible "blank" flicker between reset and the fresh ARGETRANGE.
+  const resetQuery = useCallback(() => {
+    setStart(DEFAULT_RANGE_START)
+    setEnd(DEFAULT_RANGE_END)
+    setShowEmpty(true)
+    if (!keyBuffer) return
+    dispatch(
+      fetchArrayRange({
+        key: keyBuffer,
+        start: DEFAULT_RANGE_START,
+        end: DEFAULT_RANGE_END,
+      }),
+    )
+  }, [dispatch, keyBuffer])
+
+  return {
+    start,
+    end,
+    showEmpty,
+    setStart,
+    setEnd,
+    setShowEmpty,
+    runQuery,
+    resetQuery,
+    elements: data?.elements ?? [],
+    loading,
+    error,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -8,7 +8,9 @@ import {
   scanArrayRange,
   setArrayInitialState,
 } from 'uiSrc/slices/browser/array'
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { isEqualBuffers } from 'uiSrc/utils'
+import { KeyTypes } from 'uiSrc/constants'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
 
@@ -31,6 +33,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const dispatch = useAppDispatch()
   const { loading, error } = useAppSelector(arraySelector)
   const data = useAppSelector(arrayDataSelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
 
   const [start, setStart] = useState<string>(DEFAULT_RANGE_START)
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
@@ -68,22 +71,60 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   // equality on the dep array would otherwise refire on every render that
   // produces a fresh buffer instance for the same logical key.
   //
+  // Switch detection and fetching are split across two effects so the
+  // fetch can be gated on the resolved key type (avoiding a WrongType
+  // 400 when the user clicks a non-array key while ArrayDetails is still
+  // mounted from the previous selection). The first effect handles the
+  // synchronous part — abort, reset form, wipe slice — keyed off
+  // `keyProp` alone. The second effect waits for `selectedKeyData` to
+  // catch up via `fetchKeyInfo` and only fires the request once the
+  // confirmed type is Array AND the confirmed name matches `keyProp`.
+  //
   // Refresh is owned by `refreshKey` (in `slices/browser/keys`) so this
   // effect intentionally does NOT depend on `lastRefreshTime` — the range
   // thunks update `lastRefreshTime` themselves on success, which would
   // otherwise create a fetch-update-fetch loop.
   const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
+  const fetchedKeyRef = useRef<RedisResponseBuffer | null>(null)
   useEffect(() => {
     if (!keyProp) return
     if (lastKeyRef.current && isEqualBuffers(lastKeyRef.current, keyProp)) {
       return
     }
     lastKeyRef.current = keyProp
+    fetchedKeyRef.current = null
 
+    abortArrayRange()
     dispatch(setArrayInitialState())
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)
     setShowEmpty(true)
+  }, [dispatch, keyProp])
+
+  useEffect(() => {
+    if (!keyProp) return
+    // Gate on confirmed type from the selected-key slice: until
+    // `fetchKeyInfo` resolves with `type === Array` and a `name` that
+    // matches our `keyProp`, dispatching ARGETRANGE would hit the API
+    // with a key of unknown / mismatched type and surface a WrongType
+    // 400. Skip silently — this effect refires when the slice catches
+    // up.
+    if (
+      selectedKeyData?.type !== KeyTypes.Array ||
+      !selectedKeyData?.name ||
+      !isEqualBuffers(selectedKeyData.name, keyProp)
+    ) {
+      return
+    }
+    // Fire only once per key switch; subsequent renders for the same
+    // confirmed selection (e.g. unrelated slice updates) must not refire.
+    if (
+      fetchedKeyRef.current &&
+      isEqualBuffers(fetchedKeyRef.current, keyProp)
+    ) {
+      return
+    }
+    fetchedKeyRef.current = keyProp
     dispatch(
       fetchArrayRange({
         key: keyProp,
@@ -91,7 +132,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         end: DEFAULT_RANGE_END,
       }),
     )
-  }, [dispatch, keyProp])
+  }, [dispatch, keyProp, selectedKeyData?.type, selectedKeyData?.name])
 
   // On unmount (e.g. user navigates away from an array key), cancel any
   // in-flight range/scan so its late response can't land into a stale

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
+  abortArrayRange,
   arrayDataSelector,
   arraySelector,
   fetchArrayRange,
@@ -91,6 +92,12 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
       }),
     )
   }, [dispatch, keyProp])
+
+  // On unmount (e.g. user navigates away from an array key), cancel any
+  // in-flight range/scan so its late response can't land into a stale
+  // slice. The slice-level controller is shared between range and scan,
+  // so this also covers a pending ARSCAN.
+  useEffect(() => () => abortArrayRange(), [])
 
   // Restore form defaults and refire the default-range query. The slice
   // is intentionally NOT wiped — keeping the current data prevents a

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -98,14 +98,9 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
       return
     }
     fetchedKeyRef.current = keyProp
-    dispatch(
-      fetchArrayRange({
-        key: keyProp,
-        start: DEFAULT_RANGE_START,
-        end: DEFAULT_RANGE_END,
-      }),
-    )
-  }, [dispatch, isArrayKeyReady, keyProp])
+    const params = { key: keyProp, start, end }
+    dispatch(showEmpty ? fetchArrayRange(params) : scanArrayRange(params))
+  }, [dispatch, isArrayKeyReady, keyProp, start, end, showEmpty])
 
   // Cancel any in-flight range/scan AND wipe the slice on unmount so a
   // later re-mount (e.g. user navigates away from an array key and then

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -15,19 +15,13 @@ import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
 
 /**
- * Owns the View / Browse tab query state for an array key. Holds the
- * inclusive range (`start`/`end`) and the "show empty indexes" toggle
- * that switches between ARGETRANGE (gap-preserving) and ARSCAN
- * (populated-only). The range bounds alone size the result — users who
- * want narrower or wider slices change the bounds directly. Auto-fires
- * the initial query when a new key is selected and on user-triggered
- * refresh.
+ * Owns the View / Browse tab query state for an array key: the inclusive
+ * `start`/`end` bounds and the "show empty indexes" toggle that switches
+ * between ARGETRANGE (gap-preserving) and ARSCAN (populated-only).
  *
- * Takes the raw `keyProp` buffer (the same identity threaded through
- * `KeyDetails` → `DynamicTypeDetails`) rather than reading
- * `selectedKeyData?.name`. The selector lags behind selection by one
- * `fetchKeyInfo` round-trip, which would render the previous key's
- * data until that completes; `keyProp` updates synchronously on click.
+ * Takes the raw `keyProp` buffer (threaded through `KeyDetails` →
+ * `DynamicTypeDetails`) rather than reading `selectedKeyData?.name` —
+ * the selector lags selection by one `fetchKeyInfo` round-trip.
  */
 export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const dispatch = useAppDispatch()
@@ -39,12 +33,9 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
   const [showEmpty, setShowEmpty] = useState<boolean>(true)
 
-  // True only once `fetchKeyInfo` has resolved and the resulting
-  // `selectedKeyData` matches the currently selected `keyProp` AND has
-  // type Array. Manual user actions (Run / Reset) are gated on this so a
-  // quick click during the key-switch window can't dispatch ARGETRANGE /
-  // ARSCAN against a non-array key (which the API rejects with a
-  // WrongType 400). The auto-fetch effect uses the same condition.
+  // Manual + auto dispatches are gated on this so a quick click during a
+  // key-switch can't fire ARGETRANGE/ARSCAN against a non-array key
+  // (which the API rejects with WrongType).
   const isArrayKeyReady =
     !!keyProp &&
     selectedKeyData?.type === KeyTypes.Array &&
@@ -75,27 +66,11 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     [dispatch, isArrayKeyReady, keyProp, showEmpty, start, end],
   )
 
-  // Detect key switches by raw-buffer byte equality so two binary-distinct
-  // keys whose lossy `bufferToString` forms collide (e.g. invalid UTF-8
-  // decoded with the U+FFFD replacement character) still trigger a
-  // refetch. Stored in a ref because two buffer references with the same
-  // bytes should be treated as the same key — React's default referential
-  // equality on the dep array would otherwise refire on every render that
-  // produces a fresh buffer instance for the same logical key.
-  //
   // Switch detection and fetching are split across two effects so the
-  // fetch can be gated on the resolved key type (avoiding a WrongType
-  // 400 when the user clicks a non-array key while ArrayDetails is still
-  // mounted from the previous selection). The first effect handles the
-  // synchronous part — abort, reset form, wipe slice — keyed off
-  // `keyProp` alone. The second effect waits for `selectedKeyData` to
-  // catch up via `fetchKeyInfo` and only fires the request once the
-  // confirmed type is Array AND the confirmed name matches `keyProp`.
-  //
-  // Refresh is owned by `refreshKey` (in `slices/browser/keys`) so this
-  // effect intentionally does NOT depend on `lastRefreshTime` — the range
-  // thunks update `lastRefreshTime` themselves on success, which would
-  // otherwise create a fetch-update-fetch loop.
+  // fetch can wait for `selectedKeyData` to catch up. Buffer-byte equality
+  // (via refs) avoids a refire on referentially fresh buffers for the
+  // same logical key, and handles binary-distinct keys whose lossy
+  // `bufferToString` forms would collide.
   const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
   const fetchedKeyRef = useRef<RedisResponseBuffer | null>(null)
   useEffect(() => {
@@ -114,15 +89,8 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   }, [dispatch, keyProp])
 
   useEffect(() => {
-    // Gate on confirmed type from the selected-key slice: until
-    // `fetchKeyInfo` resolves with `type === Array` and a `name` that
-    // matches our `keyProp`, dispatching ARGETRANGE would hit the API
-    // with a key of unknown / mismatched type and surface a WrongType
-    // 400. Skip silently — this effect refires when the slice catches
-    // up.
     if (!isArrayKeyReady || !keyProp) return
-    // Fire only once per key switch; subsequent renders for the same
-    // confirmed selection (e.g. unrelated slice updates) must not refire.
+    // Fire only once per key switch.
     if (
       fetchedKeyRef.current &&
       isEqualBuffers(fetchedKeyRef.current, keyProp)
@@ -139,17 +107,12 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     )
   }, [dispatch, isArrayKeyReady, keyProp])
 
-  // On unmount (e.g. user navigates away from an array key), cancel any
-  // in-flight range/scan so its late response can't land into a stale
-  // slice. The slice-level controller is shared between range and scan,
-  // so this also covers a pending ARSCAN.
+  // Cancel any in-flight range/scan on unmount so a late response
+  // doesn't land into a stale slice.
   useEffect(() => () => abortArrayRange(), [])
 
-  // Restore form defaults and refire the default-range query. The slice
-  // is intentionally NOT wiped — keeping the current data prevents a
-  // visible "blank" flicker between reset and the fresh ARGETRANGE.
-  // Same readiness gate as `runQuery` so a Reset click during a key
-  // switch can't dispatch against a non-array key either.
+  // Restore form defaults and refire the default-range query. Keeps the
+  // current data in the slice to avoid a visible blank flicker.
   const resetQuery = useCallback(() => {
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -107,12 +107,21 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     )
   }, [dispatch, isArrayKeyReady, keyProp])
 
-  // Cancel any in-flight range/scan on unmount so a late response
-  // doesn't land into a stale slice.
-  useEffect(() => () => abortArrayRange(), [])
+  // Cancel any in-flight range/scan AND wipe the slice on unmount so a
+  // later re-mount (e.g. user navigates away from an array key and then
+  // opens another one) doesn't paint the previous key's elements for one
+  // frame before the switch effect runs.
+  useEffect(
+    () => () => {
+      abortArrayRange()
+      dispatch(setArrayInitialState())
+    },
+    [dispatch],
+  )
 
   // Restore form defaults and refire the default-range query. Keeps the
-  // current data in the slice to avoid a visible blank flicker.
+  // current data in the slice (`resetData: false`) to avoid a visible
+  // blank flicker between reset and the fresh ARGETRANGE result.
   const resetQuery = useCallback(() => {
     setStart(DEFAULT_RANGE_START)
     setEnd(DEFAULT_RANGE_END)
@@ -123,6 +132,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         key: keyProp,
         start: DEFAULT_RANGE_START,
         end: DEFAULT_RANGE_END,
+        resetData: false,
       }),
     )
   }, [dispatch, isArrayKeyReady, keyProp])

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/index.ts
@@ -1,0 +1,1 @@
+export { ArrayDetails } from './ArrayDetails'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.spec.tsx
@@ -1,7 +1,8 @@
+import { cloneDeep, set } from 'lodash'
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
-import { render } from 'uiSrc/utils/test-utils'
-import { KeyTypes, ModulesKeyTypes } from 'uiSrc/constants'
+import { initialStateDefault, mockStore, render } from 'uiSrc/utils/test-utils'
+import { FeatureFlags, KeyTypes, ModulesKeyTypes } from 'uiSrc/constants'
 import { MOCK_TRUNCATED_BUFFER_VALUE } from 'uiSrc/mocks/data/bigString'
 import { Props, DynamicTypeDetails } from './DynamicTypeDetails'
 
@@ -44,5 +45,32 @@ describe('DynamicTypeDetails', () => {
       />,
     )
     expect(queryByTestId('too-long-key-name-details')).toBeInTheDocument()
+  })
+
+  it('does not render array-details when dev-array flag is disabled', () => {
+    const { queryByTestId } = render(
+      <DynamicTypeDetails
+        {...instance(mockedProps)}
+        keyType={KeyTypes.Array}
+      />,
+    )
+    expect(queryByTestId('array-details')).not.toBeInTheDocument()
+    expect(queryByTestId('unsupported-type-details')).toBeInTheDocument()
+  })
+
+  it('renders array-details when dev-array flag is enabled', () => {
+    const stateWithFlag = set(
+      cloneDeep(initialStateDefault),
+      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      { flag: true },
+    )
+    const { queryByTestId } = render(
+      <DynamicTypeDetails
+        {...instance(mockedProps)}
+        keyType={KeyTypes.Array}
+      />,
+      { store: mockStore(stateWithFlag) },
+    )
+    expect(queryByTestId('array-details')).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -7,7 +7,10 @@ import {
 } from 'uiSrc/constants'
 import { KeyDetailsHeaderProps } from 'uiSrc/pages/browser/modules'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { isTruncatedString } from 'uiSrc/utils'
 import TooLongKeyNameDetails from 'uiSrc/pages/browser/modules/key-details/components/too-long-key-name-details/TooLongKeyNameDetails'
 import ModulesTypeDetails from '../modules-type-details/ModulesTypeDetails'
@@ -20,6 +23,7 @@ import { HashDetails } from '../hash-details'
 import { ListDetails } from '../list-details'
 import { StreamDetails } from '../stream-details'
 import { VectorSetDetails } from '../vector-set-details'
+import { ArrayDetails } from '../array-details'
 
 export interface Props extends KeyDetailsHeaderProps {
   onOpenAddItemPanel: () => void
@@ -31,6 +35,7 @@ export interface Props extends KeyDetailsHeaderProps {
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
   const isVectorSet = useAppSelector(isVectorSetEnabledSelector)
+  const isArray = useAppSelector(isDevArrayEnabledSelector)
 
   const TypeDetails: any = {
     [KeyTypes.ZSet]: <ZSetDetails {...props} />,
@@ -42,6 +47,9 @@ const DynamicTypeDetails = (props: Props) => {
     [KeyTypes.Stream]: <StreamDetails {...props} />,
     ...(isVectorSet && {
       [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
+    }),
+    ...(isArray && {
+      [KeyTypes.Array]: <ArrayDetails {...props} />,
     }),
   }
 

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -20,6 +20,7 @@ import {
 } from 'uiSrc/utils'
 
 import {
+  ArrayActiveQuery,
   ArrayDataElement,
   StateArray,
   FetchArrayElementParams,
@@ -32,9 +33,21 @@ import { updateSelectedKeyRefreshTime } from './keys'
 import { AppDispatch, RootState } from '../store'
 import { addErrorNotification } from '../app/notifications'
 
+/** Inclusive default range bounds for the View tab. Mirrored in
+ * `pages/.../array-details/constants.ts`; kept duplicated here so the slice
+ * stays free of UI-layer imports.
+ */
+const DEFAULT_QUERY_START = '0'
+const DEFAULT_QUERY_END = '9'
+
 export const initialState: StateArray = {
   loading: false,
   error: '',
+  query: {
+    start: DEFAULT_QUERY_START,
+    end: DEFAULT_QUERY_END,
+    showEmpty: true,
+  },
   data: {
     keyName: '',
     length: '0',
@@ -125,6 +138,17 @@ const arraySlice = createSlice({
     ) => {
       state.data = { ...state.data, nextIndex: payload.index }
     },
+
+    /**
+     * Records the query that was just dispatched so the header refresh
+     * button can replay it instead of falling back to the default range.
+     */
+    setArrayActiveQuery: (
+      state,
+      { payload }: PayloadAction<ArrayActiveQuery>,
+    ) => {
+      state.query = payload
+    },
   },
 })
 
@@ -137,6 +161,7 @@ export const {
   loadArrayLengthSuccess,
   loadArrayCountSuccess,
   loadArrayNextIndexSuccess,
+  setArrayActiveQuery,
 } = arraySlice.actions
 
 export const arraySelector = (state: RootState) => state.browser.array
@@ -156,6 +181,13 @@ const encodingParams = (state: RootState) => ({
 export function fetchArrayRange(params: FetchArrayRangeParams) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     dispatch(loadArrayRange(params.resetData))
+    dispatch(
+      setArrayActiveQuery({
+        start: params.start,
+        end: params.end,
+        showEmpty: true,
+      }),
+    )
     try {
       const state = stateInit()
       const { data, status } = await apiService.post<GetArrayRangeResponse>(
@@ -179,6 +211,13 @@ export function fetchArrayRange(params: FetchArrayRangeParams) {
 export function scanArrayRange(params: FetchArrayScanParams) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     dispatch(loadArrayRange(params.resetData))
+    dispatch(
+      setArrayActiveQuery({
+        start: params.start,
+        end: params.end,
+        showEmpty: false,
+      }),
+    )
     try {
       const state = stateInit()
       const { data, status } = await apiService.post<GetArrayScanResponse>(
@@ -291,29 +330,23 @@ export function fetchArrayElement(
 /**
  * Reloads the array's currently-displayed surface in response to the
  * header's refresh button (dispatched via `refreshKey` in
- * `slices/browser/keys`). Refetches the default range plus length/count;
- * keeps `resetData: false` so the table doesn't flash through an empty
- * loading state.
+ * `slices/browser/keys`). Replays whichever query the form last ran —
+ * range/scan and the user's bounds — so refresh doesn't silently swap
+ * the table for a different slice. Keeps `resetData: false` so the
+ * table doesn't flash through an empty loading state.
  */
-/** Inclusive default range bounds for the View tab. Mirrored client-side in
- * `pages/.../array-details/constants.ts`; kept duplicated here so the slice
- * stays free of UI-layer imports.
- */
-const DEFAULT_REFRESH_START = '0'
-const DEFAULT_REFRESH_END = '9'
-
 export function refreshArray(key: RedisString) {
-  return async (dispatch: AppDispatch) => {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    const { start, end, showEmpty } = stateInit().browser.array.query
+
     dispatch(fetchArrayLength(key))
     dispatch(fetchArrayCount(key))
-    dispatch(
-      fetchArrayRange({
-        key,
-        start: DEFAULT_REFRESH_START,
-        end: DEFAULT_REFRESH_END,
-        resetData: false,
-      }),
-    )
+
+    if (showEmpty) {
+      dispatch(fetchArrayRange({ key, start, end, resetData: false }))
+    } else {
+      dispatch(scanArrayRange({ key, start, end, resetData: false }))
+    }
   }
 }
 

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { AxiosError } from 'axios'
+import axios, { AxiosError } from 'axios'
 import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
 import {
   GetArrayCountResponse,
@@ -177,9 +177,33 @@ const encodingParams = (state: RootState) => ({
   params: { encoding: state.app.info.encoding },
 })
 
+/**
+ * Module-scoped controller shared between `fetchArrayRange` and
+ * `scanArrayRange` since both write to the same `data.elements` slice.
+ * A newer dispatch aborts the previous in-flight request so a slower
+ * response for a previously selected key can't land on top of the
+ * fresh selection's data. Mirrors the pattern used by Vector Set's
+ * similarity-search preview.
+ */
+let arrayRangeController: AbortController | null = null
+
+/**
+ * Abort the in-flight ARGETRANGE / ARSCAN request (if any) so its late
+ * response cannot dispatch into the just-cleared slice. Called by the
+ * View tab hook on unmount; safe no-op when nothing is in flight.
+ */
+export const abortArrayRange = (): void => {
+  arrayRangeController?.abort()
+  arrayRangeController = null
+}
+
 // ARGETRANGE — gap-preserving fetch of a contiguous slot range.
 export function fetchArrayRange(params: FetchArrayRangeParams) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    arrayRangeController?.abort()
+    const controller = new AbortController()
+    arrayRangeController = controller
+
     dispatch(loadArrayRange(params.resetData))
     dispatch(
       setArrayActiveQuery({
@@ -193,16 +217,24 @@ export function fetchArrayRange(params: FetchArrayRangeParams) {
       const { data, status } = await apiService.post<GetArrayRangeResponse>(
         arrayUrl(state, ApiEndpoints.ARRAY_GET_RANGE),
         { keyName: params.key, start: params.start, end: params.end },
-        encodingParams(state),
+        { ...encodingParams(state), signal: controller.signal },
       )
+      if (controller.signal.aborted) return
       if (isStatusSuccessful(status)) {
         dispatch(loadArrayRangeSuccess({ start: params.start, response: data }))
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (error) {
+      if (axios.isCancel(error)) return
       const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
       dispatch(loadArrayRangeFailure(errorMessage))
+    } finally {
+      // Only clear the module-scoped controller if it still points to ours
+      // — a later dispatch may have already swapped a fresh one in.
+      if (arrayRangeController === controller) {
+        arrayRangeController = null
+      }
     }
   }
 }
@@ -210,6 +242,10 @@ export function fetchArrayRange(params: FetchArrayRangeParams) {
 // ARSCAN — populated-only fetch within a slot range. Gaps are skipped.
 export function scanArrayRange(params: FetchArrayScanParams) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    arrayRangeController?.abort()
+    const controller = new AbortController()
+    arrayRangeController = controller
+
     dispatch(loadArrayRange(params.resetData))
     dispatch(
       setArrayActiveQuery({
@@ -228,16 +264,22 @@ export function scanArrayRange(params: FetchArrayScanParams) {
           end: params.end,
           ...(params.limit !== undefined ? { limit: params.limit } : {}),
         },
-        encodingParams(state),
+        { ...encodingParams(state), signal: controller.signal },
       )
+      if (controller.signal.aborted) return
       if (isStatusSuccessful(status)) {
         dispatch(loadArrayScanSuccess(data))
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (error) {
+      if (axios.isCancel(error)) return
       const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
       dispatch(loadArrayRangeFailure(errorMessage))
+    } finally {
+      if (arrayRangeController === controller) {
+        arrayRangeController = null
+      }
     }
   }
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -1,0 +1,312 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
+import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
+import {
+  GetArrayCountResponse,
+  GetArrayElementResponse,
+  GetArrayLengthResponse,
+  GetArrayMultiElementsResponse,
+  GetArrayNextIndexResponse,
+  GetArrayRangeResponse,
+  GetArrayScanResponse,
+} from 'apiClient'
+import { apiService } from 'uiSrc/services'
+import { ApiEndpoints } from 'uiSrc/constants'
+import {
+  getApiErrorMessage,
+  getUrl,
+  isStatusSuccessful,
+  Maybe,
+} from 'uiSrc/utils'
+
+import {
+  ArrayDataElement,
+  StateArray,
+  FetchArrayElementParams,
+  FetchArrayMultiElementsParams,
+  FetchArrayRangeParams,
+  FetchArrayScanParams,
+} from 'uiSrc/slices/interfaces/array'
+import { RedisString } from 'uiSrc/slices/interfaces/app'
+import { updateSelectedKeyRefreshTime } from './keys'
+import { AppDispatch, RootState } from '../store'
+import { addErrorNotification } from '../app/notifications'
+
+export const initialState: StateArray = {
+  loading: false,
+  error: '',
+  data: {
+    keyName: '',
+    length: '0',
+    count: '0',
+    elements: [],
+  },
+}
+
+// Adapts an ARGETRANGE response (gap-preserving, parallel array starting at
+// `start`) into the slice's `{ index, value }` shape so range and scan
+// reducers can write to the same `data.elements` field.
+const expandRangeElements = (
+  start: string,
+  values: GetArrayRangeResponse['elements'],
+): ArrayDataElement[] => {
+  if (!values) return []
+  const base = BigInt(start)
+  return values.map((value, offset) => ({
+    index: (base + BigInt(offset)).toString(),
+    value: (value ?? null) as ArrayDataElement['value'],
+  }))
+}
+
+const arraySlice = createSlice({
+  name: 'array',
+  initialState,
+  reducers: {
+    setArrayInitialState: () => initialState,
+
+    loadArrayRange: (
+      state,
+      { payload: resetData = true }: PayloadAction<Maybe<boolean>>,
+    ) => {
+      state.loading = true
+      state.error = ''
+      if (resetData) state.data = { ...initialState.data }
+    },
+    loadArrayRangeSuccess: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{ start: string; response: GetArrayRangeResponse }>,
+    ) => {
+      state.data = {
+        ...state.data,
+        keyName: payload.response.keyName as RedisString,
+        elements: expandRangeElements(payload.start, payload.response.elements),
+      }
+      state.loading = false
+    },
+    loadArrayRangeFailure: (state, { payload }: PayloadAction<string>) => {
+      state.loading = false
+      state.error = payload
+    },
+
+    loadArrayScanSuccess: (
+      state,
+      { payload }: PayloadAction<GetArrayScanResponse>,
+    ) => {
+      state.data = {
+        ...state.data,
+        keyName: payload.keyName as RedisString,
+        elements: payload.elements.map((element) => ({
+          index: element.index,
+          value: element.value as ArrayDataElement['value'],
+        })),
+      }
+      state.loading = false
+    },
+
+    loadArrayLengthSuccess: (
+      state,
+      { payload }: PayloadAction<GetArrayLengthResponse>,
+    ) => {
+      state.data = { ...state.data, length: payload.length }
+    },
+
+    loadArrayCountSuccess: (
+      state,
+      { payload }: PayloadAction<GetArrayCountResponse>,
+    ) => {
+      state.data = { ...state.data, count: payload.count }
+    },
+
+    loadArrayNextIndexSuccess: (
+      state,
+      { payload }: PayloadAction<GetArrayNextIndexResponse>,
+    ) => {
+      state.data = { ...state.data, nextIndex: payload.index }
+    },
+  },
+})
+
+export const {
+  setArrayInitialState,
+  loadArrayRange,
+  loadArrayRangeSuccess,
+  loadArrayRangeFailure,
+  loadArrayScanSuccess,
+  loadArrayLengthSuccess,
+  loadArrayCountSuccess,
+  loadArrayNextIndexSuccess,
+} = arraySlice.actions
+
+export const arraySelector = (state: RootState) => state.browser.array
+export const arrayDataSelector = (state: RootState) => state.browser.array?.data
+
+export default arraySlice.reducer
+
+// Resolves the URL for an array endpoint scoped to the connected instance.
+const arrayUrl = (state: RootState, endpoint: ApiEndpoints) =>
+  getUrl(state.connections.instances.connectedInstance?.id, endpoint)
+
+const encodingParams = (state: RootState) => ({
+  params: { encoding: state.app.info.encoding },
+})
+
+// ARGETRANGE — gap-preserving fetch of a contiguous slot range.
+export function fetchArrayRange(params: FetchArrayRangeParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(loadArrayRange(params.resetData))
+    try {
+      const state = stateInit()
+      const { data, status } = await apiService.post<GetArrayRangeResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_GET_RANGE),
+        { keyName: params.key, start: params.start, end: params.end },
+        encodingParams(state),
+      )
+      if (isStatusSuccessful(status)) {
+        dispatch(loadArrayRangeSuccess({ start: params.start, response: data }))
+        dispatch(updateSelectedKeyRefreshTime(Date.now()))
+      }
+    } catch (error) {
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadArrayRangeFailure(errorMessage))
+    }
+  }
+}
+
+// ARSCAN — populated-only fetch within a slot range. Gaps are skipped.
+export function scanArrayRange(params: FetchArrayScanParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    dispatch(loadArrayRange(params.resetData))
+    try {
+      const state = stateInit()
+      const { data, status } = await apiService.post<GetArrayScanResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_SCAN),
+        {
+          keyName: params.key,
+          start: params.start,
+          end: params.end,
+          ...(params.limit !== undefined ? { limit: params.limit } : {}),
+        },
+        encodingParams(state),
+      )
+      if (isStatusSuccessful(status)) {
+        dispatch(loadArrayScanSuccess(data))
+        dispatch(updateSelectedKeyRefreshTime(Date.now()))
+      }
+    } catch (error) {
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadArrayRangeFailure(errorMessage))
+    }
+  }
+}
+
+// Shared body for the metadata reads (ARLEN / ARCOUNT / ARNEXT) — they all
+// take a single keyName and write a single field into `data` on success.
+async function fetchArrayMetadata<R>(
+  state: RootState,
+  endpoint: ApiEndpoints,
+  key: RedisString,
+): Promise<R | null> {
+  const { data, status } = await apiService.post<R>(
+    arrayUrl(state, endpoint),
+    { keyName: key },
+    encodingParams(state),
+  )
+  return isStatusSuccessful(status) ? data : null
+}
+
+export function fetchArrayLength(key: RedisString) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const data = await fetchArrayMetadata<GetArrayLengthResponse>(
+        stateInit(),
+        ApiEndpoints.ARRAY_GET_LENGTH,
+        key,
+      )
+      if (data) dispatch(loadArrayLengthSuccess(data))
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+export function fetchArrayCount(key: RedisString) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const data = await fetchArrayMetadata<GetArrayCountResponse>(
+        stateInit(),
+        ApiEndpoints.ARRAY_GET_COUNT,
+        key,
+      )
+      if (data) dispatch(loadArrayCountSuccess(data))
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+export function fetchArrayNextIndex(key: RedisString) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const data = await fetchArrayMetadata<GetArrayNextIndexResponse>(
+        stateInit(),
+        ApiEndpoints.ARRAY_GET_NEXT_INDEX,
+        key,
+      )
+      if (data) dispatch(loadArrayNextIndexSuccess(data))
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+// Point reads — used by edit/inspect flows. Results are returned via the
+// optional `onSuccess` callback instead of being stored on the slice, since
+// they don't influence the list view directly.
+export function fetchArrayElement(
+  params: FetchArrayElementParams,
+  onSuccess?: (response: GetArrayElementResponse) => void,
+  onFail?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { data, status } = await apiService.post<GetArrayElementResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_GET_ELEMENT),
+        { keyName: params.key, index: params.index },
+        encodingParams(state),
+      )
+      if (isStatusSuccessful(status)) onSuccess?.(data)
+      else onFail?.()
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      onFail?.()
+    }
+  }
+}
+
+export function fetchArrayMultiElements(
+  params: FetchArrayMultiElementsParams,
+  onSuccess?: (response: GetArrayMultiElementsResponse) => void,
+  onFail?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { data, status } =
+        await apiService.post<GetArrayMultiElementsResponse>(
+          arrayUrl(state, ApiEndpoints.ARRAY_GET_ELEMENTS),
+          { keyName: params.key, indexes: params.indexes },
+          encodingParams(state),
+        )
+      if (isStatusSuccessful(status)) onSuccess?.(data)
+      else onFail?.()
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      onFail?.()
+    }
+  }
+}

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -288,6 +288,35 @@ export function fetchArrayElement(
   }
 }
 
+/**
+ * Reloads the array's currently-displayed surface in response to the
+ * header's refresh button (dispatched via `refreshKey` in
+ * `slices/browser/keys`). Refetches the default range plus length/count;
+ * keeps `resetData: false` so the table doesn't flash through an empty
+ * loading state.
+ */
+/** Inclusive default range bounds for the View tab. Mirrored client-side in
+ * `pages/.../array-details/constants.ts`; kept duplicated here so the slice
+ * stays free of UI-layer imports.
+ */
+const DEFAULT_REFRESH_START = '0'
+const DEFAULT_REFRESH_END = '9'
+
+export function refreshArray(key: RedisString) {
+  return async (dispatch: AppDispatch) => {
+    dispatch(fetchArrayLength(key))
+    dispatch(fetchArrayCount(key))
+    dispatch(
+      fetchArrayRange({
+        key,
+        start: DEFAULT_REFRESH_START,
+        end: DEFAULT_REFRESH_END,
+        resetData: false,
+      }),
+    )
+  }
+}
+
 export function fetchArrayMultiElements(
   params: FetchArrayMultiElementsParams,
   onSuccess?: (response: GetArrayMultiElementsResponse) => void,

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -3,10 +3,7 @@ import axios, { AxiosError } from 'axios'
 import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
 import {
   GetArrayCountResponse,
-  GetArrayElementResponse,
   GetArrayLengthResponse,
-  GetArrayMultiElementsResponse,
-  GetArrayNextIndexResponse,
   GetArrayRangeResponse,
   GetArrayScanResponse,
 } from 'apiClient'
@@ -23,8 +20,6 @@ import {
   ArrayActiveQuery,
   ArrayDataElement,
   StateArray,
-  FetchArrayElementParams,
-  FetchArrayMultiElementsParams,
   FetchArrayRangeParams,
   FetchArrayScanParams,
 } from 'uiSrc/slices/interfaces/array'
@@ -132,13 +127,6 @@ const arraySlice = createSlice({
       state.data = { ...state.data, count: payload.count }
     },
 
-    loadArrayNextIndexSuccess: (
-      state,
-      { payload }: PayloadAction<GetArrayNextIndexResponse>,
-    ) => {
-      state.data = { ...state.data, nextIndex: payload.index }
-    },
-
     /**
      * Records the query that was just dispatched so the header refresh
      * button can replay it instead of falling back to the default range.
@@ -160,7 +148,6 @@ export const {
   loadArrayScanSuccess,
   loadArrayLengthSuccess,
   loadArrayCountSuccess,
-  loadArrayNextIndexSuccess,
   setArrayActiveQuery,
 } = arraySlice.actions
 
@@ -284,30 +271,16 @@ export function scanArrayRange(params: FetchArrayScanParams) {
   }
 }
 
-// Shared body for the metadata reads (ARLEN / ARCOUNT / ARNEXT) — they all
-// take a single keyName and write a single field into `data` on success.
-async function fetchArrayMetadata<R>(
-  state: RootState,
-  endpoint: ApiEndpoints,
-  key: RedisString,
-): Promise<R | null> {
-  const { data, status } = await apiService.post<R>(
-    arrayUrl(state, endpoint),
-    { keyName: key },
-    encodingParams(state),
-  )
-  return isStatusSuccessful(status) ? data : null
-}
-
 export function fetchArrayLength(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
-      const data = await fetchArrayMetadata<GetArrayLengthResponse>(
-        stateInit(),
-        ApiEndpoints.ARRAY_GET_LENGTH,
-        key,
+      const state = stateInit()
+      const { data, status } = await apiService.post<GetArrayLengthResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_GET_LENGTH),
+        { keyName: key },
+        encodingParams(state),
       )
-      if (data) dispatch(loadArrayLengthSuccess(data))
+      if (isStatusSuccessful(status)) dispatch(loadArrayLengthSuccess(data))
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
     }
@@ -317,54 +290,15 @@ export function fetchArrayLength(key: RedisString) {
 export function fetchArrayCount(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
-      const data = await fetchArrayMetadata<GetArrayCountResponse>(
-        stateInit(),
-        ApiEndpoints.ARRAY_GET_COUNT,
-        key,
-      )
-      if (data) dispatch(loadArrayCountSuccess(data))
-    } catch (error) {
-      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
-    }
-  }
-}
-
-export function fetchArrayNextIndex(key: RedisString) {
-  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    try {
-      const data = await fetchArrayMetadata<GetArrayNextIndexResponse>(
-        stateInit(),
-        ApiEndpoints.ARRAY_GET_NEXT_INDEX,
-        key,
-      )
-      if (data) dispatch(loadArrayNextIndexSuccess(data))
-    } catch (error) {
-      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
-    }
-  }
-}
-
-// Point reads — used by edit/inspect flows. Results are returned via the
-// optional `onSuccess` callback instead of being stored on the slice, since
-// they don't influence the list view directly.
-export function fetchArrayElement(
-  params: FetchArrayElementParams,
-  onSuccess?: (response: GetArrayElementResponse) => void,
-  onFail?: () => void,
-) {
-  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    try {
       const state = stateInit()
-      const { data, status } = await apiService.post<GetArrayElementResponse>(
-        arrayUrl(state, ApiEndpoints.ARRAY_GET_ELEMENT),
-        { keyName: params.key, index: params.index },
+      const { data, status } = await apiService.post<GetArrayCountResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_GET_COUNT),
+        { keyName: key },
         encodingParams(state),
       )
-      if (isStatusSuccessful(status)) onSuccess?.(data)
-      else onFail?.()
+      if (isStatusSuccessful(status)) dispatch(loadArrayCountSuccess(data))
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
-      onFail?.()
     }
   }
 }
@@ -388,29 +322,6 @@ export function refreshArray(key: RedisString) {
       dispatch(fetchArrayRange({ key, start, end, resetData: false }))
     } else {
       dispatch(scanArrayRange({ key, start, end, resetData: false }))
-    }
-  }
-}
-
-export function fetchArrayMultiElements(
-  params: FetchArrayMultiElementsParams,
-  onSuccess?: (response: GetArrayMultiElementsResponse) => void,
-  onFail?: () => void,
-) {
-  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    try {
-      const state = stateInit()
-      const { data, status } =
-        await apiService.post<GetArrayMultiElementsResponse>(
-          arrayUrl(state, ApiEndpoints.ARRAY_GET_ELEMENTS),
-          { keyName: params.key, indexes: params.indexes },
-          encodingParams(state),
-        )
-      if (isStatusSuccessful(status)) onSuccess?.(data)
-      else onFail?.()
-    } catch (error) {
-      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
-      onFail?.()
     }
   }
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -35,6 +35,17 @@ import { addErrorNotification } from '../app/notifications'
 const DEFAULT_QUERY_START = '0'
 const DEFAULT_QUERY_END = '9'
 
+/**
+ * Safety cap on ARSCAN result-set size. The form intentionally lets users
+ * type ranges far wider than `ARRAY_RANGE_MAX_ELEMENTS` here (unlike
+ * ARGETRANGE) because ARSCAN only returns populated slots, but a dense
+ * 0..10M region would still blow up the response. Pin to the BE's
+ * `ARRAY_RANGE_MAX_ELEMENTS` so the worst case matches what ARGETRANGE
+ * already guarantees. A dedicated Limit input will replace this default
+ * with the next vertical.
+ */
+const DEFAULT_SCAN_LIMIT = 1_000_000
+
 export const initialState: StateArray = {
   loading: false,
   error: '',
@@ -263,7 +274,12 @@ export function scanArrayRange(params: FetchArrayScanParams) {
       const state = stateInit()
       const { data, status } = await apiService.post<GetArrayScanResponse>(
         arrayUrl(state, ApiEndpoints.ARRAY_SCAN),
-        { keyName: params.key, start: params.start, end: params.end },
+        {
+          keyName: params.key,
+          start: params.start,
+          end: params.end,
+          limit: DEFAULT_SCAN_LIMIT,
+        },
         { ...encodingParams(state), signal: controller.signal },
       )
       if (controller.signal.aborted) return

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -10,6 +10,7 @@ import {
 import { apiService } from 'uiSrc/services'
 import { ApiEndpoints } from 'uiSrc/constants'
 import {
+  DEFAULT_ERROR_MESSAGE,
   getApiErrorMessage,
   getUrl,
   isStatusSuccessful,
@@ -239,6 +240,8 @@ export function fetchArrayRange(params: FetchArrayRangeParams) {
           }),
         )
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
+      } else {
+        dispatch(loadArrayRangeFailure(DEFAULT_ERROR_MESSAGE))
       }
     } catch (error) {
       if (axios.isCancel(error)) return
@@ -286,6 +289,8 @@ export function scanArrayRange(params: FetchArrayScanParams) {
       if (isStatusSuccessful(status)) {
         dispatch(loadArrayScanSuccess(data))
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
+      } else {
+        dispatch(loadArrayRangeFailure(DEFAULT_ERROR_MESSAGE))
       }
     } catch (error) {
       if (axios.isCancel(error)) return

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -44,7 +44,7 @@ const DEFAULT_QUERY_END = '9'
  * already guarantees. A dedicated Limit input will replace this default
  * with the next vertical.
  */
-const DEFAULT_SCAN_LIMIT = 1_000_000
+export const DEFAULT_SCAN_LIMIT = 1_000_000
 
 export const initialState: StateArray = {
   loading: false,

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -263,12 +263,7 @@ export function scanArrayRange(params: FetchArrayScanParams) {
       const state = stateInit()
       const { data, status } = await apiService.post<GetArrayScanResponse>(
         arrayUrl(state, ApiEndpoints.ARRAY_SCAN),
-        {
-          keyName: params.key,
-          start: params.start,
-          end: params.end,
-          ...(params.limit !== undefined ? { limit: params.limit } : {}),
-        },
+        { keyName: params.key, start: params.start, end: params.end },
         { ...encodingParams(state), signal: controller.signal },
       )
       if (controller.signal.aborted) return

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -53,15 +53,19 @@ export const initialState: StateArray = {
 
 // Adapts an ARGETRANGE response (gap-preserving, parallel array starting at
 // `start`) into the slice's `{ index, value }` shape so range and scan
-// reducers can write to the same `data.elements` field.
+// reducers can write to the same `data.elements` field. Reversed ranges
+// (`start > end`) step the offset downwards so the table reflects the
+// descending order the BE returned the elements in.
 const expandRangeElements = (
   start: string,
+  end: string,
   values: GetArrayRangeResponse['elements'],
 ): ArrayDataElement[] => {
   if (!values) return []
   const base = BigInt(start)
+  const step = BigInt(start) > BigInt(end) ? BigInt(-1) : BigInt(1)
   return values.map((value, offset) => ({
-    index: (base + BigInt(offset)).toString(),
+    index: (base + BigInt(offset) * step).toString(),
     value: (value ?? null) as ArrayDataElement['value'],
   }))
 }
@@ -84,12 +88,20 @@ const arraySlice = createSlice({
       state,
       {
         payload,
-      }: PayloadAction<{ start: string; response: GetArrayRangeResponse }>,
+      }: PayloadAction<{
+        start: string
+        end: string
+        response: GetArrayRangeResponse
+      }>,
     ) => {
       state.data = {
         ...state.data,
         keyName: payload.response.keyName as RedisString,
-        elements: expandRangeElements(payload.start, payload.response.elements),
+        elements: expandRangeElements(
+          payload.start,
+          payload.end,
+          payload.response.elements,
+        ),
       }
       state.loading = false
     },
@@ -208,7 +220,13 @@ export function fetchArrayRange(params: FetchArrayRangeParams) {
       )
       if (controller.signal.aborted) return
       if (isStatusSuccessful(status)) {
-        dispatch(loadArrayRangeSuccess({ start: params.start, response: data }))
+        dispatch(
+          loadArrayRangeSuccess({
+            start: params.start,
+            end: params.end,
+            response: data,
+          }),
+        )
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (error) {

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -54,6 +54,7 @@ import {
 } from './zset'
 import { fetchSetMembers, refreshSetMembersAction } from './set'
 import { fetchVectorSetElements } from './vectorSet'
+import { refreshArray } from './array'
 import { fetchReJSON, setEditorType, setIsWithinThreshold } from './rejson'
 import {
   setHashInitialState,
@@ -168,6 +169,7 @@ export const initialKeyInfo = {
   length: 0,
   quantType: undefined,
   vectorDim: undefined,
+  count: undefined,
 }
 
 const getInitialSelectedKeyState = (state: KeysStore) => ({
@@ -1615,6 +1617,10 @@ export function refreshKey(
       }
       case KeyTypes.VectorSet: {
         dispatch(fetchVectorSetElements({ key, resetData }))
+        break
+      }
+      case KeyTypes.Array: {
+        dispatch(refreshArray(key))
         break
       }
       default:

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -249,9 +249,17 @@ const keysSlice = createSlice({
       }
     },
     refreshKeyInfoSuccess: (state, { payload }) => {
+      // Replace `data` outright (mirroring `loadKeyInfoSuccess`) rather
+      // than spreading the payload over the previous data. The merge
+      // form preserved any field absent from the new payload, which
+      // leaked type-specific fields when an underlying key was
+      // overwritten as a different type — e.g. an array key's `count`
+      // (or a vector set's `vectorDim` / `quantType`) would survive
+      // into the refreshed header for a String/List/etc. key, since
+      // those payloads omit the field entirely.
       state.selectedKey = {
         ...state.selectedKey,
-        data: { ...state.selectedKey.data, ...payload },
+        data: { ...payload, nameString: bufferToString(payload.name) },
         refreshing: false,
       }
     },

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -1,0 +1,90 @@
+import {
+  GetArrayCountResponse,
+  GetArrayElementResponse,
+  GetArrayLengthResponse,
+  GetArrayMultiElementsResponse,
+  GetArrayNextIndexResponse,
+  GetArrayRangeResponse,
+  GetArrayScanResponse,
+} from 'apiClient'
+import { RedisString } from 'uiSrc/slices/interfaces/app'
+
+/**
+ * Redis array indexes are unsigned 64-bit integers (0 … 2^64-1) and exceed
+ * `Number.MAX_SAFE_INTEGER`, so we keep them as canonical decimal strings
+ * end-to-end. Use `parseArrayIndex` / `isValidArrayIndex` from
+ * `uiSrc/utils/arrayIndex` for any user input.
+ */
+
+export interface ArrayDataElement {
+  /** Slot index — unsigned 64-bit integer as a decimal string. */
+  index: string
+  /** Stored value, or `null` for an empty slot. */
+  value: RedisString | null
+}
+
+export interface ArrayData {
+  keyName: RedisString
+  /** ARLEN — highest set index + 1 (includes gaps). Decimal string. */
+  length: string
+  /** ARCOUNT — count of populated (non-empty) slots. Decimal string. */
+  count: string
+  /**
+   * ARNEXT — next free index (only fetched on demand). Decimal string,
+   * or `null` when the insertion cursor is exhausted (u64 max reached).
+   * `undefined` means it hasn't been queried yet.
+   */
+  nextIndex?: string | null
+  /**
+   * Currently loaded elements. Population depends on which thunk last
+   * resolved: `fetchArrayRange` fills gaps with `value: null`, while
+   * `scanArrayRange` skips empty slots entirely.
+   */
+  elements: ArrayDataElement[]
+}
+
+export interface StateArray {
+  loading: boolean
+  error: string
+  data: ArrayData
+}
+
+export interface FetchArrayRangeParams {
+  key: RedisString
+  start: string
+  end: string
+  resetData?: boolean
+}
+
+export interface FetchArrayScanParams {
+  key: RedisString
+  start: string
+  end: string
+  limit?: number
+  resetData?: boolean
+}
+
+export interface FetchArrayElementParams {
+  key: RedisString
+  index: string
+}
+
+export interface FetchArrayMultiElementsParams {
+  key: RedisString
+  indexes: string[]
+}
+
+/**
+ * Re-export the auto-generated SDK response shapes for consumers that need
+ * to pass them around (e.g. thunk callbacks). The slice itself narrows them
+ * into `ArrayData` / `ArrayDataElement` for storage.
+ */
+export type {
+  GetArrayCountResponse,
+  GetArrayElementResponse,
+  GetArrayLengthResponse,
+  GetArrayMultiElementsResponse,
+  GetArrayNextIndexResponse,
+  GetArrayRangeResponse,
+  GetArrayScanResponse,
+}

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -43,9 +43,23 @@ export interface ArrayData {
   elements: ArrayDataElement[]
 }
 
+/**
+ * Last query the user (or initial-load effect) actually executed. Tracked
+ * on the slice so the key-header refresh button can replay it instead of
+ * falling back to fixed defaults that ignore the form's current bounds /
+ * gap-mode toggle.
+ */
+export interface ArrayActiveQuery {
+  start: string
+  end: string
+  /** true → ARGETRANGE (gap-preserving); false → ARSCAN (populated-only). */
+  showEmpty: boolean
+}
+
 export interface StateArray {
   loading: boolean
   error: string
+  query: ArrayActiveQuery
   data: ArrayData
 }
 

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -1,9 +1,6 @@
 import {
   GetArrayCountResponse,
-  GetArrayElementResponse,
   GetArrayLengthResponse,
-  GetArrayMultiElementsResponse,
-  GetArrayNextIndexResponse,
   GetArrayRangeResponse,
   GetArrayScanResponse,
 } from 'apiClient'
@@ -29,12 +26,6 @@ export interface ArrayData {
   length: string
   /** ARCOUNT — count of populated (non-empty) slots. Decimal string. */
   count: string
-  /**
-   * ARNEXT — next free index (only fetched on demand). Decimal string,
-   * or `null` when the insertion cursor is exhausted (u64 max reached).
-   * `undefined` means it hasn't been queried yet.
-   */
-  nextIndex?: string | null
   /**
    * Currently loaded elements. Population depends on which thunk last
    * resolved: `fetchArrayRange` fills gaps with `value: null`, while
@@ -78,27 +69,14 @@ export interface FetchArrayScanParams {
   resetData?: boolean
 }
 
-export interface FetchArrayElementParams {
-  key: RedisString
-  index: string
-}
-
-export interface FetchArrayMultiElementsParams {
-  key: RedisString
-  indexes: string[]
-}
-
 /**
  * Re-export the auto-generated SDK response shapes for consumers that need
- * to pass them around (e.g. thunk callbacks). The slice itself narrows them
- * into `ArrayData` / `ArrayDataElement` for storage.
+ * to pass them around. The slice itself narrows them into `ArrayData` /
+ * `ArrayDataElement` for storage.
  */
 export type {
   GetArrayCountResponse,
-  GetArrayElementResponse,
   GetArrayLengthResponse,
-  GetArrayMultiElementsResponse,
-  GetArrayNextIndexResponse,
   GetArrayRangeResponse,
   GetArrayScanResponse,
 }

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -65,7 +65,6 @@ export interface FetchArrayScanParams {
   key: RedisString
   start: string
   end: string
-  limit?: number
   resetData?: boolean
 }
 

--- a/redisinsight/ui/src/slices/interfaces/index.ts
+++ b/redisinsight/ui/src/slices/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './instances'
 export * from './vectorSet'
+export * from './array'
 export * from './hash'
 export * from './app'
 export * from './workbench'

--- a/redisinsight/ui/src/slices/store.ts
+++ b/redisinsight/ui/src/slices/store.ts
@@ -17,6 +17,7 @@ import listReducer from './browser/list'
 import rejsonReducer from './browser/rejson'
 import streamReducer from './browser/stream'
 import vectorSetReducer from './browser/vectorSet'
+import arrayReducer from './browser/array'
 import bulkActionsReducer from './browser/bulkActions'
 import notificationsReducer from './app/notifications'
 import cliSettingsReducer from './cli/cli-settings'
@@ -96,6 +97,7 @@ export const rootReducer = combineReducers({
     rejson: rejsonReducer,
     stream: streamReducer,
     vectorSet: vectorSetReducer,
+    array: arrayReducer,
     bulkActions: bulkActionsReducer,
     redisearch: redisearchReducer,
   }),

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { cloneDeep } from 'lodash'
 import { apiService } from 'uiSrc/services'
 import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
@@ -10,6 +11,7 @@ import {
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 
 import reducer, {
+  abortArrayRange,
   initialState,
   setArrayInitialState,
   setArrayActiveQuery,
@@ -241,6 +243,84 @@ describe('array slice', () => {
           loadArrayScanSuccess(response.data),
           updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
         ])
+      })
+    })
+
+    describe('abort plumbing (race-safety)', () => {
+      afterEach(() => abortArrayRange())
+
+      it('passes an AbortSignal to apiService.post', async () => {
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: { keyName: mockKey, elements: [] },
+        })
+
+        await store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+
+        const [, , config] = (apiService.post as jest.Mock).mock.calls[0]
+        expect(config?.signal).toBeInstanceOf(AbortSignal)
+      })
+
+      it('does not dispatch success/failure when the request is aborted', async () => {
+        let capturedSignal: AbortSignal | undefined
+        apiService.post = jest
+          .fn()
+          .mockImplementation((_url, _body, config) => {
+            capturedSignal = config?.signal
+            return new Promise((_resolve, reject) => {
+              capturedSignal?.addEventListener('abort', () => {
+                reject(new axios.Cancel('aborted by client'))
+              })
+            })
+          })
+
+        const dispatchPromise = store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+
+        abortArrayRange()
+        await dispatchPromise
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '1', showEmpty: true }),
+        ])
+      })
+
+      it('aborts the previous in-flight range request when a newer dispatch is made', async () => {
+        const signals: AbortSignal[] = []
+        apiService.post = jest
+          .fn()
+          .mockImplementation((_url, _body, config) => {
+            signals.push(config?.signal)
+            return new Promise((resolve, reject) => {
+              config?.signal?.addEventListener('abort', () => {
+                reject(new axios.Cancel('aborted by client'))
+              })
+              // Resolve only the second call; the first stays pending so the
+              // newer dispatch can abort it.
+              if (signals.length > 1) {
+                resolve({
+                  status: 200,
+                  data: { keyName: mockKey, elements: ['b'] },
+                })
+              }
+            })
+          })
+
+        const first = store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+        const second = store.dispatch<any>(
+          scanArrayRange({ key: mockKey, start: '2', end: '3' }),
+        )
+
+        await Promise.all([first, second])
+
+        expect(signals[0].aborted).toBe(true)
+        expect(signals[1].aborted).toBe(false)
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1,0 +1,356 @@
+import { cloneDeep } from 'lodash'
+import { apiService } from 'uiSrc/services'
+import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
+import {
+  cleanup,
+  initialStateDefault,
+  mockedStore,
+} from 'uiSrc/utils/test-utils'
+import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
+
+import reducer, {
+  initialState,
+  setArrayInitialState,
+  loadArrayRange,
+  loadArrayRangeSuccess,
+  loadArrayRangeFailure,
+  loadArrayScanSuccess,
+  loadArrayLengthSuccess,
+  loadArrayCountSuccess,
+  loadArrayNextIndexSuccess,
+  arraySelector,
+  arrayDataSelector,
+  fetchArrayRange,
+  scanArrayRange,
+  fetchArrayLength,
+  fetchArrayCount,
+  fetchArrayNextIndex,
+  fetchArrayElement,
+  fetchArrayMultiElements,
+} from '../../browser/array'
+import { updateSelectedKeyRefreshTime } from '../../browser/keys'
+import { addErrorNotification } from '../../app/notifications'
+
+jest.mock('uiSrc/services', () => ({
+  ...jest.requireActual('uiSrc/services'),
+}))
+
+// A plain `string` is a valid RedisString, and avoids enum-vs-literal
+// friction with the generated DTO types (which model the Buffer branch as
+// `{ type: 'Buffer'; data: number[] }`).
+const mockKey = 'readings'
+
+let store: typeof mockedStore
+let dateNow: jest.SpyInstance<number>
+
+beforeEach(() => {
+  cleanup()
+  store = cloneDeep(mockedStore)
+  store.clearActions()
+})
+
+describe('array slice', () => {
+  beforeAll(() => {
+    dateNow = jest.spyOn(Date, 'now').mockImplementation(() => MOCK_TIMESTAMP)
+  })
+
+  afterAll(() => {
+    dateNow.mockRestore()
+  })
+
+  describe('reducers', () => {
+    it('setArrayInitialState restores the initial state', () => {
+      const dirty = {
+        ...initialState,
+        loading: true,
+        error: 'boom',
+        data: { ...initialState.data, length: '99' },
+      }
+      expect(reducer(dirty, setArrayInitialState())).toEqual(initialState)
+    })
+
+    it('loadArrayRange flips loading and resets data when requested', () => {
+      const next = reducer(
+        { ...initialState, data: { ...initialState.data, length: '5' } },
+        loadArrayRange(true),
+      )
+      expect(next.loading).toBe(true)
+      expect(next.error).toBe('')
+      expect(next.data).toEqual(initialState.data)
+    })
+
+    it('loadArrayRange keeps data when resetData=false', () => {
+      const seeded = {
+        ...initialState,
+        data: { ...initialState.data, length: '5' },
+      }
+      const next = reducer(seeded, loadArrayRange(false))
+      expect(next.loading).toBe(true)
+      expect(next.data.length).toBe('5')
+    })
+
+    it('loadArrayRangeSuccess expands gap-preserving slots from start', () => {
+      const next = reducer(
+        initialState,
+        loadArrayRangeSuccess({
+          start: '10',
+          response: {
+            keyName: mockKey,
+            elements: ['a', null, 'b'],
+          },
+        }),
+      )
+      expect(next.loading).toBe(false)
+      expect(next.data.keyName).toEqual(mockKey)
+      expect(next.data.elements).toEqual([
+        { index: '10', value: 'a' },
+        { index: '11', value: null },
+        { index: '12', value: 'b' },
+      ])
+    })
+
+    it('loadArrayRangeFailure records the error', () => {
+      const next = reducer(
+        { ...initialState, loading: true },
+        loadArrayRangeFailure('boom'),
+      )
+      expect(next).toEqual({ ...initialState, loading: false, error: 'boom' })
+    })
+
+    it('loadArrayScanSuccess passes elements through as-is', () => {
+      const next = reducer(
+        { ...initialState, loading: true },
+        loadArrayScanSuccess({
+          keyName: mockKey,
+          elements: [
+            { index: '0', value: 'a' },
+            { index: '5', value: 'b' },
+          ],
+        }),
+      )
+      expect(next.loading).toBe(false)
+      expect(next.data.elements).toEqual([
+        { index: '0', value: 'a' },
+        { index: '5', value: 'b' },
+      ])
+    })
+
+    it('loadArrayLengthSuccess writes only length', () => {
+      const next = reducer(
+        initialState,
+        loadArrayLengthSuccess({ keyName: mockKey, length: '42' }),
+      )
+      expect(next.data.length).toBe('42')
+      expect(next.data.count).toBe(initialState.data.count)
+    })
+
+    it('loadArrayCountSuccess writes only count', () => {
+      const next = reducer(
+        initialState,
+        loadArrayCountSuccess({ keyName: mockKey, count: '7' }),
+      )
+      expect(next.data.count).toBe('7')
+    })
+
+    it('loadArrayNextIndexSuccess writes only nextIndex', () => {
+      const next = reducer(
+        initialState,
+        loadArrayNextIndexSuccess({ keyName: mockKey, index: '100' }),
+      )
+      expect(next.data.nextIndex).toBe('100')
+    })
+  })
+
+  describe('selectors', () => {
+    it('arraySelector and arrayDataSelector read from state.browser.array', () => {
+      const next = reducer(
+        initialState,
+        loadArrayLengthSuccess({ keyName: mockKey, length: '3' }),
+      )
+      const root = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: next },
+      }
+      expect(arraySelector(root)).toEqual(next)
+      expect(arrayDataSelector(root)).toEqual(next.data)
+    })
+  })
+
+  describe('thunks', () => {
+    describe('fetchArrayRange', () => {
+      it('dispatches success + refresh-time on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, elements: ['a', null] },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          loadArrayRangeSuccess({ start: '0', response: response.data }),
+          updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
+        ])
+      })
+
+      it('dispatches failure + notification on error', async () => {
+        const errorMessage = 'boom'
+        const rejected = {
+          response: { status: 500, data: { message: errorMessage } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(rejected)
+
+        await store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          addErrorNotification(rejected as IAddInstanceErrorPayload),
+          loadArrayRangeFailure(errorMessage),
+        ])
+      })
+    })
+
+    describe('scanArrayRange', () => {
+      it('dispatches success + refresh-time on 200', async () => {
+        const response = {
+          status: 200,
+          data: {
+            keyName: mockKey,
+            elements: [{ index: '0', value: 'a' }],
+          },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(
+          scanArrayRange({ key: mockKey, start: '0', end: '10', limit: 5 }),
+        )
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          loadArrayScanSuccess(response.data),
+          updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
+        ])
+      })
+    })
+
+    describe('fetchArrayLength', () => {
+      it('dispatches loadArrayLengthSuccess on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, length: '6' },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(fetchArrayLength(mockKey))
+
+        expect(store.getActions()).toEqual([
+          loadArrayLengthSuccess(response.data),
+        ])
+      })
+    })
+
+    describe('fetchArrayCount', () => {
+      it('dispatches loadArrayCountSuccess on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, count: '3' },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(fetchArrayCount(mockKey))
+
+        expect(store.getActions()).toEqual([
+          loadArrayCountSuccess(response.data),
+        ])
+      })
+    })
+
+    describe('fetchArrayNextIndex', () => {
+      it('dispatches loadArrayNextIndexSuccess on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, index: '6' },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(fetchArrayNextIndex(mockKey))
+
+        expect(store.getActions()).toEqual([
+          loadArrayNextIndexSuccess(response.data),
+        ])
+      })
+
+      it('dispatches error notification on rejection', async () => {
+        const rejected = {
+          response: { status: 500, data: { message: 'nope' } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(rejected)
+
+        await store.dispatch<any>(fetchArrayNextIndex(mockKey))
+
+        expect(store.getActions()).toEqual([
+          addErrorNotification(rejected as IAddInstanceErrorPayload),
+        ])
+      })
+    })
+
+    describe('fetchArrayElement', () => {
+      it('invokes onSuccess with the response value on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, value: '20.1' },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+        const onSuccess = jest.fn()
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(
+          fetchArrayElement({ key: mockKey, index: '0' }, onSuccess, onFail),
+        )
+
+        expect(onSuccess).toHaveBeenCalledWith(response.data)
+        expect(onFail).not.toHaveBeenCalled()
+      })
+
+      it('invokes onFail on rejection', async () => {
+        apiService.post = jest.fn().mockRejectedValue({
+          response: { status: 500, data: { message: 'nope' } },
+        })
+        const onSuccess = jest.fn()
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(
+          fetchArrayElement({ key: mockKey, index: '0' }, onSuccess, onFail),
+        )
+
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(onFail).toHaveBeenCalled()
+      })
+    })
+
+    describe('fetchArrayMultiElements', () => {
+      it('invokes onSuccess with the response on 200', async () => {
+        const response = {
+          status: 200,
+          data: { keyName: mockKey, elements: ['a', null, 'b'] },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+        const onSuccess = jest.fn()
+
+        await store.dispatch<any>(
+          fetchArrayMultiElements(
+            { key: mockKey, indexes: ['0', '1', '2'] },
+            onSuccess,
+          ),
+        )
+
+        expect(onSuccess).toHaveBeenCalledWith(response.data)
+      })
+    })
+  })
+})

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -5,12 +5,14 @@ import {
   cleanup,
   initialStateDefault,
   mockedStore,
+  mockStore,
 } from 'uiSrc/utils/test-utils'
 import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 
 import reducer, {
   initialState,
   setArrayInitialState,
+  setArrayActiveQuery,
   loadArrayRange,
   loadArrayRangeSuccess,
   loadArrayRangeFailure,
@@ -27,6 +29,7 @@ import reducer, {
   fetchArrayNextIndex,
   fetchArrayElement,
   fetchArrayMultiElements,
+  refreshArray,
 } from '../../browser/array'
 import { updateSelectedKeyRefreshTime } from '../../browser/keys'
 import { addErrorNotification } from '../../app/notifications'
@@ -191,6 +194,7 @@ describe('array slice', () => {
 
         expect(store.getActions()).toEqual([
           loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '1', showEmpty: true }),
           loadArrayRangeSuccess({ start: '0', response: response.data }),
           updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
         ])
@@ -209,6 +213,7 @@ describe('array slice', () => {
 
         expect(store.getActions()).toEqual([
           loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '1', showEmpty: true }),
           addErrorNotification(rejected as IAddInstanceErrorPayload),
           loadArrayRangeFailure(errorMessage),
         ])
@@ -232,9 +237,81 @@ describe('array slice', () => {
 
         expect(store.getActions()).toEqual([
           loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '10', showEmpty: false }),
           loadArrayScanSuccess(response.data),
           updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
         ])
+      })
+    })
+
+    describe('refreshArray', () => {
+      // `mockedStore` snapshots `initialStateDefault` and ignores dispatched
+      // actions, so use the factory to seed the active query into state.
+      const storeWithQuery = (query: {
+        start: string
+        end: string
+        showEmpty: boolean
+      }) =>
+        mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: { ...initialState, query },
+          },
+        })
+
+      it('replays the active range query (showEmpty: true → ARGETRANGE)', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = storeWithQuery({
+          start: '5',
+          end: '15',
+          showEmpty: true,
+        })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        const rangeCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/get-range'),
+        )
+        expect(rangeCall?.[1]).toEqual({
+          keyName: mockKey,
+          start: '5',
+          end: '15',
+        })
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/scan'),
+          ),
+        ).toBeUndefined()
+      })
+
+      it('replays the active scan query (showEmpty: false → ARSCAN)', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = storeWithQuery({
+          start: '5',
+          end: '15',
+          showEmpty: false,
+        })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        const scanCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/scan'),
+        )
+        expect(scanCall?.[1]).toEqual({
+          keyName: mockKey,
+          start: '5',
+          end: '15',
+        })
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/get-range'),
+          ),
+        ).toBeUndefined()
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -256,6 +256,29 @@ describe('array slice', () => {
           updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
         ])
       })
+
+      it('sends the default safety LIMIT so wide ranges stay bounded', async () => {
+        // ARSCAN has no span cap on the BE; the UI form allows ranges far
+        // wider than 1M for sparse browsing. Without LIMIT, a dense
+        // 0..10M range would return millions of elements — the thunk
+        // always pins LIMIT to the BE's ARRAY_RANGE_MAX_ELEMENTS.
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: { keyName: mockKey, elements: [] },
+        })
+
+        await store.dispatch<any>(
+          scanArrayRange({ key: mockKey, start: '0', end: '10000000' }),
+        )
+
+        const [, body] = (apiService.post as jest.Mock).mock.calls[0]
+        expect(body).toEqual({
+          keyName: mockKey,
+          start: '0',
+          end: '10000000',
+          limit: 1_000_000,
+        })
+      })
     })
 
     describe('abort plumbing (race-safety)', () => {
@@ -398,6 +421,7 @@ describe('array slice', () => {
           keyName: mockKey,
           start: '5',
           end: '15',
+          limit: 1_000_000,
         })
         expect(
           (apiService.post as jest.Mock).mock.calls.find(([url]) =>

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -21,16 +21,12 @@ import reducer, {
   loadArrayScanSuccess,
   loadArrayLengthSuccess,
   loadArrayCountSuccess,
-  loadArrayNextIndexSuccess,
   arraySelector,
   arrayDataSelector,
   fetchArrayRange,
   scanArrayRange,
   fetchArrayLength,
   fetchArrayCount,
-  fetchArrayNextIndex,
-  fetchArrayElement,
-  fetchArrayMultiElements,
   refreshArray,
 } from '../../browser/array'
 import { updateSelectedKeyRefreshTime } from '../../browser/keys'
@@ -155,14 +151,6 @@ describe('array slice', () => {
         loadArrayCountSuccess({ keyName: mockKey, count: '7' }),
       )
       expect(next.data.count).toBe('7')
-    })
-
-    it('loadArrayNextIndexSuccess writes only nextIndex', () => {
-      const next = reducer(
-        initialState,
-        loadArrayNextIndexSuccess({ keyName: mockKey, index: '100' }),
-      )
-      expect(next.data.nextIndex).toBe('100')
     })
   })
 
@@ -424,89 +412,6 @@ describe('array slice', () => {
         expect(store.getActions()).toEqual([
           loadArrayCountSuccess(response.data),
         ])
-      })
-    })
-
-    describe('fetchArrayNextIndex', () => {
-      it('dispatches loadArrayNextIndexSuccess on 200', async () => {
-        const response = {
-          status: 200,
-          data: { keyName: mockKey, index: '6' },
-        }
-        apiService.post = jest.fn().mockResolvedValue(response)
-
-        await store.dispatch<any>(fetchArrayNextIndex(mockKey))
-
-        expect(store.getActions()).toEqual([
-          loadArrayNextIndexSuccess(response.data),
-        ])
-      })
-
-      it('dispatches error notification on rejection', async () => {
-        const rejected = {
-          response: { status: 500, data: { message: 'nope' } },
-        }
-        apiService.post = jest.fn().mockRejectedValue(rejected)
-
-        await store.dispatch<any>(fetchArrayNextIndex(mockKey))
-
-        expect(store.getActions()).toEqual([
-          addErrorNotification(rejected as IAddInstanceErrorPayload),
-        ])
-      })
-    })
-
-    describe('fetchArrayElement', () => {
-      it('invokes onSuccess with the response value on 200', async () => {
-        const response = {
-          status: 200,
-          data: { keyName: mockKey, value: '20.1' },
-        }
-        apiService.post = jest.fn().mockResolvedValue(response)
-        const onSuccess = jest.fn()
-        const onFail = jest.fn()
-
-        await store.dispatch<any>(
-          fetchArrayElement({ key: mockKey, index: '0' }, onSuccess, onFail),
-        )
-
-        expect(onSuccess).toHaveBeenCalledWith(response.data)
-        expect(onFail).not.toHaveBeenCalled()
-      })
-
-      it('invokes onFail on rejection', async () => {
-        apiService.post = jest.fn().mockRejectedValue({
-          response: { status: 500, data: { message: 'nope' } },
-        })
-        const onSuccess = jest.fn()
-        const onFail = jest.fn()
-
-        await store.dispatch<any>(
-          fetchArrayElement({ key: mockKey, index: '0' }, onSuccess, onFail),
-        )
-
-        expect(onSuccess).not.toHaveBeenCalled()
-        expect(onFail).toHaveBeenCalled()
-      })
-    })
-
-    describe('fetchArrayMultiElements', () => {
-      it('invokes onSuccess with the response on 200', async () => {
-        const response = {
-          status: 200,
-          data: { keyName: mockKey, elements: ['a', null, 'b'] },
-        }
-        apiService.post = jest.fn().mockResolvedValue(response)
-        const onSuccess = jest.fn()
-
-        await store.dispatch<any>(
-          fetchArrayMultiElements(
-            { key: mockKey, indexes: ['0', '1', '2'] },
-            onSuccess,
-          ),
-        )
-
-        expect(onSuccess).toHaveBeenCalledWith(response.data)
       })
     })
   })

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -95,6 +95,7 @@ describe('array slice', () => {
         initialState,
         loadArrayRangeSuccess({
           start: '10',
+          end: '12',
           response: {
             keyName: mockKey,
             elements: ['a', null, 'b'],
@@ -107,6 +108,25 @@ describe('array slice', () => {
         { index: '10', value: 'a' },
         { index: '11', value: null },
         { index: '12', value: 'b' },
+      ])
+    })
+
+    it('loadArrayRangeSuccess steps the offset downwards for reversed ranges', () => {
+      const next = reducer(
+        initialState,
+        loadArrayRangeSuccess({
+          start: '12',
+          end: '10',
+          response: {
+            keyName: mockKey,
+            elements: ['c', null, 'a'],
+          },
+        }),
+      )
+      expect(next.data.elements).toEqual([
+        { index: '12', value: 'c' },
+        { index: '11', value: null },
+        { index: '10', value: 'a' },
       ])
     })
 
@@ -185,7 +205,11 @@ describe('array slice', () => {
         expect(store.getActions()).toEqual([
           loadArrayRange(undefined),
           setArrayActiveQuery({ start: '0', end: '1', showEmpty: true }),
-          loadArrayRangeSuccess({ start: '0', response: response.data }),
+          loadArrayRangeSuccess({
+            start: '0',
+            end: '1',
+            response: response.data,
+          }),
           updateSelectedKeyRefreshTime(MOCK_TIMESTAMP),
         ])
       })

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { cloneDeep } from 'lodash'
 import { apiService } from 'uiSrc/services'
+import { DEFAULT_ERROR_MESSAGE } from 'uiSrc/utils'
 import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
 import {
   cleanup,
@@ -232,6 +233,22 @@ describe('array slice', () => {
           loadArrayRangeFailure(errorMessage),
         ])
       })
+
+      it('dispatches failure when the response resolves with a non-success status', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 304, data: null })
+
+        await store.dispatch<any>(
+          fetchArrayRange({ key: mockKey, start: '0', end: '1' }),
+        )
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '1', showEmpty: true }),
+          loadArrayRangeFailure(DEFAULT_ERROR_MESSAGE),
+        ])
+      })
     })
 
     describe('scanArrayRange', () => {
@@ -278,6 +295,22 @@ describe('array slice', () => {
           end: '10000000',
           limit: 1_000_000,
         })
+      })
+
+      it('dispatches failure when the response resolves with a non-success status', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 304, data: null })
+
+        await store.dispatch<any>(
+          scanArrayRange({ key: mockKey, start: '0', end: '10' }),
+        )
+
+        expect(store.getActions()).toEqual([
+          loadArrayRange(undefined),
+          setArrayActiveQuery({ start: '0', end: '10', showEmpty: false }),
+          loadArrayRangeFailure(DEFAULT_ERROR_MESSAGE),
+        ])
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -246,7 +246,7 @@ describe('array slice', () => {
         apiService.post = jest.fn().mockResolvedValue(response)
 
         await store.dispatch<any>(
-          scanArrayRange({ key: mockKey, start: '0', end: '10', limit: 5 }),
+          scanArrayRange({ key: mockKey, start: '0', end: '10' }),
         )
 
         expect(store.getActions()).toEqual([

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -514,7 +514,7 @@ describe('keys slice', () => {
         selectedKey: {
           ...initialState.selectedKey,
           refreshing: false,
-          data: { ...initialState.selectedKey.data, ...data },
+          data: { ...data, nameString: 'keyName' },
         },
       }
 
@@ -526,6 +526,45 @@ describe('keys slice', () => {
         browser: { keys: nextState },
       })
       expect(keysSelector(rootState)).toEqual(state)
+    })
+
+    it('should drop type-specific fields absent from the new payload', () => {
+      // Refresh after a key is overwritten as a different type should
+      // not leak stale type-specific fields (count from Array,
+      // vectorDim/quantType from Vector Set, etc.). Reducer replaces
+      // `data` outright instead of merging the payload over it.
+      const previous = {
+        ...initialState,
+        selectedKey: {
+          ...initialState.selectedKey,
+          data: {
+            name: stringToBuffer('keyName'),
+            type: KeyTypes.Array,
+            ttl: -1,
+            size: 100,
+            length: 6,
+            count: 7,
+            nameString: 'keyName',
+          },
+        },
+      }
+      // Simulates the same key being overwritten as a String — the BE's
+      // string key-info strategy omits `count`.
+      const refreshed = {
+        name: stringToBuffer('keyName'),
+        type: KeyTypes.String,
+        ttl: -1,
+        size: 5,
+        length: 5,
+      }
+
+      const nextState = reducer(previous, refreshKeyInfoSuccess(refreshed))
+
+      expect(nextState.selectedKey.data).toEqual({
+        ...refreshed,
+        nameString: 'keyName',
+      })
+      expect(nextState.selectedKey.data?.count).toBeUndefined()
     })
   })
 

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -543,7 +543,7 @@ describe('keys slice', () => {
             ttl: -1,
             size: 100,
             length: 6,
-            count: 7,
+            count: '7',
             nameString: 'keyName',
           },
         },

--- a/redisinsight/ui/src/utils/test-utils.tsx
+++ b/redisinsight/ui/src/utils/test-utils.tsx
@@ -35,6 +35,7 @@ import { initialState as initialStateList } from 'uiSrc/slices/browser/list'
 import { initialState as initialStateRejson } from 'uiSrc/slices/browser/rejson'
 import { initialState as initialStateStream } from 'uiSrc/slices/browser/stream'
 import { initialState as initialStateVectorSet } from 'uiSrc/slices/browser/vectorSet'
+import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
 import { initialState as initialStateBulkActions } from 'uiSrc/slices/browser/bulkActions'
 import { initialState as initialStateNotifications } from 'uiSrc/slices/app/notifications'
 import { initialState as initialStateAppInfo } from 'uiSrc/slices/app/info'
@@ -128,6 +129,7 @@ const initialStateDefault: RootState = {
     rejson: cloneDeep(initialStateRejson),
     stream: cloneDeep(initialStateStream),
     vectorSet: cloneDeep(initialStateVectorSet),
+    array: cloneDeep(initialStateArray),
     bulkActions: cloneDeep(initialStateBulkActions),
     redisearch: cloneDeep(initialStateRedisearch),
   },


### PR DESCRIPTION
# What

Frontend slice of the Array data type **read** vertical (RI-8219). Stacks on top of the backend PR #6064 — review/land that first since this consumes its endpoints.

| Light                                                                                                                                                           | Dark                                                                                                                                                            |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1441" height="945" alt="Screenshot 2026-06-15 at 15 00 29" src="https://github.com/user-attachments/assets/2e9fa74c-5396-4dc0-b7fe-7904daadf1b3" /> | <img width="1441" height="945" alt="Screenshot 2026-06-15 at 14 59 02" src="https://github.com/user-attachments/assets/75b2a5bc-71ff-4b0d-b28c-c2f0abb6cdfd" /> |
| <img width="1441" height="945" alt="Screenshot 2026-06-15 at 15 00 21" src="https://github.com/user-attachments/assets/99bcd13e-e511-4d14-99c7-60db83c458d7" /> | <img width="1441" height="945" alt="Screenshot 2026-06-15 at 14 59 09" src="https://github.com/user-attachments/assets/ec8f1e56-b3fa-4543-824b-f98ed6d88fcb" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new browser vertical touching Redux, key refresh, and concurrent API calls; behavior is gated by a feature flag but key-header refresh semantics changed for all types.
> 
> **Overview**
> **Adds the Array key “View / Browse” vertical** behind `dev-array`, wiring `DynamicTypeDetails` to a new `ArrayDetails` screen: header, range form (start/end, “show empty indexes”, CLI preview, validation), and a read-only index/value table with u64-safe decimal-string indexes.
> 
> **Introduces `browser.array` Redux** with thunks for `array/get-range`, `array/scan`, `array/get-length`, and `array/get-count`; abort/race handling; `refreshArray` replaying the last query on header refresh; and `useArrayRangeQuery` for auto-load on key switch and guarded dispatches until key type/name match `keyProp`.
> 
> **Surfaces ARCOUNT in the key header** via optional `count` on key info and `KeyDetailsHeaderSizeLength`. **`refreshKeyInfoSuccess` now replaces selected key data** instead of merging, so type-specific fields (e.g. array `count`) do not leak after a key is overwritten as another type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c87f2cb75ed15424a0541afddb4a8fef6d26d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->