### PR TITLE
RI-8220: Add AROP aggregate endpoint for Array data type

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Array/Aggregate.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Aggregate.bru
@@ -1,0 +1,131 @@
+meta {
+  name: Aggregate
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array/aggregate
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "readings",
+    "start": "0",
+    "end": "6",
+    "operation": "SUM"
+  }
+}
+
+docs {
+  # AROP
+
+  Aggregate the populated elements of an inclusive range with a single
+  operation. Empty slots are skipped (not treated as `0`). Range bounds are
+  reversible — the same set of populated slots is aggregated regardless of
+  `start`/`end` ordering.
+
+  ## Request body
+
+  | Field       | Type             | Notes                                                                                  |
+  |-------------|------------------|----------------------------------------------------------------------------------------|
+  | `keyName`   | string           | The Array key name.                                                                    |
+  | `start`     | string           | Inclusive start index. Unsigned 64-bit integer as string.                              |
+  | `end`       | string           | Inclusive end index. Unsigned 64-bit integer as string.                                |
+  | `operation` | string           | One of `SUM` / `MIN` / `MAX` / `AND` / `OR` / `XOR` / `MATCH` / `USED`.                 |
+  | `value`     | RedisString      | Required only for `MATCH` (the value to count, accepts strings and binary buffers); ignored otherwise. |
+
+  ### Operations
+
+  | Value   | Description                                                                 |
+  |---------|-----------------------------------------------------------------------------|
+  | `SUM`   | Sum of numeric elements. Errors if any element in range is non-numeric.     |
+  | `MIN`   | Minimum numeric element. Errors on non-numeric.                             |
+  | `MAX`   | Maximum numeric element. Errors on non-numeric.                             |
+  | `AND`   | Bitwise AND fold. Errors on non-numeric.                                    |
+  | `OR`    | Bitwise OR fold. Errors on non-numeric.                                     |
+  | `XOR`   | Bitwise XOR fold. Errors on non-numeric.                                    |
+  | `MATCH` | Count of elements equal to `value`.                                         |
+  | `USED`  | Count of populated slots in range.                                          |
+
+  ## Response
+
+  ```
+  {
+    "keyName": "readings",
+    "result": "104.7"
+  }
+  ```
+
+  `result` is a decimal string for numeric ops and an integer count as a
+  string for `MATCH` / `USED`. It is `null` when AROP yields a nil reply
+  (numeric ops over a range with no numeric values; bitwise ops over an empty
+  range). `SUM` / `MIN` / `MAX` preserve full precision; `AND` / `OR` / `XOR`
+  results above 2^53 may be rounded (see RI-8296).
+
+  ## Errors
+
+  | Status | When |
+  |--------|------|
+  | `400`  | Range exceeds 1,000,000 elements per call, `MATCH` is missing `value`, an element is non-numeric for a numeric op, or the key holds a non-array type. |
+  | `403`  | User has no permission for `AROP`. |
+  | `404`  | Key does not exist. |
+
+  ## Examples
+
+  Examples run against the `readings` sample
+  (`0:"20.1" 1:"20.4" 2:"20.9" 5:"21.4" 6:"21.9"`, gaps at `3,4`) — see
+  `Seed Sample Data` — except the bitwise `XOR` example, which needs an
+  integer-valued array.
+
+  ### SUM — total of the numeric elements
+
+  Empty slots are skipped, not counted as `0`.
+
+  ```json
+  { "keyName": "readings", "start": "0", "end": "6", "operation": "SUM" }
+  ```
+
+  → `{ "keyName": "readings", "result": "104.7" }`
+
+  ### MAX — largest numeric element
+
+  ```json
+  { "keyName": "readings", "start": "0", "end": "6", "operation": "MAX" }
+  ```
+
+  → `{ "keyName": "readings", "result": "21.9" }`
+
+  ### USED — count populated slots (works on non-numeric arrays too)
+
+  ```json
+  { "keyName": "readings", "start": "0", "end": "6", "operation": "USED" }
+  ```
+
+  → `{ "keyName": "readings", "result": "5" }`
+
+  ### MATCH — count elements equal to a value
+
+  `MATCH` is the only operation that takes the extra `value` field.
+
+  ```json
+  { "keyName": "readings", "start": "0", "end": "6", "operation": "MATCH", "value": "20.4" }
+  ```
+
+  → `{ "keyName": "readings", "result": "1" }`
+
+  ### XOR — bitwise fold over integer elements
+
+  Bitwise ops require integer elements. Results above 2^53 may be rounded by
+  the client (see RI-8296); `SUM` / `MIN` / `MAX` are unaffected.
+
+  ```json
+  { "keyName": "counters", "start": "0", "end": "9", "operation": "XOR" }
+  ```
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/src/constants/error-messages.ts
+++ b/redisinsight/api/src/constants/error-messages.ts
@@ -80,6 +80,7 @@ export default {
   INCORRECT_CLUSTER_CURSOR_FORMAT: 'Incorrect cluster cursor format.',
   ARRAY_RANGE_TOO_LARGE: (max: number) =>
     `Requested range exceeds the maximum of ${numberWithSpaces(max)} elements per call. Narrow the range and try again.`,
+  ARRAY_MATCH_VALUE_REQUIRED: 'value is required for MATCH operation.',
   REMOVING_MULTIPLE_ELEMENTS_NOT_SUPPORT: () =>
     'Removing multiple elements is available for Redis databases v. 6.2 or later.',
   SCAN_PER_KEY_TYPE_NOT_SUPPORT: () =>

--- a/redisinsight/api/src/modules/browser/__mocks__/array.ts
+++ b/redisinsight/api/src/modules/browser/__mocks__/array.ts
@@ -1,4 +1,7 @@
 import {
+  AggregateArrayDto,
+  AggregateArrayResponse,
+  ArrayAggregateOperation,
   GetArrayCountResponse,
   GetArrayElementDto,
   GetArrayElementResponse,
@@ -88,4 +91,18 @@ export const mockGetArrayCountResponse: GetArrayCountResponse = {
 export const mockGetArrayNextIndexResponse: GetArrayNextIndexResponse = {
   keyName: mockKeyDto.keyName,
   index: mockArrayNextIndex,
+};
+
+export const mockArrayAggregateSumResult = '104.7';
+
+export const mockAggregateArrayDto: AggregateArrayDto = {
+  keyName: mockKeyDto.keyName,
+  start: '0',
+  end: '6',
+  operation: ArrayAggregateOperation.Sum,
+};
+
+export const mockAggregateArrayResponse: AggregateArrayResponse = {
+  keyName: mockKeyDto.keyName,
+  result: mockArrayAggregateSumResult,
 };

--- a/redisinsight/api/src/modules/browser/__mocks__/array.ts
+++ b/redisinsight/api/src/modules/browser/__mocks__/array.ts
@@ -1,7 +1,4 @@
 import {
-  AggregateArrayDto,
-  AggregateArrayResponse,
-  ArrayAggregateOperation,
   GetArrayCountResponse,
   GetArrayElementDto,
   GetArrayElementResponse,
@@ -91,18 +88,4 @@ export const mockGetArrayCountResponse: GetArrayCountResponse = {
 export const mockGetArrayNextIndexResponse: GetArrayNextIndexResponse = {
   keyName: mockKeyDto.keyName,
   index: mockArrayNextIndex,
-};
-
-export const mockArrayAggregateSumResult = '104.7';
-
-export const mockAggregateArrayDto: AggregateArrayDto = {
-  keyName: mockKeyDto.keyName,
-  start: '0',
-  end: '6',
-  operation: ArrayAggregateOperation.Sum,
-};
-
-export const mockAggregateArrayResponse: AggregateArrayResponse = {
-  keyName: mockKeyDto.keyName,
-  result: mockArrayAggregateSumResult,
 };

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -1,6 +1,8 @@
 import { Factory } from 'fishery';
 import { faker } from '@faker-js/faker';
 import {
+  AggregateArrayDto,
+  ArrayAggregateOperation,
   ArrayCreationMode,
   ArrayElementDto,
   CreateArrayWithExpireDto,
@@ -30,3 +32,12 @@ export const createSparseArrayDtoFactory =
     mode: ArrayCreationMode.Sparse,
     elements: arrayElementFactory.buildList(2),
   }));
+
+export const aggregateArrayDtoFactory = Factory.define<AggregateArrayDto>(
+  () => ({
+    keyName: arrayKeyName(),
+    start: '0',
+    end: '6',
+    operation: ArrayAggregateOperation.Sum,
+  }),
+);

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -17,6 +17,8 @@ import { BrowserBaseController } from 'src/modules/browser/browser.base.controll
 import { KeyDto } from 'src/modules/browser/keys/dto';
 import { ArrayService } from 'src/modules/browser/array/array.service';
 import {
+  AggregateArrayDto,
+  AggregateArrayResponse,
   CreateArrayWithExpireDto,
   GetArrayCountResponse,
   GetArrayElementDto,
@@ -167,5 +169,23 @@ export class ArrayController extends BrowserBaseController {
     @Body() dto: GetArrayMultiElementsDto,
   ): Promise<GetArrayMultiElementsResponse> {
     return this.arrayService.getMultiElements(clientMetadata, dto);
+  }
+
+  @Post('/aggregate')
+  @HttpCode(200)
+  @ApiOperation({
+    description:
+      'Aggregate elements over a range — AROP. Operation is one of ' +
+      'SUM/MIN/MAX/AND/OR/XOR/MATCH/USED. Numeric ops error server-side if ' +
+      'any element in range is non-numeric; MATCH requires a `value` arg.',
+  })
+  @ApiRedisParams()
+  @ApiOkResponse({ type: AggregateArrayResponse })
+  @ApiQueryRedisStringEncoding()
+  async aggregate(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: AggregateArrayDto,
+  ): Promise<AggregateArrayResponse> {
+    return this.arrayService.aggregate(clientMetadata, dto);
   }
 }

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -747,6 +747,80 @@ describe('ArrayService', () => {
       expect(result.result).toBe('5');
     });
 
+    it('should return null when AROP yields a nil reply', async () => {
+      // SUM over an empty/non-numeric range returns nil; the API surfaces
+      // that as `result: null` instead of throwing a 500.
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          mockAggregateArrayDto.keyName,
+          mockAggregateArrayDto.start,
+          mockAggregateArrayDto.end,
+          mockAggregateArrayDto.operation,
+        ])
+        .mockResolvedValue(null);
+
+      const result = await service.aggregate(
+        mockBrowserClientMetadata,
+        mockAggregateArrayDto,
+      );
+      expect(result.result).toBeNull();
+    });
+
+    it('should pass a Buffer value through to AROP for MATCH', async () => {
+      // Elements stored as binary (RedisString) must be matchable by a
+      // Buffer comparison value — string-only DTOs would reject this.
+      const dto = {
+        ...mockAggregateArrayDto,
+        operation: ArrayAggregateOperation.Match,
+        value: Buffer.from([0x00, 0xff, 0x10]),
+      };
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          dto.keyName,
+          dto.start,
+          dto.end,
+          dto.operation,
+          dto.value,
+        ])
+        .mockResolvedValue(2);
+
+      const result = await service.aggregate(mockBrowserClientMetadata, dto);
+      expect(result.result).toBe('2');
+    });
+
+    it('should reject MATCH with an empty string value', async () => {
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, {
+          ...mockAggregateArrayDto,
+          operation: ArrayAggregateOperation.Match,
+          value: '',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject MATCH with an empty Buffer value', async () => {
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, {
+          ...mockAggregateArrayDto,
+          operation: ArrayAggregateOperation.Match,
+          value: Buffer.alloc(0),
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject MATCH when value is undefined', async () => {
+      // Mirrors the DTO @ValidateIf/@IsRedisString contract for the
+      // case where the controller layer is bypassed.
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, {
+          ...mockAggregateArrayDto,
+          operation: ArrayAggregateOperation.Match,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('should reject when key does not exist', async () => {
       when(mockStandaloneRedisClient.sendCommand)
         .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -779,72 +779,36 @@ describe('ArrayService', () => {
       expect(result.result).toBeNull();
     });
 
-    it('should pass a Buffer value through to AROP for MATCH', async () => {
-      // Elements stored as binary (RedisString) must be matchable by a
-      // Buffer comparison value — string-only DTOs would reject this.
-      const dto = {
-        ...mockAggregateArrayDto,
-        operation: ArrayAggregateOperation.Match,
-        value: Buffer.from([0x00, 0xff, 0x10]),
-      };
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([
-          BrowserToolArrayCommands.ArOp,
-          dto.keyName,
-          dto.start,
-          dto.end,
-          dto.operation,
-          dto.value,
-        ])
-        .mockResolvedValue(2);
+    // Binary elements and zero-length bulk strings are valid RedisString
+    // values the create DTO accepts, so MATCH must forward them verbatim
+    // rather than reject them.
+    it.each([
+      { description: 'a Buffer', value: Buffer.from([0x00, 0xff, 0x10]) },
+      { description: 'an empty string', value: '' },
+      { description: 'an empty Buffer', value: Buffer.alloc(0) },
+    ])(
+      'should pass $description value through to AROP for MATCH',
+      async ({ value }) => {
+        const dto = {
+          ...mockAggregateArrayDto,
+          operation: ArrayAggregateOperation.Match,
+          value,
+        };
+        when(mockStandaloneRedisClient.sendCommand)
+          .calledWith([
+            BrowserToolArrayCommands.ArOp,
+            dto.keyName,
+            dto.start,
+            dto.end,
+            dto.operation,
+            dto.value,
+          ])
+          .mockResolvedValue(2);
 
-      const result = await service.aggregate(mockBrowserClientMetadata, dto);
-      expect(result.result).toBe('2');
-    });
-
-    it('should pass an empty string value through to AROP for MATCH', async () => {
-      // Redis stores zero-length bulk strings as real elements and the
-      // create DTO accepts them, so MATCH must be able to count them.
-      const dto = {
-        ...mockAggregateArrayDto,
-        operation: ArrayAggregateOperation.Match,
-        value: '',
-      };
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([
-          BrowserToolArrayCommands.ArOp,
-          dto.keyName,
-          dto.start,
-          dto.end,
-          dto.operation,
-          dto.value,
-        ])
-        .mockResolvedValue(3);
-
-      const result = await service.aggregate(mockBrowserClientMetadata, dto);
-      expect(result.result).toBe('3');
-    });
-
-    it('should pass an empty Buffer value through to AROP for MATCH', async () => {
-      const dto = {
-        ...mockAggregateArrayDto,
-        operation: ArrayAggregateOperation.Match,
-        value: Buffer.alloc(0),
-      };
-      when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([
-          BrowserToolArrayCommands.ArOp,
-          dto.keyName,
-          dto.start,
-          dto.end,
-          dto.operation,
-          dto.value,
-        ])
-        .mockResolvedValue(3);
-
-      const result = await service.aggregate(mockBrowserClientMetadata, dto);
-      expect(result.result).toBe('3');
-    });
+        const result = await service.aggregate(mockBrowserClientMetadata, dto);
+        expect(result.result).toBe('2');
+      },
+    );
 
     it('should reject MATCH when value is undefined', async () => {
       // Mirrors the DTO @ValidateIf/@IsRedisString contract for the

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -25,6 +25,9 @@ import {
   createSparseArrayDtoFactory,
 } from 'src/modules/browser/array/__tests__/array.factory';
 import {
+  mockAggregateArrayDto,
+  mockAggregateArrayResponse,
+  mockArrayAggregateSumResult,
   mockArrayCount,
   mockArrayElement1,
   mockArrayLength,
@@ -44,6 +47,7 @@ import {
   mockKeyDto,
 } from 'src/modules/browser/__mocks__';
 import { ARRAY_RANGE_MAX_ELEMENTS } from 'src/modules/browser/array/constants';
+import { ArrayAggregateOperation } from 'src/modules/browser/array/dto';
 import { ArrayService } from 'src/modules/browser/array/array.service';
 
 describe('ArrayService', () => {
@@ -664,6 +668,125 @@ describe('ArrayService', () => {
           mockBrowserClientMetadata,
           mockGetArrayMultiElementsDto,
         ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('aggregate', () => {
+    beforeEach(() => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          mockAggregateArrayDto.keyName,
+          mockAggregateArrayDto.start,
+          mockAggregateArrayDto.end,
+          mockAggregateArrayDto.operation,
+        ])
+        .mockResolvedValue(Buffer.from(mockArrayAggregateSumResult));
+    });
+
+    it('should return the aggregation result as a string', async () => {
+      const result = await service.aggregate(
+        mockBrowserClientMetadata,
+        mockAggregateArrayDto,
+      );
+      expect(result).toEqual(mockAggregateArrayResponse);
+    });
+
+    it('should append the value arg for MATCH', async () => {
+      const dto = {
+        ...mockAggregateArrayDto,
+        operation: ArrayAggregateOperation.Match,
+        value: '20.4',
+      };
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          dto.keyName,
+          dto.start,
+          dto.end,
+          dto.operation,
+          dto.value,
+        ])
+        .mockResolvedValue(1);
+
+      const result = await service.aggregate(mockBrowserClientMetadata, dto);
+      expect(result.result).toBe('1');
+    });
+
+    it('should not append a value arg for non-MATCH operations', async () => {
+      await service.aggregate(mockBrowserClientMetadata, {
+        ...mockAggregateArrayDto,
+        // value intentionally set — should be ignored when operation !== MATCH.
+        value: 'ignored',
+      });
+      expect(mockStandaloneRedisClient.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArOp,
+        mockAggregateArrayDto.keyName,
+        mockAggregateArrayDto.start,
+        mockAggregateArrayDto.end,
+        mockAggregateArrayDto.operation,
+      ]);
+    });
+
+    it('should normalize integer replies (USED) to a string', async () => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          mockAggregateArrayDto.keyName,
+          mockAggregateArrayDto.start,
+          mockAggregateArrayDto.end,
+          ArrayAggregateOperation.Used,
+        ])
+        .mockResolvedValue(5);
+
+      const result = await service.aggregate(mockBrowserClientMetadata, {
+        ...mockAggregateArrayDto,
+        operation: ArrayAggregateOperation.Used,
+      });
+      expect(result.result).toBe('5');
+    });
+
+    it('should reject when key does not exist', async () => {
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(0);
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, mockAggregateArrayDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject when range exceeds the 1M cap', async () => {
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, {
+          ...mockAggregateArrayDto,
+          start: '0',
+          end: String(ARRAY_RANGE_MAX_ELEMENTS),
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should rethrow BadRequest on WrongType', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'AROP',
+      };
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith(expect.arrayContaining([BrowserToolArrayCommands.ArOp]))
+        .mockRejectedValue(replyError);
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, mockAggregateArrayDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should map ACL error to Forbidden', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'AROP',
+      };
+      mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
+      await expect(
+        service.aggregate(mockBrowserClientMetadata, mockAggregateArrayDto),
       ).rejects.toThrow(ForbiddenException);
     });
   });

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -21,13 +21,11 @@ import {
   BrowserToolKeysCommands,
 } from 'src/modules/browser/constants/browser-tool-commands';
 import {
+  aggregateArrayDtoFactory,
   createContiguousArrayDtoFactory,
   createSparseArrayDtoFactory,
 } from 'src/modules/browser/array/__tests__/array.factory';
 import {
-  mockAggregateArrayDto,
-  mockAggregateArrayResponse,
-  mockArrayAggregateSumResult,
   mockArrayCount,
   mockArrayElement1,
   mockArrayLength,
@@ -673,7 +671,21 @@ describe('ArrayService', () => {
   });
 
   describe('aggregate', () => {
+    const mockAggregateArrayDto = aggregateArrayDtoFactory.build();
+    const mockArrayAggregateSumResult = '104.7';
+    const mockAggregateArrayResponse = {
+      keyName: mockAggregateArrayDto.keyName,
+      result: mockArrayAggregateSumResult,
+    };
+
     beforeEach(() => {
+      // Key exists by default; the not-exists test overrides it.
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockAggregateArrayDto.keyName,
+        ])
+        .mockResolvedValue(1);
       when(mockStandaloneRedisClient.sendCommand)
         .calledWith([
           BrowserToolArrayCommands.ArOp,
@@ -847,7 +859,10 @@ describe('ArrayService', () => {
 
     it('should reject when key does not exist', async () => {
       when(mockStandaloneRedisClient.sendCommand)
-        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .calledWith([
+          BrowserToolKeysCommands.Exists,
+          mockAggregateArrayDto.keyName,
+        ])
         .mockResolvedValue(0);
       await expect(
         service.aggregate(mockBrowserClientMetadata, mockAggregateArrayDto),

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -790,24 +790,48 @@ describe('ArrayService', () => {
       expect(result.result).toBe('2');
     });
 
-    it('should reject MATCH with an empty string value', async () => {
-      await expect(
-        service.aggregate(mockBrowserClientMetadata, {
-          ...mockAggregateArrayDto,
-          operation: ArrayAggregateOperation.Match,
-          value: '',
-        }),
-      ).rejects.toThrow(BadRequestException);
+    it('should pass an empty string value through to AROP for MATCH', async () => {
+      // Redis stores zero-length bulk strings as real elements and the
+      // create DTO accepts them, so MATCH must be able to count them.
+      const dto = {
+        ...mockAggregateArrayDto,
+        operation: ArrayAggregateOperation.Match,
+        value: '',
+      };
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          dto.keyName,
+          dto.start,
+          dto.end,
+          dto.operation,
+          dto.value,
+        ])
+        .mockResolvedValue(3);
+
+      const result = await service.aggregate(mockBrowserClientMetadata, dto);
+      expect(result.result).toBe('3');
     });
 
-    it('should reject MATCH with an empty Buffer value', async () => {
-      await expect(
-        service.aggregate(mockBrowserClientMetadata, {
-          ...mockAggregateArrayDto,
-          operation: ArrayAggregateOperation.Match,
-          value: Buffer.alloc(0),
-        }),
-      ).rejects.toThrow(BadRequestException);
+    it('should pass an empty Buffer value through to AROP for MATCH', async () => {
+      const dto = {
+        ...mockAggregateArrayDto,
+        operation: ArrayAggregateOperation.Match,
+        value: Buffer.alloc(0),
+      };
+      when(mockStandaloneRedisClient.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArOp,
+          dto.keyName,
+          dto.start,
+          dto.end,
+          dto.operation,
+          dto.value,
+        ])
+        .mockResolvedValue(3);
+
+      const result = await service.aggregate(mockBrowserClientMetadata, dto);
+      expect(result.result).toBe('3');
     });
 
     it('should reject MATCH when value is undefined', async () => {

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -4,6 +4,7 @@ import { RedisErrorCodes } from 'src/constants';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { catchAclError, catchMultiTransactionError } from 'src/utils';
 import { ClientMetadata } from 'src/common/models';
+import { RedisString } from 'src/common/constants';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import {
   BrowserToolArrayCommands,
@@ -366,28 +367,43 @@ export class ArrayService {
       // Same span cap as ARGETRANGE: AROP scans the dense [start..end] window.
       this.assertValidRange(start, end);
 
+      // MATCH requires a non-empty comparison value. IsRedisString accepts
+      // strings and Buffers but doesn't enforce non-emptiness on the post-
+      // transform Buffer, so check it here.
+      if (operation === ArrayAggregateOperation.Match) {
+        const len = typeof value === 'string' ? value.length : value?.length;
+        if (!len) {
+          throw new BadRequestException(
+            'value must be a non-empty string or Buffer for MATCH operation.',
+          );
+        }
+      }
+
       const client =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
       await checkIfKeyNotExists(keyName, client);
 
-      const baseArgs = [
-        BrowserToolArrayCommands.ArOp as string,
+      // MATCH is the only operation with a trailing value arg; the guard
+      // above guarantees `value` is a non-empty RedisString when we get here.
+      const args: RedisClientCommand = [
+        BrowserToolArrayCommands.ArOp,
         keyName,
         start,
         end,
         operation,
-      ] as const;
-      // MATCH is the only operation with a trailing value arg.
-      const needsValue =
-        operation === ArrayAggregateOperation.Match && value !== undefined;
-      const reply = await client.sendCommand(
-        needsValue ? [...baseArgs, value] : [...baseArgs],
-      );
+      ];
+      if (operation === ArrayAggregateOperation.Match) {
+        args.push(value as RedisString);
+      }
+      const reply = await client.sendCommand(args);
 
       this.logger.debug('Succeed to aggregate array range.', clientMetadata);
+      // AROP returns nil for numeric ops over a range with no numeric values
+      // and for bitwise ops over an empty range; surface that as `null` rather
+      // than throwing a 500 from toRequiredIndexString.
       return plainToInstance(AggregateArrayResponse, {
         keyName,
-        result: toRequiredIndexString(reply),
+        result: toIndexString(reply),
       });
     } catch (error) {
       this.logger.error(

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -25,6 +25,9 @@ import {
   toRequiredIndexString,
 } from 'src/modules/browser/array/utils';
 import {
+  AggregateArrayDto,
+  AggregateArrayResponse,
+  ArrayAggregateOperation,
   ArrayCreationMode,
   ArrayElement,
   CreateArrayWithExpireDto,
@@ -345,6 +348,54 @@ export class ArrayService {
       return plainToInstance(GetArrayElementResponse, { keyName, value });
     } catch (error) {
       this.logger.error('Failed to get array element.', error, clientMetadata);
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
+  public async aggregate(
+    clientMetadata: ClientMetadata,
+    dto: AggregateArrayDto,
+  ): Promise<AggregateArrayResponse> {
+    try {
+      this.logger.debug('Aggregating array range.', clientMetadata);
+      const { keyName, start, end, operation, value } = dto;
+
+      // Same span cap as ARGETRANGE: AROP scans the dense [start..end] window.
+      this.assertValidRange(start, end);
+
+      const client =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      await checkIfKeyNotExists(keyName, client);
+
+      const baseArgs = [
+        BrowserToolArrayCommands.ArOp as string,
+        keyName,
+        start,
+        end,
+        operation,
+      ] as const;
+      // MATCH is the only operation with a trailing value arg.
+      const needsValue =
+        operation === ArrayAggregateOperation.Match && value !== undefined;
+      const reply = await client.sendCommand(
+        needsValue ? [...baseArgs, value] : [...baseArgs],
+      );
+
+      this.logger.debug('Succeed to aggregate array range.', clientMetadata);
+      return plainToInstance(AggregateArrayResponse, {
+        keyName,
+        result: toRequiredIndexString(reply),
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to aggregate array range.',
+        error,
+        clientMetadata,
+      );
+      if (error instanceof BadRequestException) throw error;
       if (error?.message?.includes(RedisErrorCodes.WrongType)) {
         throw new BadRequestException(error.message);
       }

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -374,9 +374,7 @@ export class ArrayService {
         operation === ArrayAggregateOperation.Match &&
         (value === undefined || value === null)
       ) {
-        throw new BadRequestException(
-          'value is required for MATCH operation.',
-        );
+        throw new BadRequestException('value is required for MATCH operation.');
       }
 
       const client =

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -374,7 +374,9 @@ export class ArrayService {
         operation === ArrayAggregateOperation.Match &&
         (value === undefined || value === null)
       ) {
-        throw new BadRequestException('value is required for MATCH operation.');
+        throw new BadRequestException(
+          ERROR_MESSAGES.ARRAY_MATCH_VALUE_REQUIRED,
+        );
       }
 
       const client =

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -367,24 +367,23 @@ export class ArrayService {
       // Same span cap as ARGETRANGE: AROP scans the dense [start..end] window.
       this.assertValidRange(start, end);
 
-      // MATCH requires a non-empty comparison value. IsRedisString accepts
-      // strings and Buffers but doesn't enforce non-emptiness on the post-
-      // transform Buffer, so check it here.
-      if (operation === ArrayAggregateOperation.Match) {
-        const len = typeof value === 'string' ? value.length : value?.length;
-        if (!len) {
-          throw new BadRequestException(
-            'value must be a non-empty string or Buffer for MATCH operation.',
-          );
-        }
+      // MATCH requires a comparison value, but empty strings / empty Buffers
+      // are valid — Redis stores zero-length bulk strings as real elements,
+      // and the create DTO allows them. Only an omitted value is rejected.
+      if (
+        operation === ArrayAggregateOperation.Match &&
+        (value === undefined || value === null)
+      ) {
+        throw new BadRequestException(
+          'value is required for MATCH operation.',
+        );
       }
 
       const client =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
       await checkIfKeyNotExists(keyName, client);
 
-      // MATCH is the only operation with a trailing value arg; the guard
-      // above guarantees `value` is a non-empty RedisString when we get here.
+      // MATCH is the only operation with a trailing value arg.
       const args: RedisClientCommand = [
         BrowserToolArrayCommands.ArOp,
         keyName,

--- a/redisinsight/api/src/modules/browser/array/dto/aggregate.array.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/aggregate.array.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import { IsArrayIndex } from 'src/common/decorators';
+
+export enum ArrayAggregateOperation {
+  Sum = 'SUM',
+  Min = 'MIN',
+  Max = 'MAX',
+  And = 'AND',
+  Or = 'OR',
+  Xor = 'XOR',
+  Match = 'MATCH',
+  Used = 'USED',
+}
+
+export class AggregateArrayDto extends KeyDto {
+  @ApiProperty({
+    description:
+      'Start index of the range (inclusive). Unsigned 64-bit integer as string.',
+    type: String,
+    example: '0',
+  })
+  @IsArrayIndex()
+  start: string;
+
+  @ApiProperty({
+    description:
+      'End index of the range (inclusive). Unsigned 64-bit integer as string. ' +
+      'AROP semantics ignore range direction — the same set of populated slots ' +
+      'is aggregated regardless of start/end ordering.',
+    type: String,
+    example: '99',
+  })
+  @IsArrayIndex()
+  end: string;
+
+  @ApiProperty({
+    description:
+      'Aggregation operation. Numeric ops (SUM/MIN/MAX/AND/OR/XOR) error ' +
+      'server-side if any element in range is non-numeric. MATCH counts ' +
+      'elements equal to `value`. USED counts populated slots.',
+    enum: ArrayAggregateOperation,
+    example: ArrayAggregateOperation.Sum,
+  })
+  @IsEnum(ArrayAggregateOperation)
+  operation: ArrayAggregateOperation;
+
+  @ApiPropertyOptional({
+    description:
+      'Comparison value for the MATCH operation. Required when operation is ' +
+      'MATCH, ignored otherwise.',
+    type: String,
+    example: '20.4',
+  })
+  @ValidateIf(
+    (o: AggregateArrayDto) => o.operation === ArrayAggregateOperation.Match,
+  )
+  @IsString()
+  @IsNotEmpty()
+  value?: string;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/aggregate.array.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/aggregate.array.dto.ts
@@ -1,7 +1,13 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, ValidateIf } from 'class-validator';
 import { KeyDto } from 'src/modules/browser/keys/dto';
-import { IsArrayIndex } from 'src/common/decorators';
+import {
+  ApiRedisString,
+  IsArrayIndex,
+  IsRedisString,
+  RedisStringType,
+} from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
 
 export enum ArrayAggregateOperation {
   Sum = 'SUM',
@@ -46,17 +52,17 @@ export class AggregateArrayDto extends KeyDto {
   @IsEnum(ArrayAggregateOperation)
   operation: ArrayAggregateOperation;
 
-  @ApiPropertyOptional({
-    description:
-      'Comparison value for the MATCH operation. Required when operation is ' +
-      'MATCH, ignored otherwise.',
-    type: String,
-    example: '20.4',
-  })
+  @ApiRedisString(
+    'Comparison value for the MATCH operation. Required when operation is ' +
+      'MATCH, ignored otherwise. Accepts strings and binary buffers so it can ' +
+      'match elements stored as raw bytes.',
+    false,
+    false,
+  )
   @ValidateIf(
     (o: AggregateArrayDto) => o.operation === ArrayAggregateOperation.Match,
   )
-  @IsString()
-  @IsNotEmpty()
-  value?: string;
+  @IsRedisString()
+  @RedisStringType()
+  value?: RedisString;
 }

--- a/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
@@ -6,9 +6,14 @@ export class AggregateArrayResponse extends KeyResponse {
     description:
       'Aggregation result. Numeric ops (SUM/MIN/MAX/AND/OR/XOR) return a ' +
       'decimal string; MATCH/USED return an integer count as a string. ' +
-      'Always serialized as a string to preserve full u64 / large-number ' +
-      'precision. Returns `null` when AROP yields a nil reply (numeric ops ' +
-      'over a range with no numeric values; bitwise ops over an empty range).',
+      'Returns `null` when AROP yields a nil reply (numeric ops over a ' +
+      'range with no numeric values; bitwise ops over an empty range). ' +
+      'Precision: SUM/MIN/MAX preserve full precision (Redis returns a ' +
+      'bulk string); MATCH/USED are bounded by the 1,000,000-element span ' +
+      'cap and always fit safely. AND/OR/XOR return RESP integers and are ' +
+      'parsed by the Node Redis client as JavaScript numbers, so results ' +
+      'above Number.MAX_SAFE_INTEGER (2^53 - 1) may be rounded — use the ' +
+      'raw AROP command via Workbench when full u64 precision is required.',
     type: String,
     nullable: true,
     example: '104.7',

--- a/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
@@ -6,9 +6,12 @@ export class AggregateArrayResponse extends KeyResponse {
     description:
       'Aggregation result. Numeric ops (SUM/MIN/MAX/AND/OR/XOR) return a ' +
       'decimal string; MATCH/USED return an integer count as a string. ' +
-      'Always serialized as a string to preserve full u64 / large-number precision.',
+      'Always serialized as a string to preserve full u64 / large-number ' +
+      'precision. Returns `null` when AROP yields a nil reply (numeric ops ' +
+      'over a range with no numeric values; bitwise ops over an empty range).',
     type: String,
+    nullable: true,
     example: '104.7',
   })
-  result: string;
+  result: string | null;
 }

--- a/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/aggregate.array.response.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { KeyResponse } from 'src/modules/browser/keys/dto';
+
+export class AggregateArrayResponse extends KeyResponse {
+  @ApiProperty({
+    description:
+      'Aggregation result. Numeric ops (SUM/MIN/MAX/AND/OR/XOR) return a ' +
+      'decimal string; MATCH/USED return an integer count as a string. ' +
+      'Always serialized as a string to preserve full u64 / large-number precision.',
+    type: String,
+    example: '104.7',
+  })
+  result: string;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -10,3 +10,5 @@ export * from './get.array-multi-elements.response';
 export * from './get.array-length.response';
 export * from './get.array-count.response';
 export * from './get.array-next-index.response';
+export * from './aggregate.array.dto';
+export * from './aggregate.array.response';

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -124,6 +124,7 @@ export enum BrowserToolArrayCommands {
   ArGetRange = 'argetrange',
   ArScan = 'arscan',
   ArNext = 'arnext',
+  ArOp = 'arop',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -67,7 +67,9 @@ const validInputData = {
 const responseSchema = Joi.object()
   .keys({
     keyName: JoiRedisString.required(),
-    result: Joi.string().required(),
+    // Nullable: AROP returns nil for numeric ops over a range with no
+    // numeric values and for bitwise ops over an empty range.
+    result: Joi.string().allow(null).required(),
   })
   .required();
 
@@ -261,6 +263,67 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
         },
         responseSchema,
         responseBody: { keyName, result: '2' },
+      });
+    });
+
+    it('Should MATCH binary (Buffer) values stored as raw bytes', async () => {
+      const keyName = constants.getRandomString();
+      // Element with unprintable bytes that can't round-trip through a
+      // JSON string body — only the Buffer-typed `value` reaches the
+      // backend intact.
+      const binValue = Buffer.from([0x00, 0xff, 0x10, 0x7f]);
+      await rte.client.call('ARSET', keyName, '0', binValue, 'other', binValue);
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '1',
+          operation: ArrayAggregateOperation.Match,
+          value: { type: 'Buffer', data: [...binValue] },
+        },
+        responseSchema,
+        responseBody: { keyName, result: '2' },
+      });
+    });
+
+    it('Should return null when SUM has no numeric values in range', async () => {
+      const keyName = constants.getRandomString();
+      // Seed only non-numeric values; SUM over the range yields a nil
+      // AROP reply, which the API surfaces as `result: null` rather than
+      // a 500 from the strict index normalizer.
+      await rte.client.call('ARSET', keyName, '0', 'alpha', 'beta');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '1',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        responseSchema,
+        responseBody: { keyName, result: null },
+      });
+    });
+
+    it('Should return null when AND is applied to an empty range', async () => {
+      const keyName = constants.getRandomString();
+      // Key exists (sparse fixture populates 0,1,5), but the [10..12]
+      // window is empty so the bitwise AND has nothing to fold → nil.
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '10',
+          end: '12',
+          operation: ArrayAggregateOperation.And,
+        },
+        responseSchema,
+        responseBody: { keyName, result: null },
       });
     });
 

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -1,0 +1,453 @@
+import {
+  expect,
+  describe,
+  it,
+  before,
+  deps,
+  Joi,
+  requirements,
+  generateInvalidDataTestCases,
+  validateInvalidDataTestCase,
+  validateApiCall,
+  getMainCheckFn,
+  JoiRedisString,
+} from '../deps';
+import { ArrayAggregateOperation } from 'src/modules/browser/array/dto';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(
+    `/${constants.API.DATABASES}/${instanceId}/array/aggregate`,
+  );
+
+// `start` and `end` carry the same @IsArrayIndex validator as get-range; the
+// harness compares Joi-emitted messages as substrings of the API output, so
+// override the per-rule messages with a label-less excerpt of what the API
+// actually returns ("must be an integer string between 0 and 2^64-2").
+const ARRAY_INDEX_MSG = 'must be an integer string between';
+
+const dataSchema = Joi.object({
+  keyName: Joi.string().allow('').required(),
+  start: Joi.string().required().messages({
+    'string.base': ARRAY_INDEX_MSG,
+    'any.required': ARRAY_INDEX_MSG,
+  }),
+  end: Joi.string().required().messages({
+    'string.base': ARRAY_INDEX_MSG,
+    'any.required': ARRAY_INDEX_MSG,
+  }),
+  operation: Joi.string()
+    .valid(...Object.values(ArrayAggregateOperation))
+    .required(),
+  value: Joi.string().optional(),
+}).strict();
+
+const validInputData = {
+  keyName: constants.getRandomString(),
+  start: '0',
+  end: '5',
+  operation: ArrayAggregateOperation.Sum,
+};
+
+const responseSchema = Joi.object()
+  .keys({
+    keyName: JoiRedisString.required(),
+    result: Joi.string().required(),
+  })
+  .required();
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// Sparse fixture: indexes 0,1,5 populated with numeric strings so the same
+// seed exercises both numeric (SUM/MIN/MAX) and structural (USED/MATCH) ops.
+const seedSparse = (key: string) =>
+  rte.client.call('ARMSET', key, '0', '20.1', '1', '20.4', '5', '21.4');
+
+describe('POST /databases/:instanceId/array/aggregate', () => {
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Validation', () => {
+    generateInvalidDataTestCases(dataSchema, validInputData).map(
+      validateInvalidDataTestCase(endpoint, dataSchema),
+    );
+
+    [
+      {
+        name: 'Should reject an unknown operation',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '5',
+          operation: 'AVG',
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject MATCH without a value arg',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Match,
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject MATCH with an empty value',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Match,
+          value: '',
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject a non-decimal start index',
+        data: {
+          keyName: constants.getRandomString(),
+          start: 'abc',
+          end: '5',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject a span exceeding 1,000,000 elements',
+        // span = |end - start| + 1 = 1_000_001 → just over the hard cap.
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '1000000',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        statusCode: 400,
+        checkFn: ({ body }: any) => {
+          expect(body.message).to.have.string('1 000 000');
+        },
+      },
+      {
+        // 2^64-1 is reserved by Redis as the "no-index" sentinel; rejected
+        // by @IsArrayIndex before reaching the AROP call.
+        name: 'Should reject when end equals the reserved 2^64-1 sentinel',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '18446744073709551615',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Main', () => {
+    it('Should SUM populated numeric values in range', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Sum of populated slots (0,1,5) → 20.1 + 20.4 + 21.4 = 61.9. Empty
+      // slots (2,3,4) are excluded by AROP rather than treated as 0.
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        responseSchema,
+        checkFn: ({ body }: any) => {
+          expect(body.keyName).to.eql(keyName);
+          expect(typeof body.result).to.eql('string');
+          expect(parseFloat(body.result)).to.be.closeTo(61.9, 1e-9);
+        },
+      });
+    });
+
+    it('Should return MIN over populated numeric values', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Min,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '20.1' },
+      });
+    });
+
+    it('Should return MAX over populated numeric values', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Max,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '21.4' },
+      });
+    });
+
+    it('Should count populated slots with USED', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // 3 populated slots (0,1,5) inside the 0..5 window — USED ignores gaps.
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Used,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '3' },
+      });
+    });
+
+    it('Should count equal occurrences with MATCH', async () => {
+      const keyName = constants.getRandomString();
+      // Two slots equal to "20.4" inside the window; MATCH returns the count.
+      await rte.client.call(
+        'ARMSET',
+        keyName,
+        '0',
+        '20.1',
+        '1',
+        '20.4',
+        '2',
+        '20.4',
+        '5',
+        '21.4',
+      );
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Match,
+          value: '20.4',
+        },
+        responseSchema,
+        responseBody: { keyName, result: '2' },
+      });
+    });
+
+    it('Should return USED=0 for a range entirely past the end', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Range 10..12 has no populated slots; AROP returns 0 rather than 404 —
+      // the key still exists, the window is just empty.
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '10',
+          end: '12',
+          operation: ArrayAggregateOperation.Used,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '0' },
+      });
+    });
+
+    it('Should ignore range direction (reversed bounds match forward result)', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Per the DTO contract: AROP aggregates the same populated slots
+      // regardless of start/end ordering. Reversed SUM must equal forward SUM.
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '5',
+          end: '0',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        responseSchema,
+        checkFn: ({ body }: any) => {
+          expect(parseFloat(body.result)).to.be.closeTo(61.9, 1e-9);
+        },
+      });
+    });
+
+    it('Should accept a span of exactly 1,000,000 elements', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('ARSET', keyName, '0', '7');
+
+      // Boundary case: span = end - start + 1 = 1_000_000 → just within cap.
+      // Only index 0 is populated, so USED is 1.
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '999999',
+          operation: ArrayAggregateOperation.Used,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '1' },
+      });
+    });
+
+    it('Should accept the maximum valid index (2^64-2) in a single-slot window', async () => {
+      const keyName = constants.getRandomString();
+      const maxIndex = '18446744073709551614';
+
+      // Pre-seed at the boundary; AROP USED [max, max] is span = 1 (within
+      // cap) and proves the validator allows the upper edge of u64.
+      await rte.client.call('ARSET', keyName, maxIndex, 'edge');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: maxIndex,
+          end: maxIndex,
+          operation: ArrayAggregateOperation.Used,
+        },
+        responseSchema,
+        responseBody: { keyName, result: '1' },
+      });
+    });
+
+    it('Should preserve precision for numeric results above MAX_SAFE_INTEGER', async () => {
+      const keyName = constants.getRandomString();
+      // Two integer-valued elements whose sum is > Number.MAX_SAFE_INTEGER
+      // (2^53 - 1). The contract is that the API returns the SUM as a
+      // decimal string so precision survives — coercing to Number would
+      // round to the nearest 2.
+      await rte.client.call(
+        'ARSET',
+        keyName,
+        '0',
+        '9007199254740992',
+        '9007199254740990',
+      );
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '1',
+          operation: ArrayAggregateOperation.Sum,
+        },
+        responseSchema,
+        checkFn: ({ body }: any) => {
+          expect(typeof body.result).to.eql('string');
+          expect(body.result).to.eql('18014398509481982');
+        },
+      });
+    });
+
+    [
+      {
+        name: 'Should return BadRequest if key holds a non-array type',
+        data: {
+          keyName: constants.TEST_STRING_KEY_1,
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Used,
+        },
+        statusCode: 400,
+        before: () => rte.data.generateKeys(true),
+      },
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Used,
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '5',
+          operation: ArrayAggregateOperation.Used,
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('ACL', () => {
+    requirements('rte.acl');
+    before(async () => rte.data.setAclUserRules('~* +@all'));
+
+    const aclEndpoint = () => endpoint(constants.TEST_INSTANCE_ACL_ID);
+    const aclKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should aggregate for an authorised user',
+        endpoint: aclEndpoint,
+        data: {
+          keyName: aclKey,
+          start: '0',
+          end: '0',
+          operation: ArrayAggregateOperation.Used,
+        },
+        responseSchema,
+        before: async () => {
+          await rte.data.setAclUserRules('~* +@all');
+          await rte.client.call('ARSET', aclKey, '0', 'x');
+        },
+      },
+      {
+        name: 'Should throw error if no permissions for "arop" command',
+        endpoint: aclEndpoint,
+        data: {
+          keyName: aclKey,
+          start: '0',
+          end: '0',
+          operation: ArrayAggregateOperation.Used,
+        },
+        statusCode: 403,
+        responseBody: { statusCode: 403, error: 'Forbidden' },
+        // beforeEach() wipes the key between tests; reseed via the root
+        // client (ACL rules below only affect the API request).
+        before: async () => {
+          await rte.client.call('ARSET', aclKey, '0', 'x');
+          await rte.data.setAclUserRules('~* +@all -arop');
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -418,17 +418,14 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
 
     it('Should preserve precision for numeric results above MAX_SAFE_INTEGER', async () => {
       const keyName = constants.getRandomString();
-      // Two integer-valued elements whose sum is > Number.MAX_SAFE_INTEGER
-      // (2^53 - 1). The contract is that the API returns the SUM as a
-      // decimal string so precision survives — coercing to Number would
-      // round to the nearest 2.
-      await rte.client.call(
-        'ARSET',
-        keyName,
-        '0',
-        '9007199254740992',
-        '9007199254740990',
-      );
+      // Sum must be ODD and above 2^53 to be a real precision probe: values in
+      // [2^53, 2^54) are only representable as even float64s, so an odd target
+      // (here 2^53 - 1 + 2 = 2^53 + 1 = 9007199254740993) cannot survive a
+      // Number round-trip — it would round to the even 9007199254740992. The
+      // contract is that the API returns SUM as a decimal string, so the exact
+      // odd value must come back intact. (An even sum would pass even if the
+      // result were coerced through Number, proving nothing.)
+      await rte.client.call('ARSET', keyName, '0', '9007199254740991', '2');
 
       await validateApiCall({
         endpoint,
@@ -441,7 +438,7 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
         responseSchema,
         checkFn: ({ body }: any) => {
           expect(typeof body.result).to.eql('string');
-          expect(body.result).to.eql('18014398509481982');
+          expect(body.result).to.eql('9007199254740993');
         },
       });
     });

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -28,6 +28,12 @@ const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
 // actually returns ("must be an integer string between 0 and 2^64-2").
 const ARRAY_INDEX_MSG = 'must be an integer string between';
 
+// class-validator's @IsEnum emits a single message for missing / non-string /
+// out-of-enum inputs ("operation must be one of the following values: SUM,
+// MIN, ..."). Override every Joi rule the harness generates with a shared
+// substring so the `body.message.join() includes message` check passes.
+const OPERATION_ENUM_MSG = 'operation must be one of the following values';
+
 const dataSchema = Joi.object({
   keyName: Joi.string().allow('').required(),
   start: Joi.string().required().messages({
@@ -40,8 +46,15 @@ const dataSchema = Joi.object({
   }),
   operation: Joi.string()
     .valid(...Object.values(ArrayAggregateOperation))
-    .required(),
-  value: Joi.string().optional(),
+    .required()
+    .messages({
+      'string.base': OPERATION_ENUM_MSG,
+      'any.required': OPERATION_ENUM_MSG,
+      'any.only': OPERATION_ENUM_MSG,
+    }),
+  // `value` is conditionally validated server-side (@ValidateIf operation ===
+  // MATCH), so the auto-generated invalid cases would skip validation and 404
+  // on the missing key. MATCH-specific coverage is added explicitly below.
 }).strict();
 
 const validInputData = {

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -288,6 +288,26 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
       });
     });
 
+    it('Should MATCH empty-string elements with an empty value', async () => {
+      const keyName = constants.getRandomString();
+      // Two slots hold the zero-length bulk string; MATCH with value=''
+      // must count them, not be rejected by the service guard.
+      await rte.client.call('ARMSET', keyName, '0', '', '1', 'x', '2', '');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          start: '0',
+          end: '2',
+          operation: ArrayAggregateOperation.Match,
+          value: '',
+        },
+        responseSchema,
+        responseBody: { keyName, result: '2' },
+      });
+    });
+
     it('Should return null when SUM has no numeric values in range', async () => {
       const keyName = constants.getRandomString();
       // Seed only non-numeric values; SUM over the range yields a nil

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -111,17 +111,6 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
         statusCode: 400,
       },
       {
-        name: 'Should reject MATCH with an empty value',
-        data: {
-          keyName: constants.getRandomString(),
-          start: '0',
-          end: '5',
-          operation: ArrayAggregateOperation.Match,
-          value: '',
-        },
-        statusCode: 400,
-      },
-      {
         name: 'Should reject a non-decimal start index',
         data: {
           keyName: constants.getRandomString(),

--- a/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-aggregate.test.ts
@@ -272,7 +272,7 @@ describe('POST /databases/:instanceId/array/aggregate', () => {
       // JSON string body — only the Buffer-typed `value` reaches the
       // backend intact.
       const binValue = Buffer.from([0x00, 0xff, 0x10, 0x7f]);
-      await rte.client.call('ARSET', keyName, '0', binValue, 'other', binValue);
+      await rte.client.call('ARMSET', keyName, '0', binValue, '1', binValue);
 
       await validateApiCall({
         endpoint,


### PR DESCRIPTION
# What

Adds the `POST /databases/:instanceId/array/aggregate` endpoint, the API wrapper around Redis 8.8's `AROP` command for the new Array data type.

**Supported operations:** `SUM`, `MIN`, `MAX`, `AND`, `OR`, `XOR`, `MATCH`, `USED`

**Behavior:**
- Range `[start, end]` is inclusive and direction-agnostic (mirrors `AROP` semantics)
- Reuses the same 1 000 000-element span cap as `ARGETRANGE`
- `MATCH` requires a non-empty `value`; ignored for other ops
- Result is always serialized as a **string** so u64 / large-number precision survives the wire
- Standard error mapping: `WRONGTYPE` → 400, missing key → 404, `NOPERM` → 403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only browser endpoint with validation and error mapping aligned to other Array APIs; broad test coverage and no auth or data-model changes beyond forwarding Redis commands.
> 
> **Overview**
> Adds **`POST /databases/:instanceId/array/aggregate`**, exposing Redis 8.8 **`AROP`** for Array keys with operations `SUM`, `MIN`, `MAX`, `AND`, `OR`, `XOR`, `MATCH`, and `USED`.
> 
> The handler reuses the same **1M-element inclusive range cap** as `ARGETRANGE`, requires **`value` only for `MATCH`** (empty string/buffer allowed), appends that arg to the Redis command when needed, and returns **`result` as a string or `null`** when AROP replies nil. Errors follow existing browser patterns (`WRONGTYPE` → 400, missing key → 404, ACL → 403). **`ArOp`** is registered in browser tool commands; Bruno docs, unit/integration tests, and `ARRAY_MATCH_VALUE_REQUIRED` complete the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccefc69fdac54813543e7ab67fefb3ee798c00fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->