### PR TITLE
docs(frontend): add hooks naming and organization conventions

### DIFF
--- a/.ai/skills/frontend/SKILL.md
+++ b/.ai/skills/frontend/SKILL.md
@@ -343,6 +343,50 @@ Always clean up subscriptions, timers, and event listeners in `useEffect` return
 
 Create custom hooks for reusable stateful logic. Store component-specific hooks in the component's `/hooks` directory.
 
+### Naming
+
+- Always prefix with `use` and use `camelCase`: `useIndexInfo`, `useSimilaritySearch`, `useVectorSetElementForm`.
+- **Named export only** — never `export default` a hook.
+- The file is named exactly like the hook it exports: `useIndexInfo.ts` exports `useIndexInfo`.
+- Hook implementation files use `camelCase.ts` (not PascalCase, even though the surrounding component files are PascalCase).
+- Context hooks are an exception: they are defined inline in the provider file (e.g. `useVectorSearch` lives in `VectorSearchContext.tsx`), not in their own hook folder.
+
+### Organization
+
+Place hooks in a `hooks/` directory, scoped as narrowly as the hook is used:
+
+- **Feature-wide hooks** → the feature's top-level `hooks/` (e.g. `pages/vector-search/hooks/`).
+- **Component-specific hooks** → that component's `hooks/` (e.g. `components/query-library-view/hooks/`).
+
+Give each non-trivial hook **its own folder** named after the hook, colocating its companion files. A hook with no types/utils/tests can stay a single flat file in `hooks/`.
+
+```
+hooks/
+  index.ts                         # barrel (3+ hooks)
+  useIndexInfo/
+    index.ts                       # re-exports the hook + its public types
+    useIndexInfo.ts                # hook implementation (named export)
+    useIndexInfo.types.ts          # types: UseIndexInfoOptions, UseIndexInfoResult, …
+    useIndexInfo.utils.ts          # extracted pure helpers (only if needed)
+    useIndexInfo.spec.ts           # tests, colocated
+    useIndexInfo.utils.spec.ts     # tests for the utils
+```
+
+Companion-file conventions (all colocated, all `camelCase` matching the hook):
+
+- `*.types.ts` — type definitions. Name the params/result types `Use<Hook>Params`/`Use<Hook>Options` and `Use<Hook>Result`.
+- `*.utils.ts` — pure helpers extracted from the hook.
+- `*.spec.ts` — tests, named `<hookName>.spec.ts` and colocated (no separate `__tests__` dir).
+
+### Barrels
+
+- The per-hook `index.ts` re-exports the hook and its public types (and any utils meant to be shared):
+  ```typescript
+  export { useIndexInfo } from './useIndexInfo'
+  export type { UseIndexInfoOptions, UseIndexInfoResult } from './useIndexInfo.types'
+  ```
+- The `hooks/index.ts` barrel aggregates the folders (`export * from './useIndexInfo'`). Per the barrel-file rule, only add it when there are **3 or more** hooks.
+
 ## Form Handling
 
 Use Formik with Yup for validation. Keep form logic in custom hooks when complex.


### PR DESCRIPTION
# What

Expands the **Custom Hooks** section of the frontend skill (`.ai/skills/frontend/SKILL.md`) with explicit naming, organization, and barrel-file conventions for custom React hooks.

Previously the skill only said "store component-specific hooks in the component's `/hooks` directory." The new content documents the conventions actually used across the vector search and vector set features:

- **Naming** — `use` prefix, `camelCase`, file named exactly after the hook, named exports only; context hooks defined inline in their provider.
- **Organization** — feature-wide vs. component-scoped `hooks/` dirs; one folder per non-trivial hook with `.types.ts` / `.utils.ts` / `.spec.ts` companions colocated.
- **Barrels** — per-hook `index.ts` re-exporting the hook + public types, and a `hooks/index.ts` aggregator (tied to the existing 3+ items barrel rule).

Docs-only change to a skill file; no code or runtime impact.

# Testing

No code changes — review the rendered Markdown in `.ai/skills/frontend/SKILL.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a skill file; no application code or runtime behavior is affected.
> 
> **Overview**
> Expands **Custom Hooks** in `.ai/skills/frontend/SKILL.md` beyond the one-line “put hooks in `/hooks`” note with conventions aligned to vector-search / vector-set patterns.
> 
> **Naming** documents `use` + `camelCase`, named exports only, hook files named after the hook (camelCase, not PascalCase), and context hooks living in their provider file.
> 
> **Organization** distinguishes feature-level vs component-scoped `hooks/`, one folder per non-trivial hook with colocated `*.types.ts`, `*.utils.ts`, and `*.spec.ts`, and simple hooks as a single file.
> 
> **Barrels** adds per-hook `index.ts` re-exports and a `hooks/index.ts` aggregator gated by the existing **3+ hooks** barrel rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e25e3a3d9adfd7b329016fef35a3b875707101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->