### PR TITLE
fix(ci): prevent command injection in nightly virustotal workflow

### DIFF
--- a/.github/workflows/nightly-virustotal-analyze.yml
+++ b/.github/workflows/nightly-virustotal-analyze.yml
@@ -34,9 +34,12 @@ jobs:
     steps:
       - name: Determine mode and files
         id: setup_matrix
+        env:
+          MODE: ${{ github.event.inputs.mode }}
+          FILE_URL: ${{ github.event.inputs.file_url }}
         run: |
-          mode="${{ github.event.inputs.mode }}"
-          file_url="${{ github.event.inputs.file_url }}"
+          mode="$MODE"
+          file_url="$FILE_URL"
 
           if [ "$mode" == "single" ] && [ -z "$file_url" ]; then
             echo "Error: For 'single' mode, a file URL must be provided."
@@ -61,18 +64,22 @@ jobs:
 
     steps:
       - name: Download file
+        env:
+          FILE: ${{ matrix.file }}
         run: |
-          echo "Downloading: ${{ matrix.file }}"
-          curl -sLo file_to_analyze "${{ matrix.file }}"
+          echo "Downloading: $FILE"
+          curl -sLo file_to_analyze "$FILE"
 
       - name: Get upload URL
         id: get_upload_url
+        env:
+          FILE: ${{ matrix.file }}
         run: |
           upload_url=$(curl -sq -XGET https://www.virustotal.com/api/v3/files/upload_url \
             -H "x-apikey: $VIRUSTOTAL_API_KEY" | jq -r '.data')
 
           if [ -z "$upload_url" ] || [ "$upload_url" == "null" ]; then
-            echo "Failed to retrieve upload URL for ${{ matrix.file }}"
+            echo "Failed to retrieve upload URL for $FILE"
             exit 1
           fi
 
@@ -80,6 +87,8 @@ jobs:
 
       - name: Upload file to VirusTotal
         id: upload_file
+        env:
+          FILE: ${{ matrix.file }}
         run: |
           upload_url="${{ env.UPLOAD_URL }}"
           analyzed_id=$(curl -sq -XPOST "$upload_url" \
@@ -87,13 +96,15 @@ jobs:
             --form "file=@file_to_analyze" | jq -r '.data.id')
 
           if [ -z "$analyzed_id" ] || [ "$analyzed_id" == "null" ]; then
-            echo "Failed to upload file: ${{ matrix.file }}"
+            echo "Failed to upload file: $FILE"
             exit 1
           fi
 
           echo "ANALYZED_ID=$analyzed_id" >> $GITHUB_ENV
 
       - name: Check analyze status
+        env:
+          FILE: ${{ matrix.file }}
         run: |
           analyzed_id="${{ env.ANALYZED_ID }}"
           retry_attempts=50
@@ -113,11 +124,13 @@ jobs:
           done
 
           if [ "$analyze_status" != "completed" ]; then
-            echo "Analysis not completed for ${{ matrix.file }}"
+            echo "Analysis not completed for $FILE"
             exit 1
           fi
 
       - name: Validate analyze
+        env:
+          FILE: ${{ matrix.file }}
         run: |
           analyzed_id="${{ env.ANALYZED_ID }}"
           analysis=$(curl -sq -XGET "https://www.virustotal.com/api/v3/analyses/${analyzed_id}" \
@@ -130,10 +143,10 @@ jobs:
           suspicious=$(echo "$analyze_stats" | jq '.suspicious')
           harmless=$(echo "$analyze_stats" | jq '.harmless')
 
-          echo "Results for ${{ matrix.file }}: Malicious: $malicious, Suspicious: $suspicious, Harmless: $harmless"
+          echo "Results for $FILE: Malicious: $malicious, Suspicious: $suspicious, Harmless: $harmless"
 
           if [ "$malicious" != "0" ] || [ "$suspicious" != "0" ]; then
-            echo "File ${{ matrix.file }} is flagged as potentially harmful."
+            echo "File $FILE is flagged as potentially harmful."
             echo "$analysis" | jq -r '.data.attributes.results[] | select(.result == "malicious" or .result == "suspicious")'
             exit 1
           fi


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/nightly-virustotal-analyze.yml` against GitHub Actions **script injection**. User-controlled values were interpolated with `${{ ... }}` directly into `run:` shell scripts; they are now passed through step-level `env:` and referenced as quoted shell variables so the shell always treats them as **data, never code**.

- **Jira:** RED-195150
- **HackerOne:** #3696891

## The issue

`${{ ... }}` expressions are substituted **textually into the script before the shell parses it** — they are not shell variables. So a user-supplied value lands verbatim in the script body and is then re-parsed by bash.

In the `Determine mode and files` step the inputs were dropped straight into the script:

```yaml
run: |
  mode="${{ github.event.inputs.mode }}"
  file_url="${{ github.event.inputs.file_url }}"
```

A `mode` value such as:

```
all"; id; cat /etc/passwd #
```

renders as `mode="all"; id; cat /etc/passwd #"`, which closes the intended string and executes arbitrary commands on the runner (exfiltrating `secrets.VIRUSTOTAL_API_KEY`, the `GITHUB_TOKEN`, etc.).

The same class of issue applied to every `${{ matrix.file }}` reference inside `run:` blocks: in `single` mode `matrix.file` is the raw `file_url` **input** flowing through `needs.analyze.outputs.files`, so it is the same user-controlled value reaching the shell.

## Severity — hardening, not an externally-exploitable RCE

Please **do not over-state** this. The workflow's only triggers are:

- `workflow_dispatch` — requires **repo write access** to set the inputs, so the injection grants no new capability to an untrusted party (such an actor could already run code via the repo).
- `schedule` (nightly cron) — takes **no user input** (uses hardcoded `DEFAULT_FILES`).

There is **no `pull_request` / `pull_request_target` / `issue_comment` / `workflow_call`** trigger, so an anonymous/outside attacker cannot reach these inputs. Real-world severity is **Low** (defense-in-depth / hygiene), despite the high CVSS framing in the report. It's worth fixing because the fix is trivial, it removes the finding, and it pre-empts this becoming critical if a PR-style trigger is ever added later.

## The fix

Bind each user-controlled expression to a step `env:` and reference it as a quoted shell variable:

```yaml
- name: Determine mode and files
  id: setup_matrix
  env:
    MODE: ${{ github.event.inputs.mode }}
    FILE_URL: ${{ github.event.inputs.file_url }}
  run: |
    mode="$MODE"
    file_url="$FILE_URL"
```

`${{ }}` still expands, but only into the env value; inside `run:`, `"$MODE"` is expanded by bash **after** the script is parsed, so the value can never terminate a string or inject commands.

Applied to:

- `github.event.inputs.mode` / `file_url` → `env: MODE` / `FILE_URL` (the primary finding).
- Every `${{ matrix.file }}` reference (`Download file`, `Get upload URL`, `Upload file to VirusTotal`, `Check analyze status`, `Validate analyze`) → `env: FILE` referenced as `"$FILE"`.

Non-user-controlled expressions (`env.DEFAULT_FILES`, `env.UPLOAD_URL`, `env.ANALYZED_ID`) were intentionally left as-is to keep the diff minimal.

## Impact on users

**None.** The `workflow_dispatch` input form (names, descriptions, defaults, `required` flags) is unchanged, the nightly matrix is unchanged, and outputs are identical for every valid input. The only behavioral difference is a strict improvement: URLs containing shell-significant characters (`&`, `$`, spaces, …) now pass through intact instead of breaking. No logic changes, no migration, no doc updates.

## Verification

- `js-yaml` parse of the workflow: **OK**.
- Re-scanned `run:` bodies: no user-controlled `${{ github.event.* }}` or `${{ matrix.file }}` remains inside any script.
- Behavioral equivalence reviewed for both `all` and `single` modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only defense-in-depth with no product behavior change; triggers are workflow_dispatch (write access) and schedule (no user input), so external exploitability is limited.
> 
> **Overview**
> Hardens the nightly VirusTotal workflow against **GitHub Actions script injection** by stopping user-controlled values from being expanded directly inside `run:` shell bodies.
> 
> `workflow_dispatch` inputs `mode` and `file_url` now bind to step `env` (`MODE`, `FILE_URL`) and are read as quoted `"$MODE"` / `"$file_url"` in the setup step. Every `${{ matrix.file }}` use in matrix job scripts is likewise routed through `env: FILE` and `"$FILE"` (download, upload, polling, validation logs/errors).
> 
> Workflow behavior for valid inputs is unchanged; URLs with shell-special characters are handled more safely. Non-user-controlled `${{ }}` expressions were left as-is to keep the diff small.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4790ddb8350de07eda73515d7e412cc0038ed765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->