### PR TITLE
Arrays: fix test with max value

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArray.spec.tsx
@@ -178,8 +178,9 @@ describe('AddKeyArray', () => {
     it('should disable submit when a contiguous range would exceed the u64 max', () => {
       renderComponent({ keyName: 'name' })
 
+      // ARRAY_INDEX_MAX = 2^64 − 2, the largest valid index.
       fireEvent.change(screen.getByTestId('start-index'), {
-        target: { value: '18446744073709551615' },
+        target: { value: '18446744073709551614' },
       })
       // a single value at the max index is still in range
       expect(screen.getByTestId('add-key-array-btn')).not.toBeDisabled()


### PR DESCRIPTION
# What

The test typed `2^64 − 1` (`18446744073709551615`) into the start-index input
and expected the submit button to be enabled with a single value present.

The codified spec — `ARRAY_INDEX_MAX` in `redisinsight/ui/src/utils/arrayIndex.ts`
(mirrored in `redisinsight/api/src/common/utils/array-index.helper.ts`) —
defines the valid range as half-open `[0, 2^64−1)`, i.e. the max valid
index is `2^64 − 2 = 18446744073709551614`. `parseArrayIndex` rejects
`2^64 − 1`, so `isValidContiguousRange` was already returning `false`
and the button stayed disabled, breaking the first assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with a clarifying comment; no runtime or validation logic is modified.
> 
> **Overview**
> Fixes a failing **AddKeyArray** unit test for contiguous-mode submit validation at the upper **u64** index bound.
> 
> The test now uses start index `18446744073709551614` (`2^64 − 2`, i.e. **`ARRAY_INDEX_MAX`**) instead of `18446744073709551615`, which **`parseArrayIndex`** rejects. That restores the intended assertions: submit stays enabled with one value at the max index, and disables after adding a second value that would exceed the valid range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5536fc60297f2bc830635566c622602d8aa8a352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->