### PR TITLE
chore(ui): reduce UI TypeScript baseline — T0 trivial fixes (-11)

### DIFF
--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -34,9 +34,6 @@
     "TS2339": 1,
     "TS2551": 1
   },
-  "src/components/base/display/collapsible-nav-group/RICollapsibleNavGroup.tsx": {
-    "TS2724": 1
-  },
   "src/components/base/forms/buttons/EmptyButton.stories.tsx": {
     "TS2322": 1
   },
@@ -45,9 +42,6 @@
   },
   "src/components/base/icons/RiIcon.tsx": {
     "TS2339": 1
-  },
-  "src/components/base/utils/resize-observer/ResizeObserver.tsx": {
-    "TS7030": 1
   },
   "src/components/bulk-actions-config/BulkActionsConfig.spec.tsx": {
     "TS2322": 1,
@@ -80,9 +74,6 @@
   "src/components/consents-settings/ConsentsSettings.tsx": {
     "TS2339": 1
   },
-  "src/components/divider/Divider.spec.tsx": {
-    "TS2614": 1
-  },
   "src/components/formated-date/FormatedDate.tsx": {
     "TS2345": 1
   },
@@ -101,9 +92,6 @@
   },
   "src/components/json-viewer/utils.spec.ts": {
     "TS2345": 3
-  },
-  "src/components/main-router/components/RedisStackRoutes.spec.tsx": {
-    "TS2614": 1
   },
   "src/components/main-router/constants/defaultRoutes.ts": {
     "TS2322": 4
@@ -203,9 +191,6 @@
   },
   "src/components/side-panels/panels/ai-assistant/components/expert-chat/components/no-indexes-initial-message/NoIndexesInitialMessage.spec.tsx": {
     "TS2741": 3
-  },
-  "src/components/side-panels/panels/ai-assistant/components/shared/markdown-message/components/chat-external-link/ChatExternalLink.tsx": {
-    "TS2305": 1
   },
   "src/components/side-panels/panels/enablement-area/EnablementArea/components/DeleteTutorialButton/DeleteTutorialButton.tsx": {
     "TS2769": 1
@@ -316,9 +301,6 @@
     "TS7031": 1,
     "TS7034": 4,
     "TS7053": 3
-  },
-  "src/packages/redisgraph/src/parser.ts": {
-    "TS6133": 1
   },
   "src/packages/redisgraph/src/utils.ts": {
     "TS7006": 11
@@ -453,9 +435,6 @@
   "src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx": {
     "TS2322": 2
   },
-  "src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.spec.tsx": {
-    "TS2305": 1
-  },
   "src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.tsx": {
     "TS2322": 3,
     "TS2339": 1,
@@ -589,9 +568,6 @@
   },
   "src/pages/database-analysis/components/analysis-data-view/AnalysisDataView.spec.tsx": {
     "TS2339": 2
-  },
-  "src/pages/home/components/add-database-screen/AddDatabaseScreen.styles.ts": {
-    "TS2304": 1
   },
   "src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx": {
     "TS7053": 1
@@ -753,9 +729,6 @@
   "src/pages/vector-search/hooks/useCreateIndexFlow/useCreateIndexFlow.spec.ts": {
     "TS2345": 1
   },
-  "src/pages/vector-search/hooks/useListContent/index.ts": {
-    "TS2724": 1
-  },
   "src/pages/vector-search/hooks/useListContent/useListContent.ts": {
     "TS2322": 1
   },
@@ -777,9 +750,6 @@
   },
   "src/pages/workbench/components/wb-view/WBViewWrapper.spec.tsx": {
     "TS2339": 1
-  },
-  "src/pages/workbench/utils/suggestions.ts": {
-    "TS6133": 1
   },
   "src/pages/workbench/utils/tests/monaco.spec.ts": {
     "TS2345": 1
@@ -1181,9 +1151,6 @@
   },
   "src/utils/tests/events/handleDownloadButton.spec.ts": {
     "TS2345": 1
-  },
-  "src/utils/tests/formatters/bufferFormatters.spec.ts": {
-    "TS2304": 1
   },
   "src/utils/tests/formatters/markdown/remarkRedisUpload.spec.ts": {
     "TS2339": 3

--- a/redisinsight/ui/src/components/base/display/collapsible-nav-group/RICollapsibleNavGroup.tsx
+++ b/redisinsight/ui/src/components/base/display/collapsible-nav-group/RICollapsibleNavGroup.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode } from 'react'
 import cx from 'classnames'
-import {
-  RiAccordion,
-  RiAccordionProps,
-} from 'uiSrc/components/base/display/accordion/RiAccordion'
+import { RiAccordion } from 'uiSrc/components/base/display/accordion/RiAccordion'
+import { RiAccordionProps } from 'uiSrc/components/base/display/accordion/RiAccordion.types'
 
 export type RICollapsibleNavGroupProps = Omit<
   RiAccordionProps,

--- a/redisinsight/ui/src/components/base/utils/resize-observer/ResizeObserver.tsx
+++ b/redisinsight/ui/src/components/base/utils/resize-observer/ResizeObserver.tsx
@@ -13,17 +13,19 @@ export const RIResizeObserver: React.FC<RIResizeObserverProps> = ({
 
   useEffect(() => {
     const element = containerRef.current
-    if (element) {
-      const observer = new window.ResizeObserver(([entry]) => {
-        const { width, height } = entry.contentRect
-        onResize({ width, height })
-      })
+    if (!element) {
+      return undefined
+    }
 
-      observer.observe(element)
+    const observer = new window.ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      onResize({ width, height })
+    })
 
-      return () => {
-        observer.disconnect()
-      }
+    observer.observe(element)
+
+    return () => {
+      observer.disconnect()
     }
   }, [onResize, containerRef.current])
 

--- a/redisinsight/ui/src/components/divider/Divider.spec.tsx
+++ b/redisinsight/ui/src/components/divider/Divider.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import { render } from 'uiSrc/utils/test-utils'
-import Divider, { DividerProps } from './Divider'
+import Divider from './Divider'
+import { DividerProps } from './Divider.types'
 
 const mockedProps = mock<DividerProps>()
 

--- a/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.spec.tsx
+++ b/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.spec.tsx
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash'
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
 import { cleanup, mockedStore, render } from 'uiSrc/utils/test-utils'
-import RedisStackRoutes, { Props } from './RedisStackRoutes'
+import RedisStackRoutes, { IProps as Props } from './RedisStackRoutes'
 
 const mockedProps = mock<Props>()
 

--- a/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.tsx
+++ b/redisinsight/ui/src/components/main-router/components/RedisStackRoutes.tsx
@@ -13,7 +13,7 @@ import { PagePlaceholder } from 'uiSrc/components'
 import ProtectedRoute from 'uiSrc/pages/redis-stack/components/protected-route/ProtectedRoute'
 import ROUTES from '../constants/redisStackRoutes'
 
-interface IProps {
+export interface IProps {
   databaseId?: string
 }
 

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/markdown-message/components/chat-external-link/ChatExternalLink.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/markdown-message/components/chat-external-link/ChatExternalLink.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { getUtmExternalLink } from 'uiSrc/utils/links'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
-import { Link, LinkProps } from 'uiSrc/components/base/link/Link'
+import { Link, type RiLinkProps } from 'uiSrc/components/base/link'
 
-const ChatExternalLink = (props: LinkProps) => {
+const ChatExternalLink = (props: RiLinkProps) => {
   const { href } = props
   return (
     <Link

--- a/redisinsight/ui/src/packages/redisgraph/src/parser.ts
+++ b/redisinsight/ui/src/packages/redisgraph/src/parser.ts
@@ -73,7 +73,7 @@ function responseParser(data: any): IResponseParser {
       danglingEdgeIds,
     }
 
-  const entries = data[1].map((entry: any) => {
+  data[1].map((entry: any) => {
     /* entry -> has headers number of items */
     entry.map((item: any) => {
       if (Array.isArray(item)) {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.spec.tsx
@@ -24,9 +24,9 @@ import {
 } from 'uiSrc/utils/tests/decompressors'
 import { setSelectedKeyRefreshDisabled } from 'uiSrc/slices/browser/keys'
 import { MOCK_TRUNCATED_BUFFER_VALUE } from 'uiSrc/mocks/data/bigString'
-import { ListDetailsTable, Props } from './ListDetailsTable'
+import { ListDetailsTable } from './ListDetailsTable'
 
-const mockedProps = mock<Props>()
+const mockedProps = mock<Record<string, never>>()
 
 const elements = [
   { element: { type: 'Buffer', data: [49] }, index: 0 },

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.styles.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 
+import { Theme } from 'uiSrc/components/base/theme/types'
+
 export const CustomHorizontalRule = styled.div`
   margin: 12px 0;
   width: 100%;

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -172,3 +172,5 @@ export const useListContent = () => {
     onCloseDelete: handleCloseDelete,
   }
 }
+
+export type UseListContentReturn = ReturnType<typeof useListContent>

--- a/redisinsight/ui/src/pages/workbench/utils/suggestions.ts
+++ b/redisinsight/ui/src/pages/workbench/utils/suggestions.ts
@@ -195,7 +195,7 @@ export const getMandatoryArgumentSuggestions = (
 
 export const getCommandSuggestions = (
   foundArg: Nullable<FoundCommandArgument>,
-  allArgs: string[],
+  _allArgs: string[],
   range: monaco.IRange,
 ) => {
   const appendCommands = foundArg?.append ?? []

--- a/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/bufferFormatters.spec.ts
@@ -1,3 +1,4 @@
+import { ObjectInputStream } from 'java-object-serialization'
 import { RedisResponseBufferType } from 'uiSrc/slices/interfaces'
 import JavaDate from 'uiSrc/utils/formatters/java-date'
 import {


### PR DESCRIPTION
# What

First batch ("T0") of a staged effort to reduce the UI TypeScript error baseline (`redisinsight/ui/.tscheck.rec.json`).

Fixes **11 trivial, single-error files** with mechanical, behaviour-preserving changes:

- import props types from their `.types` module (`Divider`, `RICollapsibleNavGroup`, `ChatExternalLink` → `RiLinkProps`)
- export `IProps` from `RedisStackRoutes`; export `UseListContentReturn` from the `useListContent` hook so its barrel re-export resolves
- add missing imports: `Theme` (AddDatabaseScreen styles), `ObjectInputStream` (bufferFormatters spec)
- add an explicit early `return` in the `ResizeObserver` effect (TS7030)
- drop unused local/param (`redisgraph` parser `entries`, workbench `suggestions` `allArgs`)
- type the `ListDetailsTable` test mock (the component takes no props)

Baseline: **347 → 336** tracked files. The rec-file entries for exactly these 11 files were removed (counts only go down).

Two originally-scoped files were **deferred** to a follow-up — they turned out non-trivial:
- `clients-list/TableView.tsx` — the plugin's nested `@redis-ui/table` version doesn't export `ColumnDefinition` (dep issue, not a typo)
- `VirtualTree.spec.tsx` — fixing the import unmasks a hidden `TS2322`; the inline `items` mock should become a Fishery factory

# Testing

- `yarn --cwd redisinsight/ui type-check` — these 11 errors gone, **no new errors** (verified with a before/after `tsc` diff)
- `yarn lint:ui` — clean on all changed files
- Jest — **111 tests pass** across the affected/related specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and unused-variable fixes with no intended runtime behavior change; baseline rec file updated to match.
> 
> **Overview**
> First batch of staged UI TypeScript baseline cleanup: **11 single-error files** fixed with mechanical, behavior-preserving edits, and their entries removed from `redisinsight/ui/.tscheck.rec.json` (**347 → 336** tracked files).
> 
> **Import / export alignment:** props pulled from `.types` modules (`Divider`, `RICollapsibleNavGroup` → `RiAccordionProps`, `ChatExternalLink` → `RiLinkProps`); **`IProps` exported** from `RedisStackRoutes` for its spec; **`UseListContentReturn` exported** from `useListContent` so the hook barrel re-export type-checks.
> 
> **Small correctness / hygiene:** missing `Theme` import in add-database styled-components; `ObjectInputStream` import in `bufferFormatters` spec; explicit early `return undefined` in `RIResizeObserver`’s `useEffect` (TS7030); unused `entries` in redisgraph parser and `_allArgs` in workbench suggestions; `ListDetailsTable` spec mocks `Record<string, never>` because the component takes no props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c65406ed49b74c9935a62d08a5f949ad6e8b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->