### PR TITLE
chore(ui): reduce UI TypeScript baseline — T2 error-payload typing (-321)

### DIFF
--- a/redisinsight/ui/.tscheck.rec.json
+++ b/redisinsight/ui/.tscheck.rec.json
@@ -48,9 +48,6 @@
     "TS2339": 5,
     "TS7016": 1
   },
-  "src/components/bulk-actions-config/BulkActionsConfig.tsx": {
-    "TS2322": 1
-  },
   "src/components/charts/bar-chart/BarChart.spec.tsx": {
     "TS2554": 1,
     "TS7031": 1
@@ -122,10 +119,10 @@
     "TS2322": 1
   },
   "src/components/oauth/oauth-jobs/OAuthJobs.spec.tsx": {
-    "TS2345": 3
+    "TS2345": 2
   },
   "src/components/oauth/oauth-jobs/OAuthJobs.tsx": {
-    "TS2345": 4
+    "TS2345": 3
   },
   "src/components/oauth/oauth-select-account-dialog/OAuthSelectAccountDialog.spec.tsx": {
     "TS2554": 1
@@ -231,8 +228,7 @@
     "TS2345": 1
   },
   "src/electron/components/ConfigOAuth/ConfigOAuth.tsx": {
-    "TS2339": 1,
-    "TS2345": 1
+    "TS2339": 1
   },
   "src/electron/utils/tests/ipcCheckUpdates.spec.ts": {
     "TS2345": 2,
@@ -453,7 +449,7 @@
     "TS2322": 13
   },
   "src/pages/browser/modules/key-details/components/rejson-details/rejson-object/RejsonObject.tsx": {
-    "TS2345": 2,
+    "TS2345": 1,
     "TS7030": 1
   },
   "src/pages/browser/modules/key-details/components/rejson-details/rejson-scalar/RejsonScalar.spec.tsx": {
@@ -664,17 +660,8 @@
   "src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.spec.tsx": {
     "TS2741": 1
   },
-  "src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx": {
-    "TS2345": 1
-  },
   "src/pages/rdi/instance/components/header/components/index.ts": {
     "TS2307": 1
-  },
-  "src/pages/rdi/pipeline-management/components/jobs-panel/Panel.spec.tsx": {
-    "TS2345": 1
-  },
-  "src/pages/rdi/pipeline-management/components/jobs-panel/Panel.tsx": {
-    "TS2345": 1
   },
   "src/pages/rdi/pipeline-management/components/test-connections-log/TestConnectionsLog.tsx": {
     "TS2305": 1,
@@ -683,15 +670,8 @@
   "src/pages/rdi/pipeline-management/components/test-connections-panel/TestConnectionsPanel.tsx": {
     "TS2322": 1
   },
-  "src/pages/rdi/pipeline-management/pages/job/Job.tsx": {
-    "TS2345": 1
-  },
-  "src/pages/rdi/pipeline-management/pages/job/JobsWrapper.spec.tsx": {
-    "TS2345": 1
-  },
   "src/pages/redis-stack/components/edit-connection/EditConnection.tsx": {
-    "TS2322": 1,
-    "TS2345": 2
+    "TS2322": 1
   },
   "src/pages/settings/SettingsPage.spec.tsx": {
     "TS2339": 2
@@ -791,64 +771,45 @@
   "src/setup-env.ts": {
     "TS2307": 1
   },
-  "src/slices/analytics/clusterDetails.ts": {
-    "TS2345": 1
-  },
-  "src/slices/analytics/dbAnalysis.ts": {
-    "TS2345": 4
-  },
-  "src/slices/analytics/slowlog.ts": {
-    "TS2345": 4
-  },
-  "src/slices/app/info.ts": {
-    "TS2345": 1
-  },
-  "src/slices/app/plugins.ts": {
-    "TS2345": 1
-  },
   "src/slices/app/redis-commands.ts": {
-    "TS2345": 2
-  },
-  "src/slices/browser/bulkActions.ts": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "src/slices/browser/hash.ts": {
     "TS2322": 2,
-    "TS2345": 17,
+    "TS2345": 4,
     "TS2769": 1
   },
   "src/slices/browser/keys.ts": {
     "TS2322": 1,
-    "TS2345": 9,
     "TS2741": 1
   },
   "src/slices/browser/list.ts": {
     "TS2322": 5,
-    "TS2345": 18,
+    "TS2345": 6,
     "TS2769": 1
   },
   "src/slices/browser/redisearch.ts": {
     "TS2322": 1,
     "TS2339": 2,
-    "TS2345": 10,
+    "TS2345": 5,
     "TS2769": 1
   },
   "src/slices/browser/rejson.ts": {
-    "TS2345": 8
+    "TS2345": 1
   },
   "src/slices/browser/set.ts": {
     "TS2322": 2,
-    "TS2345": 14
+    "TS2345": 4
   },
   "src/slices/browser/stream.ts": {
     "TS2322": 4,
     "TS2339": 1,
-    "TS2345": 30,
+    "TS2345": 13,
     "TS2698": 1,
     "TS2739": 1
   },
   "src/slices/browser/string.ts": {
-    "TS2345": 7,
+    "TS2345": 1,
     "TS2741": 1
   },
   "src/slices/browser/vectorSet.ts": {
@@ -857,37 +818,22 @@
   },
   "src/slices/browser/zset.ts": {
     "TS2322": 3,
-    "TS2345": 22
+    "TS2345": 4
   },
   "src/slices/cli/cli-output.ts": {
-    "TS2345": 2
-  },
-  "src/slices/cli/cli-settings.ts": {
-    "TS2345": 5
-  },
-  "src/slices/content/create-redis-buttons.ts": {
     "TS2345": 1
   },
   "src/slices/instances/caCerts.ts": {
-    "TS2345": 5
-  },
-  "src/slices/instances/clientCerts.ts": {
-    "TS2345": 4
-  },
-  "src/slices/instances/cloud.ts": {
-    "TS2345": 5
-  },
-  "src/slices/instances/cluster.ts": {
-    "TS2345": 5
+    "TS2345": 1
   },
   "src/slices/instances/instances.ts": {
     "TS2322": 1,
     "TS2339": 2,
-    "TS2345": 14
+    "TS2345": 1
   },
   "src/slices/instances/sentinel.ts": {
     "TS2322": 1,
-    "TS2345": 6
+    "TS2345": 3
   },
   "src/slices/interfaces/hash.ts": {
     "TS2430": 1
@@ -898,44 +844,14 @@
   "src/slices/interfaces/zset.ts": {
     "TS2430": 1
   },
-  "src/slices/oauth/cloud.ts": {
-    "TS2345": 9
-  },
-  "src/slices/panels/aiAssistant.ts": {
-    "TS2345": 3
-  },
-  "src/slices/pubsub/pubsub.ts": {
-    "TS2345": 1
-  },
-  "src/slices/rdi/dryRun.ts": {
-    "TS2345": 1
-  },
   "src/slices/rdi/instances.ts": {
     "TS2322": 2,
     "TS2339": 1,
-    "TS2345": 8
-  },
-  "src/slices/rdi/pipeline.ts": {
-    "TS2345": 7
-  },
-  "src/slices/rdi/statistics.ts": {
-    "TS2345": 1
-  },
-  "src/slices/rdi/testConnections.ts": {
-    "TS2345": 1
-  },
-  "src/slices/recommendations/recommendations.ts": {
-    "TS2345": 3
-  },
-  "src/slices/tests/analytics/clusterDetails.spec.ts": {
-    "TS2345": 1
+    "TS2345": 2
   },
   "src/slices/tests/analytics/dbAnalysis.spec.ts": {
     "TS2322": 1,
-    "TS2345": 9
-  },
-  "src/slices/tests/analytics/slowlog.spec.ts": {
-    "TS2345": 4
+    "TS2345": 5
   },
   "src/slices/tests/app/features.spec.ts": {
     "TS2345": 4
@@ -944,41 +860,41 @@
     "TS2345": 3
   },
   "src/slices/tests/browser/bulkActions.spec.ts": {
-    "TS2345": 6,
+    "TS2345": 4,
     "TS2740": 2
   },
   "src/slices/tests/browser/hash.spec.ts": {
-    "TS2345": 14
+    "TS2345": 12
   },
   "src/slices/tests/browser/keys.spec.ts": {
     "TS2322": 4,
     "TS2339": 4,
-    "TS2345": 27
+    "TS2345": 21
   },
   "src/slices/tests/browser/list.spec.ts": {
     "TS2322": 3,
-    "TS2345": 10,
+    "TS2345": 7,
     "TS2352": 1,
     "TS2554": 1
   },
   "src/slices/tests/browser/redisearch.spec.ts": {
     "TS2322": 2,
-    "TS2345": 13,
+    "TS2345": 9,
     "TS2739": 6
   },
   "src/slices/tests/browser/rejson.spec.ts": {
-    "TS2345": 12,
+    "TS2345": 8,
     "TS2554": 2
   },
   "src/slices/tests/browser/set.spec.ts": {
-    "TS2345": 17
+    "TS2345": 13
   },
   "src/slices/tests/browser/stream.spec.ts": {
     "TS2322": 11,
-    "TS2345": 24
+    "TS2345": 13
   },
   "src/slices/tests/browser/string.spec.ts": {
-    "TS2345": 9,
+    "TS2345": 6,
     "TS2554": 1
   },
   "src/slices/tests/browser/vectorSet.spec.ts": {
@@ -986,12 +902,11 @@
   },
   "src/slices/tests/browser/zset.spec.ts": {
     "TS2322": 2,
-    "TS2345": 28,
+    "TS2345": 20,
     "TS2554": 2
   },
   "src/slices/tests/cli/cli-output.spec.ts": {
-    "TS2322": 1,
-    "TS2345": 1
+    "TS2322": 1
   },
   "src/slices/tests/cli/cli-settings.spec.ts": {
     "TS2345": 3,
@@ -1001,80 +916,50 @@
     "TS7016": 1
   },
   "src/slices/tests/instances/caCerts.spec.ts": {
-    "TS2345": 4
-  },
-  "src/slices/tests/instances/clientCerts.spec.ts": {
-    "TS2345": 1
+    "TS2345": 2
   },
   "src/slices/tests/instances/cloud.spec.ts": {
     "TS2322": 3,
-    "TS2345": 6
+    "TS2345": 2
   },
   "src/slices/tests/instances/cluster.spec.ts": {
-    "TS2322": 6,
-    "TS2345": 2
+    "TS2322": 6
   },
   "src/slices/tests/instances/instances.spec.ts": {
     "TS2322": 1,
-    "TS2345": 22
+    "TS2345": 12
   },
   "src/slices/tests/instances/sentinel.spec.ts": {
     "TS2322": 3,
-    "TS2345": 7
+    "TS2345": 5
   },
   "src/slices/tests/oauth/azure.spec.ts": {
     "TS2322": 1
   },
   "src/slices/tests/oauth/cloud.spec.ts": {
-    "TS2345": 13
-  },
-  "src/slices/tests/panels/aiAssistant.spec.ts": {
-    "TS2345": 1
+    "TS2345": 5
   },
   "src/slices/tests/pubsub/pubsub.spec.ts": {
-    "TS2345": 2
-  },
-  "src/slices/tests/rdi/dryRun.spec.tsx": {
     "TS2345": 1
   },
   "src/slices/tests/rdi/instances.spec.ts": {
-    "TS2345": 4
-  },
-  "src/slices/tests/rdi/pipeline.spec.ts": {
-    "TS2345": 7
-  },
-  "src/slices/tests/rdi/testConnections.spec.ts": {
     "TS2345": 1
   },
   "src/slices/tests/recommendations/recommendations.spec.ts": {
     "TS2322": 4,
-    "TS2345": 10,
+    "TS2345": 7,
     "TS2559": 1
-  },
-  "src/slices/tests/user/user-settings.spec.ts": {
-    "TS2345": 1
-  },
-  "src/slices/tests/workbench/wb-custom-tutorials.spec.ts": {
-    "TS2345": 3
   },
   "src/slices/tests/workbench/wb-results.spec.ts": {
     "TS2322": 7,
-    "TS2345": 20,
+    "TS2345": 13,
     "TS2741": 1
   },
-  "src/slices/user/user-settings.ts": {
-    "TS2345": 1
-  },
   "src/slices/workbench/wb-custom-tutorials.ts": {
-    "TS2339": 1,
-    "TS2345": 3
+    "TS2339": 1
   },
   "src/slices/workbench/wb-results.ts": {
-    "TS2322": 1,
-    "TS2345": 6
-  },
-  "src/slices/workbench/wb-tutorials.ts": {
-    "TS2345": 1
+    "TS2322": 1
   },
   "src/telemetry/telemetryUtils.ts": {
     "TS7053": 1

--- a/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
+++ b/redisinsight/ui/src/components/bulk-actions-config/BulkActionsConfig.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { AxiosError } from 'axios'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { Socket } from 'socket.io-client'
 
@@ -151,7 +152,11 @@ const BulkActionsConfig = () => {
   const onBulkDeleting = (data: any) => {
     if (data.status === BulkActionsServerEvent.Error) {
       dispatch(disconnectBulkDeleteAction())
-      dispatch(addErrorNotification({ response: { data: data.error } }))
+      dispatch(
+        addErrorNotification({
+          response: { data: data.error },
+        } as AxiosError),
+      )
     }
 
     // Trigger download if report URL is provided

--- a/redisinsight/ui/src/pages/redis-stack/components/edit-connection/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/redis-stack/components/edit-connection/EditConnection.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
+import { AxiosError } from 'axios'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory } from 'react-router-dom'
 
@@ -68,11 +69,11 @@ const EditConnection = () => {
         setState({ ...state, loading: false, data })
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       if (isApiSubscribed) {
         setState({ ...state, loading: false, error: errorMessage })
       }
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
     }
   }
   const onInstanceChanged = () => {

--- a/redisinsight/ui/src/slices/app/info.ts
+++ b/redisinsight/ui/src/slices/app/info.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { apiService } from 'uiSrc/services'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
@@ -95,7 +96,7 @@ export function fetchServerInfo(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(getServerInfoFailure(errorMessage))
       onFailAction?.()
     }

--- a/redisinsight/ui/src/slices/app/notifications.ts
+++ b/redisinsight/ui/src/slices/app/notifications.ts
@@ -52,13 +52,14 @@ const notificationsSlice = createSlice({
   reducers: {
     addErrorNotification: (
       state,
-      { payload }: { payload: IAddInstanceErrorPayload },
+      { payload }: { payload: AxiosError & { instanceId?: string } },
     ) => {
-      const { instanceId } = payload
-      const title = payload?.response?.data?.title
+      const errorPayload = payload as IAddInstanceErrorPayload
+      const { instanceId } = errorPayload
+      const title = errorPayload?.response?.data?.title
       const errorName = getApiErrorName(payload)
       const message = getApiErrorMessage(payload)
-      const additionalInfo = payload?.response?.data?.additionalInfo
+      const additionalInfo = errorPayload?.response?.data?.additionalInfo
       const errorExistedId = state.errors.findIndex(
         (err) => err.message === message,
       )

--- a/redisinsight/ui/src/slices/app/plugins.ts
+++ b/redisinsight/ui/src/slices/app/plugins.ts
@@ -1,4 +1,5 @@
 import { flatMap, isEmpty, reject } from 'lodash'
+import { AxiosError } from 'axios'
 import { createSlice } from '@reduxjs/toolkit'
 
 import {
@@ -93,7 +94,7 @@ export function loadPluginsAction() {
         dispatch(getAllPluginsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(getAllPluginsFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/app/redis-commands.ts
+++ b/redisinsight/ui/src/slices/app/redis-commands.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { isString, uniqBy } from 'lodash'
 import { apiService, resourcesService } from 'uiSrc/services'
 import { ApiEndpoints, ICommand, ICommands } from 'uiSrc/constants'
@@ -108,7 +109,7 @@ export function fetchRedisCommandsInfo(
         }
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(getRedisCommandsFailure(errorMessage))
       onFailAction?.()
     }

--- a/redisinsight/ui/src/slices/browser/hash.ts
+++ b/redisinsight/ui/src/slices/browser/hash.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { cloneDeep, remove, isNull } from 'lodash'
 import { apiService } from 'uiSrc/services'
 import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
@@ -258,8 +259,8 @@ export function fetchHashFields(
         onSuccess?.(data)
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadHashFieldsFailure(errorMessage))
     }
   }
@@ -295,7 +296,7 @@ export function refreshHashFieldsAction(
         dispatch(loadHashFieldsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(loadHashFieldsFailure(errorMessage))
     }
   }
@@ -332,8 +333,8 @@ export function fetchMoreHashFields(
         dispatch(loadMoreHashFieldsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadMoreHashFieldsFailure(errorMessage))
     }
   }
@@ -386,8 +387,8 @@ export function deleteHashFields(
         }
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(removeHashFieldsFailure(errorMessage))
     }
   }
@@ -423,8 +424,8 @@ export function addHashFieldsAction(
       if (onFailAction) {
         onFailAction()
       }
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateValueFailure(errorMessage))
     }
   }
@@ -467,8 +468,8 @@ export function updateHashFieldsAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateValueFailure(errorMessage))
       onFailAction?.()
     }
@@ -531,8 +532,8 @@ export function updateHashTTLAction(
         dispatch(updateFieldsInList(data.fields as any))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateValueFailure(errorMessage))
       onFailAction?.()
     }

--- a/redisinsight/ui/src/slices/browser/list.ts
+++ b/redisinsight/ui/src/slices/browser/list.ts
@@ -1,4 +1,5 @@
 import { cloneDeep, isNull } from 'lodash'
+import { AxiosError } from 'axios'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { apiService } from 'uiSrc/services'
@@ -272,8 +273,8 @@ export function fetchListElements(
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadListElementsFailure(errorMessage))
     }
   }
@@ -308,8 +309,8 @@ export function fetchMoreListElements(
         dispatch(loadMoreListElementsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadMoreListElementsFailure(errorMessage))
     }
   }
@@ -346,8 +347,8 @@ export function fetchSearchingListElementAction(
         onSuccess?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadSearchingListElementFailure(errorMessage))
     }
   }
@@ -407,8 +408,8 @@ export function updateListElementAction(
         dispatch<any>(refreshKeyInfoAction(data.keyName))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateValueFailure(errorMessage))
 
       onFailAction?.()
@@ -441,8 +442,8 @@ export function insertListElementsAction(
         dispatch<any>(fetchKeyInfo(data.keyName))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(insertListElementsFailure(errorMessage))
 
       onFailAction?.()
@@ -494,8 +495,8 @@ export function deleteListElementsAction(
         }
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(deleteListElementsFailure(errorMessage))
 
       onFailAction?.()

--- a/redisinsight/ui/src/slices/browser/rejson.ts
+++ b/redisinsight/ui/src/slices/browser/rejson.ts
@@ -217,7 +217,7 @@ export function fetchReJSON(
       if (!axios.isCancel(error)) {
         const errorMessage = getApiErrorMessage(error as AxiosError)
         dispatch(loadRejsonBranchFailure(errorMessage))
-        dispatch(addErrorNotification(error))
+        dispatch(addErrorNotification(error as AxiosError))
       }
     }
   }
@@ -283,9 +283,9 @@ export function setReJSONDataAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(setReJSONDataFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
       onFailAction?.()
     }
   }
@@ -333,9 +333,9 @@ export function appendReJSONArrayItemAction(
         dispatch<any>(refreshKeyInfoAction(key))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(appendReJSONArrayItemFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
     }
   }
 }

--- a/redisinsight/ui/src/slices/browser/set.ts
+++ b/redisinsight/ui/src/slices/browser/set.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { remove } from 'lodash'
 
 import { apiService } from 'uiSrc/services'
@@ -209,8 +210,8 @@ export function fetchSetMembers(
         onSuccess?.(data)
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadSetMembersFailure(errorMessage))
     }
   }
@@ -247,8 +248,8 @@ export function fetchMoreSetMembers(
         dispatch(loadMoreSetMembersSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadMoreSetMembersFailure(errorMessage))
     }
   }
@@ -285,8 +286,8 @@ export function refreshSetMembersAction(
         dispatch(loadSetMembersSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadSetMembersFailure(errorMessage))
     }
   }
@@ -319,8 +320,8 @@ export function addSetMembersAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(addSetMembersFailure(errorMessage))
       onFailAction?.()
     }
@@ -377,8 +378,8 @@ export function deleteSetMembers(
         }
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(removeSetMembersFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/browser/stream.ts
+++ b/redisinsight/ui/src/slices/browser/stream.ts
@@ -874,8 +874,8 @@ export function deleteConsumerGroupsAction(
         )
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(deleteConsumerGroupsFailure(errorMessage))
     }
   }
@@ -967,8 +967,8 @@ export function deleteConsumersAction(
         )
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(deleteConsumersFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/browser/string.ts
+++ b/redisinsight/ui/src/slices/browser/string.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { AxiosResponseHeaders } from 'axios'
+import { AxiosError, AxiosResponseHeaders } from 'axios'
 import { ApiEndpoints, KeyTypes } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
 import {
@@ -141,8 +141,8 @@ export function fetchString(
         dispatch(getStringSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(getStringFailure(errorMessage))
     }
   }
@@ -174,8 +174,8 @@ export function fetchDownloadStringValue(
         onSuccessAction?.(data, headers)
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(downloadStringFailure(errorMessage))
     }
   }
@@ -223,8 +223,8 @@ export function updateStringValueAction(
         onSuccess?.(value)
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateValueFailure(errorMessage))
       onFailed?.()
     }

--- a/redisinsight/ui/src/slices/browser/zset.ts
+++ b/redisinsight/ui/src/slices/browser/zset.ts
@@ -1,4 +1,5 @@
 import { cloneDeep, isNull, remove } from 'lodash'
+import { AxiosError } from 'axios'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { apiService } from 'uiSrc/services'
@@ -284,8 +285,8 @@ export function fetchZSetMembers(
         dispatch(updateSelectedKeyRefreshTime(Date.now()))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadZSetMembersFailure(errorMessage))
     }
   }
@@ -322,8 +323,8 @@ export function fetchMoreZSetMembers(
         dispatch(loadMoreZSetMembersSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadMoreZSetMembersFailure(errorMessage))
     }
   }
@@ -366,8 +367,8 @@ export function fetchAddZSetMembers(
       }
     } catch (error) {
       onFailAction?.()
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateScoreFailure(errorMessage))
     }
   }
@@ -420,8 +421,8 @@ export function deleteZSetMembers(
         }
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(removeZsetMembersFailure(errorMessage))
     }
   }
@@ -464,8 +465,8 @@ export function updateZSetMembers(
       }
     } catch (error) {
       onFailAction?.()
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(updateScoreFailure(errorMessage))
     }
   }
@@ -503,8 +504,8 @@ export function fetchSearchZSetMembers(
         onSuccess?.(data)
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(searchZSetMembersFailure(errorMessage))
     }
   }
@@ -539,8 +540,8 @@ export function fetchSearchMoreZSetMembers(
         dispatch(searchMoreZSetMembersSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(searchMoreZSetMembersFailure(errorMessage))
     }
   }
@@ -578,8 +579,8 @@ export function refreshZsetMembersAction(
           dispatch(searchZSetMembersSuccess(data))
         }
       } catch (error) {
-        const errorMessage = getApiErrorMessage(error)
-        dispatch(addErrorNotification(error))
+        const errorMessage = getApiErrorMessage(error as AxiosError)
+        dispatch(addErrorNotification(error as AxiosError))
         dispatch(searchZSetMembersFailure(errorMessage))
       }
       return
@@ -608,8 +609,8 @@ export function refreshZsetMembersAction(
         dispatch(loadZSetMembersSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadZSetMembersFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/cli/cli-settings.ts
+++ b/redisinsight/ui/src/slices/cli/cli-settings.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 
 import { apiService, sessionStorageService } from 'uiSrc/services'
 import { ApiEndpoints, BrowserStorageItem } from 'uiSrc/constants'
@@ -219,7 +220,7 @@ export function createCliClientAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(processCliClientFailure(errorMessage))
       onFailAction?.(errorMessage)
     }
@@ -255,7 +256,7 @@ export function updateCliClientAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(processCliClientFailure(errorMessage))
       onFailAction?.(errorMessage)
     }
@@ -282,7 +283,7 @@ export function deleteCliClientAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(processCliClientFailure(errorMessage))
       onFailAction?.()
     }
@@ -327,7 +328,7 @@ export function fetchBlockingCliCommandsAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(processCliClientFailure(errorMessage))
       onFailAction?.()
     }
@@ -352,7 +353,7 @@ export function fetchUnsupportedCliCommandsAction(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(processCliClientFailure(errorMessage))
       onFailAction?.()
     }

--- a/redisinsight/ui/src/slices/content/create-redis-buttons.ts
+++ b/redisinsight/ui/src/slices/content/create-redis-buttons.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import {
   ContentCreateRedis as IContentItem,
   StateContentCreateRedis as IState,
@@ -61,7 +62,7 @@ export function fetchContentAction() {
         dispatch(getContentSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(getContentFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/instances/caCerts.ts
+++ b/redisinsight/ui/src/slices/instances/caCerts.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 
 import { ApiEndpoints } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
@@ -77,8 +78,8 @@ export function fetchCaCerts() {
         dispatch(loadCaCertsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(loadCaCertsFailure(errorMessage))
     }
   }
@@ -102,8 +103,8 @@ export function deleteCaCertificateAction(
         dispatch(fetchCaCerts())
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
-      dispatch(addErrorNotification(error))
+      const errorMessage = getApiErrorMessage(error as AxiosError)
+      dispatch(addErrorNotification(error as AxiosError))
       dispatch(deleteCaCertificateFailure(errorMessage))
     }
   }

--- a/redisinsight/ui/src/slices/instances/clientCerts.ts
+++ b/redisinsight/ui/src/slices/instances/clientCerts.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 
 import { ApiEndpoints } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
@@ -78,9 +79,9 @@ export function fetchClientCerts() {
         dispatch(loadClientCertsSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(loadClientCertsFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
     }
   }
 }
@@ -101,8 +102,8 @@ export function deleteClientCertAction(
         dispatch(fetchClientCerts())
       }
     } catch (error) {
-      dispatch(addErrorNotification(error))
-      dispatch(deleteClientCertFailure(getApiErrorMessage(error)))
+      dispatch(addErrorNotification(error as AxiosError))
+      dispatch(deleteClientCertFailure(getApiErrorMessage(error as AxiosError)))
     }
   }
 }

--- a/redisinsight/ui/src/slices/instances/cluster.ts
+++ b/redisinsight/ui/src/slices/instances/cluster.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { apiService } from 'uiSrc/services'
 import {
@@ -115,9 +116,9 @@ export function fetchInstancesRedisCluster(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(loadInstancesRedisClusterFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
     }
   }
 }
@@ -147,9 +148,9 @@ export function addInstancesRedisCluster(payload: {
         dispatch(createInstancesRedisClusterSuccess(data))
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(createInstancesRedisClusterFailure(errorMessage))
-      dispatch(addErrorNotification(error))
+      dispatch(addErrorNotification(error as AxiosError))
     }
   }
 }

--- a/redisinsight/ui/src/slices/workbench/wb-tutorials.ts
+++ b/redisinsight/ui/src/slices/workbench/wb-tutorials.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { AxiosError } from 'axios'
 import { ApiEndpoints } from 'uiSrc/constants'
 import { getApiErrorMessage, isStatusSuccessful } from 'uiSrc/utils'
 import { resourcesService } from 'uiSrc/services'
@@ -67,7 +68,7 @@ export function fetchTutorials(
         onSuccessAction?.()
       }
     } catch (error) {
-      const errorMessage = getApiErrorMessage(error)
+      const errorMessage = getApiErrorMessage(error as AxiosError)
       dispatch(getWBTutorialsFailure(errorMessage))
       onFailAction?.()
     }


### PR DESCRIPTION
# What

Third step of the staged UI TypeScript baseline reduction (follows #6107 T0, #6108 T1a, #6109 T1b). Resolves the `AxiosError → IAddInstanceErrorPayload` type mismatch (269 errors) plus the uncast-`catch`-variable errors entangled with it. **Baseline `1628 → 1307` (−321), 36 files cleared.**

### Root cause
`addErrorNotification` was typed to accept `IAddInstanceErrorPayload` (which `extends AxiosError` and *narrows* `response.data`), while every call site produces a plain `AxiosError<unknown>` — not assignable. The reducer only reads the extra fields via optional chaining, so this was a pure type mismatch, never a runtime issue.

### Changes (all type-only)
- **Widen the action payload** to `AxiosError & { instanceId?: string }`, with one internal `as IAddInstanceErrorPayload` cast for the narrowed `response.data` reads. Clears all 269 call-site mismatches at once — without editing the ~23 files that already cast `as AxiosError` — and keeps the `{ ...error, instanceId }` callers valid.
- **Cast the uncast `catch` error variables** (`error as AxiosError`) at the 92 `unknown → AxiosError` sites this covers, across 17 slices + a component; added the `axios` import where missing.
- **One malformed inline error mock** in `BulkActionsConfig` cast.

### Why `as` cast and not a type guard
Deliberate — this is a type-only baseline-reduction PR, so behaviour must not change (`as` casts are erased at compile time; emitted JS is identical):

- A guard (`axios.isAxiosError(error)` / `instanceof`) **would** change behaviour — non-axios errors (unexpected throws/bugs) would stop surfacing a notification, a silent-failure regression. `getApiErrorMessage` is explicitly written to handle every caught error (`if (!error || !error.response) return DEFAULT_ERROR_MESSAGE`).
- It matches the existing convention: 253 `as AxiosError` casts already exist in the codebase, and zero `isAxiosError`/`instanceof` guards.

Hardening error handling with real guards (plus an `else` so non-axios errors still notify) is worthwhile, but it's a behavioural change for its own PR.

# Testing

- `yarn --cwd redisinsight/ui type-check` — −321 errors, **0 (file × code) cells increased** (no regressions)
- `yarn lint:ui` — clean
- `yarn test` — **1253 tests pass** across all slice specs + the touched component specs (`notifications`, `BulkActionsConfig`, `EditConnection`), confirming the change is runtime-neutral

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only casts and a wider notification payload type; error notification behavior is unchanged and tests are reported passing.
> 
> **Overview**
> This PR is a **type-only** baseline cleanup: UI TypeScript errors drop by **321** (1628 → 1307), with **36 files** cleared from the recorded baseline in `.tscheck.rec.json`.
> 
> **`addErrorNotification`** no longer requires the narrow `IAddInstanceErrorPayload` at the action boundary. The reducer accepts **`AxiosError & { instanceId?: string }`**, and only uses an internal cast when reading optional `response.data` fields (`title`, `additionalInfo`). That fixes the mismatch where call sites pass plain `AxiosError` from API failures.
> 
> Across **Redux slices** (browser key types, app info/plugins/commands, instances, CLI settings, workbench, etc.) and a couple of components, **`catch` handlers** now cast `error as AxiosError` before `getApiErrorMessage` and `addErrorNotification`, with `axios` imports added where needed. **`BulkActionsConfig`** casts a socket error object shaped like an Axios response.
> 
> No runtime behavior change is intended—only compile-time assertions and the baseline registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ec6da1ce732c07a2bf641489830d1f305f9e5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->