### PR TITLE
RI-8220: Add Aggregate tab to Array key details

### DIFF
--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -81,6 +81,7 @@ enum ApiEndpoints {
   ARRAY_SCAN = 'array/scan',
   ARRAY_GET_LENGTH = 'array/get-length',
   ARRAY_GET_COUNT = 'array/get-count',
+  ARRAY_AGGREGATE = 'array/aggregate',
 
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -18,6 +18,9 @@ jest.mock('./array-details-table', () => ({
 jest.mock('./array-range-form', () => ({
   ArrayRangeForm: stubChild('array-range-form-mock'),
 }))
+jest.mock('./array-aggregate-form', () => ({
+  ArrayAggregateForm: stubChild('array-aggregate-form-mock'),
+}))
 jest.mock('uiSrc/pages/browser/modules', () => ({
   KeyDetailsHeader: stubChild('key-details-header-mock'),
 }))
@@ -34,6 +37,22 @@ jest.mock('./hooks', () => ({
     isArrayKeyReady: true,
     elements: [],
     loading: false,
+  }),
+  useArrayAggregateQuery: () => ({
+    start: '0',
+    end: '9',
+    operation: 'SUM',
+    value: '',
+    setStart: jest.fn(),
+    setEnd: jest.fn(),
+    setOperation: jest.fn(),
+    setValue: jest.fn(),
+    runQuery: jest.fn(),
+    resetQuery: jest.fn(),
+    isArrayKeyReady: true,
+    loading: false,
+    error: '',
+    result: '',
   }),
 }))
 
@@ -55,7 +74,7 @@ describe('ArrayDetails', () => {
 
     expect(screen.getByTestId('array-range-form-mock')).toBeVisible()
     expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
-    expect(screen.getByTestId('array-aggregate-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-aggregate-form-mock')).not.toBeVisible()
 
     fireEvent.mouseDown(
       screen.getByText(ARRAY_DETAILS_TAB_LABELS[ArrayDetailsTab.Search]),
@@ -63,7 +82,7 @@ describe('ArrayDetails', () => {
 
     expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
     expect(screen.getByTestId('array-search-placeholder')).toBeVisible()
-    expect(screen.getByTestId('array-aggregate-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-aggregate-form-mock')).not.toBeVisible()
 
     fireEvent.mouseDown(
       screen.getByText(ARRAY_DETAILS_TAB_LABELS[ArrayDetailsTab.Aggregate]),
@@ -71,6 +90,6 @@ describe('ArrayDetails', () => {
 
     expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
     expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
-    expect(screen.getByTestId('array-aggregate-placeholder')).toBeVisible()
+    expect(screen.getByTestId('array-aggregate-form-mock')).toBeVisible()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -52,7 +52,8 @@ jest.mock('./hooks', () => ({
     isArrayKeyReady: true,
     loading: false,
     error: '',
-    result: '',
+    result: null,
+    hasResult: false,
   }),
 }))
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -37,7 +37,7 @@ const ArrayDetails = (props: Props) => {
         <SearchTab />
       </S.TabSlot>
       <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Aggregate}>
-        <AggregateTab />
+        <AggregateTab keyProp={keyProp} />
       </S.TabSlot>
     </S.Container>
   )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -22,7 +22,9 @@ const baseHookResult = {
   result: '',
 }
 
-const mockUseArrayAggregateQuery = jest.fn(() => baseHookResult)
+const mockUseArrayAggregateQuery = jest.fn(
+  (..._args: unknown[]) => baseHookResult,
+)
 
 jest.mock('../array-aggregate-form', () => ({
   ArrayAggregateForm: () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -19,7 +19,8 @@ const baseHookResult = {
   isArrayKeyReady: true,
   loading: false,
   error: '',
-  result: '',
+  result: null as string | null,
+  hasResult: false,
 }
 
 const mockUseArrayAggregateQuery = jest.fn(
@@ -97,6 +98,7 @@ describe('AggregateTab', () => {
     mockUseArrayAggregateQuery.mockReturnValue({
       ...baseHookResult,
       result: bigResult,
+      hasResult: true,
     })
 
     render(<AggregateTab keyProp={keyBuffer} />)
@@ -108,6 +110,28 @@ describe('AggregateTab', () => {
     expect(screen.getByTestId(`${TEST_ID}-result-copy-btn`)).toBeInTheDocument()
     expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
     expect(screen.queryByTestId(`${TEST_ID}-error`)).not.toBeInTheDocument()
+  })
+
+  it('renders the nil placeholder without copy when AROP returned null', () => {
+    // hasResult=true with result=null signals AROP completed with a RESP
+    // nil reply (e.g. SUM over a range with no numeric values). The panel
+    // surfaces "(nil)" so the user can tell the query ran, and hides the
+    // copy button because there are no bytes to copy.
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      result: null,
+      hasResult: true,
+    })
+
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    const wrapper = screen.getByTestId(`${TEST_ID}-result-value`)
+    const input = wrapper.querySelector('input') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('(nil)')
+    expect(
+      screen.queryByTestId(`${TEST_ID}-result-copy-btn`),
+    ).not.toBeInTheDocument()
   })
 
   it('forwards the key buffer to the hook', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -134,6 +134,25 @@ describe('AggregateTab', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('suppresses stale slice state while the selected key is not ready', () => {
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      isArrayKeyReady: false,
+      loading: true,
+      error: 'stale error from the prior key',
+      result: '999',
+      hasResult: true,
+    })
+
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`${TEST_ID}-error`)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-result-value`),
+    ).not.toBeInTheDocument()
+  })
+
   it('forwards the key buffer to the hook', () => {
     render(<AggregateTab keyProp={keyBuffer} />)
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -142,6 +142,25 @@ describe('AggregateTab', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('keeps the existing result visible (no loader) while a refresh recompute is in flight', () => {
+    // Header-refresh replay dispatches AROP with resetData=false, so the
+    // slice keeps the prior result/hasResult while loading. The panel must
+    // hold the value on screen rather than flashing the loader.
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      loading: true,
+      result: '42',
+      hasResult: true,
+    })
+
+    renderComponent()
+
+    expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
+    const wrapper = screen.getByTestId(`${TEST_ID}-result-value`)
+    const input = wrapper.querySelector('input') as HTMLInputElement
+    expect(input.value).toBe('42')
+  })
+
   it('suppresses stale slice state while the selected key is not ready', () => {
     mockUseArrayAggregateQuery.mockReturnValue({
       ...baseHookResult,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -4,6 +4,7 @@ import { stringToBuffer } from 'uiSrc/utils'
 import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
 
 import AggregateTab from './AggregateTab'
+import { AggregateTabProps } from './AggregateTab.types'
 
 const baseHookResult = {
   start: '0',
@@ -43,6 +44,13 @@ jest.mock('../hooks', () => ({
 const TEST_ID = 'array-aggregate-tab'
 const keyBuffer = stringToBuffer('numbers')
 
+const defaultProps: AggregateTabProps = {
+  keyProp: keyBuffer,
+}
+
+const renderComponent = (propsOverride: Partial<AggregateTabProps> = {}) =>
+  render(<AggregateTab {...defaultProps} {...propsOverride} />)
+
 describe('AggregateTab', () => {
   beforeEach(() => {
     mockUseArrayAggregateQuery.mockReset()
@@ -50,7 +58,7 @@ describe('AggregateTab', () => {
   })
 
   it('renders the form and an empty results area by default', () => {
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     expect(screen.getByTestId('array-aggregate-form-mock')).toBeInTheDocument()
     expect(screen.getByTestId(TEST_ID)).toBeInTheDocument()
@@ -67,7 +75,7 @@ describe('AggregateTab', () => {
       loading: true,
     })
 
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     expect(screen.getByTestId(`${TEST_ID}-loading`)).toBeInTheDocument()
     expect(
@@ -81,7 +89,7 @@ describe('AggregateTab', () => {
       error: 'Range too large',
     })
 
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     expect(screen.getByTestId(`${TEST_ID}-error`)).toHaveTextContent(
       'Range too large',
@@ -101,7 +109,7 @@ describe('AggregateTab', () => {
       hasResult: true,
     })
 
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     const wrapper = screen.getByTestId(`${TEST_ID}-result-value`)
     const input = wrapper.querySelector('input') as HTMLInputElement
@@ -123,7 +131,7 @@ describe('AggregateTab', () => {
       hasResult: true,
     })
 
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     const wrapper = screen.getByTestId(`${TEST_ID}-result-value`)
     const input = wrapper.querySelector('input') as HTMLInputElement
@@ -144,7 +152,7 @@ describe('AggregateTab', () => {
       hasResult: true,
     })
 
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
     expect(screen.queryByTestId(`${TEST_ID}-error`)).not.toBeInTheDocument()
@@ -154,13 +162,13 @@ describe('AggregateTab', () => {
   })
 
   it('forwards the key buffer to the hook', () => {
-    render(<AggregateTab keyProp={keyBuffer} />)
+    renderComponent()
 
     expect(mockUseArrayAggregateQuery).toHaveBeenCalledWith(keyBuffer)
   })
 
   it('renders an empty form context when keyProp is null', () => {
-    render(<AggregateTab keyProp={null} />)
+    renderComponent({ keyProp: null })
 
     expect(screen.getByTestId('array-aggregate-form-mock')).toBeInTheDocument()
     expect(mockUseArrayAggregateQuery).toHaveBeenCalledWith(null)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.spec.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { stringToBuffer } from 'uiSrc/utils'
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+
+import AggregateTab from './AggregateTab'
+
+const baseHookResult = {
+  start: '0',
+  end: '9',
+  operation: ArrayAggregateOperation.Sum,
+  value: '',
+  setStart: jest.fn(),
+  setEnd: jest.fn(),
+  setOperation: jest.fn(),
+  setValue: jest.fn(),
+  runQuery: jest.fn(),
+  resetQuery: jest.fn(),
+  isArrayKeyReady: true,
+  loading: false,
+  error: '',
+  result: '',
+}
+
+const mockUseArrayAggregateQuery = jest.fn(() => baseHookResult)
+
+jest.mock('../array-aggregate-form', () => ({
+  ArrayAggregateForm: () => {
+    const ReactLib = require('react')
+    return ReactLib.createElement('div', {
+      'data-testid': 'array-aggregate-form-mock',
+    })
+  },
+}))
+jest.mock('../hooks', () => ({
+  useArrayAggregateQuery: (...args: unknown[]) =>
+    mockUseArrayAggregateQuery(...args),
+}))
+
+const TEST_ID = 'array-aggregate-tab'
+const keyBuffer = stringToBuffer('numbers')
+
+describe('AggregateTab', () => {
+  beforeEach(() => {
+    mockUseArrayAggregateQuery.mockReset()
+    mockUseArrayAggregateQuery.mockReturnValue({ ...baseHookResult })
+  })
+
+  it('renders the form and an empty results area by default', () => {
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    expect(screen.getByTestId('array-aggregate-form-mock')).toBeInTheDocument()
+    expect(screen.getByTestId(TEST_ID)).toBeInTheDocument()
+    expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`${TEST_ID}-error`)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-result-value`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the loader while the query is in flight', () => {
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      loading: true,
+    })
+
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    expect(screen.getByTestId(`${TEST_ID}-loading`)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${TEST_ID}-result-value`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the error text when the hook surfaces an error', () => {
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      error: 'Range too large',
+    })
+
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    expect(screen.getByTestId(`${TEST_ID}-error`)).toHaveTextContent(
+      'Range too large',
+    )
+    expect(
+      screen.queryByTestId(`${TEST_ID}-result-value`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the result field with the raw string and copy button on success', () => {
+    // A 20-digit value would lose precision via Number() — assert the tab
+    // surfaces the exact bytes returned by the hook (BigInt safety).
+    const bigResult = '18446744073709551614'
+    mockUseArrayAggregateQuery.mockReturnValue({
+      ...baseHookResult,
+      result: bigResult,
+    })
+
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    const wrapper = screen.getByTestId(`${TEST_ID}-result-value`)
+    const input = wrapper.querySelector('input') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe(bigResult)
+    expect(screen.getByTestId(`${TEST_ID}-result-copy-btn`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`${TEST_ID}-loading`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`${TEST_ID}-error`)).not.toBeInTheDocument()
+  })
+
+  it('forwards the key buffer to the hook', () => {
+    render(<AggregateTab keyProp={keyBuffer} />)
+
+    expect(mockUseArrayAggregateQuery).toHaveBeenCalledWith(keyBuffer)
+  })
+
+  it('renders an empty form context when keyProp is null', () => {
+    render(<AggregateTab keyProp={null} />)
+
+    expect(screen.getByTestId('array-aggregate-form-mock')).toBeInTheDocument()
+    expect(mockUseArrayAggregateQuery).toHaveBeenCalledWith(null)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
-import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Col } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { ComposedInput } from 'uiSrc/components/base/inputs'
 
 export const ResultPanel = styled(Col)`
   flex: 1;
@@ -9,17 +11,9 @@ export const ResultPanel = styled(Col)`
   overflow: auto;
 `
 
-export const ResultRow = styled(Row)``
+export const ResultField = styled(FormField)``
 
-export const ResultLabel = styled(Text)`
-  color: ${({ theme }) => theme.semantic.color.text.neutral700};
-`
-
-export const ResultValue = styled.span<{ children?: React.ReactNode }>`
-  font-family: 'Source Code Pro', Menlo, Consolas, monospace;
-  font-weight: 600;
-  word-break: break-all;
-`
+export const ResultInput = styled(ComposedInput)``
 
 export const ErrorText = styled(Text)`
   color: ${({ theme }) => theme.semantic.color.text.danger500};

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
@@ -1,19 +1,18 @@
 import styled from 'styled-components'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { Text } from 'uiSrc/components/base/text'
 
-export const ResultContainer = styled(Col)`
+export const ResultPanel = styled(Col)`
   flex: 1;
   min-height: 0;
   padding: ${({ theme }) => theme.core.space.space150};
   overflow: auto;
 `
 
-export const ResultRow = styled(Row)`
-  padding: ${({ theme }) => theme.core.space.space100}
-    ${({ theme }) => theme.core.space.space150};
-  border-radius: ${({ theme }) => theme.core.space.space050};
-  background: ${({ theme }) => theme.semantic.color.background.neutral300};
-  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+export const ResultRow = styled(Row)``
+
+export const ResultLabel = styled(Text)`
+  color: ${({ theme }) => theme.semantic.color.text.neutral700};
 `
 
 export const ResultValue = styled.span<{ children?: React.ReactNode }>`
@@ -22,6 +21,6 @@ export const ResultValue = styled.span<{ children?: React.ReactNode }>`
   word-break: break-all;
 `
 
-export const ErrorRow = styled(Row)`
+export const ErrorText = styled(Text)`
   color: ${({ theme }) => theme.semantic.color.text.danger500};
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+
+export const ResultContainer = styled(Col)`
+  flex: 1;
+  min-height: 0;
+  padding: ${({ theme }) => theme.core.space.space150};
+  overflow: auto;
+`
+
+export const ResultRow = styled(Row)`
+  padding: ${({ theme }) => theme.core.space.space100}
+    ${({ theme }) => theme.core.space.space150};
+  border-radius: ${({ theme }) => theme.core.space.space050};
+  background: ${({ theme }) => theme.semantic.color.background.neutral300};
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
+export const ResultValue = styled.span<{ children?: React.ReactNode }>`
+  font-family: 'Source Code Pro', Menlo, Consolas, monospace;
+  font-weight: 600;
+  word-break: break-all;
+`
+
+export const ErrorRow = styled(Row)`
+  color: ${({ theme }) => theme.semantic.color.text.danger500};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-import { Text } from 'uiSrc/components/base/text'
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { Loader } from 'uiSrc/components/base/display'
+import { CopyButton } from 'uiSrc/components/copy-button'
 import { bufferToString } from 'uiSrc/utils'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
@@ -57,35 +57,40 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
         disabled={!isArrayKeyReady}
       />
       <S.TabBody data-testid={AGGREGATE_TAB_TEST_ID}>
-        <L.ResultContainer gap="m">
+        <L.ResultPanel>
           {loading && (
             <FlexItem data-testid={`${AGGREGATE_TAB_TEST_ID}-loading`}>
               <Loader size="m" />
             </FlexItem>
           )}
           {!loading && error && (
-            <L.ErrorRow
-              align="center"
+            <L.ErrorText
+              size="s"
               data-testid={`${AGGREGATE_TAB_TEST_ID}-error`}
             >
-              <Text size="s">{error}</Text>
-            </L.ErrorRow>
+              {error}
+            </L.ErrorText>
           )}
           {hasResult && (
             <L.ResultRow
               align="center"
-              gap="m"
+              gap="s"
+              grow={false}
               data-testid={`${AGGREGATE_TAB_TEST_ID}-result`}
             >
-              <Text size="s">Result:</Text>
+              <L.ResultLabel>Result:</L.ResultLabel>
               <L.ResultValue
                 data-testid={`${AGGREGATE_TAB_TEST_ID}-result-value`}
               >
                 {result}
               </L.ResultValue>
+              <CopyButton
+                copy={result}
+                data-testid={`${AGGREGATE_TAB_TEST_ID}-result-copy`}
+              />
             </L.ResultRow>
           )}
-        </L.ResultContainer>
+        </L.ResultPanel>
       </S.TabBody>
     </>
   )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -37,15 +37,18 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
   } = useArrayAggregateQuery(keyProp)
 
   // When switching keys, hide the previous key's loader/error/result
-  // until the new key is ready.
-  const showLoader = isArrayKeyReady && loading
+  // until the new key is ready. The loader only shows for a fresh run
+  // (`!hasResult`); a header-refresh recompute keeps the prior result on
+  // screen (it stays in the slice via `resetData: false`) so the panel
+  // updates in place instead of flashing the loader every auto-refresh.
+  const showLoader = isArrayKeyReady && loading && !hasResult
   const showError = isArrayKeyReady && !loading && !!error
   // `hasResult` distinguishes "no AROP run yet" from "ran and got nil" —
   // both leave `result === null`, but only the latter should surface in the
   // result panel. A nil reply is rendered as a non-copyable placeholder; a
   // value reply keeps the input + copy button so the caller can grab the
   // raw bytes (BigInt-safe).
-  const showResult = isArrayKeyReady && !loading && !error && hasResult
+  const showResult = isArrayKeyReady && !error && hasResult
   const isNilResult = showResult && result === null
   const resultValue = result ?? ''
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { noop } from 'lodash'
 
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { Loader } from 'uiSrc/components/base/display'
@@ -72,23 +73,20 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
             </L.ErrorText>
           )}
           {hasResult && (
-            <L.ResultRow
-              align="center"
-              gap="s"
-              grow={false}
-              data-testid={`${AGGREGATE_TAB_TEST_ID}-result`}
-            >
-              <L.ResultLabel>Result:</L.ResultLabel>
-              <L.ResultValue
+            <L.ResultField label="Result">
+              <L.ResultInput
+                value={result}
+                onChange={noop}
                 data-testid={`${AGGREGATE_TAB_TEST_ID}-result-value`}
-              >
-                {result}
-              </L.ResultValue>
-              <CopyButton
-                copy={result}
-                data-testid={`${AGGREGATE_TAB_TEST_ID}-result-copy`}
+                after={
+                  <CopyButton
+                    copy={result}
+                    withTooltip={false}
+                    data-testid={`${AGGREGATE_TAB_TEST_ID}-result-copy`}
+                  />
+                }
               />
-            </L.ResultRow>
+            </L.ResultField>
           )}
         </L.ResultPanel>
       </S.TabBody>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -1,13 +1,94 @@
 import React from 'react'
 
 import { Text } from 'uiSrc/components/base/text'
+import { FlexItem } from 'uiSrc/components/base/layout/flex'
+import { Loader } from 'uiSrc/components/base/display'
+import { bufferToString } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
+import { ArrayAggregateForm } from '../array-aggregate-form'
+import { useArrayAggregateQuery } from '../hooks'
 import * as S from '../tabs.styles'
+import * as L from './AggregateTab.styles'
 
-const AggregateTab = () => (
-  <S.TabPlaceholder data-testid="array-aggregate-placeholder">
-    <Text>This is Aggregate</Text>
-  </S.TabPlaceholder>
-)
+export interface AggregateTabProps {
+  keyProp: RedisResponseBuffer | null
+}
+
+const AGGREGATE_TAB_TEST_ID = 'array-aggregate-tab'
+
+const AggregateTab = ({ keyProp }: AggregateTabProps) => {
+  const keyName = keyProp ? bufferToString(keyProp) : ''
+
+  const {
+    start,
+    end,
+    operation,
+    value,
+    setStart,
+    setEnd,
+    setOperation,
+    setValue,
+    runQuery,
+    resetQuery,
+    isArrayKeyReady,
+    loading,
+    error,
+    result,
+  } = useArrayAggregateQuery(keyProp)
+
+  const hasResult = !loading && !error && result !== ''
+
+  return (
+    <>
+      <ArrayAggregateForm
+        keyName={keyName}
+        start={start}
+        end={end}
+        operation={operation}
+        value={value}
+        loading={loading}
+        onChangeStart={setStart}
+        onChangeEnd={setEnd}
+        onChangeOperation={setOperation}
+        onChangeValue={setValue}
+        onRun={runQuery}
+        onReset={resetQuery}
+        disabled={!isArrayKeyReady}
+      />
+      <S.TabBody data-testid={AGGREGATE_TAB_TEST_ID}>
+        <L.ResultContainer gap="m">
+          {loading && (
+            <FlexItem data-testid={`${AGGREGATE_TAB_TEST_ID}-loading`}>
+              <Loader size="m" />
+            </FlexItem>
+          )}
+          {!loading && error && (
+            <L.ErrorRow
+              align="center"
+              data-testid={`${AGGREGATE_TAB_TEST_ID}-error`}
+            >
+              <Text size="s">{error}</Text>
+            </L.ErrorRow>
+          )}
+          {hasResult && (
+            <L.ResultRow
+              align="center"
+              gap="m"
+              data-testid={`${AGGREGATE_TAB_TEST_ID}-result`}
+            >
+              <Text size="s">Result:</Text>
+              <L.ResultValue
+                data-testid={`${AGGREGATE_TAB_TEST_ID}-result-value`}
+              >
+                {result}
+              </L.ResultValue>
+            </L.ResultRow>
+          )}
+        </L.ResultContainer>
+      </S.TabBody>
+    </>
+  )
+}
 
 export default AggregateTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -5,16 +5,12 @@ import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { Loader } from 'uiSrc/components/base/display'
 import { CopyButton } from 'uiSrc/components/copy-button'
 import { bufferToString } from 'uiSrc/utils'
-import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
 import { ArrayAggregateForm } from '../array-aggregate-form'
 import { useArrayAggregateQuery } from '../hooks'
 import * as S from '../tabs.styles'
 import * as L from './AggregateTab.styles'
-
-export interface AggregateTabProps {
-  keyProp: RedisResponseBuffer | null
-}
+import { AggregateTabProps } from './AggregateTab.types'
 
 const AGGREGATE_TAB_TEST_ID = 'array-aggregate-tab'
 const NIL_RESULT_LABEL = '(nil)'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -17,6 +17,7 @@ export interface AggregateTabProps {
 }
 
 const AGGREGATE_TAB_TEST_ID = 'array-aggregate-tab'
+const NIL_RESULT_LABEL = '(nil)'
 
 const AggregateTab = ({ keyProp }: AggregateTabProps) => {
   const keyName = keyProp ? bufferToString(keyProp) : ''
@@ -36,9 +37,17 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
     loading,
     error,
     result,
+    hasResult,
   } = useArrayAggregateQuery(keyProp)
 
-  const hasResult = !loading && !error && result !== ''
+  // `hasResult` distinguishes "no AROP run yet" from "ran and got nil" —
+  // both leave `result === null`, but only the latter should surface in the
+  // result panel. A nil reply is rendered as a non-copyable placeholder; a
+  // value reply keeps the input + copy button so the caller can grab the
+  // raw bytes (BigInt-safe).
+  const showResult = !loading && !error && hasResult
+  const isNilResult = showResult && result === null
+  const resultValue = result ?? ''
 
   return (
     <>
@@ -72,19 +81,23 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
               {error}
             </L.ErrorText>
           )}
-          {hasResult && (
+          {showResult && (
             <L.ResultField label="Result">
               <L.ResultInput
-                value={result}
+                value={isNilResult ? NIL_RESULT_LABEL : resultValue}
                 onChange={noop}
                 data-testid={`${AGGREGATE_TAB_TEST_ID}-result-value`}
-                after={
-                  <CopyButton
-                    copy={result}
-                    withTooltip={false}
-                    data-testid={`${AGGREGATE_TAB_TEST_ID}-result-copy`}
-                  />
-                }
+                {...(isNilResult
+                  ? {}
+                  : {
+                      after: (
+                        <CopyButton
+                          copy={resultValue}
+                          withTooltip={false}
+                          data-testid={`${AGGREGATE_TAB_TEST_ID}-result-copy`}
+                        />
+                      ),
+                    })}
               />
             </L.ResultField>
           )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.tsx
@@ -40,12 +40,16 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
     hasResult,
   } = useArrayAggregateQuery(keyProp)
 
+  // When switching keys, hide the previous key's loader/error/result
+  // until the new key is ready.
+  const showLoader = isArrayKeyReady && loading
+  const showError = isArrayKeyReady && !loading && !!error
   // `hasResult` distinguishes "no AROP run yet" from "ran and got nil" —
   // both leave `result === null`, but only the latter should surface in the
   // result panel. A nil reply is rendered as a non-copyable placeholder; a
   // value reply keeps the input + copy button so the caller can grab the
   // raw bytes (BigInt-safe).
-  const showResult = !loading && !error && hasResult
+  const showResult = isArrayKeyReady && !loading && !error && hasResult
   const isNilResult = showResult && result === null
   const resultValue = result ?? ''
 
@@ -68,12 +72,12 @@ const AggregateTab = ({ keyProp }: AggregateTabProps) => {
       />
       <S.TabBody data-testid={AGGREGATE_TAB_TEST_ID}>
         <L.ResultPanel>
-          {loading && (
+          {showLoader && (
             <FlexItem data-testid={`${AGGREGATE_TAB_TEST_ID}-loading`}>
               <Loader size="m" />
             </FlexItem>
           )}
-          {!loading && error && (
+          {showError && (
             <L.ErrorText
               size="s"
               data-testid={`${AGGREGATE_TAB_TEST_ID}-error`}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/aggregate-tab/AggregateTab.types.ts
@@ -1,0 +1,5 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface AggregateTabProps {
+  keyProp: RedisResponseBuffer | null
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.constants.ts
@@ -15,9 +15,6 @@ export const ARRAY_RANGE_MAX_SPAN = 1_000_000n
 export const INVALID_RANGE_TOO_LARGE_MESSAGE =
   'Range too large — aggregate at most 1,000,000 indexes per query'
 
-export const INVALID_MATCH_VALUE_MESSAGE =
-  'Value is required for the MATCH operation'
-
 export const OPERATION_OPTIONS: ReadonlyArray<{
   value: ArrayAggregateOperation
   inputDisplay: string

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.constants.ts
@@ -1,0 +1,33 @@
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+
+export const ARRAY_AGGREGATE_FORM_TEST_ID = 'array-aggregate-form'
+
+export const RUN_BUTTON_LABEL = 'Run'
+export const RESET_TOOLTIP = 'Reset to defaults'
+export const INVALID_INDEX_MESSAGE =
+  'Index must be a valid 64-bit unsigned integer'
+
+/**
+ * Mirror of the backend's `ARRAY_RANGE_MAX_ELEMENTS` cap — AROP reuses
+ * `assertValidRange` so the same span limit applies.
+ */
+export const ARRAY_RANGE_MAX_SPAN = 1_000_000n
+export const INVALID_RANGE_TOO_LARGE_MESSAGE =
+  'Range too large — aggregate at most 1,000,000 indexes per query'
+
+export const INVALID_MATCH_VALUE_MESSAGE =
+  'Value is required for the MATCH operation'
+
+export const OPERATION_OPTIONS: ReadonlyArray<{
+  value: ArrayAggregateOperation
+  inputDisplay: string
+}> = [
+  { value: ArrayAggregateOperation.Sum, inputDisplay: 'SUM' },
+  { value: ArrayAggregateOperation.Min, inputDisplay: 'MIN' },
+  { value: ArrayAggregateOperation.Max, inputDisplay: 'MAX' },
+  { value: ArrayAggregateOperation.And, inputDisplay: 'AND' },
+  { value: ArrayAggregateOperation.Or, inputDisplay: 'OR' },
+  { value: ArrayAggregateOperation.Xor, inputDisplay: 'XOR' },
+  { value: ArrayAggregateOperation.Match, inputDisplay: 'MATCH' },
+  { value: ArrayAggregateOperation.Used, inputDisplay: 'USED' },
+]

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.spec.tsx
@@ -1,0 +1,233 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+
+import { ArrayAggregateForm } from './ArrayAggregateForm'
+import { ArrayAggregateFormProps } from './ArrayAggregateForm.types'
+
+const defaultProps: ArrayAggregateFormProps = {
+  start: '0',
+  end: '9',
+  operation: ArrayAggregateOperation.Sum,
+  value: '',
+  loading: false,
+  onChangeStart: jest.fn(),
+  onChangeEnd: jest.fn(),
+  onChangeOperation: jest.fn(),
+  onChangeValue: jest.fn(),
+  onRun: jest.fn(),
+}
+
+const renderComponent = (props: Partial<ArrayAggregateFormProps> = {}) =>
+  render(<ArrayAggregateForm {...defaultProps} {...props} />)
+
+const TEST_ID = 'array-aggregate-form'
+const RUN_TESTID = `${TEST_ID}-run`
+const RESET_TESTID = `${TEST_ID}-reset`
+const START_TESTID = `${TEST_ID}-start`
+const END_TESTID = `${TEST_ID}-end`
+const VALUE_TESTID = `${TEST_ID}-value`
+const PREVIEW_TOGGLE_TESTID = `${TEST_ID}-preview-toggle`
+// CommandPreview keeps a shared, hard-coded test id across the range and
+// aggregate forms — assert against that rather than a per-form id.
+const PREVIEW_TEXT_TESTID = 'array-range-form-command-preview-text'
+
+describe('ArrayAggregateForm', () => {
+  describe('command preview', () => {
+    it('hides the command preview by default', () => {
+      renderComponent()
+
+      expect(screen.queryByTestId(PREVIEW_TEXT_TESTID)).not.toBeInTheDocument()
+    })
+
+    it('reveals the AROP preview without a value for non-MATCH operations', () => {
+      renderComponent({ operation: ArrayAggregateOperation.Sum })
+
+      fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+      expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+        /^AROP\s+<key>\s+0\s+9\s+SUM$/,
+      )
+    })
+
+    it('appends the comparison value to the preview for MATCH', () => {
+      renderComponent({
+        operation: ArrayAggregateOperation.Match,
+        value: 'needle',
+      })
+
+      fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+      expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+        /AROP\s+<key>\s+0\s+9\s+MATCH\s+needle/,
+      )
+    })
+
+    it('quotes key names containing whitespace in the command preview', () => {
+      renderComponent({ keyName: 'a b' })
+
+      fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+      expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+        /AROP\s+"a b"\s+0\s+9\s+SUM/,
+      )
+    })
+
+    it('escapes embedded quotes/backslashes in keys for the command preview', () => {
+      renderComponent({ keyName: 'a"b\\c' })
+
+      fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+      expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+        /AROP\s+"a\\"b\\\\c"\s+0\s+9\s+SUM/,
+      )
+    })
+  })
+
+  describe('the comparison-value input', () => {
+    it('renders only when the operation is MATCH', () => {
+      const { rerender } = renderComponent({
+        operation: ArrayAggregateOperation.Sum,
+      })
+      expect(screen.queryByTestId(VALUE_TESTID)).not.toBeInTheDocument()
+
+      rerender(
+        <ArrayAggregateForm
+          {...defaultProps}
+          operation={ArrayAggregateOperation.Match}
+        />,
+      )
+      expect(screen.getByTestId(VALUE_TESTID)).toBeInTheDocument()
+    })
+
+    it('forwards typed input to onChangeValue', () => {
+      const onChangeValue = jest.fn()
+      renderComponent({
+        operation: ArrayAggregateOperation.Match,
+        onChangeValue,
+      })
+
+      fireEvent.change(screen.getByTestId(VALUE_TESTID), {
+        target: { value: 'needle' },
+      })
+
+      expect(onChangeValue).toHaveBeenCalledWith('needle')
+    })
+  })
+
+  describe('Run enablement / index validation', () => {
+    it('disables Run while loading', () => {
+      renderComponent({ loading: true })
+
+      expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+    })
+
+    it('disables Run when the start index is not a valid BigInt-string', () => {
+      renderComponent({ start: '-1' })
+
+      expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+    })
+
+    it.each(['007', ' 7 ', '7.0', '1e3'])(
+      'disables Run for non-canonical index input %p (matches backend @IsArrayIndex)',
+      (input) => {
+        renderComponent({ start: input })
+
+        expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+      },
+    )
+
+    it('allows Run when end < start (AROP returns reverse-order results)', () => {
+      renderComponent({ start: '500', end: '100' })
+
+      expect(screen.getByTestId(RUN_TESTID)).not.toBeDisabled()
+    })
+
+    it('disables Run when the span exceeds the backend cap (1,000,000)', () => {
+      // span = end - start + 1 = 1_000_001, one past the cap
+      renderComponent({ start: '0', end: '1000000' })
+
+      expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+    })
+
+    it('disables Run when a reversed range exceeds the backend cap', () => {
+      // span = |end - start| + 1 = 1_000_001, one past the cap
+      renderComponent({ start: '1000000', end: '0' })
+
+      expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+    })
+
+    it('allows Run when the span equals the backend cap (1,000,000)', () => {
+      // span = end - start + 1 = 1_000_000, exactly at the cap
+      renderComponent({ start: '0', end: '999999' })
+
+      expect(screen.getByTestId(RUN_TESTID)).not.toBeDisabled()
+    })
+  })
+
+  describe('MATCH value enablement', () => {
+    // AROP MATCH accepts any RedisString, including empty / whitespace-only
+    // values — the backend only rejects an omitted `value` field. The form
+    // must not gate Run on a non-empty (or trimmed-non-empty) value, so
+    // populated zero-length / whitespace slots can be counted.
+    it.each([
+      ['an empty string', ''],
+      ['a whitespace-only string', '   '],
+    ])('allows Run for MATCH with %s', (_label, value) => {
+      renderComponent({ operation: ArrayAggregateOperation.Match, value })
+
+      expect(screen.getByTestId(RUN_TESTID)).not.toBeDisabled()
+    })
+  })
+
+  describe('the disabled prop', () => {
+    it('disables Run, Reset and the inputs when set', () => {
+      // Container passes disabled=true while the selected-key slice has not
+      // confirmed the new key is an array yet.
+      renderComponent({
+        operation: ArrayAggregateOperation.Match,
+        onReset: jest.fn(),
+        disabled: true,
+      })
+
+      expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+      expect(screen.getByTestId(RESET_TESTID)).toBeDisabled()
+      expect(screen.getByTestId(START_TESTID)).toBeDisabled()
+      expect(screen.getByTestId(END_TESTID)).toBeDisabled()
+      expect(screen.getByTestId(VALUE_TESTID)).toBeDisabled()
+    })
+  })
+
+  describe('actions', () => {
+    it('calls onRun when Run is clicked with a valid range', () => {
+      const onRun = jest.fn()
+      renderComponent({ onRun })
+
+      fireEvent.click(screen.getByTestId(RUN_TESTID))
+
+      expect(onRun).toHaveBeenCalledTimes(1)
+    })
+
+    it('forwards typed input to onChangeStart', () => {
+      const onChangeStart = jest.fn()
+      renderComponent({ onChangeStart })
+
+      fireEvent.change(screen.getByTestId(START_TESTID), {
+        target: { value: '42' },
+      })
+
+      expect(onChangeStart).toHaveBeenCalledWith('42')
+    })
+
+    it('renders the reset button only when onReset is provided', () => {
+      const { rerender } = renderComponent()
+      expect(screen.queryByTestId(RESET_TESTID)).not.toBeInTheDocument()
+
+      const onReset = jest.fn()
+      rerender(<ArrayAggregateForm {...defaultProps} onReset={onReset} />)
+
+      fireEvent.click(screen.getByTestId(RESET_TESTID))
+      expect(onReset).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo, useState } from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { IconButton, PrimaryButton } from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { ResetIcon, RiIcon } from 'uiSrc/components/base/icons'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Text } from 'uiSrc/components/base/text'
+import {
+  defaultValueRender,
+  RiSelect,
+} from 'uiSrc/components/base/forms/select/RiSelect'
+import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+
+import { CommandPreview } from '../command-preview'
+import * as RangeStyles from '../array-range-form/ArrayRangeForm.styles'
+import {
+  ARRAY_AGGREGATE_FORM_TEST_ID as TEST_ID,
+  ARRAY_RANGE_MAX_SPAN,
+  INVALID_INDEX_MESSAGE,
+  INVALID_MATCH_VALUE_MESSAGE,
+  INVALID_RANGE_TOO_LARGE_MESSAGE,
+  OPERATION_OPTIONS,
+  RESET_TOOLTIP,
+  RUN_BUTTON_LABEL,
+} from './ArrayAggregateForm.constants'
+import { ArrayAggregateFormProps } from './ArrayAggregateForm.types'
+
+const PREVIEW_TOGGLE_LABEL = 'Show preview'
+const PREVIEW_TOGGLE_ARIA_LABEL = 'Toggle command preview'
+const PREVIEW_TOGGLE_SHOW_TOOLTIP = 'Show the Redis command that will run'
+const PREVIEW_TOGGLE_HIDE_TOOLTIP = 'Hide the command preview'
+
+// Mirrors `ArrayRangeForm`'s helper — same redis-cli quoting rules so a
+// copied preview command stays runnable for binary-unsafe keys / values.
+const quoteRedisArgument = (value: string): string => {
+  if (value.length === 0) return '""'
+  if (!/[\s"\\]/.test(value)) return value
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+/**
+ * AROP form for the array Aggregate tab. Lays out range inputs + operation
+ * select above the standard action row (preview toggle, reset, Run) so the
+ * tab feels like a sibling of the View tab's `ArrayRangeForm`. The
+ * comparison-value input only appears for `operation === Match`.
+ */
+export const ArrayAggregateForm = ({
+  keyName,
+  start,
+  end,
+  operation,
+  value,
+  loading,
+  onChangeStart,
+  onChangeEnd,
+  onChangeOperation,
+  onChangeValue,
+  onRun,
+  onReset,
+  disabled = false,
+}: ArrayAggregateFormProps) => {
+  const [previewVisible, setPreviewVisible] = useState(false)
+
+  const startInvalid = parseArrayIndex(start) !== start
+  const endInvalid = parseArrayIndex(end) !== end
+  const spanInvalid =
+    !startInvalid &&
+    !endInvalid &&
+    (BigInt(start) > BigInt(end)
+      ? BigInt(start) - BigInt(end)
+      : BigInt(end) - BigInt(start)) +
+      1n >
+      ARRAY_RANGE_MAX_SPAN
+
+  const matchValueInvalid =
+    operation === ArrayAggregateOperation.Match && value.trim() === ''
+
+  const formInvalid =
+    startInvalid || endInvalid || spanInvalid || matchValueInvalid
+
+  const startError = startInvalid ? INVALID_INDEX_MESSAGE : undefined
+  const endError = endInvalid
+    ? INVALID_INDEX_MESSAGE
+    : spanInvalid
+      ? INVALID_RANGE_TOO_LARGE_MESSAGE
+      : undefined
+  const valueError = matchValueInvalid ? INVALID_MATCH_VALUE_MESSAGE : undefined
+
+  const command = useMemo(() => {
+    const name = keyName ? quoteRedisArgument(keyName) : '<key>'
+    const base = `AROP ${name} ${start} ${end} ${operation}`
+    if (operation === ArrayAggregateOperation.Match) {
+      return `${base} ${quoteRedisArgument(value)}`
+    }
+    return base
+  }, [keyName, start, end, operation, value])
+
+  const previewTooltip = previewVisible
+    ? PREVIEW_TOGGLE_HIDE_TOOLTIP
+    : PREVIEW_TOGGLE_SHOW_TOOLTIP
+
+  return (
+    <RangeStyles.FormContainer data-testid={TEST_ID} gap="m" grow={false}>
+      <Row align="end" gap="m">
+        <FlexItem>
+          <FormField label="Start index">
+            <TextInput
+              value={start}
+              onChange={onChangeStart}
+              data-testid={`${TEST_ID}-start`}
+              error={startError}
+              placeholder="0"
+              disabled={disabled}
+            />
+          </FormField>
+        </FlexItem>
+        <FlexItem>
+          <FormField label="End index">
+            <TextInput
+              value={end}
+              onChange={onChangeEnd}
+              data-testid={`${TEST_ID}-end`}
+              error={endError}
+              placeholder="9"
+              disabled={disabled}
+            />
+          </FormField>
+        </FlexItem>
+        <FlexItem grow={false}>
+          <FormField label="Operation">
+            <RiSelect
+              options={OPERATION_OPTIONS.map((option) => ({
+                ...option,
+                'data-test-subj': `${TEST_ID}-operation-option-${option.value}`,
+              }))}
+              value={operation}
+              valueRender={defaultValueRender}
+              onChange={(next) =>
+                onChangeOperation(next as ArrayAggregateOperation)
+              }
+              disabled={disabled}
+              data-test-subj={`${TEST_ID}-operation`}
+            />
+          </FormField>
+        </FlexItem>
+        {operation === ArrayAggregateOperation.Match && (
+          <FlexItem>
+            <FormField label="Value">
+              <TextInput
+                value={value}
+                onChange={onChangeValue}
+                data-testid={`${TEST_ID}-value`}
+                error={valueError}
+                placeholder="value to match"
+                disabled={disabled}
+              />
+            </FormField>
+          </FlexItem>
+        )}
+      </Row>
+
+      <RangeStyles.ActionRow align="center" gap="m">
+        <FlexItem grow={false}>
+          <RiTooltip content={previewTooltip} position="top">
+            <RangeStyles.PreviewToggleButton
+              pressed={previewVisible}
+              onPressedChange={setPreviewVisible}
+              aria-label={PREVIEW_TOGGLE_ARIA_LABEL}
+              data-testid={`${TEST_ID}-preview-toggle`}
+            >
+              <RiIcon size="m" type="CliIcon" />
+              <Text size="s">{PREVIEW_TOGGLE_LABEL}</Text>
+            </RangeStyles.PreviewToggleButton>
+          </RiTooltip>
+        </FlexItem>
+        <FlexItem grow>
+          {previewVisible && <CommandPreview command={command} />}
+        </FlexItem>
+        {onReset && (
+          <FlexItem grow={false}>
+            <RiTooltip content={RESET_TOOLTIP} position="top">
+              <IconButton
+                size="M"
+                icon={ResetIcon}
+                onClick={onReset}
+                disabled={loading || disabled}
+                aria-label="Reset array aggregate form"
+                data-testid={`${TEST_ID}-reset`}
+              />
+            </RiTooltip>
+          </FlexItem>
+        )}
+        <FlexItem grow={false}>
+          <PrimaryButton
+            onClick={() => onRun()}
+            disabled={formInvalid || loading || disabled}
+            data-testid={`${TEST_ID}-run`}
+          >
+            {RUN_BUTTON_LABEL}
+          </PrimaryButton>
+        </FlexItem>
+      </RangeStyles.ActionRow>
+    </RangeStyles.FormContainer>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
@@ -20,7 +20,6 @@ import {
   ARRAY_AGGREGATE_FORM_TEST_ID as TEST_ID,
   ARRAY_RANGE_MAX_SPAN,
   INVALID_INDEX_MESSAGE,
-  INVALID_MATCH_VALUE_MESSAGE,
   INVALID_RANGE_TOO_LARGE_MESSAGE,
   OPERATION_OPTIONS,
   RESET_TOOLTIP,
@@ -75,11 +74,10 @@ export const ArrayAggregateForm = ({
       1n >
       ARRAY_RANGE_MAX_SPAN
 
-  const matchValueInvalid =
-    operation === ArrayAggregateOperation.Match && value.trim() === ''
-
-  const formInvalid =
-    startInvalid || endInvalid || spanInvalid || matchValueInvalid
+  // MATCH accepts any RedisString — including empty strings / empty buffers
+  // — so populated zero-length slots can be counted. The BE only rejects an
+  // omitted `value` field, which the form never produces (defaults to '').
+  const formInvalid = startInvalid || endInvalid || spanInvalid
 
   const startError = startInvalid ? INVALID_INDEX_MESSAGE : undefined
   const endError = endInvalid
@@ -87,7 +85,6 @@ export const ArrayAggregateForm = ({
     : spanInvalid
       ? INVALID_RANGE_TOO_LARGE_MESSAGE
       : undefined
-  const valueError = matchValueInvalid ? INVALID_MATCH_VALUE_MESSAGE : undefined
 
   const command = useMemo(() => {
     const name = keyName ? quoteRedisArgument(keyName) : '<key>'
@@ -153,7 +150,6 @@ export const ArrayAggregateForm = ({
                 value={value}
                 onChange={onChangeValue}
                 data-testid={`${TEST_ID}-value`}
-                error={valueError}
                 placeholder="value to match"
                 disabled={disabled}
               />

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.types.ts
@@ -1,0 +1,24 @@
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+
+export interface ArrayAggregateFormProps {
+  /** Key name rendered in the preview command. Optional for isolated tests. */
+  keyName?: string
+  start: string
+  end: string
+  operation: ArrayAggregateOperation
+  /** Comparison value used only when `operation === Match`. */
+  value: string
+  loading: boolean
+  onChangeStart: (value: string) => void
+  onChangeEnd: (value: string) => void
+  onChangeOperation: (operation: ArrayAggregateOperation) => void
+  onChangeValue: (value: string) => void
+  onRun: () => void
+  onReset?: () => void
+  /**
+   * Disables Run/Reset alongside the form's own validation while the
+   * selected key's confirmed type/name has not caught up with the
+   * clicked key yet.
+   */
+  disabled?: boolean
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/index.ts
@@ -1,0 +1,2 @@
+export { ArrayAggregateForm } from './ArrayAggregateForm'
+export type { ArrayAggregateFormProps } from './ArrayAggregateForm.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useArrayRangeQuery } from './useArrayRangeQuery'
+export { useArrayAggregateQuery } from './useArrayAggregateQuery'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.spec.tsx
@@ -1,0 +1,177 @@
+import { cloneDeep } from 'lodash'
+import {
+  act,
+  initialStateDefault,
+  mockStore,
+  renderHook,
+} from 'uiSrc/utils/test-utils'
+import { apiService } from 'uiSrc/services'
+import { KeyTypes } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+import { useArrayAggregateQuery } from './useArrayAggregateQuery'
+
+const KEY = 'sensors'
+const keyBuffer = stringToBuffer(KEY)
+
+const buildState = (
+  overrides: {
+    selectedKeyType?: KeyTypes
+    selectedKeyName?: ReturnType<typeof stringToBuffer> | null
+  } = {},
+) => {
+  const next = cloneDeep(initialStateDefault)
+  next.browser.array = cloneDeep(initialStateArray)
+  next.browser.keys.selectedKey.data = overrides.selectedKeyName
+    ? ({
+        type: overrides.selectedKeyType ?? KeyTypes.Array,
+        name: overrides.selectedKeyName,
+      } as any)
+    : null
+  return next
+}
+
+const renderWithStore = (
+  prop: ReturnType<typeof stringToBuffer> | null,
+  state = buildState({ selectedKeyName: keyBuffer }),
+) => {
+  const store = mockStore(state)
+  store.clearActions()
+  const { result } = renderHook(() => useArrayAggregateQuery(prop), { store })
+  return { result, store }
+}
+
+describe('useArrayAggregateQuery', () => {
+  beforeEach(() => {
+    apiService.post = jest
+      .fn()
+      .mockResolvedValue({ status: 200, data: { result: '42' } })
+  })
+
+  it('initialises form defaults and isArrayKeyReady=true for a matching Array key', () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    expect(result.current.start).toBe('0')
+    expect(result.current.end).toBe('9')
+    expect(result.current.operation).toBe(ArrayAggregateOperation.Sum)
+    expect(result.current.value).toBe('')
+    expect(result.current.isArrayKeyReady).toBe(true)
+  })
+
+  it('isArrayKeyReady=false until selectedKeyData catches up with keyProp', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('isArrayKeyReady=false when selected key type is not Array', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({
+        selectedKeyName: keyBuffer,
+        selectedKeyType: KeyTypes.String,
+      }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('does not auto-fire AROP on first ready render (manual Run only)', () => {
+    renderWithStore(keyBuffer)
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/aggregate'),
+    )
+    expect(call).toBeUndefined()
+  })
+
+  it('runQuery dispatches AROP with current form values (omits value for non-MATCH ops)', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setStart('5')
+      result.current.setEnd('25')
+      result.current.setOperation(ArrayAggregateOperation.Xor)
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery()
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/aggregate'),
+    )
+    expect(call?.[1]).toEqual({
+      keyName: keyBuffer,
+      start: '5',
+      end: '25',
+      operation: ArrayAggregateOperation.Xor,
+    })
+  })
+
+  it('runQuery includes value when operation is MATCH', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setOperation(ArrayAggregateOperation.Match)
+      result.current.setValue('needle')
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery()
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/aggregate'),
+    )
+    expect(call?.[1]).toEqual({
+      keyName: keyBuffer,
+      start: '0',
+      end: '9',
+      operation: ArrayAggregateOperation.Match,
+      value: 'needle',
+    })
+  })
+
+  it('runQuery is a no-op while isArrayKeyReady=false', async () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+    ;(apiService.post as jest.Mock).mockClear()
+
+    await act(async () => {
+      result.current.runQuery()
+    })
+
+    expect(apiService.post as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('resetQuery restores form defaults without firing a request', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setStart('100')
+      result.current.setEnd('200')
+      result.current.setOperation(ArrayAggregateOperation.Match)
+      result.current.setValue('foo')
+    })
+    ;(apiService.post as jest.Mock).mockClear()
+
+    act(() => {
+      result.current.resetQuery()
+    })
+
+    expect(result.current.start).toBe('0')
+    expect(result.current.end).toBe('9')
+    expect(result.current.operation).toBe(ArrayAggregateOperation.Sum)
+    expect(result.current.value).toBe('')
+    expect(apiService.post as jest.Mock).not.toHaveBeenCalled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.spec.tsx
@@ -57,6 +57,30 @@ describe('useArrayAggregateQuery', () => {
     expect(result.current.operation).toBe(ArrayAggregateOperation.Sum)
     expect(result.current.value).toBe('')
     expect(result.current.isArrayKeyReady).toBe(true)
+    expect(result.current.result).toBeNull()
+    expect(result.current.hasResult).toBe(false)
+  })
+
+  it('dispatches loadArrayAggregateSuccess with a nil reply forwarded verbatim', async () => {
+    // redux-mock-store doesn't run reducers, so we assert on the dispatched
+    // success action — the slice spec covers the hasResult flip and the
+    // null-result passthrough.
+    ;(apiService.post as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      data: { result: null },
+    })
+    const { result, store } = renderWithStore(keyBuffer)
+    store.clearActions()
+
+    await act(async () => {
+      result.current.runQuery()
+    })
+
+    const success = store
+      .getActions()
+      .find((a) => a.type === 'array/loadArrayAggregateSuccess')
+    expect(success).toBeDefined()
+    expect(success?.payload).toEqual({ result: null })
   })
 
   it('isArrayKeyReady=false until selectedKeyData catches up with keyProp', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import {
+  abortArrayAggregate,
+  aggregateArray,
+  arrayAggregateSelector,
+  clearArrayAggregate,
+} from 'uiSrc/slices/browser/array'
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { isEqualBuffers } from 'uiSrc/utils'
+import { KeyTypes } from 'uiSrc/constants'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
+import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
+
+const DEFAULT_OPERATION = ArrayAggregateOperation.Sum
+const DEFAULT_VALUE = ''
+
+/**
+ * Owns the Aggregate tab form state for an array key: range bounds, the
+ * AROP operation, and the MATCH comparison value. Mirrors
+ * `useArrayRangeQuery` (key-switch reset, AbortController on unmount) but
+ * targets `state.browser.array.aggregate` so the View tab's table is not
+ * affected by aggregate dispatches.
+ */
+export const useArrayAggregateQuery = (keyProp: RedisResponseBuffer | null) => {
+  const dispatch = useAppDispatch()
+  const { loading, error, result } = useAppSelector(arrayAggregateSelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+
+  const [start, setStart] = useState<string>(DEFAULT_RANGE_START)
+  const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
+  const [operation, setOperation] =
+    useState<ArrayAggregateOperation>(DEFAULT_OPERATION)
+  const [value, setValue] = useState<string>(DEFAULT_VALUE)
+
+  // Same readiness gate as the View tab: don't fire AROP against a key
+  // whose confirmed type/name hasn't caught up with the clicked key yet.
+  const isArrayKeyReady =
+    !!keyProp &&
+    selectedKeyData?.type === KeyTypes.Array &&
+    !!selectedKeyData?.name &&
+    isEqualBuffers(selectedKeyData.name, keyProp)
+
+  const runQuery = useCallback(() => {
+    if (!isArrayKeyReady || !keyProp) return
+    dispatch(
+      aggregateArray({
+        key: keyProp,
+        start,
+        end,
+        operation,
+        ...(operation === ArrayAggregateOperation.Match ? { value } : {}),
+      }),
+    )
+  }, [dispatch, isArrayKeyReady, keyProp, start, end, operation, value])
+
+  // Reset form + aggregate slice when the selected key changes. Buffer-byte
+  // equality (via refs) avoids refire on referentially fresh buffers for
+  // the same logical key.
+  const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
+  useEffect(() => {
+    if (!keyProp) return
+    if (lastKeyRef.current && isEqualBuffers(lastKeyRef.current, keyProp)) {
+      return
+    }
+    lastKeyRef.current = keyProp
+
+    abortArrayAggregate()
+    dispatch(clearArrayAggregate())
+    setStart(DEFAULT_RANGE_START)
+    setEnd(DEFAULT_RANGE_END)
+    setOperation(DEFAULT_OPERATION)
+    setValue(DEFAULT_VALUE)
+  }, [dispatch, keyProp])
+
+  // Cancel any in-flight AROP and wipe the aggregate slice on unmount so
+  // a stale result can't paint the previous key's value for one frame
+  // after re-mount.
+  useEffect(
+    () => () => {
+      abortArrayAggregate()
+      dispatch(clearArrayAggregate())
+    },
+    [dispatch],
+  )
+
+  const resetQuery = useCallback(() => {
+    abortArrayAggregate()
+    dispatch(clearArrayAggregate())
+    setStart(DEFAULT_RANGE_START)
+    setEnd(DEFAULT_RANGE_END)
+    setOperation(DEFAULT_OPERATION)
+    setValue(DEFAULT_VALUE)
+  }, [dispatch])
+
+  return {
+    start,
+    end,
+    operation,
+    value,
+    setStart,
+    setEnd,
+    setOperation,
+    setValue,
+    runQuery,
+    resetQuery,
+    isArrayKeyReady,
+    loading,
+    error,
+    result,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayAggregateQuery.ts
@@ -25,7 +25,9 @@ const DEFAULT_VALUE = ''
  */
 export const useArrayAggregateQuery = (keyProp: RedisResponseBuffer | null) => {
   const dispatch = useAppDispatch()
-  const { loading, error, result } = useAppSelector(arrayAggregateSelector)
+  const { loading, error, result, hasResult } = useAppSelector(
+    arrayAggregateSelector,
+  )
   const selectedKeyData = useAppSelector(selectedKeyDataSelector)
 
   const [start, setStart] = useState<string>(DEFAULT_RANGE_START)
@@ -109,5 +111,6 @@ export const useArrayAggregateQuery = (keyProp: RedisResponseBuffer | null) => {
     loading,
     error,
     result,
+    hasResult,
   }
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -66,7 +66,8 @@ export const initialState: StateArray = {
   aggregate: {
     loading: false,
     error: '',
-    result: '',
+    result: null,
+    hasResult: false,
   },
 }
 
@@ -172,6 +173,8 @@ const arraySlice = createSlice({
     loadArrayAggregate: (state) => {
       state.aggregate.loading = true
       state.aggregate.error = ''
+      state.aggregate.hasResult = false
+      state.aggregate.result = null
     },
     loadArrayAggregateSuccess: (
       state,
@@ -180,6 +183,7 @@ const arraySlice = createSlice({
       state.aggregate.loading = false
       state.aggregate.error = ''
       state.aggregate.result = payload.result
+      state.aggregate.hasResult = true
     },
     loadArrayAggregateFailure: (state, { payload }: PayloadAction<string>) => {
       state.aggregate.loading = false

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   ArrayActiveQuery,
+  ArrayAggregateActiveQuery,
   ArrayDataElement,
   StateArray,
   FetchArrayAggregateParams,
@@ -68,6 +69,7 @@ export const initialState: StateArray = {
     error: '',
     result: null,
     hasResult: false,
+    query: null,
   },
 }
 
@@ -170,11 +172,26 @@ const arraySlice = createSlice({
       state.query = payload
     },
 
-    loadArrayAggregate: (state) => {
+    loadArrayAggregate: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        query: ArrayAggregateActiveQuery
+        resetData?: boolean
+      }>,
+    ) => {
       state.aggregate.loading = true
       state.aggregate.error = ''
-      state.aggregate.hasResult = false
-      state.aggregate.result = null
+      // Record the query so the header refresh can replay it. On a header
+      // refresh (`resetData: false`) keep the previous result/`hasResult`
+      // on screen so the recompute swaps in place without a loader flash;
+      // a fresh run clears them first.
+      state.aggregate.query = payload.query
+      if (payload.resetData !== false) {
+        state.aggregate.hasResult = false
+        state.aggregate.result = null
+      }
     },
     loadArrayAggregateSuccess: (
       state,
@@ -394,7 +411,17 @@ export function aggregateArray(params: FetchArrayAggregateParams) {
     const controller = new AbortController()
     arrayAggregateController = controller
 
-    dispatch(loadArrayAggregate())
+    dispatch(
+      loadArrayAggregate({
+        query: {
+          start: params.start,
+          end: params.end,
+          operation: params.operation,
+          ...(params.value !== undefined ? { value: params.value } : {}),
+        },
+        resetData: params.resetData,
+      }),
+    )
     try {
       const state = stateInit()
       const { data, status } = await apiService.post<AggregateArrayResponse>(
@@ -437,7 +464,8 @@ export function aggregateArray(params: FetchArrayAggregateParams) {
  */
 export function refreshArray(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    const { start, end, showEmpty } = stateInit().browser.array.query
+    const { query, aggregate } = stateInit().browser.array
+    const { start, end, showEmpty } = query
 
     dispatch(fetchArrayLength(key))
     dispatch(fetchArrayCount(key))
@@ -446,6 +474,16 @@ export function refreshArray(key: RedisString) {
       dispatch(fetchArrayRange({ key, start, end, resetData: false }))
     } else {
       dispatch(scanArrayRange({ key, start, end, resetData: false }))
+    }
+
+    // Replay the last AROP so the Aggregate tab's result reflects the
+    // array's current contents instead of a value computed before the
+    // refresh. `resetData: false` keeps the existing value on screen while
+    // the recompute is in flight (no loader flash), mirroring the
+    // range/scan replay above. Only runs once an aggregate has actually
+    // been computed for this key (`hasResult` + a stored query).
+    if (aggregate.hasResult && aggregate.query) {
+      dispatch(aggregateArray({ key, ...aggregate.query, resetData: false }))
     }
   }
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import axios, { AxiosError } from 'axios'
 import { IAddInstanceErrorPayload } from 'uiSrc/slices/app/notifications'
 import {
+  AggregateArrayResponse,
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,
@@ -21,6 +22,7 @@ import {
   ArrayActiveQuery,
   ArrayDataElement,
   StateArray,
+  FetchArrayAggregateParams,
   FetchArrayRangeParams,
   FetchArrayScanParams,
 } from 'uiSrc/slices/interfaces/array'
@@ -60,6 +62,11 @@ export const initialState: StateArray = {
     length: '0',
     count: '0',
     elements: [],
+  },
+  aggregate: {
+    loading: false,
+    error: '',
+    result: '',
   },
 }
 
@@ -161,6 +168,26 @@ const arraySlice = createSlice({
     ) => {
       state.query = payload
     },
+
+    loadArrayAggregate: (state) => {
+      state.aggregate.loading = true
+      state.aggregate.error = ''
+    },
+    loadArrayAggregateSuccess: (
+      state,
+      { payload }: PayloadAction<AggregateArrayResponse>,
+    ) => {
+      state.aggregate.loading = false
+      state.aggregate.error = ''
+      state.aggregate.result = payload.result
+    },
+    loadArrayAggregateFailure: (state, { payload }: PayloadAction<string>) => {
+      state.aggregate.loading = false
+      state.aggregate.error = payload
+    },
+    clearArrayAggregate: (state) => {
+      state.aggregate = { ...initialState.aggregate }
+    },
   },
 })
 
@@ -173,10 +200,16 @@ export const {
   loadArrayLengthSuccess,
   loadArrayCountSuccess,
   setArrayActiveQuery,
+  loadArrayAggregate,
+  loadArrayAggregateSuccess,
+  loadArrayAggregateFailure,
+  clearArrayAggregate,
 } = arraySlice.actions
 
 export const arraySelector = (state: RootState) => state.browser.array
 export const arrayDataSelector = (state: RootState) => state.browser.array?.data
+export const arrayAggregateSelector = (state: RootState) =>
+  state.browser.array?.aggregate
 
 export default arraySlice.reducer
 
@@ -333,6 +366,59 @@ export function fetchArrayCount(key: RedisString) {
       if (isStatusSuccessful(status)) dispatch(loadArrayCountSuccess(data))
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+    }
+  }
+}
+
+/**
+ * Dedicated controller for AROP so an in-flight aggregate isn't aborted by
+ * a concurrent range/scan in the View tab (which uses
+ * `arrayRangeController`). A newer aggregate dispatch still aborts the
+ * previous one so stale results don't land on top of a fresh request.
+ */
+let arrayAggregateController: AbortController | null = null
+
+export const abortArrayAggregate = (): void => {
+  arrayAggregateController?.abort()
+  arrayAggregateController = null
+}
+
+// AROP — aggregate elements over a range.
+export function aggregateArray(params: FetchArrayAggregateParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    arrayAggregateController?.abort()
+    const controller = new AbortController()
+    arrayAggregateController = controller
+
+    dispatch(loadArrayAggregate())
+    try {
+      const state = stateInit()
+      const { data, status } = await apiService.post<AggregateArrayResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_AGGREGATE),
+        {
+          keyName: params.key,
+          start: params.start,
+          end: params.end,
+          operation: params.operation,
+          ...(params.value !== undefined ? { value: params.value } : {}),
+        },
+        { ...encodingParams(state), signal: controller.signal },
+      )
+      if (controller.signal.aborted) return
+      if (isStatusSuccessful(status)) {
+        dispatch(loadArrayAggregateSuccess(data))
+      } else {
+        dispatch(loadArrayAggregateFailure(DEFAULT_ERROR_MESSAGE))
+      }
+    } catch (error) {
+      if (axios.isCancel(error)) return
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadArrayAggregateFailure(errorMessage))
+    } finally {
+      if (arrayAggregateController === controller) {
+        arrayAggregateController = null
+      }
     }
   }
 }

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -68,13 +68,17 @@ export interface ArrayActiveQuery {
 /**
  * Aggregate (AROP) result slice. Held alongside the range/scan data so the
  * Aggregate tab can keep its last result visible while the View tab updates
- * independently. `result` is the BE-returned decimal string (or empty when
- * no aggregation has run yet for the current key).
+ * independently. `result` mirrors the BE response (`string | null`): a
+ * decimal/integer string for a value reply, or `null` for a nil reply (e.g.
+ * SUM over a range with no numeric values). `hasResult` distinguishes
+ * "pristine — no AROP has run yet" from "ran and got nil"; both shapes
+ * present `result: null`.
  */
 export interface ArrayAggregateState {
   loading: boolean
   error: string
-  result: string
+  result: string | null
+  hasResult: boolean
 }
 
 export interface StateArray {

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -74,11 +74,27 @@ export interface ArrayActiveQuery {
  * "pristine — no AROP has run yet" from "ran and got nil"; both shapes
  * present `result: null`.
  */
+/**
+ * Last AROP query the user executed. Tracked on the slice (mirroring
+ * `ArrayActiveQuery`) so the key-header refresh button can replay it and
+ * keep the displayed aggregate in sync with the array's current contents
+ * — without it, refresh would update length/count but leave a stale
+ * aggregate result on screen. `null` until the first run.
+ */
+export interface ArrayAggregateActiveQuery {
+  start: string
+  end: string
+  operation: ArrayAggregateOperation
+  /** Present only when `operation === Match`. */
+  value?: string
+}
+
 export interface ArrayAggregateState {
   loading: boolean
   error: string
   result: string | null
   hasResult: boolean
+  query: ArrayAggregateActiveQuery | null
 }
 
 export interface StateArray {
@@ -110,6 +126,12 @@ export interface FetchArrayAggregateParams {
   operation: ArrayAggregateOperation
   /** Required when `operation === Match`; ignored otherwise. */
   value?: string
+  /**
+   * When `false` (header refresh replay), keeps the last result/`hasResult`
+   * visible while the recompute is in flight so the panel doesn't flash a
+   * loader. Defaults to a fresh run that clears the previous result.
+   */
+  resetData?: boolean
 }
 
 /**

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -1,10 +1,28 @@
 import {
+  AggregateArrayDto,
+  AggregateArrayResponse,
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,
   GetArrayScanResponse,
 } from 'apiClient'
 import { RedisString } from 'uiSrc/slices/interfaces/app'
+
+/**
+ * Mirror of the backend `ArrayAggregateOperation` enum (BE
+ * `dto/aggregate.array.dto.ts`). Kept as a TS enum so the UI form / select
+ * can reference named members instead of bare strings.
+ */
+export enum ArrayAggregateOperation {
+  Sum = 'SUM',
+  Min = 'MIN',
+  Max = 'MAX',
+  And = 'AND',
+  Or = 'OR',
+  Xor = 'XOR',
+  Match = 'MATCH',
+  Used = 'USED',
+}
 
 /**
  * Redis array indexes are unsigned 64-bit integers (0 … 2^64-1) and exceed
@@ -47,11 +65,24 @@ export interface ArrayActiveQuery {
   showEmpty: boolean
 }
 
+/**
+ * Aggregate (AROP) result slice. Held alongside the range/scan data so the
+ * Aggregate tab can keep its last result visible while the View tab updates
+ * independently. `result` is the BE-returned decimal string (or empty when
+ * no aggregation has run yet for the current key).
+ */
+export interface ArrayAggregateState {
+  loading: boolean
+  error: string
+  result: string
+}
+
 export interface StateArray {
   loading: boolean
   error: string
   query: ArrayActiveQuery
   data: ArrayData
+  aggregate: ArrayAggregateState
 }
 
 export interface FetchArrayRangeParams {
@@ -68,12 +99,23 @@ export interface FetchArrayScanParams {
   resetData?: boolean
 }
 
+export interface FetchArrayAggregateParams {
+  key: RedisString
+  start: string
+  end: string
+  operation: ArrayAggregateOperation
+  /** Required when `operation === Match`; ignored otherwise. */
+  value?: string
+}
+
 /**
  * Re-export the auto-generated SDK response shapes for consumers that need
  * to pass them around. The slice itself narrows them into `ArrayData` /
  * `ArrayDataElement` for storage.
  */
 export type {
+  AggregateArrayDto,
+  AggregateArrayResponse,
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -32,6 +32,7 @@ import reducer, {
 } from '../../browser/array'
 import { updateSelectedKeyRefreshTime } from '../../browser/keys'
 import { addErrorNotification } from '../../app/notifications'
+import { ArrayAggregateOperation } from '../../interfaces/array'
 
 jest.mock('uiSrc/services', () => ({
   ...jest.requireActual('uiSrc/services'),
@@ -459,6 +460,60 @@ describe('array slice', () => {
         expect(
           (apiService.post as jest.Mock).mock.calls.find(([url]) =>
             url.includes('array/get-range'),
+          ),
+        ).toBeUndefined()
+      })
+
+      it('replays the last AROP (recompute) when an aggregate result exists', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: {
+              ...initialState,
+              aggregate: {
+                ...initialState.aggregate,
+                hasResult: true,
+                result: '42',
+                query: {
+                  start: '5',
+                  end: '15',
+                  operation: ArrayAggregateOperation.Match,
+                  value: 'needle',
+                },
+              },
+            },
+          },
+        })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        const aggregateCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/aggregate'),
+        )
+        expect(aggregateCall?.[1]).toEqual({
+          keyName: mockKey,
+          start: '5',
+          end: '15',
+          operation: ArrayAggregateOperation.Match,
+          value: 'needle',
+        })
+      })
+
+      it('does not replay AROP when no aggregate has been run', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = storeWithQuery({ start: '0', end: '9', showEmpty: true })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/aggregate'),
           ),
         ).toBeUndefined()
       })


### PR DESCRIPTION
# What

Adds the **Aggregate** tab to the Array key details view, exposing the `POST /array/aggregate` (`AROP`) endpoint to the UI. Users can pick a range, an operation, and run aggregations from the key view.

**Form:**
- `start` / `end` index inputs (u64-safe strings, client-side validation against the 1 000 000-element span cap)
- Operation select: `SUM`, `MIN`, `MAX`, `AND`, `OR`, `XOR`, `MATCH`, `USED`
- `value` field is shown and required only when `MATCH` is selected
- **Run** / **Reset** controls; result is copyable

# Screenshots

| Dark    | Light |
| -------- | ------- |
| <img width="1048" height="499" alt="Screenshot 2026-06-18 at 12 54 24" src="https://github.com/user-attachments/assets/1e611c75-96dd-4aca-9714-876f5461b0d1" /> | <img width="1048" height="499" alt="Screenshot 2026-06-18 at 12 53 39" src="https://github.com/user-attachments/assets/b3fad91c-5539-4c51-9a31-a168dfa5080d" />  |
| <img width="1048" height="499" alt="Screenshot 2026-06-18 at 12 54 55" src="https://github.com/user-attachments/assets/ff836306-e239-4468-b720-cfb2f42edc33" /> | <img width="1048" height="499" alt="Screenshot 2026-06-18 at 12 54 45" src="https://github.com/user-attachments/assets/b63b8865-e720-46bb-a1bb-cdd3c8b85518" />     |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Browser-only feature on a new aggregate code path, isolated from range/scan via separate abort controller and slice; extensive unit tests cover validation, refresh replay, and edge cases.
> 
> **Overview**
> Replaces the Array key **Aggregate** tab placeholder with a full **AROP** (`POST array/aggregate`) workflow: range + operation form, result panel, and Redux wiring separate from the View tab’s range/scan state.
> 
> **UI:** `ArrayAggregateForm` mirrors the View tab’s range form (index validation, 1M span cap, optional MATCH value, command preview, Run/Reset). `AggregateTab` shows loading/errors, displays results as raw strings (BigInt-safe) or `(nil)`, and hides stale state while the selected key is not ready.
> 
> **State:** New `browser.array.aggregate` slice + `aggregateArray` thunk with its own `AbortController` (so View range/scan does not cancel AROP). `refreshArray` replays the last aggregate when `hasResult` is set, using `resetData: false` to avoid loader flash on header refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec32d36f280e22802b4260ec14ad464ef4a89271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->