### PR TITLE
RI-8220: Fix Aggregate operation dropdown width to prevent layout jump

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
+
+const OPERATION_SELECT_MIN_WIDTH = '100px'
+
+export const OperationSelect = styled(RiSelect)`
+  min-width: ${OPERATION_SELECT_MIN_WIDTH};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-aggregate-form/ArrayAggregateForm.tsx
@@ -7,15 +7,13 @@ import { ResetIcon, RiIcon } from 'uiSrc/components/base/icons'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
-import {
-  defaultValueRender,
-  RiSelect,
-} from 'uiSrc/components/base/forms/select/RiSelect'
+import { defaultValueRender } from 'uiSrc/components/base/forms/select/RiSelect'
 import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import { ArrayAggregateOperation } from 'uiSrc/slices/interfaces/array'
 
 import { CommandPreview } from '../command-preview'
 import * as RangeStyles from '../array-range-form/ArrayRangeForm.styles'
+import * as S from './ArrayAggregateForm.styles'
 import {
   ARRAY_AGGREGATE_FORM_TEST_ID as TEST_ID,
   ARRAY_RANGE_MAX_SPAN,
@@ -128,7 +126,7 @@ export const ArrayAggregateForm = ({
         </FlexItem>
         <FlexItem grow={false}>
           <FormField label="Operation">
-            <RiSelect
+            <S.OperationSelect
               options={OPERATION_OPTIONS.map((option) => ({
                 ...option,
                 'data-test-subj': `${TEST_ID}-operation-option-${option.value}`,


### PR DESCRIPTION
# What

The operation select in the array Aggregate tab sized its trigger to the
selected value, so switching between operations of different lengths
(SUM, MATCH, USED, …) resized the control and made the form row visible
jump. Pinned the select to a fixed minimum width so the layout stays
stable across selections.

# Before

https://github.com/user-attachments/assets/d3b2f54d-5b8b-4c35-ba3c-d0bf357c9ed0

# After

https://github.com/user-attachments/assets/5e87f2d1-c623-40a7-b482-16be4a5a9d13


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout styling on a single form control; no behavior, API, or data-path changes.
> 
> **Overview**
> Fixes layout shift in the array key **Aggregate** tab when changing the operation dropdown between labels of different lengths (e.g. SUM vs MATCH).
> 
> Adds `ArrayAggregateForm.styles.ts` with a styled `OperationSelect` (`min-width: 100px`) and wires the form’s Operation field to use it instead of a plain `RiSelect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716d98f43625929f0d3a003f5e5cd8d2b8a336ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->