### PR TITLE
RI-8220: Add View/Search/Aggregate tabs to array details

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -50,23 +50,27 @@ describe('ArrayDetails', () => {
     expect(screen.getByTestId('array-details-table-mock')).toBeInTheDocument()
   })
 
-  it.each([
-    [ArrayDetailsTab.Aggregate, 'array-aggregate-placeholder'],
-    [ArrayDetailsTab.Search, 'array-search-placeholder'],
-  ])(
-    'swaps the body for the %s placeholder and hides the View surfaces',
-    (tab, placeholderTestId) => {
-      render(<ArrayDetails {...instance(mockedProps)} />)
+  it('keeps every tab mounted and toggles visibility on tab change', () => {
+    render(<ArrayDetails {...instance(mockedProps)} />)
 
-      fireEvent.mouseDown(screen.getByText(ARRAY_DETAILS_TAB_LABELS[tab]))
+    expect(screen.getByTestId('array-range-form-mock')).toBeVisible()
+    expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-aggregate-placeholder')).not.toBeVisible()
 
-      expect(screen.getByTestId(placeholderTestId)).toBeInTheDocument()
-      expect(
-        screen.queryByTestId('array-range-form-mock'),
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByTestId('array-details-table-mock'),
-      ).not.toBeInTheDocument()
-    },
-  )
+    fireEvent.mouseDown(
+      screen.getByText(ARRAY_DETAILS_TAB_LABELS[ArrayDetailsTab.Search]),
+    )
+
+    expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
+    expect(screen.getByTestId('array-search-placeholder')).toBeVisible()
+    expect(screen.getByTestId('array-aggregate-placeholder')).not.toBeVisible()
+
+    fireEvent.mouseDown(
+      screen.getByText(ARRAY_DETAILS_TAB_LABELS[ArrayDetailsTab.Aggregate]),
+    )
+
+    expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
+    expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-aggregate-placeholder')).toBeVisible()
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
-import { render, screen } from 'uiSrc/utils/test-utils'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 
 import { ArrayDetails, Props } from './ArrayDetails'
+import { ARRAY_DETAILS_TAB_LABELS, ArrayDetailsTab } from './constants'
 
 // Stub out the child components so this spec covers only the composition
 // surface — the children have their own focused specs.
@@ -39,12 +40,33 @@ jest.mock('./hooks', () => ({
 const mockedProps = mock<Props>()
 
 describe('ArrayDetails', () => {
-  it('renders the header, range form, and table', () => {
+  it('renders the header, tabs, range form, and table on the View tab by default', () => {
     render(<ArrayDetails {...instance(mockedProps)} />)
 
     expect(screen.getByTestId('array-details')).toBeInTheDocument()
     expect(screen.getByTestId('key-details-header-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('array-tabs')).toBeInTheDocument()
     expect(screen.getByTestId('array-range-form-mock')).toBeInTheDocument()
     expect(screen.getByTestId('array-details-table-mock')).toBeInTheDocument()
   })
+
+  it.each([
+    [ArrayDetailsTab.Aggregate, 'array-aggregate-placeholder'],
+    [ArrayDetailsTab.Search, 'array-search-placeholder'],
+  ])(
+    'swaps the body for the %s placeholder and hides the View surfaces',
+    (tab, placeholderTestId) => {
+      render(<ArrayDetails {...instance(mockedProps)} />)
+
+      fireEvent.mouseDown(screen.getByText(ARRAY_DETAILS_TAB_LABELS[tab]))
+
+      expect(screen.getByTestId(placeholderTestId)).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('array-range-form-mock'),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('array-details-table-mock'),
+      ).not.toBeInTheDocument()
+    },
+  )
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
@@ -7,6 +7,13 @@ export const Container = styled(Col)`
   height: 100%;
 `
 
+export const TabsWrapper = styled.div`
+  padding: ${({ theme }) =>
+    `${theme.core.space.space100} ${theme.core.space.space200}`};
+  border-bottom: 1px solid
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
 export const DetailsBody = styled(Col)`
   position: relative;
   flex: 1;
@@ -18,4 +25,11 @@ export const TableWrapper = styled(Col)`
   flex: 1;
   min-height: 0;
   overflow: hidden;
+`
+
+export const PlaceholderWrapper = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
@@ -13,23 +13,3 @@ export const TabsWrapper = styled.div`
   border-bottom: 1px solid
     ${({ theme }) => theme.semantic.color.border.neutral500};
 `
-
-export const DetailsBody = styled(Col)`
-  position: relative;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-`
-
-export const TableWrapper = styled(Col)`
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-`
-
-export const PlaceholderWrapper = styled(Col)`
-  flex: 1;
-  min-height: 0;
-  align-items: center;
-  justify-content: center;
-`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.styles.ts
@@ -13,3 +13,9 @@ export const TabsWrapper = styled.div`
   border-bottom: 1px solid
     ${({ theme }) => theme.semantic.color.border.neutral500};
 `
+
+export const TabSlot = styled(Col)<{ $hidden?: boolean }>`
+  flex: 1;
+  min-height: 0;
+  display: ${({ $hidden }) => ($hidden ? 'none' : 'flex')};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -1,67 +1,28 @@
 import React, { useState } from 'react'
-import { useAppSelector } from 'uiSrc/slices/hooks'
 
-import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import {
   KeyDetailsHeader,
   KeyDetailsHeaderProps,
 } from 'uiSrc/pages/browser/modules'
-import { bufferToString } from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { Text } from 'uiSrc/components/base/text'
 
-import { ArrayDetailsTable } from './array-details-table'
-import { ArrayRangeForm } from './array-range-form'
+import AggregateTab from './aggregate-tab'
 import ArrayTabs from './array-tabs'
-import {
-  ARRAY_DETAILS_TAB_LABELS,
-  ArrayDetailsTab,
-  DEFAULT_ARRAY_DETAILS_TAB,
-} from './constants'
-import { useArrayRangeQuery } from './hooks'
+import SearchTab from './search-tab'
+import ViewTab from './view-tab'
+import { ArrayDetailsTab, DEFAULT_ARRAY_DETAILS_TAB } from './constants'
 import * as S from './ArrayDetails.styles'
 
 export interface Props extends KeyDetailsHeaderProps {
   keyProp: RedisResponseBuffer | null
 }
 
-/**
- * View / Browse vertical container for the array key type. Composes the
- * standard `KeyDetailsHeader` (length + count surfaced via the array
- * key-info strategy), a range/scan query form, and the virtualized
- * result table. Editing, deleting, and the Aggregate / Search / Add
- * tabs live in their own verticals (see
- * docs/redis-array-type-initiative.md §6 Tasks 2,4-7).
- */
 const ArrayDetails = (props: Props) => {
   const { keyProp } = props
-  const { loading } = useAppSelector(selectedKeySelector)
-  // Render the form's CLI preview off `keyProp` rather than the cached
-  // `selectedKeyData?.name` so the displayed key matches the one the
-  // form will actually query — avoids a one-fetch lag while
-  // `fetchKeyInfo` populates the selected-key slice.
-  const keyName = keyProp ? bufferToString(keyProp) : ''
 
   const [activeTab, setActiveTab] = useState<ArrayDetailsTab>(
     DEFAULT_ARRAY_DETAILS_TAB,
   )
-
-  const {
-    start,
-    end,
-    showEmpty,
-    setStart,
-    setEnd,
-    setShowEmpty,
-    runQuery,
-    resetQuery,
-    isArrayKeyReady,
-    elements,
-    loading: rangeLoading,
-    error: rangeError,
-  } = useArrayRangeQuery(keyProp)
-
-  const isViewTab = activeTab === ArrayDetailsTab.View
 
   return (
     <S.Container data-testid="array-details">
@@ -69,37 +30,9 @@ const ArrayDetails = (props: Props) => {
       <S.TabsWrapper>
         <ArrayTabs value={activeTab} onChange={setActiveTab} />
       </S.TabsWrapper>
-      {isViewTab && (
-        <ArrayRangeForm
-          keyName={keyName}
-          start={start}
-          end={end}
-          showEmpty={showEmpty}
-          loading={rangeLoading}
-          onChangeStart={setStart}
-          onChangeEnd={setEnd}
-          onToggleShowEmpty={setShowEmpty}
-          onRun={runQuery}
-          onReset={resetQuery}
-          disabled={!isArrayKeyReady}
-        />
-      )}
-      <S.DetailsBody>
-        {isViewTab && !loading && (
-          <S.TableWrapper>
-            <ArrayDetailsTable
-              elements={elements}
-              loading={rangeLoading}
-              error={rangeError}
-            />
-          </S.TableWrapper>
-        )}
-        {!isViewTab && (
-          <S.PlaceholderWrapper data-testid={`array-${activeTab}-placeholder`}>
-            <Text>{`This is ${ARRAY_DETAILS_TAB_LABELS[activeTab]}`}</Text>
-          </S.PlaceholderWrapper>
-        )}
-      </S.DetailsBody>
+      {activeTab === ArrayDetailsTab.View && <ViewTab keyProp={keyProp} />}
+      {activeTab === ArrayDetailsTab.Aggregate && <AggregateTab />}
+      {activeTab === ArrayDetailsTab.Search && <SearchTab />}
     </S.Container>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useAppSelector } from 'uiSrc/slices/hooks'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -8,9 +8,16 @@ import {
 } from 'uiSrc/pages/browser/modules'
 import { bufferToString } from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { Text } from 'uiSrc/components/base/text'
 
 import { ArrayDetailsTable } from './array-details-table'
 import { ArrayRangeForm } from './array-range-form'
+import ArrayTabs from './array-tabs'
+import {
+  ARRAY_DETAILS_TAB_LABELS,
+  ArrayDetailsTab,
+  DEFAULT_ARRAY_DETAILS_TAB,
+} from './constants'
 import { useArrayRangeQuery } from './hooks'
 import * as S from './ArrayDetails.styles'
 
@@ -35,6 +42,10 @@ const ArrayDetails = (props: Props) => {
   // `fetchKeyInfo` populates the selected-key slice.
   const keyName = keyProp ? bufferToString(keyProp) : ''
 
+  const [activeTab, setActiveTab] = useState<ArrayDetailsTab>(
+    DEFAULT_ARRAY_DETAILS_TAB,
+  )
+
   const {
     start,
     end,
@@ -50,28 +61,31 @@ const ArrayDetails = (props: Props) => {
     error: rangeError,
   } = useArrayRangeQuery(keyProp)
 
+  const isViewTab = activeTab === ArrayDetailsTab.View
+
   return (
     <S.Container data-testid="array-details">
       <KeyDetailsHeader {...props} key="key-details-header" />
-      <ArrayRangeForm
-        keyName={keyName}
-        start={start}
-        end={end}
-        showEmpty={showEmpty}
-        loading={rangeLoading}
-        onChangeStart={setStart}
-        onChangeEnd={setEnd}
-        onToggleShowEmpty={setShowEmpty}
-        onRun={runQuery}
-        onReset={resetQuery}
-        // While the selected-key slice hasn't caught up with `keyProp`
-        // (or the resolved type isn't Array), disable manual actions —
-        // the hook also guards internally but this gives the user
-        // immediate feedback rather than a no-op click.
-        disabled={!isArrayKeyReady}
-      />
+      <S.TabsWrapper>
+        <ArrayTabs value={activeTab} onChange={setActiveTab} />
+      </S.TabsWrapper>
+      {isViewTab && (
+        <ArrayRangeForm
+          keyName={keyName}
+          start={start}
+          end={end}
+          showEmpty={showEmpty}
+          loading={rangeLoading}
+          onChangeStart={setStart}
+          onChangeEnd={setEnd}
+          onToggleShowEmpty={setShowEmpty}
+          onRun={runQuery}
+          onReset={resetQuery}
+          disabled={!isArrayKeyReady}
+        />
+      )}
       <S.DetailsBody>
-        {!loading && (
+        {isViewTab && !loading && (
           <S.TableWrapper>
             <ArrayDetailsTable
               elements={elements}
@@ -79,6 +93,11 @@ const ArrayDetails = (props: Props) => {
               error={rangeError}
             />
           </S.TableWrapper>
+        )}
+        {!isViewTab && (
+          <S.PlaceholderWrapper data-testid={`array-${activeTab}-placeholder`}>
+            <Text>{`This is ${ARRAY_DETAILS_TAB_LABELS[activeTab]}`}</Text>
+          </S.PlaceholderWrapper>
         )}
       </S.DetailsBody>
     </S.Container>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -30,9 +30,15 @@ const ArrayDetails = (props: Props) => {
       <S.TabsWrapper>
         <ArrayTabs value={activeTab} onChange={setActiveTab} />
       </S.TabsWrapper>
-      {activeTab === ArrayDetailsTab.View && <ViewTab keyProp={keyProp} />}
-      {activeTab === ArrayDetailsTab.Aggregate && <AggregateTab />}
-      {activeTab === ArrayDetailsTab.Search && <SearchTab />}
+      <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.View}>
+        <ViewTab keyProp={keyProp} />
+      </S.TabSlot>
+      <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Search}>
+        <SearchTab />
+      </S.TabSlot>
+      <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Aggregate}>
+        <AggregateTab />
+      </S.TabSlot>
     </S.Container>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Text } from 'uiSrc/components/base/text'
+
+import * as S from '../tabs.styles'
+
+const AggregateTab = () => (
+  <S.TabPlaceholder data-testid="array-aggregate-placeholder">
+    <Text>This is Aggregate</Text>
+  </S.TabPlaceholder>
+)
+
+export default AggregateTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/index.ts
@@ -1,0 +1,3 @@
+import AggregateTab from './AggregateTab'
+
+export default AggregateTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.spec.tsx
@@ -2,11 +2,20 @@ import React from 'react'
 import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 
 import ArrayTabs from './ArrayTabs'
+import { ArrayTabsProps } from './ArrayTabs.types'
 import { ARRAY_DETAILS_TAB_LABELS, ArrayDetailsTab } from '../constants'
 
 describe('ArrayTabs', () => {
+  const defaultProps: ArrayTabsProps = {
+    value: ArrayDetailsTab.View,
+    onChange: jest.fn(),
+  }
+
+  const renderComponent = (propsOverride?: Partial<ArrayTabsProps>) =>
+    render(<ArrayTabs {...defaultProps} {...propsOverride} />)
+
   it('renders View, Aggregate and Search tabs with the active one selected', () => {
-    render(<ArrayTabs value={ArrayDetailsTab.View} onChange={jest.fn()} />)
+    renderComponent()
 
     expect(screen.getByTestId('array-tabs')).toBeInTheDocument()
 
@@ -19,7 +28,7 @@ describe('ArrayTabs', () => {
 
   it('calls onChange with the picked tab id', () => {
     const onChange = jest.fn()
-    render(<ArrayTabs value={ArrayDetailsTab.View} onChange={onChange} />)
+    renderComponent({ onChange })
 
     fireEvent.mouseDown(screen.getByText(ARRAY_DETAILS_TAB_LABELS.aggregate))
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import ArrayTabs from './ArrayTabs'
+import { ARRAY_DETAILS_TAB_LABELS, ArrayDetailsTab } from '../constants'
+
+describe('ArrayTabs', () => {
+  it('renders View, Aggregate and Search tabs with the active one selected', () => {
+    render(<ArrayTabs value={ArrayDetailsTab.View} onChange={jest.fn()} />)
+
+    expect(screen.getByTestId('array-tabs')).toBeInTheDocument()
+
+    Object.values(ArrayDetailsTab).forEach((tab) => {
+      expect(
+        screen.getByText(ARRAY_DETAILS_TAB_LABELS[tab]),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('calls onChange with the picked tab id', () => {
+    const onChange = jest.fn()
+    render(<ArrayTabs value={ArrayDetailsTab.View} onChange={onChange} />)
+
+    fireEvent.mouseDown(screen.getByText(ARRAY_DETAILS_TAB_LABELS.aggregate))
+
+    expect(onChange).toHaveBeenCalledWith(ArrayDetailsTab.Aggregate)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo } from 'react'
+
+import Tabs, { TabInfo } from 'uiSrc/components/base/layout/tabs'
+import { ARRAY_DETAILS_TAB_LABELS, ArrayDetailsTab } from '../constants'
+
+export interface ArrayTabsProps {
+  value: ArrayDetailsTab
+  onChange: (tab: ArrayDetailsTab) => void
+}
+
+const ArrayTabs = ({ value, onChange }: ArrayTabsProps) => {
+  const tabs: TabInfo[] = useMemo(
+    () =>
+      (Object.values(ArrayDetailsTab) as ArrayDetailsTab[]).map((tab) => ({
+        value: tab,
+        label: ARRAY_DETAILS_TAB_LABELS[tab],
+        content: null,
+      })),
+    [],
+  )
+
+  return (
+    <Tabs
+      tabs={tabs}
+      value={value}
+      onChange={(id) => onChange(id as ArrayDetailsTab)}
+      data-testid="array-tabs"
+    />
+  )
+}
+
+export default ArrayTabs

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.tsx
@@ -2,11 +2,7 @@ import React, { useMemo } from 'react'
 
 import Tabs, { TabInfo } from 'uiSrc/components/base/layout/tabs'
 import { ARRAY_DETAILS_TAB_LABELS, ArrayDetailsTab } from '../constants'
-
-export interface ArrayTabsProps {
-  value: ArrayDetailsTab
-  onChange: (tab: ArrayDetailsTab) => void
-}
+import { ArrayTabsProps } from './ArrayTabs.types'
 
 const ArrayTabs = ({ value, onChange }: ArrayTabsProps) => {
   const tabs: TabInfo[] = useMemo(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/ArrayTabs.types.ts
@@ -1,0 +1,6 @@
+import { ArrayDetailsTab } from '../constants'
+
+export interface ArrayTabsProps {
+  value: ArrayDetailsTab
+  onChange: (tab: ArrayDetailsTab) => void
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/index.ts
@@ -1,0 +1,4 @@
+import ArrayTabs from './ArrayTabs'
+
+export default ArrayTabs
+export type { ArrayTabsProps } from './ArrayTabs'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-tabs/index.ts
@@ -1,4 +1,4 @@
 import ArrayTabs from './ArrayTabs'
 
 export default ArrayTabs
-export type { ArrayTabsProps } from './ArrayTabs'
+export type { ArrayTabsProps } from './ArrayTabs.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -13,3 +13,17 @@ export const DEFAULT_RANGE_START = '0'
  * so the table comfortably fits without scrolling on first load.
  */
 export const DEFAULT_RANGE_END = '9'
+
+export enum ArrayDetailsTab {
+  View = 'view',
+  Aggregate = 'aggregate',
+  Search = 'search',
+}
+
+export const DEFAULT_ARRAY_DETAILS_TAB = ArrayDetailsTab.View
+
+export const ARRAY_DETAILS_TAB_LABELS: Record<ArrayDetailsTab, string> = {
+  [ArrayDetailsTab.View]: 'View',
+  [ArrayDetailsTab.Aggregate]: 'Aggregate',
+  [ArrayDetailsTab.Search]: 'Search',
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -16,14 +16,14 @@ export const DEFAULT_RANGE_END = '9'
 
 export enum ArrayDetailsTab {
   View = 'view',
-  Aggregate = 'aggregate',
   Search = 'search',
+  Aggregate = 'aggregate',
 }
 
 export const DEFAULT_ARRAY_DETAILS_TAB = ArrayDetailsTab.View
 
 export const ARRAY_DETAILS_TAB_LABELS: Record<ArrayDetailsTab, string> = {
   [ArrayDetailsTab.View]: 'View',
-  [ArrayDetailsTab.Aggregate]: 'Aggregate',
   [ArrayDetailsTab.Search]: 'Search',
+  [ArrayDetailsTab.Aggregate]: 'Aggregate',
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Text } from 'uiSrc/components/base/text'
+
+import * as S from '../tabs.styles'
+
+const SearchTab = () => (
+  <S.TabPlaceholder data-testid="array-search-placeholder">
+    <Text>This is Search</Text>
+  </S.TabPlaceholder>
+)
+
+export default SearchTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/index.ts
@@ -1,0 +1,3 @@
+import SearchTab from './SearchTab'
+
+export default SearchTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/tabs.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/tabs.styles.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+export const TabBody = styled(Col)`
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`
+
+export const TabTableWrapper = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`
+
+export const TabPlaceholder = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { bufferToString } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+import { ArrayDetailsTable } from '../array-details-table'
+import { ArrayRangeForm } from '../array-range-form'
+import { useArrayRangeQuery } from '../hooks'
+import * as S from '../tabs.styles'
+
+export interface ViewTabProps {
+  keyProp: RedisResponseBuffer | null
+}
+
+const ViewTab = ({ keyProp }: ViewTabProps) => {
+  const { loading } = useAppSelector(selectedKeySelector)
+  const keyName = keyProp ? bufferToString(keyProp) : ''
+
+  const {
+    start,
+    end,
+    showEmpty,
+    setStart,
+    setEnd,
+    setShowEmpty,
+    runQuery,
+    resetQuery,
+    isArrayKeyReady,
+    elements,
+    loading: rangeLoading,
+    error: rangeError,
+  } = useArrayRangeQuery(keyProp)
+
+  return (
+    <>
+      <ArrayRangeForm
+        keyName={keyName}
+        start={start}
+        end={end}
+        showEmpty={showEmpty}
+        loading={rangeLoading}
+        onChangeStart={setStart}
+        onChangeEnd={setEnd}
+        onToggleShowEmpty={setShowEmpty}
+        onRun={runQuery}
+        onReset={resetQuery}
+        disabled={!isArrayKeyReady}
+      />
+      <S.TabBody>
+        {!loading && (
+          <S.TabTableWrapper>
+            <ArrayDetailsTable
+              elements={elements}
+              loading={rangeLoading}
+              error={rangeError}
+            />
+          </S.TabTableWrapper>
+        )}
+      </S.TabBody>
+    </>
+  )
+}
+
+export default ViewTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -3,16 +3,12 @@ import React from 'react'
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { bufferToString } from 'uiSrc/utils'
-import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
 import { ArrayDetailsTable } from '../array-details-table'
 import { ArrayRangeForm } from '../array-range-form'
 import { useArrayRangeQuery } from '../hooks'
 import * as S from '../tabs.styles'
-
-export interface ViewTabProps {
-  keyProp: RedisResponseBuffer | null
-}
+import { ViewTabProps } from './ViewTab.types'
 
 const ViewTab = ({ keyProp }: ViewTabProps) => {
   const { loading } = useAppSelector(selectedKeySelector)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.types.ts
@@ -1,0 +1,5 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface ViewTabProps {
+  keyProp: RedisResponseBuffer | null
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/index.ts
@@ -1,4 +1,4 @@
 import ViewTab from './ViewTab'
 
 export default ViewTab
-export type { ViewTabProps } from './ViewTab'
+export type { ViewTabProps } from './ViewTab.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/index.ts
@@ -1,0 +1,4 @@
+import ViewTab from './ViewTab'
+
+export default ViewTab
+export type { ViewTabProps } from './ViewTab'


### PR DESCRIPTION
# What

Refactors `ArrayDetails` into a tabbed shell ahead of the next tasks:

- Adds an `ArrayTabs` wrapper over the Redis UI `Tabs` component (mirrors the `StreamTabs` precedent).
- Extracts the existing range-form + table into a self-contained `ViewTab`.
- Adds `AggregateTab` and `SearchTab` placeholders so the verticals can drop content in without re-shaping the parent.
- Shared tab layout primitives live in `tabs.styles.ts`.

No behavior change on the default View tab.

| View                                                                                                                                                           | Search                                                                                                                                                         | Aggregate                                                                                                                                                      |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 11" src="https://github.com/user-attachments/assets/a513310b-0cf0-47c3-ae00-93eeb47aaf20" /> | <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 14" src="https://github.com/user-attachments/assets/a80bf12e-2238-4db4-b681-6b1a6737583b" /> | <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 17" src="https://github.com/user-attachments/assets/82329b40-359e-4e3d-9364-5488012434b2" /> |
| <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 29" src="https://github.com/user-attachments/assets/eb93e0e9-a60c-443a-aad7-9f85ee31350c" /> | <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 32" src="https://github.com/user-attachments/assets/b63eace6-769b-43ab-9c27-4df2f4449c08" /> | <img width="1241" height="945" alt="Screenshot 2026-06-18 at 9 44 35" src="https://github.com/user-attachments/assets/25704c80-0147-475f-b479-e0dcc072ca65" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI composition refactor with View tab logic moved unchanged; placeholders only affect non-default tabs.
> 
> **Overview**
> **Array key details** is now a tabbed shell (View, Search, Aggregate) instead of a single range-form + table layout. Tab state lives in `ArrayDetails`; **`ArrayTabs`** wraps the shared `Tabs` component, following the stream-details pattern.
> 
> The existing browse behavior moves into **`ViewTab`** (range form, `useArrayRangeQuery`, and `ArrayDetailsTable`). **Search** and **Aggregate** are placeholder panels for upcoming work. All three tab bodies stay mounted; inactive tabs are hidden via **`TabSlot`** (`display: none`), not unmounted.
> 
> Styling splits between a tabs header bar (`TabsWrapper`) and shared tab layout in `tabs.styles.ts`. Specs cover default View content and visibility when switching tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba17a4039a1bf5b5bc1ba571d4b5af028acf465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->