### PR TITLE
merge latest to main 

### DIFF
--- a/.github/actions/install-all-build-libs/action.yml
+++ b/.github/actions/install-all-build-libs/action.yml
@@ -14,6 +14,11 @@ inputs:
     description: SQLite3 binary host mirror
     required: false
 
+  cache-node-modules:
+    description: Cache node_modules between runs ('1' enabled, '0' disabled). Disable for jobs that build the application to avoid stale nested deps surviving lockfile changes.
+    default: '1'
+    required: false
+
 runs:
   using: 'composite'
   steps:
@@ -24,6 +29,7 @@ runs:
 
     - name: Cache node_modules
       id: cache-node-modules
+      if: inputs.cache-node-modules != '0'
       uses: actions/cache@v5
       with:
         path: |

--- a/.github/workflows/pipeline-build-docker.yml
+++ b/.github/workflows/pipeline-build-docker.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Build sources
         run: ./.github/build/build.sh

--- a/.github/workflows/pipeline-build-linux.yml
+++ b/.github/workflows/pipeline-build-linux.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics

--- a/.github/workflows/pipeline-build-macos.yml
+++ b/.github/workflows/pipeline-build-macos.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           keytar-host-mirror: ${{ secrets.NPM_CONFIG_KEYTAR_BINARY_HOST_MIRROR }}
           sqlite3-host-mirror: ${{ secrets.NPM_CONFIG_NODE_SQLITE3_BINARY_HOST_MIRROR }}
+          cache-node-modules: '0'
 
       - name: Install plugins dependencies and build plugins
         run: yarn build:statics

--- a/.github/workflows/pipeline-build-windows.yml
+++ b/.github/workflows/pipeline-build-windows.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install all libs and dependencies
         uses: ./.github/actions/install-all-build-libs
+        with:
+          cache-node-modules: '0'
 
       - name: Setup certs
         uses: ./.github/actions/install-windows-certs

--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Install application dependencies
         uses: ./.github/actions/install-all-build-libs
+        with:
+          cache-node-modules: '0'
 
       - name: Setup E2E environment
         uses: ./.github/actions/setup-e2e-playwright

--- a/docs/release-notes/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/release-notes/RELEASE_NOTES_TEMPLATE.md
@@ -24,6 +24,14 @@
 
 ---
 
+### New Contributors
+
+* @[github-handle] made their first contribution in [PR link]
+
+(Include this section only when there is at least one new contributor since the previous release. Start from GitHub's auto-generated list via `gh api -X POST repos/redis/RedisInsight/releases/generate-notes -f tag_name=[VERSION] -f previous_tag_name=[LAST_RELEASED] -f target_commitish=main --jq '.body'`, but note it only catches authors whose commits land directly on `main` — external contributors whose work was merged through a feature branch (and then squashed) will be missed and must be added manually.)
+
+---
+
 **SHA-512 Checksums**
 
 [Link to checksums]

--- a/redisinsight/api/bruno/RedisInsight/Array/Create Array (Contiguous).bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Create Array (Contiguous).bru
@@ -1,0 +1,57 @@
+meta {
+  name: Create Array (Contiguous)
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "ar:readings",
+    "mode": "contiguous",
+    "startIndex": "0",
+    "values": ["20.1", "20.4", "20.9"],
+    "expire": 3600
+  }
+}
+
+docs {
+  # Create Array (Contiguous)
+
+  Creates a new Array key in contiguous mode. Uses the Redis `ARSET` command internally: `ARSET key startIndex value [value ...]` writes the provided values as a consecutive run starting at `startIndex`.
+
+  The example above creates the `ar:readings` array with three values at indexes `0`, `1`, and `2`, expiring after one hour.
+
+  Indexes are passed as numeric strings because the Array type supports the full unsigned 64-bit range, which exceeds JavaScript's safe integer range.
+
+  ## Request Body
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The key name for the new Array |
+  | `mode` | string | Must be `contiguous` for this request shape |
+  | `startIndex` | string | Start index as a numeric string (`0` to `18446744073709551615`) |
+  | `values` | string[] | Value(s) to write starting at `startIndex` |
+  | `expire` | number (optional) | TTL in seconds |
+
+  ## Response
+
+  Returns `201 Created` with no body on success.
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Validation failed, e.g. a non-canonical index: `startIndex must be an integer string between 0 and 18446744073709551615` |
+  | `403` | User has no permissions |
+  | `409` | Key with this name already exists |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Array/Create Array (Sparse).bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Create Array (Sparse).bru
@@ -1,0 +1,60 @@
+meta {
+  name: Create Array (Sparse)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "ar:readings:sparse",
+    "mode": "sparse",
+    "elements": [
+      { "index": "0", "value": "20.1" },
+      { "index": "5", "value": "21.4" },
+      { "index": "42", "value": "23.1" }
+    ]
+  }
+}
+
+docs {
+  # Create Array (Sparse)
+
+  Creates a new Array key in sparse mode. Uses the Redis `ARMSET` command internally: `ARMSET key index value [index value ...]` writes explicit index/value pairs, leaving the gaps between them unset.
+
+  The example above creates the `ar:readings:sparse` array with values at indexes `0`, `5`, and `42` only.
+
+  Indexes are passed as numeric strings because the Array type supports the full unsigned 64-bit range, which exceeds JavaScript's safe integer range.
+
+  ## Request Body
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `keyName` | string | The key name for the new Array |
+  | `mode` | string | Must be `sparse` for this request shape |
+  | `elements` | array | Index/value pairs to write |
+  | `elements[].index` | string | Element index as a numeric string (`0` to `18446744073709551615`) |
+  | `elements[].value` | string | Element value |
+  | `expire` | number (optional) | TTL in seconds |
+
+  ## Response
+
+  Returns `201 Created` with no body on success.
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Validation failed, e.g. a non-canonical index: `elements.0.index must be an integer string between 0 and 18446744073709551615` |
+  | `403` | User has no permissions |
+  | `409` | Key with this name already exists |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Array/folder.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Array
+}
+

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.91,
+  "version": 3.93,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -139,17 +139,17 @@
       "flag": false,
       "perc": [[0, 100]]
     },
-    "dev-vectorSet": {
-      "flag": false,
-      "perc": [[0, 100]]
+    "vectorSet": {
+      "flag": true,
+      "perc": [[0, 10]]
     },
     "dev-array": {
       "flag": false,
       "perc": [[0, 100]]
     },
     "prodMode": {
-      "flag": false,
-      "perc": [[0, 100]]
+      "flag": true,
+      "perc": [[0, 10]]
     }
   }
 }

--- a/redisinsight/api/src/common/decorators/array-index/array-index.decorator.spec.ts
+++ b/redisinsight/api/src/common/decorators/array-index/array-index.decorator.spec.ts
@@ -1,0 +1,65 @@
+import { validate } from 'class-validator';
+import { IsArrayIndex } from 'src/common/decorators';
+
+class SingleIndexDto {
+  @IsArrayIndex()
+  index: string;
+}
+
+class MultiIndexDto {
+  @IsArrayIndex({ each: true })
+  indexes: string[];
+}
+
+const validateSingle = async (index: any) => {
+  const dto = new SingleIndexDto();
+  dto.index = index;
+  return validate(dto);
+};
+
+describe('IsArrayIndex', () => {
+  it.each(['0', '42', '18446744073709551615'])(
+    'should pass for valid index %p',
+    async (input) => {
+      expect(await validateSingle(input)).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    '-1',
+    '1.5',
+    'abc',
+    '',
+    '18446744073709551616',
+    42,
+    undefined,
+    '007',
+    ' 42 ',
+  ])('should fail for %p', async (input) => {
+    const errors = await validateSingle(input);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('should fail with the documented (stable) message', async () => {
+    const errors = await validateSingle('-1');
+    // Consumers may match on this exact format — changing it is breaking.
+    expect(errors[0].constraints).toEqual({
+      ArrayIndexValidator:
+        'index must be an integer string between 0 and 18446744073709551615',
+    });
+  });
+
+  it('should fail with { each: true } when any element is invalid', async () => {
+    const dto = new MultiIndexDto();
+    dto.indexes = ['1', '-1', '3'];
+
+    expect(await validate(dto)).toHaveLength(1);
+  });
+
+  it('should pass with { each: true } when all elements are valid', async () => {
+    const dto = new MultiIndexDto();
+    dto.indexes = ['1', '2', '18446744073709551615'];
+
+    expect(await validate(dto)).toHaveLength(0);
+  });
+});

--- a/redisinsight/api/src/common/decorators/array-index/array-index.decorator.ts
+++ b/redisinsight/api/src/common/decorators/array-index/array-index.decorator.ts
@@ -1,0 +1,14 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { ArrayIndexValidator } from 'src/common/validators';
+
+export function IsArrayIndex(validationOptions?: ValidationOptions) {
+  return (object: any, propertyName: string) => {
+    registerDecorator({
+      name: 'isArrayIndex',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: ArrayIndexValidator,
+    });
+  };
+}

--- a/redisinsight/api/src/common/decorators/array-index/index.ts
+++ b/redisinsight/api/src/common/decorators/array-index/index.ts
@@ -1,0 +1,1 @@
+export * from './array-index.decorator';

--- a/redisinsight/api/src/common/decorators/index.ts
+++ b/redisinsight/api/src/common/decorators/index.ts
@@ -1,5 +1,6 @@
 export * from './redis-string';
 export * from './zset-score';
+export * from './array-index';
 export * from './default';
 export * from './data-as-json-string.decorator';
 export * from './session';

--- a/redisinsight/api/src/common/utils/array-index.helper.spec.ts
+++ b/redisinsight/api/src/common/utils/array-index.helper.spec.ts
@@ -1,0 +1,53 @@
+import {
+  ARRAY_INDEX_MAX,
+  isValidArrayIndex,
+  parseArrayIndex,
+} from 'src/common/utils';
+
+describe('array-index.helper', () => {
+  it('should expose max unsigned 64-bit value', () => {
+    expect(ARRAY_INDEX_MAX).toEqual(BigInt('18446744073709551615'));
+  });
+
+  describe('parseArrayIndex', () => {
+    it.each([
+      { input: '0', expected: '0' },
+      { input: '7', expected: '7' },
+      { input: '007', expected: '7' }, // leading zeros normalized
+      { input: ' 42 ', expected: '42' }, // outer whitespace trimmed
+      { input: '18446744073709551615', expected: '18446744073709551615' }, // max u64
+      { input: '18446744073709551616', expected: null }, // max + 1
+      { input: '184467440737095516150', expected: null }, // 21 digits — length guard
+      { input: '00000000000000000000042', expected: null }, // >20 chars — guard trumps normalization
+      { input: '-1', expected: null },
+      { input: '1.5', expected: null },
+      { input: '1e3', expected: null },
+      { input: '0x10', expected: null },
+      { input: 'abc', expected: null },
+      { input: '1 2', expected: null }, // internal whitespace
+      { input: '', expected: null },
+      { input: '   ', expected: null },
+    ])('should return $expected for $input', ({ input, expected }) => {
+      expect(parseArrayIndex(input)).toEqual(expected);
+    });
+
+    it.each([null, undefined, 7, BigInt(7), {}])(
+      'should return null for non-string %p',
+      (input) => {
+        expect(parseArrayIndex(input)).toEqual(null);
+      },
+    );
+  });
+
+  describe('isValidArrayIndex', () => {
+    it('should return true for a valid index', () => {
+      expect(isValidArrayIndex('123')).toEqual(true);
+    });
+    it('should return false for an invalid index', () => {
+      expect(isValidArrayIndex('-1')).toEqual(false);
+    });
+    it('should return false for non-string input', () => {
+      expect(isValidArrayIndex(42)).toEqual(false);
+    });
+  });
+});

--- a/redisinsight/api/src/common/utils/array-index.helper.ts
+++ b/redisinsight/api/src/common/utils/array-index.helper.ts
@@ -1,0 +1,43 @@
+/**
+ * Redis array indexes are unsigned 64-bit integers (0 … 2^64−1) and exceed
+ * Number.MAX_SAFE_INTEGER, so they travel as numeric strings end-to-end —
+ * never parseInt/Number, no JS-side arithmetic on indexes.
+ *
+ * Mirrored in redisinsight/ui/src/utils/arrayIndex.ts — keep semantics and
+ * tests in sync.
+ */
+// 2^64 - 1; BigInt() call (not a literal) — this tsconfig targets es2019,
+// where BigInt literals are a syntax error (TS2737).
+export const ARRAY_INDEX_MAX = BigInt('18446744073709551615');
+
+const ARRAY_INDEX_REGEX = /^\d+$/;
+
+// Max u64 is 20 digits; longer all-digit inputs can't be valid and a length
+// guard keeps BigInt() from parsing arbitrarily large request payloads.
+const ARRAY_INDEX_MAX_LENGTH = 20;
+
+/**
+ * Returns the canonical decimal string for a valid index ("007" → "7"),
+ * or null for anything else (empty or whitespace-only, negative,
+ * fractional, exponent, hex, > 2^64−1, non-string input).
+ */
+export const parseArrayIndex = (input: unknown): string | null => {
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const value = input.trim();
+  if (!ARRAY_INDEX_REGEX.test(value)) {
+    return null;
+  }
+
+  if (value.length > ARRAY_INDEX_MAX_LENGTH) {
+    return null;
+  }
+
+  const index = BigInt(value);
+  return index > ARRAY_INDEX_MAX ? null : index.toString();
+};
+
+export const isValidArrayIndex = (input: unknown): boolean =>
+  parseArrayIndex(input) !== null;

--- a/redisinsight/api/src/common/utils/index.ts
+++ b/redisinsight/api/src/common/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './array-index.helper';
 export * from './certificate-import.util';
 export * from './errors.util';
 export * from './merge.util';

--- a/redisinsight/api/src/common/validators/array-index.validator.ts
+++ b/redisinsight/api/src/common/validators/array-index.validator.ts
@@ -1,0 +1,23 @@
+import {
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import {
+  ARRAY_INDEX_MAX,
+  parseArrayIndex,
+} from 'src/common/utils/array-index.helper';
+
+@ValidatorConstraint({ name: 'ArrayIndexValidator', async: false })
+export class ArrayIndexValidator implements ValidatorConstraintInterface {
+  validate(value: unknown) {
+    // Validators don't transform, so anything accepted reaches Redis verbatim;
+    // only the canonical form passes ('007' / ' 42 ' are rejected).
+    return typeof value === 'string' && parseArrayIndex(value) === value;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    // Stable message — consumers may match on it; changing it is breaking.
+    return `${args?.property || 'field'} must be an integer string between 0 and ${ARRAY_INDEX_MAX}`;
+  }
+}

--- a/redisinsight/api/src/common/validators/index.ts
+++ b/redisinsight/api/src/common/validators/index.ts
@@ -4,3 +4,4 @@ export * from './multi-number.validator';
 export * from './bigger-than.validator';
 export * from './github-link.validator';
 export * from './no-duplicates.validator';
+export * from './array-index.validator';

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -1,0 +1,32 @@
+import { Factory } from 'fishery';
+import { faker } from '@faker-js/faker';
+import {
+  ArrayCreationMode,
+  ArrayElementDto,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
+
+const arrayKeyName = () => Buffer.from(`array:${faker.string.alphanumeric(6)}`);
+const arrayValue = () => Buffer.from(faker.string.alphanumeric(8));
+
+export const arrayElementFactory = Factory.define<ArrayElementDto>(
+  ({ sequence }) => ({
+    index: `${sequence}`,
+    value: arrayValue(),
+  }),
+);
+
+export const createContiguousArrayDtoFactory =
+  Factory.define<CreateArrayWithExpireDto>(() => ({
+    keyName: arrayKeyName(),
+    mode: ArrayCreationMode.Contiguous,
+    startIndex: '0',
+    values: [arrayValue(), arrayValue()],
+  }));
+
+export const createSparseArrayDtoFactory =
+  Factory.define<CreateArrayWithExpireDto>(() => ({
+    keyName: arrayKeyName(),
+    mode: ArrayCreationMode.Sparse,
+    elements: arrayElementFactory.buildList(2),
+  }));

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,0 +1,20 @@
+import {
+  Controller,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { BrowserSerializeInterceptor } from 'src/common/interceptors';
+import { BrowserBaseController } from 'src/modules/browser/browser.base.controller';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+
+@ApiTags('Browser: Array')
+@UseInterceptors(BrowserSerializeInterceptor)
+@Controller('array')
+@UsePipes(new ValidationPipe({ transform: true }))
+export class ArrayController extends BrowserBaseController {
+  constructor(private arrayService: ArrayService) {
+    super();
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,13 +1,20 @@
 import {
+  Body,
   Controller,
+  Post,
   UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiRedisParams } from 'src/decorators/api-redis-params.decorator';
+import { ApiQueryRedisStringEncoding } from 'src/common/decorators';
+import { ClientMetadata } from 'src/common/models';
 import { BrowserSerializeInterceptor } from 'src/common/interceptors';
+import { BrowserClientMetadata } from 'src/modules/browser/decorators/browser-client-metadata.decorator';
 import { BrowserBaseController } from 'src/modules/browser/browser.base.controller';
 import { ArrayService } from 'src/modules/browser/array/array.service';
+import { CreateArrayWithExpireDto } from 'src/modules/browser/array/dto';
 
 @ApiTags('Browser: Array')
 @UseInterceptors(BrowserSerializeInterceptor)
@@ -16,5 +23,17 @@ import { ArrayService } from 'src/modules/browser/array/array.service';
 export class ArrayController extends BrowserBaseController {
   constructor(private arrayService: ArrayService) {
     super();
+  }
+
+  @Post('')
+  @ApiOperation({ description: 'Set key to hold Array data type' })
+  @ApiRedisParams()
+  @ApiBody({ type: CreateArrayWithExpireDto })
+  @ApiQueryRedisStringEncoding()
+  async createArray(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    return this.arrayService.createArray(clientMetadata, dto);
   }
 }

--- a/redisinsight/api/src/modules/browser/array/array.module.ts
+++ b/redisinsight/api/src/modules/browser/array/array.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+import { ArrayController } from 'src/modules/browser/array/array.controller';
+
+@Module({})
+export class ArrayModule {
+  static register({ route }: { route: string }): DynamicModule {
+    return {
+      module: ArrayModule,
+      imports: [
+        RouterModule.register([
+          {
+            path: route,
+            module: ArrayModule,
+          },
+        ]),
+      ],
+      controllers: [ArrayController],
+      providers: [ArrayService],
+    };
+  }
+}

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -3,41 +3,22 @@ import { ConflictException, ForbiddenException } from '@nestjs/common';
 import { when } from 'jest-when';
 import { ReplyError } from 'src/models/redis-client';
 import { mockBrowserClientMetadata, mockRedisNoPermError } from 'src/__mocks__';
-import { mockKeyDto } from 'src/modules/browser/__mocks__';
 import {
   BrowserToolArrayCommands,
   BrowserToolKeysCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
 import {
-  ArrayCreationMode,
-  CreateArrayWithExpireDto,
-} from 'src/modules/browser/array/dto';
+  createContiguousArrayDtoFactory,
+  createSparseArrayDtoFactory,
+} from 'src/modules/browser/array/__tests__/array.factory';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { mockDatabaseClientFactory } from 'src/__mocks__/databases-client';
 import { mockStandaloneRedisClient } from 'src/__mocks__/redis-client';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ArrayService } from 'src/modules/browser/array/array.service';
 
-const mockArrayValue = Buffer.from('Lorem ipsum dolor sit amet.');
-const mockArrayValue2 = Buffer.from('Lorem ipsum dolor sit amet2.');
-
-const mockCreateContiguousArrayDto: CreateArrayWithExpireDto = {
-  keyName: mockKeyDto.keyName,
-  mode: ArrayCreationMode.Contiguous,
-  startIndex: '0',
-  values: [mockArrayValue, mockArrayValue2],
-};
-
-const mockCreateSparseArrayDto: CreateArrayWithExpireDto = {
-  keyName: mockKeyDto.keyName,
-  mode: ArrayCreationMode.Sparse,
-  elements: [
-    { index: '5', value: mockArrayValue },
-    { index: '17', value: mockArrayValue2 },
-  ],
-};
-
 describe('ArrayService', () => {
+  const client = mockStandaloneRedisClient;
   let service: ArrayService;
 
   beforeEach(async () => {
@@ -52,12 +33,8 @@ describe('ArrayService', () => {
     }).compile();
 
     service = module.get(ArrayService);
-    mockStandaloneRedisClient.sendCommand = jest
-      .fn()
-      .mockResolvedValue(undefined);
-    mockStandaloneRedisClient.sendPipeline = jest
-      .fn()
-      .mockResolvedValue(undefined);
+    client.sendCommand = jest.fn().mockResolvedValue(undefined);
+    client.sendPipeline = jest.fn().mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
@@ -65,58 +42,54 @@ describe('ArrayService', () => {
   });
 
   describe('createArray', () => {
-    beforeEach(() => {
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
-        .mockResolvedValue(false);
-    });
-
     it('create contiguous array without expiration', async () => {
+      const dto = createContiguousArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+      expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolArrayCommands.ArSet,
-        mockKeyDto.keyName,
-        '0',
-        mockArrayValue,
-        mockArrayValue2,
+        dto.keyName,
+        dto.startIndex,
+        ...(dto.values ?? []),
       ]);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it('create sparse array without expiration', async () => {
+      const dto = createSparseArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateSparseArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+      expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolArrayCommands.ArMSet,
-        mockKeyDto.keyName,
-        '5',
-        mockArrayValue,
-        '17',
-        mockArrayValue2,
+        dto.keyName,
+        ...(dto.elements ?? []).flatMap(({ index, value }) => [index, value]),
       ]);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it('create contiguous array with expiration', async () => {
-      const dto: CreateArrayWithExpireDto = {
-        keyName: mockKeyDto.keyName,
-        mode: ArrayCreationMode.Contiguous,
-        startIndex: '0',
-        values: [mockArrayValue],
-        expire: 1000,
-      };
-      when(mockStandaloneRedisClient.sendPipeline)
+      const dto = createContiguousArrayDtoFactory.build({ expire: 1000 });
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(false);
+      when(client.sendPipeline)
         .calledWith([
-          [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+          [
+            BrowserToolArrayCommands.ArSet,
+            dto.keyName,
+            dto.startIndex,
+            ...(dto.values ?? []),
+          ],
           [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
         ])
         .mockResolvedValue([
@@ -127,42 +100,43 @@ describe('ArrayService', () => {
       await expect(
         service.createArray(mockBrowserClientMetadata, dto),
       ).resolves.not.toThrow();
-      expect(mockStandaloneRedisClient.sendPipeline).toHaveBeenCalledWith([
-        [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+      expect(client.sendPipeline).toHaveBeenCalledWith([
+        [
+          BrowserToolArrayCommands.ArSet,
+          dto.keyName,
+          dto.startIndex,
+          ...(dto.values ?? []),
+        ],
         [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
       ]);
     });
 
     it('key with this name exist', async () => {
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+      const dto = createContiguousArrayDtoFactory.build();
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
         .mockResolvedValue(true);
 
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(new ConflictException(ERROR_MESSAGES.KEY_NAME_EXIST));
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendCommand).toHaveBeenCalledTimes(1);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
 
     it("user don't have required permissions for createArray", async () => {
+      const dto = createContiguousArrayDtoFactory.build();
       const replyError: ReplyError = {
         ...mockRedisNoPermError,
         command: 'ARSET',
       };
-      mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
+      client.sendCommand.mockRejectedValue(replyError);
 
       await expect(
-        service.createArray(
-          mockBrowserClientMetadata,
-          mockCreateContiguousArrayDto,
-        ),
+        service.createArray(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(ForbiddenException);
-      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
-      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+      expect(client.sendCommand).toHaveBeenCalledTimes(1);
+      expect(client.sendPipeline).not.toHaveBeenCalled();
     });
   });
 });

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDatabaseClientFactory } from 'src/__mocks__';
+import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { ArrayService } from 'src/modules/browser/array/array.service';
+
+describe('ArrayService', () => {
+  let service: ArrayService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArrayService,
+        {
+          provide: DatabaseClientFactory,
+          useFactory: mockDatabaseClientFactory,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ArrayService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -1,7 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { mockDatabaseClientFactory } from 'src/__mocks__';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { when } from 'jest-when';
+import { ReplyError } from 'src/models/redis-client';
+import { mockBrowserClientMetadata, mockRedisNoPermError } from 'src/__mocks__';
+import { mockKeyDto } from 'src/modules/browser/__mocks__';
+import {
+  BrowserToolArrayCommands,
+  BrowserToolKeysCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
+import {
+  ArrayCreationMode,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { mockDatabaseClientFactory } from 'src/__mocks__/databases-client';
+import { mockStandaloneRedisClient } from 'src/__mocks__/redis-client';
+import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ArrayService } from 'src/modules/browser/array/array.service';
+
+const mockArrayValue = Buffer.from('Lorem ipsum dolor sit amet.');
+const mockArrayValue2 = Buffer.from('Lorem ipsum dolor sit amet2.');
+
+const mockCreateContiguousArrayDto: CreateArrayWithExpireDto = {
+  keyName: mockKeyDto.keyName,
+  mode: ArrayCreationMode.Contiguous,
+  startIndex: '0',
+  values: [mockArrayValue, mockArrayValue2],
+};
+
+const mockCreateSparseArrayDto: CreateArrayWithExpireDto = {
+  keyName: mockKeyDto.keyName,
+  mode: ArrayCreationMode.Sparse,
+  elements: [
+    { index: '5', value: mockArrayValue },
+    { index: '17', value: mockArrayValue2 },
+  ],
+};
 
 describe('ArrayService', () => {
   let service: ArrayService;
@@ -18,9 +52,117 @@ describe('ArrayService', () => {
     }).compile();
 
     service = module.get(ArrayService);
+    mockStandaloneRedisClient.sendCommand = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    mockStandaloneRedisClient.sendPipeline = jest
+      .fn()
+      .mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createArray', () => {
+    beforeEach(() => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(false);
+    });
+
+    it('create contiguous array without expiration', async () => {
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArSet,
+        mockKeyDto.keyName,
+        '0',
+        mockArrayValue,
+        mockArrayValue2,
+      ]);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('create sparse array without expiration', async () => {
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateSparseArrayDto,
+        ),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArMSet,
+        mockKeyDto.keyName,
+        '5',
+        mockArrayValue,
+        '17',
+        mockArrayValue2,
+      ]);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it('create contiguous array with expiration', async () => {
+      const dto: CreateArrayWithExpireDto = {
+        keyName: mockKeyDto.keyName,
+        mode: ArrayCreationMode.Contiguous,
+        startIndex: '0',
+        values: [mockArrayValue],
+        expire: 1000,
+      };
+      when(mockStandaloneRedisClient.sendPipeline)
+        .calledWith([
+          [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+          [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
+        ])
+        .mockResolvedValue([
+          [null, 'OK'],
+          [null, 1],
+        ]);
+
+      await expect(
+        service.createArray(mockBrowserClientMetadata, dto),
+      ).resolves.not.toThrow();
+      expect(mockStandaloneRedisClient.sendPipeline).toHaveBeenCalledWith([
+        [BrowserToolArrayCommands.ArSet, dto.keyName, '0', mockArrayValue],
+        [BrowserToolKeysCommands.Expire, dto.keyName, dto.expire],
+      ]);
+    });
+
+    it('key with this name exist', async () => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(true);
+
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).rejects.toThrow(new ConflictException(ERROR_MESSAGES.KEY_NAME_EXIST));
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
+
+    it("user don't have required permissions for createArray", async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARSET',
+      };
+      mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
+
+      await expect(
+        service.createArray(
+          mockBrowserClientMetadata,
+          mockCreateContiguousArrayDto,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledTimes(1);
+      expect(mockStandaloneRedisClient.sendPipeline).not.toHaveBeenCalled();
+    });
   });
 });

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+
+@Injectable()
+export class ArrayService {
+  constructor(private databaseClientFactory: DatabaseClientFactory) {}
+}

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -1,7 +1,95 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { catchAclError, catchMultiTransactionError } from 'src/utils';
+import { ClientMetadata } from 'src/common/models';
+import {
+  ArrayCreationMode,
+  CreateArrayWithExpireDto,
+} from 'src/modules/browser/array/dto';
+import {
+  BrowserToolArrayCommands,
+  BrowserToolKeysCommands,
+} from 'src/modules/browser/constants/browser-tool-commands';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import {
+  RedisClient,
+  RedisClientCommand,
+  RedisClientCommandReply,
+} from 'src/modules/redis/client';
+import { checkIfKeyExists } from 'src/modules/browser/utils';
 
 @Injectable()
 export class ArrayService {
+  private logger = new Logger('ArrayService');
+
   constructor(private databaseClientFactory: DatabaseClientFactory) {}
+
+  public async createArray(
+    clientMetadata: ClientMetadata,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    try {
+      this.logger.debug('Creating array data type.', clientMetadata);
+      const { keyName, expire } = dto;
+      const client: RedisClient =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+
+      await checkIfKeyExists(keyName, client);
+
+      if (expire) {
+        await this.createArrayWithExpiration(client, dto);
+      } else {
+        await this.createSimpleArray(client, dto);
+      }
+
+      this.logger.debug('Succeed to create array data type.', clientMetadata);
+    } catch (error) {
+      this.logger.error(
+        'Failed to create array data type.',
+        error,
+        clientMetadata,
+      );
+      throw catchAclError(error);
+    }
+  }
+
+  public async createSimpleArray(
+    client: RedisClient,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    await client.sendCommand(this.buildCreateCommand(dto));
+  }
+
+  public async createArrayWithExpiration(
+    client: RedisClient,
+    dto: CreateArrayWithExpireDto,
+  ): Promise<void> {
+    const { keyName, expire } = dto;
+    const transactionResults = await client.sendPipeline([
+      this.buildCreateCommand(dto),
+      [BrowserToolKeysCommands.Expire, keyName, expire] as RedisClientCommand,
+    ]);
+    catchMultiTransactionError(
+      transactionResults as [Error, RedisClientCommandReply][],
+    );
+  }
+
+  private buildCreateCommand(
+    dto: CreateArrayWithExpireDto,
+  ): RedisClientCommand {
+    // DTO validation guarantees startIndex + values in contiguous mode
+    // and elements in sparse mode; defaults only satisfy strict null checks.
+    const { keyName, mode, startIndex = '0', values = [], elements = [] } = dto;
+
+    if (mode === ArrayCreationMode.Contiguous) {
+      // ARSET key startIndex value [value ...] — contiguous run from startIndex
+      return [BrowserToolArrayCommands.ArSet, keyName, startIndex, ...values];
+    }
+
+    // ARMSET key index value [index value ...] — sparse index/value pairs
+    return [
+      BrowserToolArrayCommands.ArMSet,
+      keyName,
+      ...elements.flatMap(({ index, value }) => [index, value]),
+    ];
+  }
 }

--- a/redisinsight/api/src/modules/browser/array/dto/create.array-with-expire.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/create.array-with-expire.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsDefined,
+  IsEnum,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ApiRedisString,
+  IsArrayIndex,
+  IsRedisString,
+  RedisStringType,
+} from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+import { KeyWithExpireDto } from 'src/modules/browser/keys/dto';
+
+export enum ArrayCreationMode {
+  Contiguous = 'contiguous',
+  Sparse = 'sparse',
+}
+
+export class ArrayElementDto {
+  @ApiProperty({
+    type: String,
+    description: 'Element index as a numeric string (unsigned 64-bit range)',
+  })
+  @IsDefined()
+  @IsArrayIndex()
+  index: string;
+
+  @ApiRedisString('Element value')
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  value: RedisString;
+}
+
+export class CreateArrayWithExpireDto extends KeyWithExpireDto {
+  @ApiProperty({
+    enum: ArrayCreationMode,
+    description:
+      'Contiguous mode writes values as a run starting at startIndex. ' +
+      'Sparse mode writes explicit index/value pairs.',
+  })
+  @IsDefined()
+  @IsEnum(ArrayCreationMode)
+  mode: ArrayCreationMode;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Start index as a numeric string (unsigned 64-bit range). ' +
+      'Required in contiguous mode.',
+  })
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Contiguous)
+  @IsDefined()
+  @IsArrayIndex()
+  startIndex?: string;
+
+  @ApiRedisString(
+    'Element value(s) to write starting at startIndex. Required in contiguous mode.',
+    true,
+    false,
+  )
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Contiguous)
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsRedisString({ each: true })
+  @RedisStringType({ each: true })
+  values?: RedisString[];
+
+  @ApiPropertyOptional({
+    type: ArrayElementDto,
+    isArray: true,
+    description: 'Index/value pairs to write. Required in sparse mode.',
+  })
+  @ValidateIf((o) => o.mode === ArrayCreationMode.Sparse)
+  @IsDefined()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => ArrayElementDto)
+  elements?: ArrayElementDto[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './create.array-with-expire.dto';

--- a/redisinsight/api/src/modules/browser/browser.module.ts
+++ b/redisinsight/api/src/modules/browser/browser.module.ts
@@ -10,6 +10,7 @@ import { StreamModule } from 'src/modules/browser/stream/stream.module';
 import { RedisearchModule } from 'src/modules/browser/redisearch/redisearch.module';
 import { KeysModule } from 'src/modules/browser/keys/keys.module';
 import { VectorSetModule } from 'src/modules/browser/vector-set/vector-set.module';
+import { ArrayModule } from 'src/modules/browser/array/array.module';
 import { BrowserHistoryRepository } from './browser-history/repositories/browser-history.repository';
 import { LocalBrowserHistoryRepository } from './browser-history/repositories/local.browser-history.repository';
 
@@ -34,6 +35,7 @@ export class BrowserModule {
         RedisearchModule.register({ route }),
         KeysModule.register({ route }),
         VectorSetModule.register({ route }),
+        ArrayModule.register({ route }),
       ],
       exports: [BrowserHistoryModule],
     };

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -114,6 +114,10 @@ export enum BrowserToolVectorSetCommands {
   VSim = 'VSIM',
 }
 
+export enum BrowserToolArrayCommands {
+  ARGet = 'arget',
+}
+
 export type BrowserToolCommands =
   | BrowserToolKeysCommands
   | BrowserToolStringCommands
@@ -125,4 +129,5 @@ export type BrowserToolCommands =
   | BrowserToolStreamCommands
   | BrowserToolGraphCommands
   | BrowserToolTSCommands
-  | BrowserToolVectorSetCommands;
+  | BrowserToolVectorSetCommands
+  | BrowserToolArrayCommands;

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -116,6 +116,8 @@ export enum BrowserToolVectorSetCommands {
 
 export enum BrowserToolArrayCommands {
   ARGet = 'arget',
+  ArSet = 'arset',
+  ArMSet = 'armset',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -36,7 +36,7 @@ export enum KnownFeatures {
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
-  DevVectorSet = 'dev-vectorSet',
+  VectorSet = 'vectorSet',
   DevArray = 'dev-array',
   ProdMode = 'prodMode',
 }

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -83,8 +83,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevBrowser,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.DevVectorSet]: {
-    name: KnownFeatures.DevVectorSet,
+  [KnownFeatures.VectorSet]: {
+    name: KnownFeatures.VectorSet,
     storage: FeatureStorage.Database,
   },
   [KnownFeatures.DevArray]: {

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -100,7 +100,7 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
-      KnownFeatures.DevVectorSet,
+      KnownFeatures.VectorSet,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -10,6 +10,7 @@ import {
 import { RedisString } from 'src/common/constants';
 import { ClientMetadata } from 'src/common/models';
 import {
+  BrowserToolArrayCommands,
   BrowserToolHashCommands,
   BrowserToolVectorSetCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
@@ -45,6 +46,9 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSetAttr);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VRem);
     client.addBuiltinCommand(BrowserToolVectorSetCommands.VSim);
+    // Array commands
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArSet);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArMSet);
   }
 
   static prepareCommandOptions(options: IRedisClientCommandOptions): any {

--- a/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.spec.ts
@@ -1,0 +1,155 @@
+import { mockCommonClientMetadata } from 'src/__mocks__/common';
+import { MockRedisClient } from 'src/__mocks__/redis-client';
+import { BrowserToolArrayCommands } from 'src/modules/browser/constants/browser-tool-commands';
+import { RedisClient, RedisFeature } from './redis.client';
+
+// Bypass MockRedisClient's per-instance jest.fn() override and invoke the
+// real RedisClient.isFeatureSupported implementation.
+const callRealIsFeatureSupported = (
+  client: MockRedisClient,
+  feature: RedisFeature,
+): Promise<boolean> =>
+  RedisClient.prototype.isFeatureSupported.call(client, feature);
+
+describe('RedisClient', () => {
+  let client: MockRedisClient;
+
+  beforeEach(() => {
+    client = new MockRedisClient(mockCommonClientMetadata);
+  });
+
+  describe('isFeatureSupported(ArrayCommands)', () => {
+    it('returns true when COMMAND INFO reports the probe command', async () => {
+      client.call = jest
+        .fn()
+        .mockResolvedValue([
+          ['arget', 2, ['readonly', 'fast'], 1, 1, 1, [], [], [], []],
+        ]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(true);
+      expect(client.call).toHaveBeenCalledWith(
+        ['command', 'info', BrowserToolArrayCommands.ARGet],
+        { replyEncoding: 'utf8' },
+      );
+    });
+
+    it('returns false when COMMAND INFO returns a nil entry (unknown command)', async () => {
+      client.call = jest.fn().mockResolvedValue([null]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO returns an empty array', async () => {
+      client.call = jest.fn().mockResolvedValue([]);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO returns a non-array reply', async () => {
+      client.call = jest.fn().mockResolvedValue(null);
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('falls back to a version check when COMMAND INFO throws on a 8.8+ server', async () => {
+      // Reproduces the ACL-restricted user case: COMMAND INFO is forbidden
+      // (@slow / @connection) but @array data commands are permitted.
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      client.getInfo = jest
+        .fn()
+        .mockResolvedValue({ server: { redis_version: '8.8.0' } });
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when COMMAND INFO throws on a pre-8.8 server', async () => {
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      client.getInfo = jest
+        .fn()
+        .mockResolvedValue({ server: { redis_version: '8.4.0' } });
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when COMMAND INFO throws and the server version is unknown', async () => {
+      client.call = jest.fn().mockRejectedValue(new Error('NOPERM'));
+      // Default MockRedisClient.getInfo resolves to undefined, leaving the
+      // probe with no fallback signal.
+
+      const result = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('caches the probe result across repeated invocations', async () => {
+      client.call = jest
+        .fn()
+        .mockResolvedValue([
+          ['arget', 2, ['readonly', 'fast'], 1, 1, 1, [], [], [], []],
+        ]);
+
+      const first = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+      const second = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a negative probe result across repeated invocations', async () => {
+      client.call = jest.fn().mockResolvedValue([null]);
+
+      const first = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+      const second = await callRealIsFeatureSupported(
+        client,
+        RedisFeature.ArrayCommands,
+      );
+
+      expect(first).toBe(false);
+      expect(second).toBe(false);
+      expect(client.call).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -9,6 +9,7 @@ import * as semverCompare from 'node-version-compare';
 import { RedisDatabaseHelloResponse } from 'src/modules/database/dto/redis-info.dto';
 import { plainToClass } from 'class-transformer';
 import { Database } from 'src/modules/database/models/database';
+import { BrowserToolArrayCommands } from 'src/modules/browser/constants/browser-tool-commands';
 
 const REDIS_CLIENTS_CONFIG = apiConfig.get('redis_clients');
 
@@ -58,6 +59,7 @@ export enum RedisFeature {
   UnlinkCommand = 'UnlinkCommand',
   VRangeCommand = 'VRangeCommand',
   VsimWithAttribs = 'VsimWithAttribs',
+  ArrayCommands = 'ArrayCommands',
 }
 
 const CLIENT_DATABASE_FIELDS: (keyof Database)[] = ['providerDetails'];
@@ -70,6 +72,8 @@ export abstract class RedisClient extends EventEmitter2 {
   protected _redisVersion: string | undefined;
 
   protected _isInfoCommandDisabled: boolean | undefined;
+
+  protected _arrayCommandGroupSupported: boolean | undefined;
 
   protected lastTimeUsed: number;
 
@@ -187,9 +191,41 @@ export abstract class RedisClient extends EventEmitter2 {
       case RedisFeature.VsimWithAttribs:
         // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
         return this.isRedisVersionAtLeast('8.0.3');
+      case RedisFeature.ArrayCommands:
+        // @array command group is preview-status in Redis 8.8+. Probe via
+        // COMMAND INFO because some 8.8.0+ builds may omit the group; fall
+        // back to a version check if the probe itself is not allowed.
+        return this.isArrayCommandGroupSupported();
       default:
         return false;
     }
+  }
+
+  private async isArrayCommandGroupSupported(): Promise<boolean> {
+    if (this._arrayCommandGroupSupported !== undefined) {
+      return this._arrayCommandGroupSupported;
+    }
+
+    try {
+      const reply = (await this.call(
+        ['command', 'info', BrowserToolArrayCommands.ARGet],
+        { replyEncoding: 'utf8' },
+      )) as RedisClientCommandReply[];
+
+      this._arrayCommandGroupSupported =
+        Array.isArray(reply) && reply.some((info) => info != null);
+    } catch (e) {
+      // COMMAND INFO is categorised under @slow / @connection in Redis ACL,
+      // so a least-privilege user with only data-command access can still
+      // run @array commands but cannot run the probe. Fall back to a
+      // version check so we don't misclassify supported servers as
+      // unsupported; this matches how every other RedisFeature case resolves
+      // support today.
+      this._arrayCommandGroupSupported =
+        await this.isRedisVersionAtLeast('8.8');
+    }
+
+    return this._arrayCommandGroupSupported;
   }
 
   private async isRedisVersionAtLeast(minVersion: string): Promise<boolean> {

--- a/redisinsight/api/test/api/array/POST-databases-id-array.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array.test.ts
@@ -1,0 +1,250 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+import { ArrayCreationMode } from 'src/modules/browser/array/dto';
+
+const { server, request, constants } = deps;
+// The harness types `deps.rte` as null until initRTE runs; tests access it
+// freely (the api test layer is untyped by design), so widen it here.
+const rte = deps.rte as any;
+
+// endpoint to test
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(`/${constants.API.DATABASES}/${instanceId}/array`);
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARSET/ARMSET are Redis 8.8 preview commands; rte.client has no typed method
+// for them, so assert array state through the generic `call`.
+const arlen = (key: string) => rte.client.call('ARLEN', key);
+const arcount = (key: string) => rte.client.call('ARCOUNT', key);
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+
+interface CreateArrayTestCase {
+  name: string;
+  data: { keyName: string } & Record<string, unknown>;
+  statusCode: number;
+  endpoint?: () => unknown;
+  responseBody?: object;
+  before?: () => Promise<unknown>;
+  after?: () => Promise<unknown>;
+}
+
+const createCheckFn = async (testCase: CreateArrayTestCase) => {
+  it(testCase.name, async () => {
+    if (testCase.before) {
+      await testCase.before();
+    } else if (testCase.statusCode === 201) {
+      expect(await rte.client.exists(testCase.data.keyName)).to.eql(0);
+    }
+
+    await validateApiCall({
+      endpoint,
+      ...testCase,
+    });
+
+    if (testCase.after) {
+      await testCase.after();
+    }
+  });
+};
+
+describe('POST /databases/:id/array', () => {
+  // Array is a Redis 8.8 preview type; skip where the server lacks ARSET.
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Contiguous (ARSET)', () => {
+    const contiguousKey = constants.getRandomString();
+    const nonZeroKey = constants.getRandomString();
+    const ttlKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should create a contiguous array',
+        data: {
+          keyName: contiguousKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['20.1', '20.4', '20.9'],
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await rte.client.exists(contiguousKey)).to.eql(1);
+          expect(await arlen(contiguousKey)).to.eql(3);
+          expect(await arget(contiguousKey, '0')).to.eql('20.1');
+          expect(await arget(contiguousKey, '2')).to.eql('20.9');
+          expect(await rte.client.ttl(contiguousKey)).to.eql(-1);
+        },
+      },
+      {
+        name: 'Should create a contiguous array starting at a non-zero index',
+        data: {
+          keyName: nonZeroKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '5',
+          values: ['a', 'b'],
+        },
+        statusCode: 201,
+        after: async () => {
+          // Length is highest set index + 1, so a run at 5..6 reports 7.
+          expect(await arlen(nonZeroKey)).to.eql(7);
+          expect(await arget(nonZeroKey, '5')).to.eql('a');
+        },
+      },
+      {
+        name: 'Should create a contiguous array with a TTL (pipeline path)',
+        data: {
+          keyName: ttlKey,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['x'],
+          expire: 100,
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await arlen(ttlKey)).to.eql(1);
+          expect(await rte.client.ttl(ttlKey)).to.gte(95);
+        },
+      },
+    ].map(createCheckFn);
+  });
+
+  describe('Sparse (ARMSET)', () => {
+    const sparseKey = constants.getRandomString();
+    const sparseTtlKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should create a sparse array with index gaps',
+        data: {
+          keyName: sparseKey,
+          mode: ArrayCreationMode.Sparse,
+          elements: [
+            { index: '5', value: 'v5' },
+            { index: '17', value: 'v17' },
+          ],
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await rte.client.exists(sparseKey)).to.eql(1);
+          // Length follows the highest index (17 + 1); count is the populated slots.
+          expect(await arlen(sparseKey)).to.eql(18);
+          expect(await arcount(sparseKey)).to.eql(2);
+          expect(await arget(sparseKey, '5')).to.eql('v5');
+          expect(await arget(sparseKey, '17')).to.eql('v17');
+          expect(await arget(sparseKey, '6')).to.eql(null);
+        },
+      },
+      {
+        name: 'Should create a sparse array with a TTL (pipeline path)',
+        data: {
+          keyName: sparseTtlKey,
+          mode: ArrayCreationMode.Sparse,
+          elements: [{ index: '0', value: 'only' }],
+          expire: 100,
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await arcount(sparseTtlKey)).to.eql(1);
+          expect(await rte.client.ttl(sparseTtlKey)).to.gte(95);
+        },
+      },
+    ].map(createCheckFn);
+  });
+
+  describe('Validation', () => {
+    [
+      {
+        name: 'Should reject a non-canonical index',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '007',
+          values: ['x'],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an out-of-range (> u64) index',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Sparse,
+          elements: [{ index: '18446744073709551616', value: 'x' }],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject contiguous mode with empty values',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: [],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an unknown mode',
+        data: {
+          keyName: constants.getRandomString(),
+          mode: 'whatever',
+          values: ['x'],
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Errors', () => {
+    it('Should return conflict error if key already exists', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('ARSET', keyName, '0', 'existing');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['new'],
+        },
+        statusCode: 409,
+        responseBody: {
+          statusCode: 409,
+          error: 'Conflict',
+          message: 'This key name is already in use.',
+        },
+      });
+
+      // The existing value must not be overwritten.
+      expect(await arget(keyName, '0')).to.eql('existing');
+    });
+
+    [
+      {
+        name: 'Should return NotFound error if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: {
+          keyName: constants.getRandomString(),
+          mode: ArrayCreationMode.Contiguous,
+          startIndex: '0',
+          values: ['x'],
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -65,6 +65,8 @@ enum ApiEndpoints {
   REJSON_ARRAPPEND = 'rejson-rl/arrappend',
   REJSON_DOWNLOAD = 'rejson-rl/download-value',
 
+  ARRAY = 'array',
+
   VECTOR_SET = 'vector-set',
   VECTOR_SET_GET_ELEMENTS = 'vector-set/get-elements',
   VECTOR_SET_ELEMENTS = 'vector-set/elements',

--- a/redisinsight/ui/src/constants/commandsVersions.ts
+++ b/redisinsight/ui/src/constants/commandsVersions.ts
@@ -15,6 +15,6 @@ export const CommandsVersions = {
     since: '8.0',
   },
   ARRAY: {
-    since: '8.8',
+    since: '8.8.0',
   },
 }

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -12,7 +12,7 @@ export enum FeatureFlags {
   databaseManagement = 'databaseManagement',
   customTutorials = 'customTutorials',
   vectorSearchV2 = 'vectorSearchV2',
-  devVectorSet = 'dev-vectorSet',
+  vectorSet = 'vectorSet',
   devArray = 'dev-array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -193,6 +193,7 @@ export const ENDPOINT_BASED_ON_KEY_TYPE = Object.freeze({
   [KeyTypes.ReJSON]: ApiEndpoints.REJSON,
   [KeyTypes.Stream]: ApiEndpoints.STREAMS,
   [KeyTypes.VectorSet]: ApiEndpoints.VECTOR_SET,
+  [KeyTypes.Array]: ApiEndpoints.ARRAY,
 })
 
 export type EndpointBasedOnKeyType = keyof typeof ENDPOINT_BASED_ON_KEY_TYPE

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -41,7 +41,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 }))
 
 /**
- * Build a fresh store with the `devVectorSet` feature flag pre-seeded so the
+ * Build a fresh store with the `vectorSet` feature flag pre-seeded so the
  * Vector Set option's `isEnabledSelector` (which reads the flag from the
  * features slice) resolves correctly. We seed the store rather than spying
  * on the selector because the option config holds an import-time reference
@@ -50,7 +50,7 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 const renderWithVectorSetFlag = (enabled: boolean) => {
   const storeState = set(
     cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+    `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
     { flag: enabled },
   )
   return render(

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -46,6 +46,7 @@ import AddKeyList from './AddKeyList'
 import AddKeyReJSON from './AddKeyReJSON'
 import AddKeyStream from './AddKeyStream'
 import AddKeyVectorSet from './AddKeyVectorSet'
+import AddKeyArray from './AddKeyArray'
 import { ContentFields } from './AddKey.styles'
 
 import styles from './styles.module.scss'
@@ -235,6 +236,14 @@ const AddKey = (props: Props) => {
               )}
               {typeSelected === KeyTypes.VectorSet && (
                 <AddKeyVectorSet
+                  onCancel={closeAddKeyPanel}
+                  setKeyName={setKeyName}
+                  setKeyNameDisabled={setKeyNameDisabled}
+                  {...defaultFields}
+                />
+              )}
+              {typeSelected === KeyTypes.Array && (
+                <AddKeyArray
                   onCancel={closeAddKeyPanel}
                   setKeyName={setKeyName}
                   setKeyNameDisabled={setKeyNameDisabled}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { instance, mock } from 'ts-mockito'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import AddKeyArray, { Props } from './AddKeyArray'
+
+const mockedProps = mock<Props>()
+
+describe('AddKeyArray', () => {
+  beforeEach(() => {
+    // ActionFooter renders via a portal to #formFooterBar
+    const footer = document.createElement('div')
+    footer.setAttribute('id', 'formFooterBar')
+    document.body.appendChild(footer)
+  })
+
+  afterEach(() => {
+    document.getElementById('formFooterBar')?.remove()
+  })
+
+  it('should render', () => {
+    expect(render(<AddKeyArray {...instance(mockedProps)} />)).toBeTruthy()
+  })
+
+  it('should keep the submit button disabled', () => {
+    render(<AddKeyArray {...instance(mockedProps)} keyName="name" />)
+
+    expect(screen.getByTestId('add-key-array-btn')).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import { render, screen } from 'uiSrc/utils/test-utils'
-import AddKeyArray, { Props } from './AddKeyArray'
+import AddKeyArray from './AddKeyArray'
+import { Props } from './AddKeyArray.types'
 
 const mockedProps = mock<Props>()
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { Maybe } from 'uiSrc/utils'
+import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
+import { Text } from 'uiSrc/components/base/text'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+  setKeyName?: (value: string) => void
+  setKeyNameDisabled?: (disabled: boolean) => void
+}
+
+// Creation forms land in follow-up PRs; submit stays disabled until then.
+const AddKeyArray = ({ onCancel }: Props) => (
+  <>
+    <Text size="M" color="secondary" data-testid="add-key-array-placeholder">
+      Array creation options are coming soon.
+    </Text>
+    <ActionFooter
+      onCancel={() => onCancel(true)}
+      onAction={() => undefined}
+      actionText="Add Key"
+      disabled
+      actionTestId="add-key-array-btn"
+    />
+  </>
+)
+
+export default AddKeyArray

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.tsx
@@ -1,16 +1,9 @@
 import React from 'react'
 
-import { Maybe } from 'uiSrc/utils'
 import { ActionFooter } from 'uiSrc/pages/browser/components/action-footer'
 import { Text } from 'uiSrc/components/base/text'
 
-export interface Props {
-  keyName: string
-  keyTTL: Maybe<number>
-  onCancel: (isCancelled?: boolean) => void
-  setKeyName?: (value: string) => void
-  setKeyNameDisabled?: (disabled: boolean) => void
-}
+import { Props } from './AddKeyArray.types'
 
 // Creation forms land in follow-up PRs; submit stays disabled until then.
 const AddKeyArray = ({ onCancel }: Props) => (

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.types.ts
@@ -1,0 +1,18 @@
+import { Maybe } from 'uiSrc/utils'
+
+export interface Props {
+  keyName: string
+  keyTTL: Maybe<number>
+  onCancel: (isCancelled?: boolean) => void
+  /**
+   * Setter for the parent-owned `keyName` field. Used by the sample-dataset
+   * mode to auto-populate the common key-name input with a bundled dataset's
+   * fixed key, and clear it again on switching back to manual entry.
+   */
+  setKeyName?: (value: string) => void
+  /**
+   * Setter for the parent-owned `keyName` input's `disabled` flag. Locked to
+   * `true` in sample-dataset mode (the key name is fixed) and `false` otherwise.
+   */
+  setKeyNameDisabled?: (disabled: boolean) => void
+}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
@@ -1,4 +1,4 @@
 import AddKeyArray from './AddKeyArray'
 
 export default AddKeyArray
-export type { Props } from './AddKeyArray'
+export type { Props } from './AddKeyArray.types'

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/index.ts
@@ -1,0 +1,4 @@
+import AddKeyArray from './AddKeyArray'
+
+export default AddKeyArray
+export type { Props } from './AddKeyArray'

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
@@ -125,6 +125,33 @@ export const AddJSONFormConfig: IAddJSONFormConfig = {
   },
 }
 
+interface IAddArrayFormConfig {
+  startIndex: IFormField
+  index: IFormField
+  value: IFormField
+}
+
+export const AddArrayFormConfig: IAddArrayFormConfig = {
+  startIndex: {
+    name: 'startIndex',
+    isRequire: true,
+    label: 'Start Index*',
+    placeholder: 'Enter Start Index',
+  },
+  index: {
+    name: 'index',
+    isRequire: true,
+    label: 'Index*',
+    placeholder: 'Enter Index',
+  },
+  value: {
+    name: 'value',
+    isRequire: true,
+    label: 'Value*',
+    placeholder: 'Enter Value',
+  },
+}
+
 interface IAddStreamFormConfig {
   entryId: IFormField
   name: IFormField

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,6 +1,9 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import {
+  isDevArrayEnabledSelector,
+  isVectorSetEnabledSelector,
+} from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -13,6 +16,13 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     text: 'List',
     value: KeyTypes.List,
     color: GROUP_TYPES_COLORS[KeyTypes.List],
+  },
+  {
+    text: 'Array',
+    value: KeyTypes.Array,
+    color: GROUP_TYPES_COLORS[KeyTypes.Array],
+    minVersion: CommandsVersions.ARRAY.since,
+    isEnabledSelector: isDevArrayEnabledSelector,
   },
   {
     text: 'Set',

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,6 +1,6 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -44,6 +44,6 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isDevVectorSetEnabledSelector,
+    isEnabledSelector: isVectorSetEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -201,7 +201,7 @@ describe('FilterKeyType', () => {
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {
@@ -232,7 +232,7 @@ describe('FilterKeyType', () => {
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devVectorSet}`,
+      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -7,7 +7,7 @@ import {
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 import {
   isDevArrayEnabledSelector,
-  isDevVectorSetEnabledSelector,
+  isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { FilterKeyTypeOption } from './FilterKeyType.types'
@@ -60,7 +60,7 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isDevVectorSetEnabledSelector,
+    isEnabledSelector: isVectorSetEnabledSelector,
   },
   {
     text: 'Graph',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -7,7 +7,7 @@ import {
 } from 'uiSrc/constants'
 import { KeyDetailsHeaderProps } from 'uiSrc/pages/browser/modules'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { isDevVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
+import { isVectorSetEnabledSelector } from 'uiSrc/slices/app/features'
 import { isTruncatedString } from 'uiSrc/utils'
 import TooLongKeyNameDetails from 'uiSrc/pages/browser/modules/key-details/components/too-long-key-name-details/TooLongKeyNameDetails'
 import ModulesTypeDetails from '../modules-type-details/ModulesTypeDetails'
@@ -30,7 +30,7 @@ export interface Props extends KeyDetailsHeaderProps {
 
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
-  const isDevVectorSet = useAppSelector(isDevVectorSetEnabledSelector)
+  const isVectorSet = useAppSelector(isVectorSetEnabledSelector)
 
   const TypeDetails: any = {
     [KeyTypes.ZSet]: <ZSetDetails {...props} />,
@@ -40,7 +40,7 @@ const DynamicTypeDetails = (props: Props) => {
     [KeyTypes.List]: <ListDetails {...props} />,
     [KeyTypes.ReJSON]: <RejsonDetailsWrapper {...props} />,
     [KeyTypes.Stream]: <StreamDetails {...props} />,
-    ...(isDevVectorSet && {
+    ...(isVectorSet && {
       [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
     }),
   }

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -65,7 +65,7 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.vectorSearchV2]: {
         flag: false,
       },
-      [FeatureFlags.devVectorSet]: {
+      [FeatureFlags.vectorSet]: {
         flag: false,
       },
       [FeatureFlags.devArray]: {
@@ -230,13 +230,13 @@ export const isAzureEntraIdEnabledSelector = (state: RootState): boolean => {
   return azureEntraIdEnabled && envDependentEnabled
 }
 
-export const isDevVectorSetEnabledSelector = (state: RootState): boolean => {
+export const isVectorSetEnabledSelector = (state: RootState): boolean => {
   if (isDevelopment) {
     return true
   }
 
   const features = state.app.features.featureFlags.features
-  return features[FeatureFlags.devVectorSet]?.flag ?? false
+  return features[FeatureFlags.vectorSet]?.flag ?? false
 }
 
 export const isDevArrayEnabledSelector = (state: RootState): boolean => {

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -102,6 +102,7 @@ import {
   CreateHashWithExpireDto,
   CreateRejsonRlWithExpireDto,
   CreateSetWithExpireDto,
+  CreateArrayWithExpireDto,
   GetKeyInfoResponse,
   GetKeysWithDetailsResponse,
   CreateStreamDto,
@@ -1040,6 +1041,15 @@ export function addListKey(
   onFailAction?: () => void,
 ) {
   return addTypedKey(data, KeyTypes.List, onSuccessAction, onFailAction)
+}
+
+// Asynchronous thunk action
+export function addArrayKey(
+  data: CreateArrayWithExpireDto,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return addTypedKey(data, KeyTypes.Array, onSuccessAction, onFailAction)
 }
 
 // Asynchronous thunk action

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -14,6 +14,8 @@ import {
   CustomErrorCodes,
   DatabaseListColumn,
 } from 'uiSrc/constants'
+import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
+import { isVersionHigherOrEquals } from 'uiSrc/utils/comparisons/compareVersions'
 import { setAppContextInitialState } from 'uiSrc/slices/app/context'
 import { resetKeys } from 'uiSrc/slices/browser/keys'
 import successMessages from 'uiSrc/components/notifications/success-messages'
@@ -390,6 +392,13 @@ export const connectedInstanceOverviewSelector = (state: RootState) =>
   state.connections.instances.instanceOverview
 export const importInstancesSelector = (state: RootState) =>
   state.connections.instances.importInstances
+
+export const isArraySupportedSelector = (state: RootState): boolean => {
+  const { version } = state.connections.instances.instanceOverview
+  return (
+    !!version && isVersionHigherOrEquals(version, CommandsVersions.ARRAY.since)
+  )
+}
 
 // The reducer
 export default instancesSlice.reducer

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { faker } from '@faker-js/faker'
 import { AxiosError } from 'axios'
 import { configureStore } from '@reduxjs/toolkit'
 import { getConfig } from 'uiSrc/config'
@@ -10,6 +11,7 @@ import {
 } from 'uiSrc/constants'
 import {
   ListElementDestination,
+  CreateArrayWithExpireDto,
   CreateHashWithExpireDto,
   CreateListWithExpireDto,
   CreateRejsonRlWithExpireDto,
@@ -52,6 +54,7 @@ import reducer, {
   addKey,
   addKeyFailure,
   addKeySuccess,
+  addArrayKey,
   addListKey,
   addReJSONKey,
   addSetKey,
@@ -1756,6 +1759,33 @@ describe('keys slice', () => {
           addKeySuccess(),
           updateKeyList({ keyName: data.keyName, keyType: 'list' }),
           addMessageNotification(successMessages.ADDED_NEW_KEY(data.keyName)),
+        ]
+        expect(store.getActions()).toEqual(expectedActions)
+      })
+    })
+
+    describe('addArrayKey', () => {
+      it('success to add key', async () => {
+        // Arrange
+        const keyName = stringToBuffer(faker.string.alphanumeric(10))
+        const data = {
+          keyName,
+          mode: 'sparse',
+          elements: [{ index: '5', value: 'value' }],
+        } as unknown as CreateArrayWithExpireDto
+        const responsePayload = { data, status: 200 }
+
+        apiService.post = jest.fn().mockResolvedValue(responsePayload)
+
+        // Act
+        await store.dispatch<any>(addArrayKey(data, jest.fn()))
+
+        // Assert
+        const expectedActions = [
+          addKey(),
+          addKeySuccess(),
+          updateKeyList({ keyName: data.keyName, keyType: KeyTypes.Array }),
+          addMessageNotification(successMessages.ADDED_NEW_KEY(keyName)),
         ]
         expect(store.getActions()).toEqual(expectedActions)
       })

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -71,6 +71,7 @@ import reducer, {
   resetConnectedInstanceDangerousCommands,
   fetchConnectedInstanceDangerousCommandsAction,
   connectedInstanceDangerousCommandsSelector,
+  isArraySupportedSelector,
 } from '../../instances/instances'
 import { Environment } from 'apiClient'
 import {
@@ -2092,6 +2093,38 @@ describe('instances slice', () => {
         // Assert
         expect(store.getActions()).toEqual([])
         expect(onFail).toHaveBeenCalled()
+      })
+    })
+
+    describe('isArraySupportedSelector', () => {
+      const buildRootState = (version: string) =>
+        Object.assign(cloneDeep(initialStateDefault), {
+          connections: {
+            instances: {
+              ...initialState,
+              instanceOverview: {
+                ...initialState.instanceOverview,
+                version,
+              },
+            },
+          },
+        })
+
+      it('returns false when version is empty', () => {
+        expect(isArraySupportedSelector(buildRootState(''))).toBe(false)
+      })
+
+      it('returns false for versions below 8.8', () => {
+        expect(isArraySupportedSelector(buildRootState('7.4.0'))).toBe(false)
+        expect(isArraySupportedSelector(buildRootState('8.0.0'))).toBe(false)
+        expect(isArraySupportedSelector(buildRootState('8.7.99'))).toBe(false)
+      })
+
+      it('returns true for 8.8.0 and above', () => {
+        expect(isArraySupportedSelector(buildRootState('8.8'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('8.8.0'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('8.8.5'))).toBe(true)
+        expect(isArraySupportedSelector(buildRootState('9.0.0'))).toBe(true)
       })
     })
   })

--- a/redisinsight/ui/src/utils/arrayIndex.ts
+++ b/redisinsight/ui/src/utils/arrayIndex.ts
@@ -1,0 +1,44 @@
+/**
+ * Redis array indexes are unsigned 64-bit integers (0 … 2^64−1) and exceed
+ * Number.MAX_SAFE_INTEGER, so they stay numeric strings end-to-end —
+ * never parseInt/Number, no JS-side arithmetic on indexes; Redux stores
+ * them as strings.
+ *
+ * Mirrored in redisinsight/api/src/common/utils/array-index.helper.ts —
+ * keep semantics and tests in sync.
+ */
+// 2^64 - 1; BigInt() call form (not a literal) for parity with the API
+// mirror, whose tsconfig targets es2019 (where BigInt literals are TS2737).
+export const ARRAY_INDEX_MAX = BigInt('18446744073709551615')
+
+const ARRAY_INDEX_REGEX = /^\d+$/
+
+// Max u64 is 20 digits; longer all-digit inputs can't be valid and a length
+// guard keeps BigInt() from parsing arbitrarily large request payloads.
+const ARRAY_INDEX_MAX_LENGTH = 20
+
+/**
+ * Returns the canonical decimal string for a valid index ("007" → "7"),
+ * or null for anything else (empty or whitespace-only, negative,
+ * fractional, exponent, hex, > 2^64−1, non-string input).
+ */
+export const parseArrayIndex = (input: unknown): string | null => {
+  if (typeof input !== 'string') {
+    return null
+  }
+
+  const value = input.trim()
+  if (!ARRAY_INDEX_REGEX.test(value)) {
+    return null
+  }
+
+  if (value.length > ARRAY_INDEX_MAX_LENGTH) {
+    return null
+  }
+
+  const index = BigInt(value)
+  return index > ARRAY_INDEX_MAX ? null : index.toString()
+}
+
+export const isValidArrayIndex = (input: unknown): boolean =>
+  parseArrayIndex(input) !== null

--- a/redisinsight/ui/src/utils/index.ts
+++ b/redisinsight/ui/src/utils/index.ts
@@ -4,6 +4,7 @@ import RouterWithSubRoutes from './routerWithSubRoutes'
 
 export * from './common'
 export * from './validations'
+export * from './arrayIndex'
 export * from './statuses'
 export * from './instance'
 export * from './apiResponse'

--- a/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
+++ b/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
@@ -1,0 +1,53 @@
+import {
+  ARRAY_INDEX_MAX,
+  isValidArrayIndex,
+  parseArrayIndex,
+} from 'uiSrc/utils'
+
+describe('arrayIndex', () => {
+  it('should expose max unsigned 64-bit value', () => {
+    expect(ARRAY_INDEX_MAX).toEqual(BigInt('18446744073709551615'))
+  })
+
+  describe('parseArrayIndex', () => {
+    it.each([
+      { input: '0', expected: '0' },
+      { input: '7', expected: '7' },
+      { input: '007', expected: '7' }, // leading zeros normalized
+      { input: ' 42 ', expected: '42' }, // outer whitespace trimmed
+      { input: '18446744073709551615', expected: '18446744073709551615' }, // max u64
+      { input: '18446744073709551616', expected: null }, // max + 1
+      { input: '184467440737095516150', expected: null }, // 21 digits — length guard
+      { input: '00000000000000000000042', expected: null }, // >20 chars — guard trumps normalization
+      { input: '-1', expected: null },
+      { input: '1.5', expected: null },
+      { input: '1e3', expected: null },
+      { input: '0x10', expected: null },
+      { input: 'abc', expected: null },
+      { input: '1 2', expected: null }, // internal whitespace
+      { input: '', expected: null },
+      { input: '   ', expected: null },
+    ])('should return $expected for $input', ({ input, expected }) => {
+      expect(parseArrayIndex(input)).toEqual(expected)
+    })
+
+    it.each([null, undefined, 7, BigInt(7), {}])(
+      'should return null for non-string %p',
+      (input) => {
+        expect(parseArrayIndex(input)).toEqual(null)
+      },
+    )
+  })
+
+  describe('isValidArrayIndex', () => {
+    it('should return true for a valid index', () => {
+      expect(isValidArrayIndex('123')).toEqual(true)
+    })
+    it('should return false for an invalid index', () => {
+      expect(isValidArrayIndex('-1')).toEqual(false)
+    })
+    it('should return false for non-string input', () => {
+      expect(isValidArrayIndex(42)).toEqual(false)
+    })
+  })
+})

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
@@ -5,7 +5,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory, toFp32EscapedString } from 'e2eSr
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Elements', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
@@ -3,7 +3,7 @@ import { StandaloneV880ConfigFactory } from 'e2eSrc/test-data/databases';
 import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Key (manual)', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
@@ -4,7 +4,7 @@ import { DatabaseInstance } from 'e2eSrc/types';
 
 const VEC2WORD_KEY = 'vec2word';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Add Key (sample data)', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
@@ -4,7 +4,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Element actions', () => {
   let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
@@ -4,7 +4,7 @@ import { DatabaseInstance } from 'e2eSrc/types';
 
 test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => {
   // V8 factory points at redis:8.0-M02, which reports redis_version:7.9.225.
-  test.use({ featureFlags: { 'dev-vectorSet': true } });
+  test.use({ featureFlags: { vectorSet: true } });
 
   let database: DatabaseInstance;
 
@@ -45,7 +45,7 @@ test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => 
 });
 
 test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
-  test.use({ featureFlags: { 'dev-vectorSet': false } });
+  test.use({ featureFlags: { vectorSet: false } });
 
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
@@ -4,7 +4,7 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { 'dev-vectorSet': true } });
+test.use({ featureFlags: { vectorSet: true } });
 
 test.describe('Browser > Vector Set > Similarity search', () => {
   let database: DatabaseInstance;


### PR DESCRIPTION
# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
<!-- Please explain how you've ensured the change works properly - Manual and/or Automation tests as well as Screenshots and Recordings for visual changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New browser API talks to preview Redis 8.8 array commands and changes Vector Set/prodMode rollout percentages; build pipelines now skip node_modules cache, increasing CI sensitivity to dependency drift.
> 
> **Overview**
> Adds **Redis Array** support end-to-end for **creating** keys: a new `POST /databases/:id/array` browser API (contiguous via `ARSET`, sparse via `ARMSET`) with u64 index validation (`IsArrayIndex` / shared API+UI helpers), ioredis builtin commands, `RedisFeature.ArrayCommands` probing with ACL-safe fallback, and integration/API tests (Redis ≥ 8.8). Bruno requests document the contract.
> 
> The UI wires **Array** into key types, filters, and `addArrayKey` → `ApiEndpoints.ARRAY`, plus `isArraySupportedSelector` (8.8+). **Add Key → Array** is a placeholder (“coming soon”) with submit disabled until a follow-up form lands; `dev-array` still gates visibility.
> 
> **Vector Set** graduates from `dev-vectorSet` to **`vectorSet`** (API/UI/E2E); remote `features-config.json` enables `vectorSet` and `prodMode` at 10% rollout.
> 
> CI adds optional **`cache-node-modules`** on `install-all-build-libs` (default on); **build** and **Playwright E2E** jobs pass `cache-node-modules: '0'` to avoid stale nested deps after lockfile changes. Release notes template gains a **New Contributors** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80527c5394e4b524d984359aa8abd5baeb463156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->