### PR TITLE
Hide Inspect Element context menu in production builds

### DIFF
--- a/redisinsight/desktop/src/lib/window/browserWindow.ts
+++ b/redisinsight/desktop/src/lib/window/browserWindow.ts
@@ -87,7 +87,7 @@ export const createWindow = async ({
 
   initWindowHandlers(newWindow, prevWindow, windows, id)
 
-  contextMenu({ window: newWindow, showInspectElement: true })
+  contextMenu({ window: newWindow, showInspectElement: config.isDevelopment })
 
   windows.set(id, newWindow)
 


### PR DESCRIPTION
# What

The desktop right-click menu (provided by `electron-context-menu`) previously always exposed an **Inspect Element** item, even in packaged/production builds, because `showInspectElement` was hardcoded to `true`.

This change gates `showInspectElement` on `config.isDevelopment`, so:
- **Development builds** keep Inspect Element for debugging.
- **Production builds** show the native OS-style context menu (Copy/Paste/etc.) without exposing developer tools.

https://github.com/user-attachments/assets/8f06b821-6a4b-4920-aa14-41432585b3c9

# Testing

1. Run `yarn dev:desktop` → right-click → "Inspect Element" is present.
2. Build a production package (`yarn package:prod`) and launch the app → right-click → native copy/paste menu appears, but "Inspect Element" is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavior change for a dev-only menu item; no auth, data, or core app logic affected.
> 
> **Overview**
> **Production desktop builds** no longer show **Inspect Element** on the right-click context menu; that option stays available only when `config.isDevelopment` is true.
> 
> In `createWindow`, `electron-context-menu`’s `showInspectElement` is wired to `config.isDevelopment` instead of always being `true`, matching how dev vs production URL loading is already decided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9283b4067b9c26e02a5ac7b45e386e05a3b5c58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->