### PR TITLE
RI-8292 Add basic array Search tab (single predicate)

### DIFF
--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -82,6 +82,7 @@ enum ApiEndpoints {
   ARRAY_GET_LENGTH = 'array/get-length',
   ARRAY_GET_COUNT = 'array/get-count',
   ARRAY_AGGREGATE = 'array/aggregate',
+  ARRAY_SEARCH = 'array/search',
 
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',

--- a/redisinsight/ui/src/mocks/factories/browser/array/arrayGrepPredicate.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/browser/array/arrayGrepPredicate.factory.ts
@@ -1,0 +1,18 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import {
+  ArrayGrepCriteria,
+  ArrayGrepPredicate,
+} from 'uiSrc/slices/interfaces/array'
+
+/**
+ * `ArrayGrepPredicate` factory. Defaults to an EXACT match on a random word;
+ * override `criteria` / `value` per test (e.g. `.build({ criteria:
+ * ArrayGrepCriteria.Glob, value: 'a*' })`).
+ */
+export const arrayGrepPredicateFactory = Factory.define<ArrayGrepPredicate>(
+  () => ({
+    criteria: ArrayGrepCriteria.Exact,
+    value: faker.word.noun(),
+  }),
+)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.spec.tsx
@@ -21,6 +21,9 @@ jest.mock('./array-range-form', () => ({
 jest.mock('./array-aggregate-form', () => ({
   ArrayAggregateForm: stubChild('array-aggregate-form-mock'),
 }))
+jest.mock('./array-search-form', () => ({
+  ArraySearchForm: stubChild('array-search-form-mock'),
+}))
 jest.mock('uiSrc/pages/browser/modules', () => ({
   KeyDetailsHeader: stubChild('key-details-header-mock'),
 }))
@@ -55,6 +58,18 @@ jest.mock('./hooks', () => ({
     result: null,
     hasResult: false,
   }),
+  useArraySearchQuery: () => ({
+    criteria: 'EXACT',
+    value: '',
+    setCriteria: jest.fn(),
+    setValue: jest.fn(),
+    runSearch: jest.fn(),
+    isArrayKeyReady: true,
+    elements: [],
+    loading: false,
+    error: '',
+    loaded: false,
+  }),
 }))
 
 const mockedProps = mock<Props>()
@@ -74,7 +89,7 @@ describe('ArrayDetails', () => {
     render(<ArrayDetails {...instance(mockedProps)} />)
 
     expect(screen.getByTestId('array-range-form-mock')).toBeVisible()
-    expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-search-form-mock')).not.toBeVisible()
     expect(screen.getByTestId('array-aggregate-form-mock')).not.toBeVisible()
 
     fireEvent.mouseDown(
@@ -82,7 +97,7 @@ describe('ArrayDetails', () => {
     )
 
     expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
-    expect(screen.getByTestId('array-search-placeholder')).toBeVisible()
+    expect(screen.getByTestId('array-search-form-mock')).toBeVisible()
     expect(screen.getByTestId('array-aggregate-form-mock')).not.toBeVisible()
 
     fireEvent.mouseDown(
@@ -90,7 +105,7 @@ describe('ArrayDetails', () => {
     )
 
     expect(screen.getByTestId('array-range-form-mock')).not.toBeVisible()
-    expect(screen.getByTestId('array-search-placeholder')).not.toBeVisible()
+    expect(screen.getByTestId('array-search-form-mock')).not.toBeVisible()
     expect(screen.getByTestId('array-aggregate-form-mock')).toBeVisible()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -34,7 +34,7 @@ const ArrayDetails = (props: Props) => {
         <ViewTab keyProp={keyProp} />
       </S.TabSlot>
       <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Search}>
-        <SearchTab />
+        <SearchTab keyProp={keyProp} />
       </S.TabSlot>
       <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Aggregate}>
         <AggregateTab keyProp={keyProp} />

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-range-form/ArrayRangeForm.tsx
@@ -12,6 +12,7 @@ import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import { DEFAULT_SCAN_LIMIT } from 'uiSrc/slices/browser/array'
 
 import { CommandPreview } from '../command-preview'
+import { quoteRedisArgument } from '../utils'
 import {
   ARRAY_RANGE_FORM_TEST_ID as TEST_ID,
   ARRAY_RANGE_MAX_SPAN,
@@ -26,16 +27,6 @@ import {
 } from './ArrayRangeForm.constants'
 import { ArrayRangeFormProps } from './ArrayRangeForm.types'
 import * as S from './ArrayRangeForm.styles'
-
-// Wraps a Redis argument that may contain whitespace or quotes so the
-// preview text stays runnable when copied into CLI / Workbench. Mirrors
-// the same escaping rules the redis-cli parser applies to double-quoted
-// strings: backslash and double-quote get backslash-escaped.
-const quoteRedisArgument = (value: string): string => {
-  if (value.length === 0) return '""'
-  if (!/[\s"\\]/.test(value)) return value
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
-}
 
 /**
  * Range/scan query form for the array View tab. Lays out inputs above a

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.constants.ts
@@ -1,0 +1,26 @@
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+
+export const ARRAY_SEARCH_FORM_TEST_ID = 'array-search-form'
+
+export const CRITERIA_LABEL = 'Criteria'
+export const VALUE_LABEL = 'Value'
+export const VALUE_PLACEHOLDER = 'Value to match'
+export const RUN_BUTTON_LABEL = 'Run'
+
+export const PREVIEW_TOGGLE_LABEL = 'Show preview'
+export const PREVIEW_TOGGLE_ARIA_LABEL = 'Toggle command preview'
+export const PREVIEW_TOGGLE_SHOW_TOOLTIP =
+  'Show the Redis command that will run'
+export const PREVIEW_TOGGLE_HIDE_TOOLTIP = 'Hide the command preview'
+
+/** Criteria dropdown options, in ARGREP command-token order. */
+export const ARRAY_GREP_CRITERIA_OPTIONS: {
+  value: ArrayGrepCriteria
+  label: string
+  inputDisplay: string
+}[] = [
+  { value: ArrayGrepCriteria.Exact, label: 'Exact', inputDisplay: 'Exact' },
+  { value: ArrayGrepCriteria.Match, label: 'Match', inputDisplay: 'Match' },
+  { value: ArrayGrepCriteria.Glob, label: 'Glob', inputDisplay: 'Glob' },
+  { value: ArrayGrepCriteria.Re, label: 'Regex', inputDisplay: 'Regex' },
+]

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { fireEvent, render, screen, userEvent } from 'uiSrc/utils/test-utils'
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+
+import { ArraySearchForm } from './ArraySearchForm'
+import { ArraySearchFormProps } from './ArraySearchForm.types'
+import { ARRAY_SEARCH_FORM_TEST_ID as TEST_ID } from './ArraySearchForm.constants'
+
+const defaultProps: ArraySearchFormProps = {
+  criteria: ArrayGrepCriteria.Exact,
+  value: 'redis',
+  loading: false,
+  onChangeCriteria: jest.fn(),
+  onChangeValue: jest.fn(),
+  onRun: jest.fn(),
+}
+
+const renderComponent = (props: Partial<ArraySearchFormProps> = {}) =>
+  render(<ArraySearchForm {...defaultProps} {...props} />)
+
+// CommandPreview is shared with the View tab, so its internal test ids keep
+// the `array-range-form` prefix until it moves to a shared location.
+const PREVIEW_TEXT_TESTID = 'array-range-form-command-preview-text'
+const PREVIEW_TOGGLE_TESTID = `${TEST_ID}-preview-toggle`
+const RUN_TESTID = `${TEST_ID}-run`
+const VALUE_TESTID = `${TEST_ID}-value`
+const CRITERIA_TESTID = `${TEST_ID}-criteria`
+
+describe('ArraySearchForm', () => {
+  it('hides the command preview by default', () => {
+    renderComponent()
+
+    expect(screen.queryByTestId(PREVIEW_TEXT_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('reveals the ARGREP preview (whole-array bounds + WITHVALUES) when toggled', () => {
+    // Preview mirrors the command the backend builds from the request the
+    // thunk sends: whole-array bounds (`- +`) and the default WITHVALUES.
+    renderComponent({ keyName: 'readings' })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      'ARGREP readings - + EXACT redis WITHVALUES LIMIT 1000000',
+    )
+  })
+
+  it('reflects the selected criteria token in the preview', () => {
+    renderComponent({
+      keyName: 'readings',
+      criteria: ArrayGrepCriteria.Glob,
+      value: 'a*',
+    })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      'ARGREP readings - + GLOB a* WITHVALUES LIMIT 1000000',
+    )
+  })
+
+  it('quotes and escapes values with whitespace/quotes in the preview', () => {
+    renderComponent({ keyName: 'k', value: 'a "b"' })
+
+    fireEvent.click(screen.getByTestId(PREVIEW_TOGGLE_TESTID))
+
+    expect(screen.getByTestId(PREVIEW_TEXT_TESTID)).toHaveTextContent(
+      'ARGREP k - + EXACT "a \\"b\\"" WITHVALUES LIMIT 1000000',
+    )
+  })
+
+  it('calls onChangeValue when the value input changes', () => {
+    const onChangeValue = jest.fn()
+    renderComponent({ onChangeValue })
+
+    fireEvent.change(screen.getByTestId(VALUE_TESTID), {
+      target: { value: 'abc' },
+    })
+
+    expect(onChangeValue).toHaveBeenCalledWith('abc')
+  })
+
+  it('calls onChangeCriteria when a criteria option is picked', async () => {
+    const onChangeCriteria = jest.fn()
+    renderComponent({ onChangeCriteria })
+
+    await userEvent.click(screen.getByTestId(CRITERIA_TESTID))
+    await userEvent.click(await screen.findByText('Glob'))
+
+    expect(onChangeCriteria).toHaveBeenCalledWith(ArrayGrepCriteria.Glob)
+  })
+
+  it('calls onRun when Run is clicked with a non-empty value', () => {
+    const onRun = jest.fn()
+    renderComponent({ onRun })
+
+    fireEvent.click(screen.getByTestId(RUN_TESTID))
+
+    expect(onRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps Run enabled with an empty value — EXACT "" is a valid array search', () => {
+    renderComponent({ value: '' })
+
+    expect(screen.getByTestId(RUN_TESTID)).not.toBeDisabled()
+  })
+
+  it('disables Run while loading', () => {
+    renderComponent({ loading: true })
+
+    expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+  })
+
+  it('disables Run and the value input when the disabled prop is set', () => {
+    renderComponent({ disabled: true })
+
+    expect(screen.getByTestId(RUN_TESTID)).toBeDisabled()
+    expect(screen.getByTestId(VALUE_TESTID)).toBeDisabled()
+  })
+
+  it('runs the search when Enter is pressed in the value input', () => {
+    const onRun = jest.fn()
+    renderComponent({ onRun })
+
+    fireEvent.keyDown(screen.getByTestId(VALUE_TESTID), { key: 'Enter' })
+
+    expect(onRun).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([{ loading: true }, { disabled: true }])(
+    'ignores Enter in the value input when %p',
+    (props) => {
+      const onRun = jest.fn()
+      renderComponent({ onRun, ...props })
+
+      fireEvent.keyDown(screen.getByTestId(VALUE_TESTID), { key: 'Enter' })
+
+      expect(onRun).not.toHaveBeenCalled()
+    },
+  )
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.styles.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+import { ToggleButton } from 'uiSrc/components/base/forms/buttons'
+import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+
+/**
+ * Height of the action row, sized to fit the expanded `CommandPreview` bar
+ * so toggling the preview on/off doesn't reflow the surrounding layout.
+ * Matches `ArrayRangeForm`'s ACTION_ROW_HEIGHT so the two tabs feel like
+ * siblings.
+ */
+const ACTION_ROW_HEIGHT = '40px'
+
+export const FormContainer = styled(Col)`
+  width: 100%;
+  padding: ${({ theme }) => theme.core.space.space150};
+  background: ${({ theme }) => theme.semantic.color.background.neutral300};
+  border-bottom: 1px solid
+    ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
+export const ActionRow = styled(Row)`
+  min-height: ${ACTION_ROW_HEIGHT};
+`
+
+/**
+ * Fixed minimum width so the action row doesn't reflow when the selected
+ * criteria label changes width (Exact / Match / Glob / Regex).
+ */
+export const CriteriaSelect = styled(RiSelect)`
+  min-width: 85px;
+`
+
+export const PreviewToggleButton = styled(ToggleButton)`
+  ${({ theme, pressed }) =>
+    !pressed && `border-color: ${theme.semantic.color.border.neutral600};`}
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { PrimaryButton } from 'uiSrc/components/base/forms/buttons'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { RiIcon } from 'uiSrc/components/base/icons'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Text } from 'uiSrc/components/base/text'
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+import { DEFAULT_SEARCH_LIMIT } from 'uiSrc/slices/browser/array'
+
+import { CommandPreview } from '../command-preview'
+import { quoteRedisArgument } from '../utils'
+import {
+  ARRAY_GREP_CRITERIA_OPTIONS,
+  ARRAY_SEARCH_FORM_TEST_ID as TEST_ID,
+  CRITERIA_LABEL,
+  PREVIEW_TOGGLE_ARIA_LABEL,
+  PREVIEW_TOGGLE_HIDE_TOOLTIP,
+  PREVIEW_TOGGLE_LABEL,
+  PREVIEW_TOGGLE_SHOW_TOOLTIP,
+  RUN_BUTTON_LABEL,
+  VALUE_LABEL,
+  VALUE_PLACEHOLDER,
+} from './ArraySearchForm.constants'
+import { ArraySearchFormProps } from './ArraySearchForm.types'
+import * as S from './ArraySearchForm.styles'
+
+/**
+ * Single-predicate ARGREP search form for the array Search tab. Lays out a
+ * criteria dropdown and a value input above a single action row containing a
+ * toggleable command preview and the primary Run button — matching the View
+ * tab's `ArrayRangeForm` so the two verticals feel like siblings.
+ */
+export const ArraySearchForm = ({
+  keyName,
+  criteria,
+  value,
+  loading,
+  onChangeCriteria,
+  onChangeValue,
+  onRun,
+  disabled = false,
+}: ArraySearchFormProps) => {
+  const [previewVisible, setPreviewVisible] = useState(false)
+
+  const command = useMemo(() => {
+    // Mirror the command the backend builds from what the thunk sends:
+    // whole-array bounds (`- +`), the default WITHVALUES, and the safety
+    // LIMIT. Quote the key and value so binary-unsafe content stays runnable
+    // when copied out.
+    const name = keyName ? quoteRedisArgument(keyName) : '<key>'
+    return `ARGREP ${name} - + ${criteria} ${quoteRedisArgument(value)} WITHVALUES LIMIT ${DEFAULT_SEARCH_LIMIT}`
+  }, [keyName, criteria, value])
+
+  const previewTooltip = previewVisible
+    ? PREVIEW_TOGGLE_HIDE_TOOLTIP
+    : PREVIEW_TOGGLE_SHOW_TOOLTIP
+
+  return (
+    <S.FormContainer data-testid={TEST_ID} gap="m" grow={false}>
+      <Row align="end" gap="m">
+        <FlexItem grow={false}>
+          <FormField label={CRITERIA_LABEL}>
+            <S.CriteriaSelect
+              value={criteria}
+              options={ARRAY_GREP_CRITERIA_OPTIONS}
+              onChange={(next: string) =>
+                onChangeCriteria(next as ArrayGrepCriteria)
+              }
+              disabled={disabled}
+              data-testid={`${TEST_ID}-criteria`}
+            />
+          </FormField>
+        </FlexItem>
+        <FlexItem grow>
+          <FormField label={VALUE_LABEL}>
+            <TextInput
+              value={value}
+              onChange={onChangeValue}
+              // Enter mirrors the Run button so the single-field form works
+              // as a search box; gated on the same conditions as Run.
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !loading && !disabled) onRun()
+              }}
+              placeholder={VALUE_PLACEHOLDER}
+              disabled={disabled}
+              data-testid={`${TEST_ID}-value`}
+            />
+          </FormField>
+        </FlexItem>
+      </Row>
+
+      <S.ActionRow align="center" gap="m">
+        <FlexItem grow={false}>
+          <RiTooltip content={previewTooltip} position="top">
+            <S.PreviewToggleButton
+              pressed={previewVisible}
+              onPressedChange={setPreviewVisible}
+              aria-label={PREVIEW_TOGGLE_ARIA_LABEL}
+              data-testid={`${TEST_ID}-preview-toggle`}
+            >
+              <RiIcon size="m" type="CliIcon" />
+              <Text size="s">{PREVIEW_TOGGLE_LABEL}</Text>
+            </S.PreviewToggleButton>
+          </RiTooltip>
+        </FlexItem>
+        <FlexItem grow>
+          {previewVisible && <CommandPreview command={command} />}
+        </FlexItem>
+        <FlexItem grow={false}>
+          <PrimaryButton
+            onClick={() => onRun()}
+            disabled={loading || disabled}
+            data-testid={`${TEST_ID}-run`}
+          >
+            {RUN_BUTTON_LABEL}
+          </PrimaryButton>
+        </FlexItem>
+      </S.ActionRow>
+    </S.FormContainer>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.types.ts
@@ -1,0 +1,23 @@
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+
+export interface ArraySearchFormProps {
+  /**
+   * Key name rendered in the preview command. Optional so the form can be
+   * rendered in isolation (tests, Storybook); in the live composition the
+   * container always passes the selected key.
+   */
+  keyName?: string
+  criteria: ArrayGrepCriteria
+  value: string
+  loading: boolean
+  onChangeCriteria: (criteria: ArrayGrepCriteria) => void
+  onChangeValue: (value: string) => void
+  onRun: () => void
+  /**
+   * Disables the criteria / value inputs and the Run action. Container
+   * passes `true` while the selected key's confirmed type/name has not
+   * caught up with the clicked key yet, so a quick click cannot dispatch a
+   * search against a non-array key.
+   */
+  disabled?: boolean
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/index.ts
@@ -1,0 +1,2 @@
+export { ArraySearchForm } from './ArraySearchForm'
+export type { ArraySearchFormProps } from './ArraySearchForm.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -4,6 +4,8 @@
  * strings to preserve the BigInt-as-string contract (§8.1) — never numbers.
  */
 
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+
 /** Inclusive lower bound for the initial range query. */
 export const DEFAULT_RANGE_START = '0'
 
@@ -13,6 +15,9 @@ export const DEFAULT_RANGE_START = '0'
  * so the table comfortably fits without scrolling on first load.
  */
 export const DEFAULT_RANGE_END = '9'
+
+/** Criteria pre-selected when the Search tab opens. */
+export const DEFAULT_SEARCH_CRITERIA = ArrayGrepCriteria.Exact
 
 export enum ArrayDetailsTab {
   View = 'view',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useArrayRangeQuery } from './useArrayRangeQuery'
 export { useArrayAggregateQuery } from './useArrayAggregateQuery'
+export { useArraySearchQuery } from './useArraySearchQuery'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArraySearchQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArraySearchQuery.spec.tsx
@@ -1,0 +1,173 @@
+import { cloneDeep } from 'lodash'
+import {
+  act,
+  initialStateDefault,
+  mockStore,
+  renderHook,
+} from 'uiSrc/utils/test-utils'
+import { apiService } from 'uiSrc/services'
+import { KeyTypes } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+import { useArraySearchQuery } from './useArraySearchQuery'
+
+const KEY = 'readings'
+const keyBuffer = stringToBuffer(KEY)
+const otherKeyBuffer = stringToBuffer('other')
+
+const buildState = (
+  overrides: {
+    selectedKeyType?: KeyTypes
+    selectedKeyName?: ReturnType<typeof stringToBuffer> | null
+  } = {},
+) => {
+  const next = cloneDeep(initialStateDefault)
+  next.browser.array = cloneDeep(initialStateArray)
+  next.browser.keys.selectedKey.data = overrides.selectedKeyName
+    ? ({
+        type: overrides.selectedKeyType ?? KeyTypes.Array,
+        name: overrides.selectedKeyName,
+      } as any)
+    : null
+  return next
+}
+
+const renderWithStore = (
+  prop: ReturnType<typeof stringToBuffer> | null,
+  state = buildState({ selectedKeyName: keyBuffer }),
+) => {
+  const store = mockStore(state)
+  store.clearActions()
+  const view = renderHook((p) => useArraySearchQuery(p as typeof prop), {
+    store,
+    initialProps: prop,
+  } as any)
+  return { ...view, store }
+}
+
+describe('useArraySearchQuery', () => {
+  beforeEach(() => {
+    apiService.post = jest
+      .fn()
+      .mockResolvedValue({ status: 200, data: { keyName: KEY, elements: [] } })
+  })
+
+  it('initialises form defaults and isArrayKeyReady=true for a matching Array key', () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    expect(result.current.criteria).toBe(ArrayGrepCriteria.Exact)
+    expect(result.current.value).toBe('')
+    expect(result.current.isArrayKeyReady).toBe(true)
+  })
+
+  it('isArrayKeyReady=false until selectedKeyData catches up with keyProp', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('isArrayKeyReady=false when the selected key type is not Array', () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({
+        selectedKeyName: keyBuffer,
+        selectedKeyType: KeyTypes.String,
+      }),
+    )
+
+    expect(result.current.isArrayKeyReady).toBe(false)
+  })
+
+  it('does not auto-fire a search on first render (search is user-initiated)', () => {
+    renderWithStore(keyBuffer)
+
+    expect(
+      (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+        url.includes('array/search'),
+      ),
+    ).toBeUndefined()
+  })
+
+  it('runSearch posts a single predicate from the current criteria + value', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setCriteria(ArrayGrepCriteria.Glob)
+      result.current.setValue('redis*')
+    })
+
+    await act(async () => {
+      result.current.runSearch()
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/search'),
+    )
+    expect(call?.[1]).toEqual({
+      keyName: keyBuffer,
+      predicates: [{ criteria: ArrayGrepCriteria.Glob, value: 'redis*' }],
+      limit: 1_000_000,
+    })
+  })
+
+  it('runSearch is a no-op while isArrayKeyReady=false', async () => {
+    const { result } = renderWithStore(
+      keyBuffer,
+      buildState({ selectedKeyName: null }),
+    )
+
+    act(() => {
+      result.current.setValue('redis')
+    })
+    await act(async () => {
+      result.current.runSearch()
+    })
+
+    expect(
+      (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+        url.includes('array/search'),
+      ),
+    ).toBeUndefined()
+  })
+
+  it('runSearch posts an empty value verbatim — EXACT "" is a valid search', async () => {
+    const { result } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setValue('')
+    })
+    await act(async () => {
+      result.current.runSearch()
+    })
+
+    const call = (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+      url.includes('array/search'),
+    )
+    expect(call?.[1]).toEqual({
+      keyName: keyBuffer,
+      predicates: [{ criteria: ArrayGrepCriteria.Exact, value: '' }],
+      limit: 1_000_000,
+    })
+  })
+
+  it('resets the form when the selected key changes', () => {
+    const { result, rerender } = renderWithStore(keyBuffer)
+
+    act(() => {
+      result.current.setCriteria(ArrayGrepCriteria.Re)
+      result.current.setValue('stale')
+    })
+    expect(result.current.value).toBe('stale')
+
+    act(() => {
+      rerender(otherKeyBuffer)
+    })
+
+    expect(result.current.value).toBe('')
+    expect(result.current.criteria).toBe(ArrayGrepCriteria.Exact)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArraySearchQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArraySearchQuery.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import {
+  abortArraySearch,
+  arraySearchSelector,
+  resetArraySearch,
+  searchArray,
+} from 'uiSrc/slices/browser/array'
+import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
+import { isEqualBuffers } from 'uiSrc/utils'
+import { KeyTypes } from 'uiSrc/constants'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { ArrayGrepCriteria } from 'uiSrc/slices/interfaces/array'
+import { DEFAULT_SEARCH_CRITERIA } from '../constants'
+
+/**
+ * Owns the Search tab's single-predicate ARGREP form state — the match
+ * criteria and the value — and dispatches `searchArray` on demand.
+ *
+ * Unlike the View tab, search is user-initiated: nothing fires on key
+ * switch. Switching keys instead resets the form and clears the previous
+ * key's results so the tab never shows stale matches.
+ *
+ * Takes the raw `keyProp` buffer (threaded through `KeyDetails` →
+ * `DynamicTypeDetails`) rather than reading `selectedKeyData?.name` — the
+ * selector lags selection by one `fetchKeyInfo` round-trip.
+ */
+export const useArraySearchQuery = (keyProp: RedisResponseBuffer | null) => {
+  const dispatch = useAppDispatch()
+  const { loading, error, loaded, data } = useAppSelector(arraySearchSelector)
+  const selectedKeyData = useAppSelector(selectedKeyDataSelector)
+
+  const [criteria, setCriteria] = useState<ArrayGrepCriteria>(
+    DEFAULT_SEARCH_CRITERIA,
+  )
+  const [value, setValue] = useState<string>('')
+
+  // Gated exactly like the View tab so a quick click during a key switch
+  // can't fire ARGREP against a non-array key (which the API rejects with
+  // WrongType).
+  const isArrayKeyReady =
+    !!keyProp &&
+    selectedKeyData?.type === KeyTypes.Array &&
+    !!selectedKeyData?.name &&
+    isEqualBuffers(selectedKeyData.name, keyProp)
+
+  const runSearch = useCallback(() => {
+    if (!isArrayKeyReady || !keyProp) return
+    // Value is sent verbatim, including empty/whitespace — arrays can hold
+    // empty strings, so `EXACT ""` and space-bearing patterns are valid.
+    dispatch(searchArray({ key: keyProp, predicates: [{ criteria, value }] }))
+  }, [dispatch, isArrayKeyReady, keyProp, criteria, value])
+
+  // Reset the form and drop prior results whenever the selected key
+  // changes. Buffer-byte equality (via a ref) avoids refiring on a
+  // referentially fresh buffer for the same logical key.
+  const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
+  useEffect(() => {
+    if (!keyProp) return
+    if (lastKeyRef.current && isEqualBuffers(lastKeyRef.current, keyProp)) {
+      return
+    }
+    lastKeyRef.current = keyProp
+
+    abortArraySearch()
+    dispatch(resetArraySearch())
+    setCriteria(DEFAULT_SEARCH_CRITERIA)
+    setValue('')
+  }, [dispatch, keyProp])
+
+  // Cancel any in-flight search AND wipe the search sub-state on unmount so
+  // a later re-mount doesn't paint the previous key's matches for a frame.
+  useEffect(
+    () => () => {
+      abortArraySearch()
+      dispatch(resetArraySearch())
+    },
+    [dispatch],
+  )
+
+  return {
+    criteria,
+    value,
+    setCriteria,
+    setValue,
+    runSearch,
+    isArrayKeyReady,
+    elements: data,
+    loading,
+    error,
+    loaded,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { cloneDeep } from 'lodash'
+import {
+  initialStateDefault,
+  mockStore,
+  render,
+  screen,
+} from 'uiSrc/utils/test-utils'
+import { KeyTypes } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
+import { ArraySearchState } from 'uiSrc/slices/interfaces/array'
+import { arrayElementWithValueFactory } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
+import SearchTab from './SearchTab'
+
+const KEY = 'readings'
+const keyBuffer = stringToBuffer(KEY)
+
+const buildState = (
+  search: Partial<ArraySearchState> = {},
+  keyLoading = false,
+) => {
+  const next = cloneDeep(initialStateDefault)
+  next.browser.array = cloneDeep(initialStateArray)
+  next.browser.array.search = { ...next.browser.array.search, ...search }
+  next.browser.keys.selectedKey.loading = keyLoading
+  next.browser.keys.selectedKey.data = {
+    type: KeyTypes.Array,
+    name: keyBuffer,
+  } as any
+  return next
+}
+
+const renderTab = (search?: Partial<ArraySearchState>, keyLoading = false) => {
+  const store = mockStore(buildState(search, keyLoading))
+  store.clearActions()
+  return render(<SearchTab keyProp={keyBuffer} />, { store })
+}
+
+describe('SearchTab', () => {
+  it('renders the search form', () => {
+    renderTab()
+
+    expect(screen.getByTestId('array-search-form')).toBeInTheDocument()
+  })
+
+  it('does not render the results table before a search has run', () => {
+    renderTab({ loaded: false, loading: false, data: [] })
+
+    expect(screen.queryByTestId('array-details-table')).not.toBeInTheDocument()
+  })
+
+  it('hides the results table while the selected key is loading (no stale flash on key switch)', () => {
+    // Mirrors ViewTab: gate the table on the selected key not loading so a
+    // key switch can't paint the previous key's matches for a frame before
+    // the hook's reset effect runs.
+    renderTab(
+      {
+        loaded: true,
+        loading: false,
+        error: '',
+        data: [arrayElementWithValueFactory.build({ index: '7' })],
+      },
+      true,
+    )
+
+    expect(screen.queryByTestId('array-details-table')).not.toBeInTheDocument()
+  })
+
+  it('renders the matched index + value after a successful search', () => {
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    expect(screen.getByTestId('array-details-table')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('array-details-table-index-7'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('array-details-table-value-7'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a distinct error state when the search fails', () => {
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: 'Search failed',
+      data: [],
+    })
+
+    expect(screen.getByText('Search failed')).toBeInTheDocument()
+    // The error must read differently from the no-matches empty state.
+    expect(screen.queryByText('No elements in range')).not.toBeInTheDocument()
+  })
+
+  it('shows the empty state — distinct from an error — when a search finds no matches', () => {
+    renderTab({ loaded: true, loading: false, error: '', data: [] })
+
+    expect(screen.getByText('No elements in range')).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -1,13 +1,61 @@
 import React from 'react'
 
-import { Text } from 'uiSrc/components/base/text'
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { bufferToString } from 'uiSrc/utils'
 
+import { ArrayDetailsTable } from '../array-details-table'
+import { ArraySearchForm } from '../array-search-form'
+import { useArraySearchQuery } from '../hooks'
 import * as S from '../tabs.styles'
+import { SearchTabProps } from './SearchTab.types'
 
-const SearchTab = () => (
-  <S.TabPlaceholder data-testid="array-search-placeholder">
-    <Text>This is Search</Text>
-  </S.TabPlaceholder>
-)
+const SearchTab = ({ keyProp }: SearchTabProps) => {
+  const { loading: keyLoading } = useAppSelector(selectedKeySelector)
+  const keyName = keyProp ? bufferToString(keyProp) : ''
+
+  const {
+    criteria,
+    value,
+    setCriteria,
+    setValue,
+    runSearch,
+    isArrayKeyReady,
+    elements,
+    loading,
+    error,
+    loaded,
+  } = useArraySearchQuery(keyProp)
+
+  return (
+    <>
+      <ArraySearchForm
+        keyName={keyName}
+        criteria={criteria}
+        value={value}
+        loading={loading}
+        onChangeCriteria={setCriteria}
+        onChangeValue={setValue}
+        onRun={runSearch}
+        disabled={!isArrayKeyReady}
+      />
+      <S.TabBody>
+        {/* Keep the tab blank until the user runs a search, then let
+            ArrayDetailsTable own the loading / error / empty states. Gate on
+            the key not loading too, so a key switch can't flash the previous
+            key's matches before the hook's reset effect runs. */}
+        {!keyLoading && (loaded || loading) && (
+          <S.TabTableWrapper>
+            <ArrayDetailsTable
+              elements={elements}
+              loading={loading}
+              error={error}
+            />
+          </S.TabTableWrapper>
+        )}
+      </S.TabBody>
+    </>
+  )
+}
 
 export default SearchTab

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.types.ts
@@ -1,0 +1,5 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface SearchTabProps {
+  keyProp: RedisResponseBuffer | null
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/index.ts
@@ -1,3 +1,4 @@
 import SearchTab from './SearchTab'
 
 export default SearchTab
+export type { SearchTabProps } from './SearchTab.types'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Quotes a Redis argument that may contain whitespace or quotes so a command
+ * preview stays runnable when copied into CLI / Workbench. Mirrors redis-cli's
+ * double-quoted-string rules: backslash and double-quote are backslash-escaped.
+ */
+export const quoteRedisArgument = (value: string): string => {
+  if (value.length === 0) return '""'
+  if (!/[\s"\\]/.test(value)) return value
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -6,6 +6,7 @@ import {
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,
+  GetArraySearchResponse,
   GetArrayScanResponse,
 } from 'apiClient'
 import { apiService } from 'uiSrc/services'
@@ -22,10 +23,12 @@ import {
   ArrayActiveQuery,
   ArrayAggregateActiveQuery,
   ArrayDataElement,
+  ArrayGrepPredicate,
   StateArray,
   FetchArrayAggregateParams,
   FetchArrayRangeParams,
   FetchArrayScanParams,
+  SearchArrayParams,
 } from 'uiSrc/slices/interfaces/array'
 import { RedisString } from 'uiSrc/slices/interfaces/app'
 import { updateSelectedKeyRefreshTime } from './keys'
@@ -50,6 +53,14 @@ const DEFAULT_QUERY_END = '9'
  */
 export const DEFAULT_SCAN_LIMIT = 1_000_000
 
+/**
+ * Safety cap on ARGREP result-set size. Without a LIMIT, a broad predicate
+ * would return every match (with values) and could build a huge response /
+ * table. Pinned to the backend's `ARRAY_RANGE_MAX_ELEMENTS`, mirroring the
+ * scan cap.
+ */
+export const DEFAULT_SEARCH_LIMIT = 1_000_000
+
 export const initialState: StateArray = {
   loading: false,
   error: '',
@@ -70,6 +81,13 @@ export const initialState: StateArray = {
     result: null,
     hasResult: false,
     query: null,
+  },
+  search: {
+    loading: false,
+    error: '',
+    loaded: false,
+    data: [],
+    predicates: [],
   },
 }
 
@@ -209,6 +227,38 @@ const arraySlice = createSlice({
     clearArrayAggregate: (state) => {
       state.aggregate = { ...initialState.aggregate }
     },
+
+    // ARGREP search lives in its own sub-state so the View and Search tabs
+    // (both mounted at once) never overwrite each other's results. The
+    // predicates are recorded so the header refresh button can replay them.
+    loadArraySearch: (
+      state,
+      { payload }: PayloadAction<ArrayGrepPredicate[]>,
+    ) => {
+      state.search.loading = true
+      state.search.error = ''
+      state.search.data = []
+      state.search.predicates = payload
+    },
+    loadArraySearchSuccess: (
+      state,
+      { payload }: PayloadAction<GetArraySearchResponse>,
+    ) => {
+      state.search.loading = false
+      state.search.loaded = true
+      state.search.data = payload.elements.map((element) => ({
+        index: element.index,
+        value: element.value as ArrayDataElement['value'],
+      }))
+    },
+    loadArraySearchFailure: (state, { payload }: PayloadAction<string>) => {
+      state.search.loading = false
+      state.search.loaded = true
+      state.search.error = payload
+    },
+    resetArraySearch: (state) => {
+      state.search = { ...initialState.search }
+    },
   },
 })
 
@@ -225,12 +275,18 @@ export const {
   loadArrayAggregateSuccess,
   loadArrayAggregateFailure,
   clearArrayAggregate,
+  loadArraySearch,
+  loadArraySearchSuccess,
+  loadArraySearchFailure,
+  resetArraySearch,
 } = arraySlice.actions
 
 export const arraySelector = (state: RootState) => state.browser.array
 export const arrayDataSelector = (state: RootState) => state.browser.array?.data
 export const arrayAggregateSelector = (state: RootState) =>
   state.browser.array?.aggregate
+export const arraySearchSelector = (state: RootState) =>
+  state.browser.array?.search
 
 export default arraySlice.reducer
 
@@ -359,6 +415,63 @@ export function scanArrayRange(params: FetchArrayScanParams) {
   }
 }
 
+/**
+ * Search-tab counterpart to `arrayRangeController`. Kept separate so a
+ * search and a View-tab range fetch can be in flight at once (both tabs
+ * stay mounted) without aborting each other. A newer search aborts the
+ * previous one so a slow earlier response can't land on fresh results.
+ */
+let arraySearchController: AbortController | null = null
+
+/**
+ * Abort the in-flight ARGREP search (if any). Called by the Search tab hook
+ * on key switch / unmount; safe no-op when nothing is in flight.
+ */
+export const abortArraySearch = (): void => {
+  arraySearchController?.abort()
+  arraySearchController = null
+}
+
+// ARGREP — predicate search across the array's index range. WITHVALUES is
+// left to the API default (true) so results carry values for the table; a
+// safety LIMIT caps the result set like ARSCAN does.
+export function searchArray(params: SearchArrayParams) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    arraySearchController?.abort()
+    const controller = new AbortController()
+    arraySearchController = controller
+
+    dispatch(loadArraySearch(params.predicates))
+    try {
+      const state = stateInit()
+      const { data, status } = await apiService.post<GetArraySearchResponse>(
+        arrayUrl(state, ApiEndpoints.ARRAY_SEARCH),
+        {
+          keyName: params.key,
+          predicates: params.predicates,
+          limit: DEFAULT_SEARCH_LIMIT,
+        },
+        { ...encodingParams(state), signal: controller.signal },
+      )
+      if (controller.signal.aborted) return
+      if (isStatusSuccessful(status)) {
+        dispatch(loadArraySearchSuccess(data))
+      } else {
+        dispatch(loadArraySearchFailure(DEFAULT_ERROR_MESSAGE))
+      }
+    } catch (error) {
+      if (axios.isCancel(error)) return
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      dispatch(loadArraySearchFailure(errorMessage))
+    } finally {
+      if (arraySearchController === controller) {
+        arraySearchController = null
+      }
+    }
+  }
+}
+
 export function fetchArrayLength(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
@@ -460,11 +573,12 @@ export function aggregateArray(params: FetchArrayAggregateParams) {
  * `slices/browser/keys`). Replays whichever query the form last ran —
  * range/scan and the user's bounds — so refresh doesn't silently swap
  * the table for a different slice. Keeps `resetData: false` so the
- * table doesn't flash through an empty loading state.
+ * table doesn't flash through an empty loading state. Also replays the
+ * last Search-tab query so its results don't go stale after a refresh.
  */
 export function refreshArray(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
-    const { query, aggregate } = stateInit().browser.array
+    const { query, aggregate, search } = stateInit().browser.array
     const { start, end, showEmpty } = query
 
     dispatch(fetchArrayLength(key))
@@ -484,6 +598,10 @@ export function refreshArray(key: RedisString) {
     // been computed for this key (`hasResult` + a stored query).
     if (aggregate.hasResult && aggregate.query) {
       dispatch(aggregateArray({ key, ...aggregate.query, resetData: false }))
+    }
+
+    if (search.predicates.length > 0) {
+      dispatch(searchArray({ key, predicates: search.predicates }))
     }
   }
 }

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -4,6 +4,7 @@ import {
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,
+  GetArraySearchResponse,
   GetArrayScanResponse,
 } from 'apiClient'
 import { RedisString } from 'uiSrc/slices/interfaces/app'
@@ -36,6 +37,24 @@ export interface ArrayDataElement {
   index: string
   /** Stored value, or `null` for an empty slot. */
   value: RedisString | null
+}
+
+/**
+ * Match criteria for an ARGREP predicate. Values are the literal command
+ * tokens; mirrors the backend `ArrayGrepCriteria` enum.
+ */
+export enum ArrayGrepCriteria {
+  Exact = 'EXACT',
+  Match = 'MATCH',
+  Glob = 'GLOB',
+  Re = 'RE',
+}
+
+/** One criteria/value pair sent to ARGREP. */
+export interface ArrayGrepPredicate {
+  criteria: ArrayGrepCriteria
+  /** Pattern / value to match — a plain string is a valid `RedisString`. */
+  value: string
 }
 
 export interface ArrayData {
@@ -97,12 +116,29 @@ export interface ArrayAggregateState {
   query: ArrayAggregateActiveQuery | null
 }
 
+/**
+ * Search (ARGREP) sub-state, kept separate from the View tab's range state
+ * so the two tabs — both mounted at once — never clobber each other's
+ * results. `loaded` flips true once the first search resolves (success or
+ * failure) so the tab can stay blank until the user actually runs one.
+ * `predicates` records the last-run query so the key-details refresh button
+ * can replay it (mirrors `ArrayActiveQuery` for the View tab).
+ */
+export interface ArraySearchState {
+  loading: boolean
+  error: string
+  loaded: boolean
+  data: ArrayDataElement[]
+  predicates: ArrayGrepPredicate[]
+}
+
 export interface StateArray {
   loading: boolean
   error: string
   query: ArrayActiveQuery
   data: ArrayData
   aggregate: ArrayAggregateState
+  search: ArraySearchState
 }
 
 export interface FetchArrayRangeParams {
@@ -135,6 +171,16 @@ export interface FetchArrayAggregateParams {
 }
 
 /**
+ * ARGREP search request. Only the predicates are modelled here; the thunk
+ * pins a safety LIMIT and lets the API default the rest (range, NOCASE, and
+ * WITHVALUES — `true`, so the response carries values for the table).
+ */
+export interface SearchArrayParams {
+  key: RedisString
+  predicates: ArrayGrepPredicate[]
+}
+
+/**
  * Re-export the auto-generated SDK response shapes for consumers that need
  * to pass them around. The slice itself narrows them into `ArrayData` /
  * `ArrayDataElement` for storage.
@@ -145,5 +191,6 @@ export type {
   GetArrayCountResponse,
   GetArrayLengthResponse,
   GetArrayRangeResponse,
+  GetArraySearchResponse,
   GetArrayScanResponse,
 }

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -13,6 +13,7 @@ import { MOCK_TIMESTAMP } from 'uiSrc/mocks/data/dateNow'
 
 import reducer, {
   abortArrayRange,
+  abortArraySearch,
   initialState,
   setArrayInitialState,
   setArrayActiveQuery,
@@ -22,14 +23,21 @@ import reducer, {
   loadArrayScanSuccess,
   loadArrayLengthSuccess,
   loadArrayCountSuccess,
+  loadArraySearch,
+  loadArraySearchSuccess,
+  loadArraySearchFailure,
+  resetArraySearch,
   arraySelector,
   arrayDataSelector,
+  arraySearchSelector,
   fetchArrayRange,
   scanArrayRange,
   fetchArrayLength,
   fetchArrayCount,
   refreshArray,
+  searchArray,
 } from '../../browser/array'
+import { arrayGrepPredicateFactory } from 'uiSrc/mocks/factories/browser/array/arrayGrepPredicate.factory'
 import { updateSelectedKeyRefreshTime } from '../../browser/keys'
 import { addErrorNotification } from '../../app/notifications'
 import { ArrayAggregateOperation } from '../../interfaces/array'
@@ -174,6 +182,76 @@ describe('array slice', () => {
       )
       expect(next.data.count).toBe('7')
     })
+
+    describe('search sub-state', () => {
+      const dirtySearch = {
+        ...initialState,
+        search: {
+          loading: false,
+          error: 'boom',
+          loaded: true,
+          data: [{ index: '1', value: 'x' }],
+          predicates: arrayGrepPredicateFactory.buildList(1),
+        },
+      }
+
+      it('loadArraySearch flips loading, drops stale results, and records the query', () => {
+        const query = arrayGrepPredicateFactory.buildList(1)
+        const next = reducer(dirtySearch, loadArraySearch(query))
+        expect(next.search.loading).toBe(true)
+        expect(next.search.error).toBe('')
+        expect(next.search.data).toEqual([])
+        // `loaded` stays put until the request resolves — the tab keeps
+        // showing the loading state rather than briefly going blank.
+        expect(next.search.loaded).toBe(true)
+        // Records the predicates so refresh can replay them.
+        expect(next.search.predicates).toEqual(query)
+      })
+
+      it('loadArraySearchSuccess stores matches (u64 index as string) and marks loaded', () => {
+        const next = reducer(
+          {
+            ...initialState,
+            search: { ...initialState.search, loading: true },
+          },
+          loadArraySearchSuccess({
+            keyName: mockKey,
+            elements: [
+              { index: '3', value: 'a' },
+              { index: '900719925474099300000', value: null },
+            ],
+          }),
+        )
+        expect(next.search.loading).toBe(false)
+        expect(next.search.loaded).toBe(true)
+        expect(next.search.error).toBe('')
+        expect(next.search.data).toEqual([
+          { index: '3', value: 'a' },
+          { index: '900719925474099300000', value: null },
+        ])
+      })
+
+      it('loadArraySearchFailure records a distinct error and marks loaded', () => {
+        const next = reducer(
+          {
+            ...initialState,
+            search: { ...initialState.search, loading: true },
+          },
+          loadArraySearchFailure('nope'),
+        )
+        expect(next.search.loading).toBe(false)
+        expect(next.search.loaded).toBe(true)
+        expect(next.search.error).toBe('nope')
+        expect(next.search.data).toEqual([])
+      })
+
+      it('resetArraySearch restores the initial search sub-state only', () => {
+        const next = reducer(dirtySearch, resetArraySearch())
+        expect(next.search).toEqual(initialState.search)
+        // View-tab range state is untouched.
+        expect(next.data).toEqual(dirtySearch.data)
+      })
+    })
   })
 
   describe('selectors', () => {
@@ -188,6 +266,21 @@ describe('array slice', () => {
       }
       expect(arraySelector(root)).toEqual(next)
       expect(arrayDataSelector(root)).toEqual(next.data)
+    })
+
+    it('arraySearchSelector reads state.browser.array.search', () => {
+      const next = reducer(
+        initialState,
+        loadArraySearchSuccess({
+          keyName: mockKey,
+          elements: [{ index: '0', value: 'a' }],
+        }),
+      )
+      const root = {
+        ...initialStateDefault,
+        browser: { ...initialStateDefault.browser, array: next },
+      }
+      expect(arraySearchSelector(root)).toEqual(next.search)
     })
   })
 
@@ -517,6 +610,50 @@ describe('array slice', () => {
           ),
         ).toBeUndefined()
       })
+
+      it('replays the active search when predicates were recorded', async () => {
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: { keyName: mockKey, elements: [] },
+        })
+        const predicates = arrayGrepPredicateFactory.buildList(1)
+        const local = mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: {
+              ...initialState,
+              search: { ...initialState.search, loaded: true, predicates },
+            },
+          },
+        })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        const searchCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/search'),
+        )
+        expect(searchCall?.[1]).toEqual({
+          keyName: mockKey,
+          predicates,
+          limit: 1_000_000,
+        })
+      })
+
+      it('does not replay a search on refresh when none has run', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = storeWithQuery({ start: '0', end: '9', showEmpty: true })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/search'),
+          ),
+        ).toBeUndefined()
+      })
     })
 
     describe('fetchArrayLength', () => {
@@ -548,6 +685,88 @@ describe('array slice', () => {
         expect(store.getActions()).toEqual([
           loadArrayCountSuccess(response.data),
         ])
+      })
+    })
+
+    describe('searchArray', () => {
+      const predicates = arrayGrepPredicateFactory.buildList(1)
+
+      afterEach(() => abortArraySearch())
+
+      it('posts keyName + predicates and dispatches success', async () => {
+        const response = {
+          status: 200,
+          data: {
+            keyName: mockKey,
+            elements: [{ index: '0', value: 'redis' }],
+          },
+        }
+        apiService.post = jest.fn().mockResolvedValue(response)
+
+        await store.dispatch<any>(searchArray({ key: mockKey, predicates }))
+
+        const [url, body] = (apiService.post as jest.Mock).mock.calls[0]
+        expect(url).toContain('array/search')
+        // WITHVALUES is intentionally omitted so the API default (true)
+        // applies; a safety LIMIT caps the result set like ARSCAN does.
+        expect(body).toEqual({
+          keyName: mockKey,
+          predicates,
+          limit: 1_000_000,
+        })
+        expect(store.getActions()).toEqual([
+          loadArraySearch(predicates),
+          loadArraySearchSuccess(response.data),
+        ])
+      })
+
+      it('dispatches failure + notification on error', async () => {
+        const rejected = {
+          response: { status: 500, data: { message: 'boom' } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(rejected)
+
+        await store.dispatch<any>(searchArray({ key: mockKey, predicates }))
+
+        expect(store.getActions()).toEqual([
+          loadArraySearch(predicates),
+          addErrorNotification(rejected as IAddInstanceErrorPayload),
+          loadArraySearchFailure('boom'),
+        ])
+      })
+
+      it('dispatches failure when the response resolves with a non-success status', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 304, data: null })
+
+        await store.dispatch<any>(searchArray({ key: mockKey, predicates }))
+
+        expect(store.getActions()).toEqual([
+          loadArraySearch(predicates),
+          loadArraySearchFailure(DEFAULT_ERROR_MESSAGE),
+        ])
+      })
+
+      it('passes an AbortSignal and stays silent once aborted', async () => {
+        apiService.post = jest.fn().mockImplementation(
+          (_url, _body, config) =>
+            new Promise((_resolve, reject) => {
+              config?.signal?.addEventListener('abort', () => {
+                reject(new axios.Cancel('aborted by client'))
+              })
+            }),
+        )
+
+        const dispatchPromise = store.dispatch<any>(
+          searchArray({ key: mockKey, predicates }),
+        )
+        abortArraySearch()
+        await dispatchPromise
+
+        const [, , config] = (apiService.post as jest.Mock).mock.calls[0]
+        expect(config?.signal).toBeInstanceOf(AbortSignal)
+        expect(store.getActions()).toEqual([loadArraySearch(predicates)])
       })
     })
   })


### PR DESCRIPTION
# What

Adds the **Search** tab to the array key details panel — slice 2 of the ARGREP search vertical (RI-8221), on top of the S1 backend (RI-8291, merged in #6090). A single predicate (criteria dropdown + value) with a command preview and a Run action; results reuse `ArrayDetailsTable` with a distinct error state (failed ≠ empty).

- `ApiEndpoints.ARRAY_SEARCH` + a `search` sub-state and `searchArray` thunk on the array slice (own abort controller, separate from the View range fetch)
- `useArraySearchQuery` hook — single-predicate form state, key-switch reset, abort/cleanup on unmount
- Empty values are allowed (`EXACT ""` is a valid array search); Enter in the value field runs the search; a safety `LIMIT` caps the result set like ARSCAN
- `quoteRedisArgument` extracted to a shared `array-details/utils.ts` (used by both the View and Search forms)

UI-only; multi-predicate + the AND/OR connective + range/NOCASE/LIMIT options come in the next slice.

# Testing

`yarn lint`, `yarn type-check`, and `yarn test` (98 array specs: slice thunk/reducers, controlled form, hook, and the SearchTab integration incl. the distinct error state).

Light
<img width="806" height="470" alt="image" src="https://github.com/user-attachments/assets/d098422f-d2ee-4dab-b59e-2d8b1e0bea2c" />
<img width="806" height="533" alt="image" src="https://github.com/user-attachments/assets/b4e87abb-e8fb-4273-aa9f-0bb12192bad0" />
<img width="796" height="465" alt="image" src="https://github.com/user-attachments/assets/228aaa7b-03df-4701-b689-4abb33357a2f" />
<img width="803" height="495" alt="image" src="https://github.com/user-attachments/assets/b6d4f7fb-adb9-418d-92d3-949c5b164fad" />

Dark 
<img width="806" height="463" alt="image" src="https://github.com/user-attachments/assets/f852b5a8-9750-4248-8ae4-a3cc96d10922" />

---

Closes #RI-8292


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only feature on an existing search API, with result caps, abort/race handling, and key-type gating; no auth or data-model changes.
> 
> **Overview**
> Replaces the array key **Search** tab placeholder with a working **ARGREP** flow: criteria (**Exact** / **Match** / **Glob** / **Regex**) plus value, optional command preview, and **Run** (including **Enter** in the value field). Matches are shown in the existing **`ArrayDetailsTable`**, with separate empty vs error states.
> 
> **Redux** adds a dedicated **`search`** sub-state and **`searchArray`** thunk (separate abort controller from the View tab), **`ARRAY_SEARCH`** API wiring, a **1M** result **LIMIT**, and **refresh** replay of the last predicates. **`useArraySearchQuery`** owns form state, blocks runs until the selected key is a ready array, resets on key change, and does not auto-search on load.
> 
> **`quoteRedisArgument`** is moved to shared **`array-details/utils`** for View and Search previews. Multi-predicate and extra ARGREP options are explicitly out of scope for this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905c9fd74720217ea4865d4baef14fae6460e8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->