### PR TITLE
test(ui): reduce UI TypeScript baseline — T1b reducer actions (-32)

### DIFF
--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -928,44 +928,32 @@
     "TS2345": 3
   },
   "src/slices/tests/analytics/clusterDetails.spec.ts": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "src/slices/tests/analytics/dbAnalysis.spec.ts": {
     "TS2322": 1,
-    "TS2345": 10
-  },
-  "src/slices/tests/analytics/settings.spec.ts": {
-    "TS2345": 1
+    "TS2345": 9
   },
   "src/slices/tests/analytics/slowlog.spec.ts": {
-    "TS2345": 5
+    "TS2345": 4
   },
   "src/slices/tests/app/features.spec.ts": {
     "TS2345": 4
   },
-  "src/slices/tests/app/info.spec.ts": {
-    "TS2345": 1
-  },
-  "src/slices/tests/app/notifications.spec.ts": {
-    "TS2345": 1
-  },
-  "src/slices/tests/app/plugins.spec.ts": {
-    "TS2345": 1
-  },
   "src/slices/tests/app/redis-commands.spec.ts": {
-    "TS2345": 4
+    "TS2345": 3
   },
   "src/slices/tests/browser/bulkActions.spec.ts": {
-    "TS2345": 7,
+    "TS2345": 6,
     "TS2740": 2
   },
   "src/slices/tests/browser/hash.spec.ts": {
-    "TS2345": 15
+    "TS2345": 14
   },
   "src/slices/tests/browser/keys.spec.ts": {
     "TS2322": 4,
     "TS2339": 4,
-    "TS2345": 28
+    "TS2345": 27
   },
   "src/slices/tests/browser/list.spec.ts": {
     "TS2322": 3,
@@ -975,22 +963,22 @@
   },
   "src/slices/tests/browser/redisearch.spec.ts": {
     "TS2322": 2,
-    "TS2345": 14,
+    "TS2345": 13,
     "TS2739": 6
   },
   "src/slices/tests/browser/rejson.spec.ts": {
-    "TS2345": 13,
+    "TS2345": 12,
     "TS2554": 2
   },
   "src/slices/tests/browser/set.spec.ts": {
-    "TS2345": 18
+    "TS2345": 17
   },
   "src/slices/tests/browser/stream.spec.ts": {
     "TS2322": 11,
-    "TS2345": 25
+    "TS2345": 24
   },
   "src/slices/tests/browser/string.spec.ts": {
-    "TS2345": 10,
+    "TS2345": 9,
     "TS2554": 1
   },
   "src/slices/tests/browser/vectorSet.spec.ts": {
@@ -998,7 +986,7 @@
   },
   "src/slices/tests/browser/zset.spec.ts": {
     "TS2322": 2,
-    "TS2345": 29,
+    "TS2345": 28,
     "TS2554": 2
   },
   "src/slices/tests/cli/cli-output.spec.ts": {
@@ -1012,48 +1000,39 @@
   "src/slices/tests/cli/monitor.spec.ts": {
     "TS7016": 1
   },
-  "src/slices/tests/content/create-redis-buttons.spec.ts": {
-    "TS2345": 1
-  },
-  "src/slices/tests/content/guide-links.spec.ts": {
-    "TS2345": 1
-  },
   "src/slices/tests/instances/caCerts.spec.ts": {
-    "TS2345": 5
+    "TS2345": 4
   },
   "src/slices/tests/instances/clientCerts.spec.ts": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "src/slices/tests/instances/cloud.spec.ts": {
     "TS2322": 3,
-    "TS2345": 7
+    "TS2345": 6
   },
   "src/slices/tests/instances/cluster.spec.ts": {
     "TS2322": 6,
-    "TS2345": 3
+    "TS2345": 2
   },
   "src/slices/tests/instances/instances.spec.ts": {
     "TS2322": 1,
-    "TS2345": 23
+    "TS2345": 22
   },
   "src/slices/tests/instances/sentinel.spec.ts": {
     "TS2322": 3,
-    "TS2345": 8
+    "TS2345": 7
   },
   "src/slices/tests/oauth/azure.spec.ts": {
     "TS2322": 1
   },
   "src/slices/tests/oauth/cloud.spec.ts": {
-    "TS2345": 14
+    "TS2345": 13
   },
   "src/slices/tests/panels/aiAssistant.spec.ts": {
     "TS2345": 1
   },
-  "src/slices/tests/panels/sidePanels.spec.ts": {
-    "TS2345": 1
-  },
   "src/slices/tests/pubsub/pubsub.spec.ts": {
-    "TS2345": 3
+    "TS2345": 2
   },
   "src/slices/tests/rdi/dryRun.spec.tsx": {
     "TS2345": 1
@@ -1069,22 +1048,19 @@
   },
   "src/slices/tests/recommendations/recommendations.spec.ts": {
     "TS2322": 4,
-    "TS2345": 11,
+    "TS2345": 10,
     "TS2559": 1
   },
   "src/slices/tests/user/user-settings.spec.ts": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "src/slices/tests/workbench/wb-custom-tutorials.spec.ts": {
-    "TS2345": 4
+    "TS2345": 3
   },
   "src/slices/tests/workbench/wb-results.spec.ts": {
     "TS2322": 7,
     "TS2345": 20,
     "TS2741": 1
-  },
-  "src/slices/tests/workbench/wb-tutorials.spec.ts": {
-    "TS2345": 1
   },
   "src/slices/user/user-settings.ts": {
     "TS2345": 1

--- a/redisinsight/ui/src/slices/tests/analytics/clusterDetails.spec.ts
+++ b/redisinsight/ui/src/slices/tests/analytics/clusterDetails.spec.ts
@@ -38,7 +38,7 @@ describe('clusterDetails slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/analytics/dbAnalysis.spec.ts
+++ b/redisinsight/ui/src/slices/tests/analytics/dbAnalysis.spec.ts
@@ -92,7 +92,7 @@ describe('db analysis slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/analytics/settings.spec.ts
+++ b/redisinsight/ui/src/slices/tests/analytics/settings.spec.ts
@@ -14,7 +14,7 @@ describe('analytics settings slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/analytics/slowlog.spec.ts
+++ b/redisinsight/ui/src/slices/tests/analytics/slowlog.spec.ts
@@ -56,7 +56,7 @@ describe('slowLog slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/app/info.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/info.spec.ts
@@ -37,7 +37,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/app/notifications.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/notifications.spec.ts
@@ -77,7 +77,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/app/plugins.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/plugins.spec.ts
@@ -56,7 +56,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/app/redis-commands.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/redis-commands.spec.ts
@@ -39,7 +39,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/bulkActions.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/bulkActions.spec.ts
@@ -64,7 +64,7 @@ describe('bulkActions slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/hash.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/hash.spec.ts
@@ -78,7 +78,7 @@ describe('hash slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/keys.spec.ts
@@ -147,7 +147,7 @@ describe('keys slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/redisearch.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/redisearch.spec.ts
@@ -91,7 +91,7 @@ describe('redisearch slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/rejson.spec.ts
@@ -89,7 +89,7 @@ describe('rejson slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/set.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/set.spec.ts
@@ -71,7 +71,7 @@ describe('set slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/stream.spec.ts
@@ -180,7 +180,7 @@ describe('stream slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/string.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/string.spec.ts
@@ -62,7 +62,7 @@ describe('string slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/browser/zset.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/zset.spec.ts
@@ -88,7 +88,7 @@ describe('zset slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/content/create-redis-buttons.spec.ts
+++ b/redisinsight/ui/src/slices/tests/content/create-redis-buttons.spec.ts
@@ -40,7 +40,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/content/guide-links.spec.ts
+++ b/redisinsight/ui/src/slices/tests/content/guide-links.spec.ts
@@ -29,7 +29,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/caCerts.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/caCerts.spec.ts
@@ -38,7 +38,7 @@ describe('caCerts slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/clientCerts.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/clientCerts.spec.ts
@@ -38,7 +38,7 @@ describe('clientCerts slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/cloud.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/cloud.spec.ts
@@ -82,7 +82,7 @@ describe('cloud slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/cluster.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/cluster.spec.ts
@@ -160,7 +160,7 @@ describe('cluster slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -168,7 +168,7 @@ describe('instances slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/instances/sentinel.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/sentinel.spec.ts
@@ -95,7 +95,7 @@ describe('sentinel slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/oauth/cloud.spec.ts
+++ b/redisinsight/ui/src/slices/tests/oauth/cloud.spec.ts
@@ -84,7 +84,7 @@ describe('oauth cloud slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/panels/sidePanels.spec.ts
+++ b/redisinsight/ui/src/slices/tests/panels/sidePanels.spec.ts
@@ -36,7 +36,7 @@ describe('sidePanels slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/pubsub/pubsub.spec.ts
+++ b/redisinsight/ui/src/slices/tests/pubsub/pubsub.spec.ts
@@ -39,7 +39,7 @@ describe('pubsub slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/recommendations/recommendations.spec.ts
+++ b/redisinsight/ui/src/slices/tests/recommendations/recommendations.spec.ts
@@ -61,7 +61,7 @@ describe('recommendations slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/user/user-settings.spec.ts
+++ b/redisinsight/ui/src/slices/tests/user/user-settings.spec.ts
@@ -42,7 +42,7 @@ describe('userSettings slice', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/workbench/wb-custom-tutorials.spec.ts
+++ b/redisinsight/ui/src/slices/tests/workbench/wb-custom-tutorials.spec.ts
@@ -55,7 +55,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)

--- a/redisinsight/ui/src/slices/tests/workbench/wb-tutorials.spec.ts
+++ b/redisinsight/ui/src/slices/tests/workbench/wb-tutorials.spec.ts
@@ -32,7 +32,7 @@ describe('slices', () => {
       const nextState = initialState
 
       // Act
-      const result = reducer(undefined, {})
+      const result = reducer(undefined, { type: '' })
 
       // Assert
       expect(result).toEqual(nextState)


### PR DESCRIPTION
# What

Third batch ("T1b") of the staged UI TypeScript baseline reduction. **Stacked on #6108 (T1a)** — base branch is `test/ts-baseline-t1a-rootstate-mocks`; GitHub will retarget this to `main` once T1a merges.

Types the empty action in `reducer(undefined, {})` across 32 slice specs. `{}` isn't assignable to the reducer's `UnknownAction` parameter; passing a minimal `{ type: '' }` (an existing idiom in the repo) fixes it with no import or cast. Behaviour-identical — an action matching no case still yields the initial state.

Decrements the matching `TS2345` counts in `redisinsight/ui/.tscheck.rec.json` (−1 per file, **−32** total).

# Testing

- `yarn --cwd redisinsight/ui type-check` — these 32 `TS2345` errors gone, no new errors (verified via before/after tsc diff, exactly 1 removed per file)
- `yarn lint:ui` — clean
- Jest — **786 tests pass** across the 32 specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only typing and baseline bookkeeping; no production slice or runtime behavior changes.
> 
> **Overview**
> **T1b** continues shrinking the UI TypeScript baseline by fixing how slice specs invoke reducers for the “initial state” case.
> 
> In **32** `src/slices/tests/**/*.spec.ts` files, `reducer(undefined, {})` becomes `reducer(undefined, { type: '' })` so the second argument satisfies `UnknownAction` instead of triggering **TS2345**. Behavior is unchanged—an unmatched action still returns the initial state—and the repo already uses this minimal action shape elsewhere.
> 
> `redisinsight/ui/.tscheck.rec.json` is updated to drop **one** `TS2345` per touched spec (and remove entries where that was the only remaining error), for **−32** baseline errors total.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745ea86dcf05679f8c30d9e015b4e685ee3ffe61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->