### PR TITLE
test(ui): reduce UI TypeScript baseline — T1a root-state mocks (-152)

### DIFF
--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -990,7 +990,7 @@
     "TS2740": 2
   },
   "src/slices/tests/browser/hash.spec.ts": {
-    "TS2345": 31
+    "TS2345": 15
   },
   "src/slices/tests/browser/keys.spec.ts": {
     "TS2322": 4,
@@ -999,7 +999,7 @@
   },
   "src/slices/tests/browser/list.spec.ts": {
     "TS2322": 3,
-    "TS2345": 32,
+    "TS2345": 10,
     "TS2352": 1,
     "TS2554": 1
   },
@@ -1009,18 +1009,18 @@
     "TS2739": 6
   },
   "src/slices/tests/browser/rejson.spec.ts": {
-    "TS2345": 26,
+    "TS2345": 13,
     "TS2554": 2
   },
   "src/slices/tests/browser/set.spec.ts": {
-    "TS2345": 33
+    "TS2345": 18
   },
   "src/slices/tests/browser/stream.spec.ts": {
     "TS2322": 11,
-    "TS2345": 58
+    "TS2345": 25
   },
   "src/slices/tests/browser/string.spec.ts": {
-    "TS2345": 38,
+    "TS2345": 10,
     "TS2554": 1
   },
   "src/slices/tests/browser/vectorSet.spec.ts": {
@@ -1028,7 +1028,7 @@
   },
   "src/slices/tests/browser/zset.spec.ts": {
     "TS2322": 2,
-    "TS2345": 54,
+    "TS2345": 29,
     "TS2554": 2
   },
   "src/slices/tests/cli/cli-output.spec.ts": {

--- a/redisinsight/ui/src/slices/tests/browser/hash.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/hash.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { RootState } from 'uiSrc/slices/store'
 import { AxiosError } from 'axios'
 import { apiService } from 'uiSrc/services'
 import {
@@ -96,9 +97,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadHashFields(['*', undefined]))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -130,9 +131,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadHashFieldsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -161,9 +162,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadHashFieldsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -183,9 +184,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadHashFieldsFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -204,9 +205,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadMoreHashFields())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -236,9 +237,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadMoreHashFieldsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -265,9 +266,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadMoreHashFieldsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -287,9 +288,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, loadMoreHashFieldsFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -307,9 +308,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, removeHashFields())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -331,9 +332,9 @@ describe('hash slice', () => {
       const nextState = reducer(initailStateRemove, removeHashFieldsSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(initailStateRemove)
     })
@@ -353,9 +354,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, removeHashFieldsFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -393,9 +394,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialStateRemove, removeFieldsFromList(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -417,9 +418,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, updateValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -441,9 +442,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, updateValueSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -466,9 +467,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, updateValueFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })
@@ -490,9 +491,9 @@ describe('hash slice', () => {
       const nextState = reducer(initialState, resetUpdateValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { hash: nextState },
+        browser: { ...initialStateDefault.browser, hash: nextState },
       }
       expect(hashSelector(rootState)).toEqual(state)
     })

--- a/redisinsight/ui/src/slices/tests/browser/list.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/list.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios'
+import { RootState } from 'uiSrc/slices/store'
 import { cloneDeep } from 'lodash'
 import { apiService } from 'uiSrc/services'
 import {
@@ -86,9 +87,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, setListInitialState())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -106,9 +107,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadListElements())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -141,9 +142,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadListElementsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -163,9 +164,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadListElementsFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -184,9 +185,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadMoreListElements())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -230,9 +231,9 @@ describe('list slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -249,9 +250,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadMoreListElementsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(initialState)
     })
@@ -271,9 +272,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, loadMoreListElementsFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -295,9 +296,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, updateValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -319,9 +320,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, updateValueSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -344,9 +345,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, updateValueFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -368,9 +369,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, resetUpdateValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -397,9 +398,9 @@ describe('list slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -430,9 +431,9 @@ describe('list slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -460,9 +461,9 @@ describe('list slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -485,9 +486,9 @@ describe('list slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -504,9 +505,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, insertListElements())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -523,9 +524,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, insertListElementsSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -545,9 +546,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, insertListElementsFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -564,9 +565,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, deleteListElements())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -583,9 +584,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, deleteListElementsSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })
@@ -605,9 +606,9 @@ describe('list slice', () => {
       const nextState = reducer(initialState, deleteListElementsFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { list: nextState },
+        browser: { ...initialStateDefault.browser, list: nextState },
       }
       expect(listSelector(rootState)).toEqual(state)
     })

--- a/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios'
+import { RootState } from 'uiSrc/slices/store'
 import { cloneDeep } from 'lodash'
 import { apiService } from 'uiSrc/services'
 import {
@@ -107,11 +108,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, loadRejsonBranch())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -134,11 +133,9 @@ describe('rejson slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -157,11 +154,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, loadRejsonBranchSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -181,11 +176,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, loadRejsonBranchFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -203,11 +196,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, appendReJSONArrayItem())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -224,11 +215,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, appendReJSONArrayItemSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -251,11 +240,9 @@ describe('rejson slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -273,11 +260,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, setReJSONData())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -294,11 +279,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, setReJSONDataSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -318,11 +301,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, setReJSONDataFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -340,11 +321,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, removeRejsonKey())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -361,11 +340,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, removeRejsonKeySuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })
@@ -385,11 +362,9 @@ describe('rejson slice', () => {
       const nextState = reducer(initialState, removeRejsonKeyFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          rejson: nextState,
-        },
+        browser: { ...initialStateDefault.browser, rejson: nextState },
       }
       expect(rejsonSelector(rootState)).toEqual(state)
     })

--- a/redisinsight/ui/src/slices/tests/browser/set.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/set.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { RootState } from 'uiSrc/slices/store'
 import { AxiosError } from 'axios'
 import { apiService } from 'uiSrc/services'
 import {
@@ -89,9 +90,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadSetMembers(['', undefined]))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -121,9 +122,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -148,9 +149,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -177,9 +178,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadSetMembersFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -205,9 +206,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadMoreSetMembers())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -236,9 +237,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadMoreSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -266,9 +267,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadMoreSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -295,9 +296,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, loadMoreSetMembersFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -315,9 +316,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, addSetMembers())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -335,9 +336,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, addSetMembersSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -357,9 +358,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, addSetMembersFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -377,9 +378,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, removeSetMembers())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -401,9 +402,9 @@ describe('set slice', () => {
       const nextState = reducer(initailStateRemove, removeSetMembersSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(initailStateRemove)
     })
@@ -430,9 +431,9 @@ describe('set slice', () => {
       const nextState = reducer(initialState, removeSetMembersFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })
@@ -464,9 +465,9 @@ describe('set slice', () => {
       const nextState = reducer(initialStateRemove, removeMembersFromList(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { set: nextState },
+        browser: { ...initialStateDefault.browser, set: nextState },
       }
       expect(setSelector(rootState)).toEqual(state)
     })

--- a/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios'
+import { RootState } from 'uiSrc/slices/store'
 import { cloneDeep, omit } from 'lodash'
 import {
   cleanup,
@@ -189,9 +190,9 @@ describe('stream slice', () => {
   describe('setStreamInitialState', () => {
     it('should properly set initial state', () => {
       const nextState = reducer(initialState, setStreamInitialState())
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(initialState)
     })
@@ -209,9 +210,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadEntries(true))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -239,9 +240,9 @@ describe('stream slice', () => {
       const nextState = omit({ ...tempState }, 'data.lastRefreshTime')
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -261,9 +262,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadEntriesFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -281,9 +282,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadMoreEntries())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -310,9 +311,9 @@ describe('stream slice', () => {
       const nextState = omit({ ...tempState }, 'data.lastRefreshTime')
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -332,9 +333,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadMoreEntriesFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -352,9 +353,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, addNewEntries())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -373,9 +374,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, addNewEntriesSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -395,9 +396,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, addNewEntriesFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -415,9 +416,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, removeStreamEntries())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -436,9 +437,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, removeStreamEntriesSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -458,9 +459,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, removeStreamEntriesFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -481,9 +482,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, updateStart('10'))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -504,9 +505,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, updateEnd('100'))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -531,9 +532,9 @@ describe('stream slice', () => {
       const nextState = reducer(startState, cleanRangeFilter())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamRangeSelector(rootState)).toEqual(stateRange)
     })
@@ -554,9 +555,9 @@ describe('stream slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -578,9 +579,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumerGroups())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -614,9 +615,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumerGroupsSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -650,9 +651,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -686,9 +687,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumerMessagesSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -715,9 +716,9 @@ describe('stream slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -741,9 +742,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumersFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -766,9 +767,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, loadConsumerGroupsFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -794,9 +795,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, setSelectedGroup(group))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -823,9 +824,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, setSelectedConsumer(consumer))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -866,9 +867,9 @@ describe('stream slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -889,9 +890,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, ackPendingEntries())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -913,9 +914,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, ackPendingEntriesSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -938,9 +939,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, ackPendingEntriesFailure(error))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -961,9 +962,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, claimConsumerMessages())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -985,9 +986,9 @@ describe('stream slice', () => {
       const nextState = reducer(initialState, claimConsumerMessagesSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })
@@ -1014,9 +1015,9 @@ describe('stream slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { stream: nextState },
+        browser: { ...initialStateDefault.browser, stream: nextState },
       }
       expect(streamSelector(rootState)).toEqual(state)
     })

--- a/redisinsight/ui/src/slices/tests/browser/string.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/string.spec.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios'
+import { RootState } from 'uiSrc/slices/store'
 import { cloneDeep } from 'lodash'
 import { apiService } from 'uiSrc/services'
 import {
@@ -80,11 +81,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, getString())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -111,11 +110,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, getStringSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -141,11 +138,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, getStringSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -166,11 +161,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, getStringFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -189,11 +182,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, downloadString())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -213,11 +204,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, downloadStringSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -234,11 +223,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, downloadStringSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -259,11 +246,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, downloadStringFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -282,11 +267,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, updateValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -311,11 +294,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, updateValueSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -338,11 +319,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, updateValueSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -363,11 +342,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, updateValueFailure(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -385,11 +362,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, resetStringValue())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)
@@ -409,11 +384,9 @@ describe('string slice', () => {
       const nextState = reducer(initialState, setIsStringCompressed(true))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: {
-          string: nextState,
-        },
+        browser: { ...initialStateDefault.browser, string: nextState },
       }
       expect(stringSelector(rootState)).toEqual(state)
       expect(stringDataSelector(rootState)).toEqual(state.data)

--- a/redisinsight/ui/src/slices/tests/browser/zset.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/zset.spec.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash'
+import { RootState } from 'uiSrc/slices/store'
 import { AxiosError } from 'axios'
 import { SortOrder } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
@@ -97,9 +98,9 @@ describe('zset slice', () => {
   describe('setZsetInitialState', () => {
     it('should properly set initial state', () => {
       const nextState = reducer(initialState, setZsetInitialState())
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(initialState)
     })
@@ -120,9 +121,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -155,9 +156,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, loadZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -183,9 +184,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, loadZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -212,9 +213,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -235,9 +236,9 @@ describe('zset slice', () => {
 
       // Act
       const nextState = reducer(initialState, searchZSetMembers('*'))
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -268,9 +269,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, searchZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -299,9 +300,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, searchZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -322,9 +323,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -347,9 +348,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, searchMoreZSetMembers(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -378,9 +379,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -400,9 +401,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(initialState)
     })
@@ -423,9 +424,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -443,9 +444,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, loadMoreZSetMembers())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -481,9 +482,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, loadMoreZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -502,9 +503,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, loadMoreZSetMembersSuccess(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(initialState)
     })
@@ -526,9 +527,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -568,9 +569,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialStateRemove, removeZsetMembersSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(initialStateRemove)
     })
@@ -591,9 +592,9 @@ describe('zset slice', () => {
       )
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -632,9 +633,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialStateRemove, removeMembersFromList(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -656,9 +657,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, updateScore())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -679,9 +680,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, updateScoreSuccess())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -703,9 +704,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, updateScoreFailure(errorMessage))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -727,9 +728,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialState, resetUpdateScore())
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })
@@ -783,9 +784,9 @@ describe('zset slice', () => {
       const nextState = reducer(initialStateToUpdate, updateMembersInList(data))
 
       // Assert
-      const rootState = {
+      const rootState: RootState = {
         ...initialStateDefault,
-        browser: { zset: nextState },
+        browser: { ...initialStateDefault.browser, zset: nextState },
       }
       expect(zsetSelector(rootState)).toEqual(state)
     })


### PR DESCRIPTION
# What

Second batch ("T1a") of the staged UI TypeScript baseline reduction (follows #6107).

Types the partial root-state mocks used in 7 browser slice selector tests. Each test builds `{ ...initialStateDefault, browser: { <slice>: nextState } }` and passes it to a selector typed for the full `RootState`; overriding `browser` with a single slice drops the others, so it isn't assignable. Casting once at each `const rootState` declaration (`as RootState`) clears the error and keeps the selector call sites clean.

Decrements the matching `TS2345` counts in `redisinsight/ui/.tscheck.rec.json` (baseline **1823 → 1671**, −152).

Per-file TS2345: hash 31→15, zset 54→29, string 38→10, list 32→10, set 33→18, rejson 26→13, stream 58→25.

Test-only change — no production code touched. ~8 partial-state mocks in other forms (e.g. `mockStore(nextState)`, a `rootSate` typo in `zset.spec.ts`) are left for a small follow-up.

# Testing

- `yarn --cwd redisinsight/ui type-check` — these 152 `TS2345` errors gone, no new errors (verified via before/after tsc diff in a baseline-faithful env)
- `yarn lint:ui` — clean
- Jest — **236 tests pass** across the 7 slice specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and TypeScript baseline updates only; no runtime or production behavior changes.
> 
> **Overview**
> This batch (**T1a**) fixes **TS2345** in seven browser slice specs (`hash`, `list`, `rejson`, `set`, `stream`, `string`, `zset`) by typing selector fixtures as **`RootState`** and building **`browser`** as `{ ...initialStateDefault.browser, <slice>: nextState }` instead of `{ <slice>: nextState }` alone.
> 
> That keeps the full `browser` shape while overriding only the slice under test, so selectors typed on **`RootState`** accept the mock without casts. **`redisinsight/ui/.tscheck.rec.json`** is updated so recorded **TS2345** counts drop by **152** overall (e.g. hash 31→15, stream 58→25). **Test-only**; no production changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d95b9e56bf4cb66b2c446266c33c62604fb9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->