### PR TITLE
RI-8288: Аdd oss-st-8 RTE for Redis 8.8

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -57,6 +57,7 @@ env:
       "oss-st-5": "OSS Standalone v5",
       "oss-st-5-pass": "OSS Standalone v5 with admin pass required",
       "oss-st-6": "OSS Standalone v6 and all modules",
+      "oss-st-8": "OSS Standalone v8.8",
       "mods-preview": "OSS Standalone and all preview modules",
       "oss-st-6-tls": "OSS Standalone v6 with TLS enabled",
       "oss-st-6-tls-auth": "OSS Standalone v6 with TLS auth required",
@@ -71,6 +72,7 @@ env:
   ITESTS_NAMES_SHORT: |
     {
       "mods-preview": "OSS Standalone and all preview modules",
+      "oss-st-8": "OSS Standalone v8.8",
       "oss-st-5-pass": "OSS Standalone v5 with admin pass required",
       "oss-st-6-tls-auth": "OSS Standalone v6 with TLS auth required",
       "oss-clu-tls": "OSS Cluster with TLS enabled",

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -34,7 +34,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand -w 1",
     "test:e2e": "jest --config ./test/jest-e2e.json -w 1",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js -d ./config/ormconfig.ts",
-    "test:api": "cross-env NODE_ENV=test ts-mocha --paths --config ./test/api/.mocharc.yml",
+    "test:api": "cross-env NODE_ENV=test ts-mocha --paths --config ./test/api/.mocharc.cjs",
     "test:api:cov": "nyc --reporter=html --reporter=text --reporter=text-summary yarn run test:api",
     "test:api:ci:cov": "cross-env nyc -r text -r text-summary -r html yarn run test:api --reporter mocha-multi-reporters --reporter-options configFile=test/api/reporters.json && nyc merge .nyc_output ./coverage/test-run-coverage.json",
     "typeorm:migrate": "cross-env NODE_ENV=staging yarn typeorm migration:generate ./migration/migration",

--- a/redisinsight/api/test/api/.mocharc.cjs
+++ b/redisinsight/api/test/api/.mocharc.cjs
@@ -1,0 +1,29 @@
+// Mocha config. Dynamic so the spec list can react to TEST_TAGS.
+//
+// When TEST_TAGS is set on an RTE (e.g. oss-st-8 sets TEST_TAGS=array
+// because redis:8.8-alpine lacks modules and other suites fail against
+// Redis 8.8 semantics — per-field hash TTL, RediSearch flag changes,
+// etc.), mocha only loads the file globs that map to the requested tag(s).
+// When TEST_TAGS is unset (every other RTE) the wildcard runs everything,
+// preserving prior behaviour exactly.
+const TAG_SPECS = {
+  array: ['test/api/array/**/*.test.ts'],
+};
+
+const tags = (process.env.TEST_TAGS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const spec = tags.length
+  ? [...new Set(tags.flatMap((t) => TAG_SPECS[t] || []))]
+  : ['test/**/*.test.ts'];
+
+module.exports = {
+  spec,
+  require: 'test/api/api.deps.init.ts',
+  project: './test/api/api.tsconfig.json',
+  retries: 2,
+  timeout: 60000,
+  exit: true,
+};

--- a/redisinsight/api/test/api/.mocharc.yml
+++ b/redisinsight/api/test/api/.mocharc.yml
@@ -1,7 +1,0 @@
-spec:
-  - test/**/*.test.ts
-require: 'test/api/api.deps.init.ts'
-project: ./test/api/api.tsconfig.json
-retries: 2
-timeout: 60000
-exit: true

--- a/redisinsight/api/test/test-runs/oss-st-8/docker-compose.yml
+++ b/redisinsight/api/test/test-runs/oss-st-8/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.4'
+
+services:
+  redis:
+    image: redis:8.8-alpine
+
+  # Scope the run to suites that declared `tag('array')` (the new Array data
+  # type read endpoints). redis:8.8-alpine has no modules and ships Redis 8.8
+  # semantics (per-field hash TTL, RediSearch flag changes, etc.) that other
+  # untagged suites don't tolerate, so leaving them in would produce noise
+  # unrelated to the suite this RTE was added for.
+  test:
+    environment:
+      TEST_TAGS: array


### PR DESCRIPTION
# What

Аdds a new integration-test RTE — `oss-st-8` — running `redis:8.8-alpine`,
needed for the upcoming Array integration tests (RI-8219).

The new RTE is **scoped to a subset of suites** because plain
`redis:8.8-alpine` ships no modules and brings Redis 8.8 semantics
(per-field hash TTL, RediSearch flag changes, etc.) that the rest of the
integration test pool doesn't tolerate. Scoping is done at mocha's
file-discovery layer:

This is intentionally the smallest change that unblocks running the
Array integration tests on Redis 8.8 — the lookup-table format isn't
necessarily the long-term shape we want; it can be revisited (richer
matchers, per-suite metadata, etc.) once we have more than the one
`array` consumer. For now the goal is just to enable it for arrays.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI wiring only; production API behavior is unchanged, and other RTEs keep the full suite when TEST_TAGS is unset.
> 
> **Overview**
> Adds **`oss-st-8`** as a new integration-test RTE using **`redis:8.8-alpine`**, registered in both full and short CI matrices, so Array-related API tests can run against Redis 8.8.
> 
> Mocha config moves from static **`.mocharc.yml`** to **`.mocharc.cjs`**, which reads **`TEST_TAGS`** and limits loaded specs via a small tag→glob map (today only **`array`** → `test/api/array/**/*.test.ts`). When **`TEST_TAGS`** is unset, behavior stays the same: all `test/**/*.test.ts` files run.
> 
> The **`oss-st-8`** compose file sets **`TEST_TAGS=array`** on the test service so that RTE only runs array suites—plain 8.8 has no modules and 8.8-specific semantics would otherwise fail unrelated suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4c7205b36fcd4dc2747ee2b78a7f031679cc66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->