### PR TITLE
RI-8222: Add array set-element endpoint (ARSET)

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Array/Set Element.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Set Element.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Set Element
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array/set-element
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "readings",
+    "index": "1",
+    "value": "20.5"
+  }
+}
+
+docs {
+  # ARSET (single element)
+
+  Set the value of a single element at an explicit index — `ARSET key index
+  value`. Overwrites a populated slot or fills an empty one. The key must
+  already exist (Modify edits an existing array; it does not create one).
+
+  ## Request body
+
+  | Field     | Type   | Notes                                              |
+  |-----------|--------|----------------------------------------------------|
+  | `keyName` | string | The Array key name.                                |
+  | `index`   | string | Unsigned 64-bit integer as string.                 |
+  | `value`   | string | Value to store at the index.                       |
+
+  ## Response
+
+  `200 OK` with an empty body.
+
+  ## Errors
+
+  | Status | When |
+  |--------|------|
+  | `400`  | Key holds a non-array type. |
+  | `403`  | User has no permission for `ARSET`. |
+  | `404`  | Key does not exist. |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -9,6 +9,7 @@ import {
   CreateArrayWithExpireDto,
   GetArraySearchDto,
   GetArraySearchResponse,
+  SetArrayElementDto,
 } from 'src/modules/browser/array/dto';
 
 const arrayKeyName = () => Buffer.from(`array:${faker.string.alphanumeric(6)}`);
@@ -35,6 +36,14 @@ export const createSparseArrayDtoFactory =
     mode: ArrayCreationMode.Sparse,
     elements: arrayElementFactory.buildList(2),
   }));
+
+export const setArrayElementDtoFactory = Factory.define<SetArrayElementDto>(
+  () => ({
+    keyName: arrayKeyName(),
+    index: '0',
+    value: arrayValue(),
+  }),
+);
 
 export const aggregateArrayDtoFactory = Factory.define<AggregateArrayDto>(
   () => ({

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -33,6 +33,7 @@ import {
   GetArrayScanResponse,
   GetArraySearchDto,
   GetArraySearchResponse,
+  SetArrayElementDto,
 } from 'src/modules/browser/array/dto';
 
 @ApiTags('Browser: Array')
@@ -56,7 +57,24 @@ export class ArrayController extends BrowserBaseController {
     return this.arrayService.createArray(clientMetadata, dto);
   }
 
-  // The key name can be very large, so it is better to send it in the request body
+  @Post('/set-element')
+  @HttpCode(200)
+  @ApiOperation({
+    description:
+      'Set the value of a single element at an explicit index (ARSET key ' +
+      'index value). Overwrites a populated slot or fills an empty one; the ' +
+      'key must already exist.',
+  })
+  @ApiRedisParams()
+  @ApiBody({ type: SetArrayElementDto })
+  @ApiQueryRedisStringEncoding()
+  async setElement(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: SetArrayElementDto,
+  ): Promise<void> {
+    return this.arrayService.setElement(clientMetadata, dto);
+  }
+
   @Post('/get-range')
   @HttpCode(200)
   @ApiOperation({

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -26,6 +26,7 @@ import {
   createSparseArrayDtoFactory,
   getArraySearchDtoFactory,
   getArraySearchResponseFactory,
+  setArrayElementDtoFactory,
 } from 'src/modules/browser/array/__tests__/array.factory';
 import {
   mockArrayCount,
@@ -612,6 +613,59 @@ describe('ArrayService', () => {
       mockStandaloneRedisClient.sendCommand.mockRejectedValue(replyError);
       await expect(
         service.getElement(mockBrowserClientMetadata, mockGetArrayElementDto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('setElement', () => {
+    // keyName matches mockKeyDto so the shared key-existence stub resolves.
+    const dto = setArrayElementDtoFactory.build({
+      keyName: mockKeyDto.keyName,
+      index: '5',
+    });
+
+    it('should set the element via ARSET key index value', async () => {
+      await expect(
+        service.setElement(mockBrowserClientMetadata, dto),
+      ).resolves.not.toThrow();
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArSet,
+        dto.keyName,
+        dto.index,
+        dto.value,
+      ]);
+    });
+
+    it('should reject when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(0);
+      await expect(
+        service.setElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should rethrow BadRequest on WrongType', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'ARSET',
+      };
+      when(client.sendCommand)
+        .calledWith(expect.arrayContaining([BrowserToolArrayCommands.ArSet]))
+        .mockRejectedValue(replyError);
+      await expect(
+        service.setElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should map ACL error to Forbidden', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARSET',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+      await expect(
+        service.setElement(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(ForbiddenException);
     });
   });

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -46,6 +46,7 @@ import {
   GetArrayScanResponse,
   GetArraySearchDto,
   GetArraySearchResponse,
+  SetArrayElementDto,
 } from 'src/modules/browser/array/dto';
 
 @Injectable()
@@ -500,6 +501,36 @@ export class ArrayService {
         clientMetadata,
       );
       if (error instanceof BadRequestException) throw error;
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
+  public async setElement(
+    clientMetadata: ClientMetadata,
+    dto: SetArrayElementDto,
+  ): Promise<void> {
+    try {
+      this.logger.debug('Setting array element.', clientMetadata);
+      const { keyName, index, value } = dto;
+      const client =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      // Modify edits an existing slot, so the key must already exist —
+      // guard rather than letting ARSET create a fresh key from an edit.
+      await checkIfKeyNotExists(keyName, client);
+
+      await client.sendCommand([
+        BrowserToolArrayCommands.ArSet,
+        keyName,
+        index,
+        value,
+      ]);
+
+      this.logger.debug('Succeed to set array element.', clientMetadata);
+    } catch (error) {
+      this.logger.error('Failed to set array element.', error, clientMetadata);
       if (error?.message?.includes(RedisErrorCodes.WrongType)) {
         throw new BadRequestException(error.message);
       }

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -5,6 +5,7 @@ export * from './get.array-scan.dto';
 export * from './get.array-scan.response';
 export * from './get.array-element.dto';
 export * from './get.array-element.response';
+export * from './set.array-element.dto';
 export * from './get.array-multi-elements.dto';
 export * from './get.array-multi-elements.response';
 export * from './get.array-length.response';

--- a/redisinsight/api/src/modules/browser/array/dto/set.array-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/set.array-element.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined } from 'class-validator';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import {
+  ApiRedisString,
+  IsArrayIndex,
+  IsRedisString,
+  RedisStringType,
+} from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+/**
+ * Sets a single element at an explicit index (ARSET key index value). Index
+ * stays a numeric string per the unsigned-64-bit contract.
+ */
+export class SetArrayElementDto extends KeyDto {
+  @ApiProperty({
+    description:
+      'Index of the element to set. Unsigned 64-bit integer as string.',
+    type: String,
+    example: '42',
+  })
+  @IsArrayIndex()
+  index: string;
+
+  @ApiRedisString('Value to store at the index')
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  value: RedisString;
+}

--- a/redisinsight/api/test/api/array/POST-databases-id-array-set_element.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-set_element.test.ts
@@ -1,0 +1,262 @@
+import {
+  expect,
+  describe,
+  it,
+  before,
+  deps,
+  Joi,
+  requirements,
+  generateInvalidDataTestCases,
+  validateInvalidDataTestCase,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(
+    `/${constants.API.DATABASES}/${instanceId}/array/set-element`,
+  );
+
+// `index` is validated by @IsArrayIndex on the API side, which emits a single
+// combined message ("<field> must be an integer string between 0 and
+// 18446744073709551614") for any non-canonical input. Override the per-rule
+// Joi messages with a label-less substring of the API output so the harness's
+// substring-contains check passes for undefined / null / number / boolean /
+// object / array cases.
+const ARRAY_INDEX_MSG = 'must be an integer string between';
+
+const dataSchema = Joi.object({
+  keyName: Joi.string().allow('').required(),
+  index: Joi.string().required().messages({
+    'string.base': ARRAY_INDEX_MSG,
+    'any.required': ARRAY_INDEX_MSG,
+  }),
+  value: Joi.string().required(),
+}).strict();
+
+const validInputData = {
+  keyName: constants.getRandomString(),
+  index: '0',
+  value: constants.getRandomString(),
+};
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARSET/ARMSET/ARLEN/ARCOUNT are Redis 8.8 preview commands with no typed
+// ioredis method; assert array state through the generic `call`.
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+const arlen = (key: string) => rte.client.call('ARLEN', key);
+const arcount = (key: string) => rte.client.call('ARCOUNT', key);
+
+// Seed shape mirrors the canonical `readings` fixture: indexes 0,1,5 populated,
+// gaps at 2,3,4 (logical length 6, count 3).
+const seedSparse = (key: string) =>
+  rte.client.call('ARMSET', key, '0', '20.1', '1', '20.4', '5', '21.4');
+
+describe('POST /databases/:instanceId/array/set-element', () => {
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Validation', () => {
+    generateInvalidDataTestCases(dataSchema, validInputData).map(
+      validateInvalidDataTestCase(endpoint, dataSchema),
+    );
+
+    [
+      {
+        name: 'Should reject a non-decimal index',
+        data: {
+          keyName: constants.getRandomString(),
+          index: 'abc',
+          value: 'x',
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject a non-canonical index with a leading zero',
+        data: {
+          keyName: constants.getRandomString(),
+          index: '007',
+          value: 'x',
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an index outside u64',
+        data: {
+          keyName: constants.getRandomString(),
+          index: '18446744073709551616',
+          value: 'x',
+        },
+        statusCode: 400,
+      },
+      {
+        // 2^64-1 is reserved by Redis as the "no-index" sentinel — ARSET
+        // rejects it server-side, so the API validator must too.
+        name: 'Should reject the reserved 2^64-1 sentinel index',
+        data: {
+          keyName: constants.getRandomString(),
+          index: '18446744073709551615',
+          value: 'x',
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Main', () => {
+    it('Should overwrite a populated slot in place', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, index: '1', value: '99.9' },
+      });
+
+      expect(await arget(keyName, '1')).to.eql('99.9');
+      // Overwriting a populated slot leaves length and count untouched.
+      expect(await arlen(keyName)).to.eql(6);
+      expect(await arcount(keyName)).to.eql(3);
+    });
+
+    it('Should fill an empty slot inside the array (count grows)', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Index 3 is a gap inside length 0..5; filling it adds a populated slot
+      // without changing the logical length.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, index: '3', value: 'filled' },
+      });
+
+      expect(await arget(keyName, '3')).to.eql('filled');
+      expect(await arlen(keyName)).to.eql(6);
+      expect(await arcount(keyName)).to.eql(4);
+    });
+
+    it('Should set a value past the current length (length grows)', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, index: '20', value: 'far' },
+      });
+
+      expect(await arget(keyName, '20')).to.eql('far');
+      // Length follows the highest set index + 1.
+      expect(await arlen(keyName)).to.eql(21);
+      expect(await arcount(keyName)).to.eql(4);
+    });
+
+    it('Should round-trip a value stored at the maximum valid index (2^64-2)', async () => {
+      const keyName = constants.getRandomString();
+      const maxIndex = '18446744073709551614';
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, index: maxIndex, value: 'edge' },
+      });
+
+      expect(await arget(keyName, maxIndex)).to.eql('edge');
+    });
+
+    it('Should store a value sent as encoding=buffer byte-for-byte', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        query: { encoding: 'buffer' },
+        data: {
+          keyName,
+          index: '1',
+          value: { type: 'Buffer', data: [...Buffer.from('20.5')] },
+        },
+      });
+
+      expect(await arget(keyName, '1')).to.eql('20.5');
+    });
+
+    [
+      {
+        name: 'Should return BadRequest if key holds a non-array type',
+        data: { keyName: constants.TEST_STRING_KEY_1, index: '0', value: 'x' },
+        statusCode: 400,
+        before: () => rte.data.generateKeys(true),
+        after: async () => {
+          // The non-array key must be left untouched.
+          expect(await rte.client.get(constants.TEST_STRING_KEY_1)).to.eql(
+            constants.TEST_STRING_VALUE_1,
+          );
+        },
+      },
+      {
+        // Modify edits an existing array; ARSET on a missing key would create
+        // one, so the service guards it as a 404 instead.
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), index: '0', value: 'x' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), index: '0', value: 'x' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('ACL', () => {
+    requirements('rte.acl');
+    before(async () => rte.data.setAclUserRules('~* +@all'));
+
+    const aclEndpoint = () => endpoint(constants.TEST_INSTANCE_ACL_ID);
+    const aclKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should set the element for an authorised user',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, index: '0', value: 'authorised' },
+        before: async () => {
+          await rte.data.setAclUserRules('~* +@all');
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+        },
+        after: async () => {
+          expect(await arget(aclKey, '0')).to.eql('authorised');
+        },
+      },
+      {
+        name: 'Should throw error if no permissions for "arset" command',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, index: '0', value: 'x' },
+        statusCode: 403,
+        responseBody: { statusCode: 403, error: 'Forbidden' },
+        // beforeEach() wipes the key between tests; reseed via the root client
+        // (the ACL rule below only affects the API request's user).
+        before: async () => {
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+          await rte.data.setAclUserRules('~* +@all -arset');
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});


### PR DESCRIPTION
# What

Backend for editing a single array element in place.
Overwrites a populated slot or fills an empty one; the key must already exist
(404 otherwise), `WRONGTYPE` → 400, ACL denial → 403. Index is carried as a
numeric string per the unsigned-64-bit contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped new browser API endpoint with validation and tests; mutates Redis data only for existing array keys, following the same error-handling patterns as other array routes.
> 
> **Overview**
> Adds **`POST …/array/set-element`** so the browser can edit one array slot via Redis **`ARSET key index value`**, with **`SetArrayElementDto`** (`keyName`, u64 index string, `value`).
> 
> **`ArrayService.setElement`** checks the key exists first (returns **404** instead of letting ARSET create a key), then issues ARSET; **wrong type → 400**, **ACL → 403**. Swagger, Bruno docs, unit tests, and Redis 8.8 integration tests cover overwrite, gap fill, length growth, index validation (including the **2^64−1** sentinel), buffer encoding, and ACL on **`arset`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945671e386b161b900707f2225ce3ca1ace9bf0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->