### PR TITLE
chore(ui): rename "Redis Query Engine" to "Redis Search"

### DIFF
--- a/redisinsight/ui/src/components/messages/feature-not-available/constants.ts
+++ b/redisinsight/ui/src/components/messages/feature-not-available/constants.ts
@@ -14,9 +14,9 @@ export const FILTER_NOT_AVAILABLE_CONTENT: FeatureNotAvailableContent = {
 
 export const REDISEARCH_VERSION_REQUIRED_CONTENT: FeatureNotAvailableContent = {
   testId: 'redisearch-version-required',
-  title: 'Redis Query Engine 2.0+ required',
+  title: 'Redis Search 2.0+ required',
   description:
-    'This feature requires Redis Query Engine 2.0 or later (included with Redis 6+). ' +
+    'This feature requires Redis Search 2.0 or later (included with Redis 6+). ' +
     'Older versions of the query engine are not compatible with the commands used here.',
   freeInstanceText:
     'Use your free all-in-one Redis Cloud database to start exploring these capabilities.',

--- a/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/ModuleNotLoadedMinimalized.spec.tsx
+++ b/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/ModuleNotLoadedMinimalized.spec.tsx
@@ -70,7 +70,7 @@ describe('ModuleNotLoadedMinimalized', () => {
     expect(screen.queryByTestId('connect-free-db-btn')).not.toBeInTheDocument()
     expect(screen.getByText(/Redis Databases page/)).toBeInTheDocument()
     expect(
-      screen.getByText(/Open a database with Redis Query Engine/),
+      screen.getByText(/Open a database with Redis Search/),
     ).toBeInTheDocument()
   })
 

--- a/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/constants.ts
+++ b/redisinsight/ui/src/components/messages/module-not-loaded-minimalized/constants.ts
@@ -15,7 +15,7 @@ export const MODULE_CAPABILITY_TEXT_NOT_AVAILABLE: {
     text: 'Create a free Redis Cloud database with JSON capability that extends the core capabilities of your Redis.',
   },
   [RedisDefaultModules.Search]: {
-    title: 'Redis Query Engine capability is not available',
+    title: 'Redis Search capability is not available',
     text: 'Create a free Redis Cloud database with search and query features that extend the core capabilities of your Redis.',
   },
   [RedisDefaultModules.TimeSeries]: {
@@ -39,8 +39,8 @@ export const MODULE_CAPABILITY_TEXT_NOT_AVAILABLE_ENTERPRISE: {
     text: 'Open a database with JSON.',
   },
   [RedisDefaultModules.Search]: {
-    title: 'Redis Query Engine capability is not available',
-    text: 'Open a database with Redis Query Engine.',
+    title: 'Redis Search capability is not available',
+    text: 'Open a database with Redis Search.',
   },
   [RedisDefaultModules.TimeSeries]: {
     title: 'Time series data structure is not available',

--- a/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoaded.spec.tsx
+++ b/redisinsight/ui/src/components/messages/module-not-loaded/ModuleNotLoaded.spec.tsx
@@ -80,9 +80,7 @@ describe('ModuleNotLoaded', () => {
     })
     mockGetDbWithModuleLoaded(true) // should not affect output
     const { queryByText } = render(<ModuleNotLoaded {...props} />)
-    expect(
-      queryByText(/Open a database with Redis Query Engine/),
-    ).toBeInTheDocument()
+    expect(queryByText(/Open a database with Redis Search/)).toBeInTheDocument()
   })
 
   it('should not show CTA button when envDependant feature is disabled', () => {
@@ -133,9 +131,7 @@ describe('ModuleNotLoaded', () => {
       },
     })
     const { getByText } = render(<ModuleNotLoaded {...props} />)
-    expect(
-      getByText(/Open a database with Redis Query Engine/),
-    ).toBeInTheDocument()
+    expect(getByText(/Open a database with Redis Search/)).toBeInTheDocument()
   })
 
   it('should show expected text when free db exists', () => {

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
@@ -673,7 +673,7 @@ describe('ONBOARDING_FEATURES', () => {
         </OnboardingTour>,
       )
       expect(screen.getByTestId('step-content')).toHaveTextContent(
-        'This is Search, where you can index your data and query it using Redis Query Engine.',
+        'This is Search, where you can index your data and query it using Redis Search.',
       )
       expect(screen.getByTestId('step-content')).toHaveTextContent(
         'Load sample data to create your first index and run sample queries to see results instantly.',

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
@@ -332,8 +332,8 @@ const ONBOARDING_FEATURES = {
         content: (
           <>
             This is Search, where you can index your data and query it using
-            Redis Query Engine. Run full-text search, vector similarity, and
-            filtered queries right from the UI.
+            Redis Search. Run full-text search, vector similarity, and filtered
+            queries right from the UI.
             <Spacer size="xs" />
             Load sample data to create your first index and run sample queries
             to see results instantly.

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/ExpertChat.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/ExpertChat.tsx
@@ -198,16 +198,16 @@ const ExpertChat = () => {
       return {
         title: 'Open a database',
         content:
-          'Open your Redis database with Redis Query Engine, or create a new database to get started.',
+          'Open your Redis database with Redis Search, or create a new database to get started.',
       }
     }
 
     if (!isRedisearchAvailable(modules)) {
       return {
-        title: 'Redis Query Engine capability is not available',
+        title: 'Redis Search capability is not available',
         content: freeInstances?.length
           ? 'Use your free all-in-one Redis Cloud database to start exploring these capabilities.'
-          : 'Create a free Redis Cloud database with Redis Query Engine capability that extends the core capabilities of open-source Redis.',
+          : 'Create a free Redis Cloud database with Redis Search capability that extends the core capabilities of open-source Redis.',
         icon: <TelescopeImg className={styles.iconTelescope} />,
       }
     }

--- a/redisinsight/ui/src/constants/workbenchResults.ts
+++ b/redisinsight/ui/src/constants/workbenchResults.ts
@@ -25,8 +25,8 @@ export const MODULE_NOT_LOADED_CONTENT: { [key in RedisDefaultModules]?: any } =
       link: 'https://redis.io/docs/latest/develop/data-types/timeseries/',
     },
     [RedisDefaultModules.Search]: {
-      title: ['Redis Query Engine is not available for this database'],
-      text: ['Redis Query Engine allows to:'],
+      title: ['Redis Search is not available for this database'],
+      text: ['Redis Search allows to:'],
       improvements: ['Query', 'Secondary index', 'Full-text search'],
       additionalText: [
         'These features enable multi-field queries, aggregation, exact phrase matching, numeric filtering, ',
@@ -45,7 +45,7 @@ export const MODULE_NOT_LOADED_CONTENT: { [key in RedisDefaultModules]?: any } =
         'Retrieve JSON documents',
       ],
       additionalText: [
-        'JSON data structure also works seamlessly with Redis Query Engine to let you index and query JSON documents.',
+        'JSON data structure also works seamlessly with Redis Search to let you index and query JSON documents.',
       ],
       link: 'https://redis.io/docs/latest/develop/data-types/json/',
     },
@@ -68,6 +68,6 @@ export const MODULE_NOT_LOADED_CONTENT: { [key in RedisDefaultModules]?: any } =
 export const MODULE_TEXT_VIEW: { [key in RedisDefaultModules]?: string } = {
   [RedisDefaultModules.Bloom]: 'probabilistic data structures',
   [RedisDefaultModules.ReJSON]: 'JSON data structure',
-  [RedisDefaultModules.Search]: 'Redis Query Engine',
+  [RedisDefaultModules.Search]: 'Redis Search',
   [RedisDefaultModules.TimeSeries]: 'time series data structure',
 }

--- a/redisinsight/ui/src/packages/geodata/package.json
+++ b/redisinsight/ui/src/packages/geodata/package.json
@@ -136,7 +136,7 @@
       },
       "iconDark": "./dist/geodata_icon_dark.svg",
       "iconLight": "./dist/geodata_icon_light.svg",
-      "description": "Show Redis Query Engine GEO results as plotted locations",
+      "description": "Show Redis Search GEO results as plotted locations",
       "default": false
     },
     {
@@ -156,7 +156,7 @@
       },
       "iconDark": "./dist/geodata_heatmap_icon_dark.svg",
       "iconLight": "./dist/geodata_heatmap_icon_light.svg",
-      "description": "Show Redis Query Engine GEO result density",
+      "description": "Show Redis Search GEO result density",
       "default": false
     },
     {
@@ -177,7 +177,7 @@
       },
       "iconDark": "./dist/geodata_inspector_icon_dark.svg",
       "iconLight": "./dist/geodata_inspector_icon_light.svg",
-      "description": "Inspect Redis Query Engine geospatial command inputs and results",
+      "description": "Inspect Redis Search geospatial command inputs and results",
       "default": false
     },
     {
@@ -196,7 +196,7 @@
       },
       "iconDark": "./dist/geodata_inspector_icon_dark.svg",
       "iconLight": "./dist/geodata_inspector_icon_light.svg",
-      "description": "Show Redis Query Engine GEOSHAPE WKT results",
+      "description": "Show Redis Search GEOSHAPE WKT results",
       "default": false
     }
   ],

--- a/redisinsight/ui/src/packages/geodata/src/App.spec.tsx
+++ b/redisinsight/ui/src/packages/geodata/src/App.spec.tsx
@@ -163,7 +163,7 @@ describe('Geodata App', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders Redis Query Engine GEO points on a map', () => {
+  it('renders Redis Search GEO points on a map', () => {
     renderComponent(
       'FT.SEARCH cities "@coords:[2.34 48.86 1000 km]" RETURN 1 coords',
       [1, 'city:1', ['name', 'Paris', 'coords', '2.34,48.86']],
@@ -176,7 +176,7 @@ describe('Geodata App', () => {
     expect(screen.queryByText('Map tiles disabled')).not.toBeInTheDocument()
   })
 
-  it('renders Redis Query Engine GEO points on a heatmap', () => {
+  it('renders Redis Search GEO points on a heatmap', () => {
     renderComponent(
       'FT.SEARCH cities "@coords:[2.34 48.86 1000 km]" RETURN 1 coords',
       [1, 'city:1', ['name', 'Paris', 'coords', '2.34,48.86']],
@@ -187,7 +187,7 @@ describe('Geodata App', () => {
     expect(screen.getByRole('cell', { name: 'Paris' })).toBeInTheDocument()
   })
 
-  it('renders Redis Query Engine command parse errors', () => {
+  it('renders Redis Search command parse errors', () => {
     renderComponent(
       'FT.SEARCH idx "*"',
       [0],
@@ -196,7 +196,7 @@ describe('Geodata App', () => {
 
     expect(screen.getByText('Cannot inspect RQE geo command')).toBeInTheDocument()
     expect(
-      screen.getByText('No Redis Query Engine geospatial predicate found.'),
+      screen.getByText('No Redis Search geospatial predicate found.'),
     ).toBeInTheDocument()
   })
 
@@ -215,7 +215,7 @@ describe('Geodata App', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders Redis Query Engine GEO inspector summaries', () => {
+  it('renders Redis Search GEO inspector summaries', () => {
     renderComponent(
       'FT.AGGREGATE idx "@coords:[$lon $lat $radius km]" PARAMS 6 lon 2.34 lat 48.86 radius 1000 LOAD 1 @coords',
       [1, ['name', 'Paris', 'coords', '2.34,48.86']],
@@ -228,7 +228,7 @@ describe('Geodata App', () => {
     expect(screen.getByText('1000 km')).toBeInTheDocument()
   })
 
-  it('renders Redis Query Engine GEOSHAPE results', () => {
+  it('renders Redis Search GEOSHAPE results', () => {
     renderComponent(
       'FT.SEARCH idx "@geom:[CONTAINS $shape]" PARAMS 2 shape "POINT (2 2)" RETURN 1 geom DIALECT 3',
       [1, 'shape:1', ['name', 'Zone', 'geom', 'POLYGON ((1 1, 1 3, 3 3, 1 1))']],

--- a/redisinsight/ui/src/packages/geodata/src/components/RqeGeoVisualization/RqeGeoVisualization.spec.tsx
+++ b/redisinsight/ui/src/packages/geodata/src/components/RqeGeoVisualization/RqeGeoVisualization.spec.tsx
@@ -134,7 +134,7 @@ describe('RqeGeoVisualization', () => {
   it('shows a heatmap-specific error title when heatmap command parsing fails', () => {
     jest.spyOn(rqeGeoParser, 'parseRqeGeoCommand').mockReturnValue({
       ok: false,
-      error: 'No Redis Query Engine geospatial predicate found.',
+      error: 'No Redis Search geospatial predicate found.',
     })
 
     render(

--- a/redisinsight/ui/src/packages/geodata/src/utils/rqeGeoParser.spec.ts
+++ b/redisinsight/ui/src/packages/geodata/src/utils/rqeGeoParser.spec.ts
@@ -166,7 +166,7 @@ describe('rqeGeoParser', () => {
       ),
     ).toEqual({
       ok: false,
-      error: 'No Redis Query Engine geospatial predicate found.',
+      error: 'No Redis Search geospatial predicate found.',
     })
   })
 
@@ -177,7 +177,7 @@ describe('rqeGeoParser', () => {
       ),
     ).toEqual({
       ok: false,
-      error: 'No Redis Query Engine geospatial predicate found.',
+      error: 'No Redis Search geospatial predicate found.',
     })
 
     expect(
@@ -186,7 +186,7 @@ describe('rqeGeoParser', () => {
       ),
     ).toEqual({
       ok: false,
-      error: 'No Redis Query Engine geospatial predicate found.',
+      error: 'No Redis Search geospatial predicate found.',
     })
   })
 
@@ -282,11 +282,11 @@ describe('rqeGeoParser', () => {
   it('rejects malformed RQE geo predicates', () => {
     expect(parseRqeGeoCommand('')).toEqual({
       ok: false,
-      error: 'Missing Redis Query Engine command.',
+      error: 'Missing Redis Search command.',
     })
     expect(parseRqeGeoCommand('FT.INFO idx')).toEqual({
       ok: false,
-      error: 'Unsupported Redis Query Engine command: FT.INFO.',
+      error: 'Unsupported Redis Search command: FT.INFO.',
     })
     expect(parseRqeGeoCommand('FT.SEARCH')).toEqual({
       ok: false,
@@ -791,7 +791,7 @@ describe('rqeGeoParser', () => {
   it('rejects unsupported RQE geo commands and malformed shapes', () => {
     expect(parseRqeGeoCommand('FT.SEARCH idx "*"')).toEqual({
       ok: false,
-      error: 'No Redis Query Engine geospatial predicate found.',
+      error: 'No Redis Search geospatial predicate found.',
     })
     expect(
       parseRqeGeoCommand(

--- a/redisinsight/ui/src/packages/geodata/src/utils/rqeGeoParser.ts
+++ b/redisinsight/ui/src/packages/geodata/src/utils/rqeGeoParser.ts
@@ -307,10 +307,10 @@ export const parseRqeGeoCommand = (
   const tokens = tokenizeRedisCommand(command)
   const commandToken = tokens[0]?.toUpperCase() as RqeGeoCommand | undefined
   if (!commandToken) {
-    return { ok: false, error: 'Missing Redis Query Engine command.' }
+    return { ok: false, error: 'Missing Redis Search command.' }
   }
   if (!RQE_GEO_COMMANDS.has(commandToken)) {
-    return { ok: false, error: `Unsupported Redis Query Engine command: ${tokens[0]}.` }
+    return { ok: false, error: `Unsupported Redis Search command: ${tokens[0]}.` }
   }
   if (!tokens[1]) {
     return { ok: false, error: `${commandToken} requires an index.` }
@@ -333,7 +333,7 @@ export const parseRqeGeoCommand = (
     queryOverlay
 
   if (!parsedOverlay) {
-    return { ok: false, error: 'No Redis Query Engine geospatial predicate found.' }
+    return { ok: false, error: 'No Redis Search geospatial predicate found.' }
   }
   if (!parsedOverlay.ok) {
     return parsedOverlay
@@ -534,7 +534,7 @@ const parseRqeRows = (
 
   return {
     ok: false,
-    error: `Unsupported Redis Query Engine command: ${command.command}.`,
+    error: `Unsupported Redis Search command: ${command.command}.`,
   }
 }
 

--- a/redisinsight/ui/src/packages/redisearch/index.html
+++ b/redisinsight/ui/src/packages/redisearch/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Redis Query Engine plugin</title>
+    <title>Redis Search plugin</title>
 
     <script type="module" src="./src/main.tsx"></script>
     <!-- Run Conditions-->

--- a/redisinsight/ui/src/pages/vector-search/components/search-page-fallback/constants.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/search-page-fallback/constants.ts
@@ -3,8 +3,8 @@ import { SearchPageFallbackContent } from './SearchPageFallback.types'
 
 export const RQE_NOT_AVAILABLE_CONTENT: SearchPageFallbackContent = {
   testId: 'rqe-not-available',
-  title: 'Redis Query Engine is not available for this database',
-  subtitle: 'Redis Query Engine allows to:',
+  title: 'Redis Search is not available for this database',
+  subtitle: 'Redis Search allows to:',
   features: ['Query', 'Secondary index', 'Full-text search'],
   description:
     'These features enable multi-field queries, aggregation, exact phrase matching, numeric filtering, ' +
@@ -16,9 +16,9 @@ export const RQE_NOT_AVAILABLE_CONTENT: SearchPageFallbackContent = {
 
 export const VERSION_NOT_SUPPORTED_CONTENT: SearchPageFallbackContent = {
   testId: 'version-not-supported',
-  title: 'Redis Query Engine 2.0+ required',
+  title: 'Redis Search 2.0+ required',
   description:
-    'This page requires Redis Query Engine 2.0 or later (included with Redis 6+). ' +
+    'This page requires Redis Search 2.0 or later (included with Redis 6+). ' +
     'Older versions of the query engine are not compatible with the commands used here.',
   ctaText:
     'Create a free Redis Cloud database to start exploring these capabilities.',

--- a/redisinsight/ui/src/slices/interfaces/instances.ts
+++ b/redisinsight/ui/src/slices/interfaces/instances.ts
@@ -214,10 +214,10 @@ export const DATABASE_LIST_MODULES_TEXT = Object.freeze({
   [RedisDefaultModules.TimeSeries]: 'Time Series',
   [RedisCustomModulesName.Proto]: 'redis-protobuf',
   [RedisCustomModulesName.IpTables]: 'RedisPushIpTables',
-  [RedisDefaultModules.Search]: 'Redis Query Engine',
-  [RedisDefaultModules.SearchLight]: 'Redis Query Engine',
-  [RedisDefaultModules.FT]: 'Redis Query Engine',
-  [RedisDefaultModules.FTL]: 'Redis Query Engine',
+  [RedisDefaultModules.Search]: 'Redis Search',
+  [RedisDefaultModules.SearchLight]: 'Redis Search',
+  [RedisDefaultModules.FT]: 'Redis Search',
+  [RedisDefaultModules.FTL]: 'Redis Search',
   [RedisDefaultModules.VectorSet]: 'Vector Set',
 })
 

--- a/redisinsight/ui/src/utils/capability.ts
+++ b/redisinsight/ui/src/utils/capability.ts
@@ -27,7 +27,7 @@ export const getTutorialCapability = (source: any = '') => {
     case getSourceTutorialByCapability(RedisDefaultModules.FTL):
       return getCapability(
         'searchAndQuery',
-        'Redis Query Engine',
+        'Redis Search',
         findMarkdownPath(store.getState()?.workbench?.tutorials?.items, {
           id: 'sq-intro',
         }),

--- a/redisinsight/ui/src/utils/tests/capability.spec.ts
+++ b/redisinsight/ui/src/utils/tests/capability.spec.ts
@@ -22,7 +22,7 @@ describe('getSourceTutorialByCapability', () => {
 
 const emptyCapability = { name: '', telemetryName: '', path: null }
 const searchCapability = {
-  name: 'Redis Query Engine',
+  name: 'Redis Search',
   telemetryName: 'searchAndQuery',
   path: null,
 }

--- a/redisinsight/ui/src/utils/tests/modules.spec.ts
+++ b/redisinsight/ui/src/utils/tests/modules.spec.ts
@@ -11,7 +11,7 @@ import {
 const modules1: IDatabaseModule[] = [
   { moduleName: 'JSON', abbreviation: 'RS' },
   { moduleName: 'My1Module', abbreviation: 'MD' },
-  { moduleName: 'Redis Query Engine', abbreviation: 'RS' },
+  { moduleName: 'Redis Search', abbreviation: 'RS' },
 ]
 const modules2: IDatabaseModule[] = [
   { moduleName: '', abbreviation: '' },
@@ -23,17 +23,17 @@ const modules2: IDatabaseModule[] = [
   { moduleName: 'My1Module', abbreviation: 'MD' },
   { moduleName: 'JSON', abbreviation: 'RS' },
   { moduleName: 'My2Modul2e', abbreviation: 'MX' },
-  { moduleName: 'Redis Query Engine', abbreviation: 'RS' },
+  { moduleName: 'Redis Search', abbreviation: 'RS' },
 ]
 
 const result1: IDatabaseModule[] = [
-  { moduleName: 'Redis Query Engine', abbreviation: 'RS' },
+  { moduleName: 'Redis Search', abbreviation: 'RS' },
   { moduleName: 'JSON', abbreviation: 'RS' },
   { moduleName: 'My1Module', abbreviation: 'MD' },
 ]
 
 const result2: IDatabaseModule[] = [
-  { moduleName: 'Redis Query Engine', abbreviation: 'RS' },
+  { moduleName: 'Redis Search', abbreviation: 'RS' },
   { moduleName: 'JSON', abbreviation: 'RS' },
   { moduleName: 'Probabilistic', abbreviation: 'RS' },
   { moduleName: 'MycvModule', abbreviation: 'MC' },

--- a/tests/e2e-playwright/TEST_PLAN.md
+++ b/tests/e2e-playwright/TEST_PLAN.md
@@ -398,7 +398,7 @@ The test plan is organized by feature area. Tests are grouped for parallel execu
 | 🔲 | main | Search by index in Tree view |
 | 🔲 | main | View filter history for RediSearch queries |
 | 🔲 | main | Verify context persistence for RediSearch across navigation |
-| 🔲 | main | Display "No Redis Query Engine" message when module not available |
+| 🔲 | main | Display "No Redis Search" message when module not available |
 | 🔲 | main | Delete search index with FT.DROPINDEX |
 
 ### 2.14 Key Filtering Patterns

--- a/tests/e2e-playwright/pages/vector-search/components/RqeNotAvailable.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/RqeNotAvailable.ts
@@ -19,7 +19,7 @@ export class RqeNotAvailable {
     this.page = page;
 
     this.container = page.getByTestId('rqe-not-available');
-    this.title = page.getByText('Redis Query Engine is not available for this database');
+    this.title = page.getByText('Redis Search is not available for this database');
     this.description = page.getByTestId('rqe-description');
     this.featureList = page.getByTestId('rqe-feature-list');
     this.getStartedButton = page.getByRole('button', { name: 'Get started for free' });

--- a/tests/e2e-playwright/tests/parallel/browser/key-list/key-list-view.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-list/key-list-view.spec.ts
@@ -201,7 +201,7 @@ test.describe('Browser > Key List View', () => {
     // Verify switching between Pattern search and Search by values UI
     await browserPage.keyList.searchByValuesButton.click();
     const indexOrHint = browserPage.keyList.indexSelector.or(
-      browserPage.page.getByText(/Redis Query Engine|Select an index|Query Engine/i),
+      browserPage.page.getByText(/Redis Search|Select an index|Query Engine/i),
     );
     await expect(indexOrHint.first()).toBeVisible();
     await browserPage.keyList.filterByNameButton.click();


### PR DESCRIPTION
## What

Renames the retired product name **"Redis Query Engine" → "Redis Search"** in user-facing copy, per the *Redis product copy & naming style guide (June 2026)*. Found and triaged with the new `redis-copy-style` audit skill.

22 files, display strings only:
- UI messages/fallbacks: `feature-not-available`, `module-not-loaded(-minimalized)`, vector-search `search-page-fallback`
- Onboarding (`OnboardingFeatures`), AI assistant (`ExpertChat`), `workbenchResults`
- Module display-name map (`slices/interfaces/instances.ts`), `utils/capability.ts`
- Plugins: `geodata` manifest descriptions + parser error messages, `redisearch` page title
- Matching `*.spec` tests and e2e page object / spec / TEST_PLAN references

## Why

These strings are shown to users and must match current Redis naming. The values are typed as `string` (the display-name map is `Object.freeze`, `getCapability` takes `name: string`), so this is a pure copy change — **no behavior or type changes**.

## Deliberately NOT changed (and why)

The skill flagged these but they aren't marketing copy to rewrite:
- **Generated files** — `redisinsight/api-client/*.gen.ts`, `api/openapi.json` (regenerated from source).
- **`api/src/modules/redis-enterprise/**`** — describes connecting to the actual Redis Enterprise/Software product (API descriptions, log messages); not RedisInsight's own brand copy.
- **`"Azure Cache for Redis Enterprise"`** — a Microsoft Azure product name.
- **`"Redis Enterprise Software Subscription Agreement"`** — a legal agreement title.
- **`mock-recommendations.ts`** + `api/defaults/content`, `api/defaults/tutorials` — mock/API-mirroring data and content downloaded at build time (not repo source).
- **Minified bundles** — `**/index2.js`, `api/static/plugins/**`.

The broader "Enterprise" → descriptive-language and "create" → "build" rules were left out of this PR — they need product/PM judgment per occurrence rather than a mechanical rename.

## Verification

- `eslint` clean on all changed files (geodata package is eslint-ignored by config; its pre-existing formatting is untouched).
- `tsc` shows no new errors at changed lines (repo has a pre-existing baseline of ~2000 tracked TS errors; this change adds none).
- UI jest specs can't run in this local env due to a **pre-existing** circular-import failure (`Environment` not exported from `apiClient`) that fails identically on a clean tree — unrelated to this change; CI (Node ≥24) runs them.

## Status

**Draft** — opening for review of scope and naming before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)