### PR TITLE
Roll out vectorSet and prodMode flags to 100%

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.93,
+  "version": 3.94,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -141,7 +141,7 @@
     },
     "vectorSet": {
       "flag": true,
-      "perc": [[0, 10]]
+      "perc": [[0, 100]]
     },
     "dev-array": {
       "flag": false,
@@ -149,7 +149,7 @@
     },
     "prodMode": {
       "flag": true,
-      "perc": [[0, 10]]
+      "perc": [[0, 100]]
     }
   }
 }


### PR DESCRIPTION
# What

Increase feature flag rollout percentage for `vectorSet` and `prodMode` from 10% to 100% in `features-config.json`. Bumps config version to 3.94.

# Testing

Deploy the updated config and verify both flags are active for all users via the features API endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens exposure of vector-set browser support and prod-mode behavior to the full user base without code changes; regressions would affect everyone immediately after config deploy.
> 
> **Overview**
> Completes the gradual rollout for **`vectorSet`** and **`prodMode`** by changing each feature’s `perc` from `[[0, 10]]` to `[[0, 100]]` in `features-config.json`. Both flags stay enabled (`flag: true`); only the audience bucket expands from ~10% to all users.
> 
> The config **`version`** is bumped from **3.93** to **3.94** so clients pick up the new percentages via the features API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb65ab184055f9f53ec7bffefa3d8208ba134bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->