### PR TITLE
docs(skills): add comments rule to code-quality skill

### DIFF
--- a/.ai/skills/code-quality/SKILL.md
+++ b/.ai/skills/code-quality/SKILL.md
@@ -58,6 +58,44 @@ The UI workspace must not import from the backend codebase directly. Use `apiCli
 - **Constants**: `UPPER_SNAKE_CASE` - `MAX_RETRY_ATTEMPTS`
 - **Booleans**: Use `is/has/should` prefix - `isLoading`, `hasError`
 
+## Comments
+
+**Default to fewer comments.** Clear names, small functions, and good
+tests should carry the meaning. Write a comment only when the code
+genuinely can't explain itself — or when the user explicitly asks for
+more (for example, on a piece of complex logic).
+
+When you do write one, keep it short and use plain words to say
+**what** the code is doing or **why** it has to exist — not how it
+works under the hood, and not the story of why you made the change
+(that belongs in the commit message or PR description).
+
+✅ **Good** — plain, names the situation:
+
+```ts
+// When switching keys, hide the previous key's loader/error/result
+// until the new key is ready.
+const showLoader = isArrayKeyReady && loading
+```
+
+❌ **Avoid** — long, mechanism-heavy, re-derives what the code shows:
+
+```ts
+// Gate every aggregate-slice surface (loader, error, result) on
+// `isArrayKeyReady`: when the user switches keys, `keyProp` flips
+// immediately but `selectedKeyData` lags by a round-trip, so the
+// prior key's slice state would otherwise paint under the newly
+// selected (or empty) key for one frame before the hook's reset
+// effect fires.
+const showLoader = isArrayKeyReady && loading
+```
+
+Also avoid:
+
+- Restating identifier names in prose (`// set loading to true`).
+- Comments that duplicate what a clearly-named test already asserts.
+- Block comments that summarize obvious blocks (`// loop over items`).
+
 ## SonarJS Rules
 
 - Keep cognitive complexity low (refactor complex functions)
@@ -101,4 +139,5 @@ When updating npm packages (especially `@redis-ui/*` packages):
 - [ ] Descriptive variable names
 - [ ] Low cognitive complexity
 - [ ] No duplicate code
+- [ ] Comments kept to a minimum; any present are short and plain-language
 - [ ] Vite cache cleared (if updated dependencies)


### PR DESCRIPTION
# What

The rule, in short:

- **Default to fewer comments.** Clear names, small functions, and
  good tests should carry the meaning.
- Write a comment only when the code genuinely can't explain itself,
  or when the user explicitly asks for more (e.g. complex logic).
- When you do write one, keep it short, in plain words, and focused
  on *what* / *why* — not *how*, and not the story of the change
  (that belongs in the commit message or PR description).

# Motivation

Personal preference, but one worth writing down: comments are often a
code smell. They signal that something isn't clear enough from the
code itself, and an extra mechanism is needed to explain it. There's
a lot of material on this already — the goal here isn't to re-litigate
the debate, it's to be explicit about how *this* codebase treats them.

We do have comments today, and we'll keep adding them where they earn
their keep. The rule just restricts the broad, reflexive usage and
sets a shape for the ones that do stay: short, plain words, focused
on **what** the code does or **why** it has to exist — not **how** it
works, and not the story of the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent skills; no application or runtime behavior is affected.
> 
> **Overview**
> Documents **comment policy** in the `code-quality` agent skill so AI assistants and contributors follow the same bar.
> 
> The new **Comments** section says to default to fewer comments, use them only when code or tests can't carry the meaning (or when explicitly requested), and keep any comment short and focused on **what/why**—not implementation detail or change history. It includes good vs bad TypeScript examples and a short list of anti-patterns (restating names, duplicating tests, obvious block summaries).
> 
> The **Pre-Commit Checklist** gains an item to keep comments minimal and plain-language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539143aa42656d16e5d89c73d7563e4222b51500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->