### PR TITLE
docs(skills): fix styleguide skills + add hook so they actually trigger

### DIFF
--- a/.ai/hooks/styleguide-reminder.sh
+++ b/.ai/hooks/styleguide-reminder.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse hook: nudges the agent to the right styleguide skill based on which
+# part of the repo it's editing, so the rules don't depend on a skill self-triggering.
+# Maps path -> frontend / backend / testing / e2e-testing skill reminders.
+set -euo pipefail
+
+input=$(cat)
+path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
+[ -z "$path" ] && exit 0
+
+reminders=()
+
+# E2E first: its specs are *.spec.ts too, but use the e2e skill, not the unit one.
+case "$path" in
+  *tests/e2e-playwright/*)
+    reminders+=("e2e-testing skill (.ai/skills/e2e-testing/SKILL.md): use Page Object Models (no raw selectors in tests), fixtures for setup, and Playwright auto-waiting/expect — never fixed waitForTimeout. Build test data with Fishery factories + faker.")
+    ;;
+  *redisinsight/ui/src/*)
+    reminders+=("frontend skill (.ai/skills/frontend/SKILL.md): one component per directory (Name.tsx / .styles.ts / .types.ts / .spec.tsx); styles in .styles.ts via styled-components imported as 'import * as S' (local only); layout components (Row/Col/FlexGroup) over div; theme spacing/colors over magic values; internal wrappers from uiSrc/components/ui, never @redis-ui/* directly.")
+    case "$path" in
+      *.spec.ts|*.spec.tsx)
+        reminders+=("testing skill (.ai/skills/testing/SKILL.md): build UI test data with Fishery factories from redisinsight/ui/src/mocks/factories/<domain>/ — reuse an existing <Name>.factory.ts or add one there, never inline mock objects. Shared renderComponent helper, faker for primitives, waitFor over fixed timeouts.")
+        ;;
+    esac
+    ;;
+  *redisinsight/api/src/*|*redisinsight/api/test/*)
+    reminders+=("backend skill (.ai/skills/backend/SKILL.md): NestJS module/controller/service/DTO structure, constructor dependency injection, DTOs with class-validator, and proper Nest exceptions for error handling.")
+    case "$path" in
+      *.spec.ts)
+        reminders+=("testing skill (.ai/skills/testing/SKILL.md): use Fishery factories + faker for test data (never hardcoded mocks), AAA structure, and clear mocks between tests.")
+        ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+[ ${#reminders[@]} -eq 0 ] && exit 0
+
+ctx=$(printf '%s\n' "${reminders[@]}")
+jq -n --arg ctx "$ctx" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}'

--- a/.ai/skills/frontend/SKILL.md
+++ b/.ai/skills/frontend/SKILL.md
@@ -9,7 +9,6 @@ description: >-
   the user mentions UI, frontend, React, Redux, or styled-components.
 ---
 
-
 # Frontend Development (React/Redux)
 
 ## Component Structure
@@ -97,10 +96,10 @@ export { ExternalStyledComponent } from '../ExternalComponent/ExternalComponent.
 
 ```typescript
 // ❌ BAD: Importing styled components directly from external component
-import * as S from '../ExternalComponent/ExternalComponent.styles'
+import * as S from '../ExternalComponent/ExternalComponent.styles';
 
 // ❌ BAD: Named imports instead of namespace
-import { Container, Title, Content } from './Component.styles'
+import { Container, Title, Content } from './Component.styles';
 ```
 
 ### Use Layout Components Instead of div
@@ -401,11 +400,14 @@ Only create custom SVG icons if:
 
 **CRITICAL**: Create a `renderComponent` helper function for each component test file:
 
+Pull entity data from a shared Fishery factory in `redisinsight/ui/src/mocks/factories/`
+(reuse one, or add a new `<domain>/<TypeName>.factory.ts`); inline only callbacks/primitives.
+
 ```typescript
 describe('MyComponent', () => {
+  const mockUser = UserFactory.build();
   const defaultProps: MyComponentProps = {
-    id: faker.string.uuid(),
-    name: faker.person.fullName(),
+    user: mockUser,
     onComplete: jest.fn(),
   }
 

--- a/.ai/skills/testing/SKILL.md
+++ b/.ai/skills/testing/SKILL.md
@@ -10,7 +10,6 @@ description: >-
   library, faker, or test patterns.
 ---
 
-
 # Testing Standards and Practices
 
 ## Core Principles
@@ -58,13 +57,14 @@ node 'node_modules/.bin/jest' 'redisinsight/ui/src/slices/tests/browser/keys.spe
 
 ```typescript
 import { faker } from '@faker-js/faker';
+// Pull structured data from a shared factory (redisinsight/ui/src/mocks/factories/);
+// only build ad-hoc primitives/callbacks inline.
 
 describe('MyComponent', () => {
-  // Define default props with faker
+  // Default props: factory for the entity, inline only for callbacks/primitives
+  const mockUser = UserFactory.build();
   const defaultProps: MyComponentProps = {
-    id: faker.string.uuid(),
-    name: faker.person.fullName(),
-    email: faker.internet.email(),
+    user: mockUser,
     onComplete: jest.fn(),
   };
 
@@ -380,10 +380,25 @@ const user = { id: '123', name: 'Test User' };
 
 ### Use Factories Instead of Static Mocks
 
-**Use Fishery** for creating test data factories with sensible defaults and overrides:
+**Use Fishery** for creating test data factories with sensible defaults and overrides.
+
+**CRITICAL — UI factories live in `redisinsight/ui/src/mocks/factories/`**, organized by
+domain (`<domain>/<TypeName>.factory.ts`), exported as `<TypeName>Factory`. Before writing
+test data in a UI spec, **check for an existing factory there and reuse it**; if none fits,
+**add a new factory file in that directory** rather than inlining mocks in the spec.
 
 ```typescript
-// ✅ GOOD: Fishery factory
+// ✅ GOOD: reuse the shared factory (redisinsight/ui/src/mocks/factories/database/DBInstance.factory.ts)
+import { DBInstanceFactory } from 'uiSrc/mocks/factories/database/DBInstance.factory';
+
+const instance = DBInstanceFactory.build();
+const cluster = DBInstanceFactory.build({
+  connectionType: ConnectionType.Cluster,
+});
+const many = DBInstanceFactory.buildList(5);
+
+// ✅ GOOD: a new factory file, when none exists yet
+// redisinsight/ui/src/mocks/factories/<domain>/<TypeName>.factory.ts
 import { Factory } from 'fishery';
 import { faker } from '@faker-js/faker';
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.ai/hooks/styleguide-reminder.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Why

We've been seeing PRs where agents ignore our frontend file-organization and testing (factory) conventions. Investigation found **two** root causes — not "skills aren't installed":

1. **Triggering is model-discretionary.** Skills are registered fine (`.claude/skills` → `.ai/skills`, good descriptions). But skill invocation is up to the model: on a task like "implement feature X", an agent dives into editing files and never pauses to load `frontend`/`testing`. The rules that get violated (FE structure, test factories) are exactly the ones **not** in CLAUDE.md's always-loaded layer — so they depended entirely on a skill firing.

2. **The skills taught the wrong pattern.** The repo has an established convention — `redisinsight/ui/src/mocks/factories/` (21 Fishery factories used by 55 specs) — that the `testing` skill **never mentioned**. Its frontend examples modeled **inline** mock objects, i.e. the anti-pattern. So even when the skill fired, the agent followed it correctly into the wrong code.

## What changed

**Fix the skills (commits 1–2)**
- `testing` skill now documents the real `mocks/factories/<domain>/<Name>.factory.ts` convention and shows reuse instead of inline mocks.
- `frontend` skill's `renderComponent` example builds default props from a factory.

**Enforce triggering (commit 3)**
- New `PreToolUse` hook (`.ai/hooks/styleguide-reminder.sh`) on Edit/Write/MultiEdit that maps the changed path to its styleguide and injects a reminder, so the rules no longer rely on a skill self-triggering:

  | Path edited | Skill(s) surfaced |
  |---|---|
  | `redisinsight/ui/src/**` | frontend (+ testing for `*.spec.ts(x)`) |
  | `redisinsight/api/src` / `/test/**` | backend (+ testing for `*.spec.ts`) |
  | `tests/e2e-playwright/**` | e2e-testing |
  | other (desktop, configs) | silent |

  E2E specs get the e2e skill, not the unit-testing one. Reminders name the skill file so the agent loads full detail on demand.

## Notes

- `.claude/settings.json` is committed so the team gets the hook. It merges with each dev's gitignored `settings.local.json`.
- Takes effect in **new** Claude Code sessions; first run prompts once to approve the hook command.
- Hook is `jq`-only (no node startup), exits silently for unrelated paths. Self-tested across all branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Claude Code hook configuration only; no application runtime or production code paths change.
> 
> **Overview**
> Aligns AI agent guidance with repo conventions and **automatically surfaces the right styleguide** when editing files, instead of relying on the model to load skills on its own.
> 
> **Skill doc fixes:** The `testing` and `frontend` skills now point at **`redisinsight/ui/src/mocks/factories/<domain>/<Name>.factory.ts`** (Fishery reuse) and show `renderComponent` examples that build entities from factories—not inline mock objects.
> 
> **Enforcement:** A new **`PreToolUse` hook** (`.ai/hooks/styleguide-reminder.sh`) runs on Edit/Write/MultiEdit, maps the target path to **frontend**, **backend**, **testing**, or **e2e-testing** reminders (E2E paths checked first), and injects `additionalContext`. **`.claude/settings.json`** is committed so the team gets the hook; unrelated paths exit silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91637f5e3709e24ad371e5ca8e5c14badbeaf737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->