### PR TITLE
RI-8293 Array Search form: extract helpers, trim const comments (review nits)

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
@@ -18,7 +18,6 @@ import {
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
-import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import {
   ArrayCombinator,
   ArrayGrepCriteria,
@@ -32,7 +31,6 @@ import {
   APPLIES_TO_ALL_LABEL,
   ARRAY_GREP_CRITERIA_OPTIONS,
   ARRAY_SEARCH_FORM_TEST_ID as TEST_ID,
-  ARRAY_SEARCH_LIMIT_MAX,
   COMBINATOR_ARIA,
   REMOVE_PREDICATE_ARIA,
   END_PLACEHOLDER,
@@ -58,22 +56,9 @@ import {
   WITHVALUES_LABEL,
 } from './ArraySearchForm.constants'
 import { ArraySearchFormProps } from './ArraySearchForm.types'
+import { isBoundInvalid, isLimitInvalid } from './ArraySearchForm.utils'
+import { InfoHint } from './components/InfoHint'
 import * as S from './ArraySearchForm.styles'
-
-// A blank bound is valid (omitted → server `-`/`+`); a non-blank one must be a
-// canonical u64 index, matching the backend `@IsArrayIndex` validator.
-const isBoundInvalid = (bound: string): boolean =>
-  bound !== '' && parseArrayIndex(bound) !== bound
-
-// LIMIT must be a whole number in 1..ARRAY_SEARCH_LIMIT_MAX (the backend cap).
-const isLimitInvalid = (limit: string): boolean =>
-  !/^[1-9]\d*$/.test(limit) || Number(limit) > ARRAY_SEARCH_LIMIT_MAX
-
-const InfoHint = ({ content }: { content: string }) => (
-  <RiTooltip content={content} position="top" anchorClassName="inline-flex">
-    <RiIcon type="InfoIcon" size="m" />
-  </RiTooltip>
-)
 
 /**
  * Multi-predicate ARGREP search form for the array Search tab: a list of

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.utils.ts
@@ -1,0 +1,12 @@
+import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
+
+import { ARRAY_SEARCH_LIMIT_MAX } from './ArraySearchForm.constants'
+
+// A blank bound is valid (omitted → server `-`/`+`); a non-blank one must be a
+// canonical u64 index, matching the backend `@IsArrayIndex` validator.
+export const isBoundInvalid = (bound: string): boolean =>
+  bound !== '' && parseArrayIndex(bound) !== bound
+
+// LIMIT must be a whole number in 1..ARRAY_SEARCH_LIMIT_MAX (the backend cap).
+export const isLimitInvalid = (limit: string): boolean =>
+  !/^[1-9]\d*$/.test(limit) || Number(limit) > ARRAY_SEARCH_LIMIT_MAX

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/components/InfoHint.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/components/InfoHint.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+import { RiTooltip } from 'uiSrc/components'
+import { RiIcon } from 'uiSrc/components/base/icons'
+
+import { InfoHintProps } from './InfoHint.types'
+
+export const InfoHint = ({ content }: InfoHintProps) => (
+  <RiTooltip content={content} position="top" anchorClassName="inline-flex">
+    <RiIcon type="InfoIcon" size="m" />
+  </RiTooltip>
+)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/components/InfoHint.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/components/InfoHint.types.ts
@@ -1,0 +1,3 @@
+export interface InfoHintProps {
+  content: string
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -1,7 +1,6 @@
 /**
- * Defaults for the array View / Browse vertical (see
- * `docs/redis-array-type-initiative.md` §6 Task 3). All indexes are decimal
- * strings to preserve the BigInt-as-string contract (§8.1) — never numbers.
+ * Defaults for the array View / Browse vertical. All indexes are decimal
+ * strings, never numbers, to preserve the full u64 range.
  */
 
 import {
@@ -29,19 +28,10 @@ export const DEFAULT_SEARCH_CRITERIA = ArrayGrepCriteria.Exact
  */
 export const DEFAULT_SEARCH_COMBINATOR = ArrayCombinator.Or
 
-/**
- * Pre-filled LIMIT value. The input stays visible (but disabled) until the
- * user ticks LIMIT, so it shows a sensible starting count and ticking the box
- * doesn't shift the layout. Only applied once enabled — otherwise no LIMIT is
- * sent and the search runs uncapped.
- */
+/** Pre-filled LIMIT value, applied only once the user enables LIMIT. */
 export const DEFAULT_LIMIT = '10'
 
-/**
- * Initial Search-tab options. Blank bounds search the whole array; WITHVALUES
- * is on so results carry values; LIMIT is pre-filled but only applied once the
- * user enables it.
- */
+/** Initial Search-tab option state. */
 export const DEFAULT_SEARCH_OPTIONS: ArraySearchOptions = {
   start: '',
   end: '',


### PR DESCRIPTION
# What

Follow-up to #6111 addressing two post-merge review nits (from @KrumTy):

- **Extract inline helpers/sub-component** — moved the `isBoundInvalid` / `isLimitInvalid` validators into `ArraySearchForm.utils.ts`, and the `InfoHint` tooltip-icon into `components/InfoHint.tsx` (+ `InfoHint.types.ts`), matching the FE folder-structure convention (mirrors `array-details-table/components`).
- **Trim `constants.ts` comments** — `DEFAULT_LIMIT` / `DEFAULT_SEARCH_OPTIONS` comments narrated component behavior the const knows nothing about (that logic already lives in the form). Reduced to what each value is, and dropped the `docs/…§` references.

Pure refactor + comment cleanup — no behavior change.

# Testing

- `ArraySearchForm.spec.tsx` — 20/20 pass (behavior unchanged)
- `yarn lint`, `yarn type-check` — clean

---

Follow-up to #6111 (RI-8293)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural moves and comment edits only; existing tests cover unchanged form behavior.
> 
> **Overview**
> Refactors the array **Search** tab form layout only—no validation or ARGREP behavior changes.
> 
> **`ArraySearchForm.tsx`** drops inline `isBoundInvalid` / `isLimitInvalid` and the local `InfoHint` wrapper; it imports them from **`ArraySearchForm.utils.ts`** and **`components/InfoHint.tsx`** (+ **`InfoHint.types.ts`**) so the form file matches the same `components/` pattern as `array-details-table`.
> 
> **`array-details/constants.ts`** shortens comments on `DEFAULT_LIMIT` and `DEFAULT_SEARCH_OPTIONS` (removes UI-behavior narration and doc § references) while keeping the same default values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f877403dcda03540a31e517bc33b13d9b7800941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->