### PR TITLE
fix(vector-set): fall back to VRANDMEMBER when VRANGE is unavailable

### DIFF
--- a/redisinsight/api/src/constants/error-messages.ts
+++ b/redisinsight/api/src/constants/error-messages.ts
@@ -106,6 +106,8 @@ export default {
     `Node ${node} not exist in OSS Cluster.`,
   REDIS_MODULE_IS_REQUIRED: (module: string) =>
     `Required ${module} module is not loaded.`,
+  UNABLE_TO_LIST_VECTOR_SET_ELEMENTS: (commands: string[]) =>
+    `Unable to list vector set elements. The following commands failed: ${commands.join(', ')}.`,
   APP_SETTINGS_NOT_FOUND: () => 'Could not find application settings.',
   SERVER_INFO_NOT_FOUND: () => 'Could not find server info.',
   INCREASE_MINIMUM_LIMIT: (count?: number) =>

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ForbiddenException,
+  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -39,6 +40,7 @@ import { BrowserToolKeysCommands } from 'src/modules/browser/constants/browser-t
 import { VectorSetService } from 'src/modules/browser/vector-set/vector-set.service';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { RedisFeature } from 'src/modules/redis/client';
+import ERROR_MESSAGES from 'src/constants/error-messages';
 
 describe('VectorSetService', () => {
   const client = mockStandaloneRedisClient;
@@ -326,8 +328,6 @@ describe('VectorSetService', () => {
     ]);
 
     beforeEach(() => {
-      client.isFeatureSupported = jest.fn().mockResolvedValue(true);
-
       when(client.sendCommand)
         .calledWith([BrowserToolKeysCommands.Exists, mockDto.keyName])
         .mockResolvedValue(true);
@@ -357,9 +357,6 @@ describe('VectorSetService', () => {
         mockDto,
       );
 
-      expect(client.isFeatureSupported).toHaveBeenCalledWith(
-        RedisFeature.VRangeCommand,
-      );
       expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolVectorSetCommands.VRange,
         mockDto.keyName,
@@ -465,8 +462,16 @@ describe('VectorSetService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('should fallback to VRANDMEMBER when VRANGE is not supported', async () => {
-      client.isFeatureSupported = jest.fn().mockResolvedValue(false);
+    it('should fallback to VRANDMEMBER when VRANGE fails', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VRange,
+          mockDto.keyName,
+          mockDto.start,
+          mockDto.end,
+          mockDto.count,
+        ])
+        .mockRejectedValue(new Error('ERR VRANGE is not supported'));
 
       when(client.sendCommand)
         .calledWith([
@@ -481,9 +486,6 @@ describe('VectorSetService', () => {
         mockDto,
       );
 
-      expect(client.isFeatureSupported).toHaveBeenCalledWith(
-        RedisFeature.VRangeCommand,
-      );
       expect(client.sendCommand).toHaveBeenCalledWith([
         BrowserToolVectorSetCommands.VRandMember,
         mockDto.keyName,
@@ -492,6 +494,37 @@ describe('VectorSetService', () => {
       expect(result.elements).toHaveLength(mockElements.length);
       expect(result.nextCursor).toBeUndefined();
       expect(result.isPaginationSupported).toBe(false);
+    });
+
+    it('should throw a server error when neither VRANGE nor VRANDMEMBER can list elements', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VRange,
+          mockDto.keyName,
+          mockDto.start,
+          mockDto.end,
+          mockDto.count,
+        ])
+        .mockRejectedValue(new Error('ERR VRANGE is not supported'));
+
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VRandMember,
+          mockDto.keyName,
+          mockDto.count,
+        ])
+        .mockRejectedValue(new Error('ERR VRANDMEMBER is not supported'));
+
+      await expect(
+        service.getElements(mockBrowserClientMetadata, mockDto),
+      ).rejects.toThrow(
+        new InternalServerErrorException(
+          ERROR_MESSAGES.UNABLE_TO_LIST_VECTOR_SET_ELEMENTS([
+            BrowserToolVectorSetCommands.VRange,
+            BrowserToolVectorSetCommands.VRandMember,
+          ]),
+        ),
+      );
     });
 
     it('should keep attributes undefined when VGETATTR fails for an element', async () => {

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.spec.ts
@@ -462,7 +462,7 @@ describe('VectorSetService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('should fallback to VRANDMEMBER when VRANGE fails', async () => {
+    it('should fallback to VRANDMEMBER when VRANGE is an unknown command', async () => {
       when(client.sendCommand)
         .calledWith([
           BrowserToolVectorSetCommands.VRange,
@@ -471,7 +471,7 @@ describe('VectorSetService', () => {
           mockDto.end,
           mockDto.count,
         ])
-        .mockRejectedValue(new Error('ERR VRANGE is not supported'));
+        .mockRejectedValue(new Error("ERR unknown command 'VRANGE'"));
 
       when(client.sendCommand)
         .calledWith([
@@ -496,7 +496,7 @@ describe('VectorSetService', () => {
       expect(result.isPaginationSupported).toBe(false);
     });
 
-    it('should throw a server error when neither VRANGE nor VRANDMEMBER can list elements', async () => {
+    it('should not fallback and should surface the error when VRANGE fails with a non-command error', async () => {
       when(client.sendCommand)
         .calledWith([
           BrowserToolVectorSetCommands.VRange,
@@ -505,7 +505,32 @@ describe('VectorSetService', () => {
           mockDto.end,
           mockDto.count,
         ])
-        .mockRejectedValue(new Error('ERR VRANGE is not supported'));
+        .mockRejectedValue({
+          ...mockRedisNoPermError,
+          command: 'VRANGE',
+        });
+
+      await expect(
+        service.getElements(mockBrowserClientMetadata, mockDto),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(client.sendCommand).not.toHaveBeenCalledWith([
+        BrowserToolVectorSetCommands.VRandMember,
+        mockDto.keyName,
+        mockDto.count,
+      ]);
+    });
+
+    it('should throw a server error when both VRANGE and VRANDMEMBER are unknown commands', async () => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolVectorSetCommands.VRange,
+          mockDto.keyName,
+          mockDto.start,
+          mockDto.end,
+          mockDto.count,
+        ])
+        .mockRejectedValue(new Error("ERR unknown command 'VRANGE'"));
 
       when(client.sendCommand)
         .calledWith([
@@ -513,7 +538,7 @@ describe('VectorSetService', () => {
           mockDto.keyName,
           mockDto.count,
         ])
-        .mockRejectedValue(new Error('ERR VRANDMEMBER is not supported'));
+        .mockRejectedValue(new Error("ERR unknown command 'VRANDMEMBER'"));
 
       await expect(
         service.getElements(mockBrowserClientMetadata, mockDto),

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -496,9 +496,12 @@ export class VectorSetService {
   }
 
   /**
-   * Send a command and return its reply, or `null` when the command is rejected
-   * (e.g. unsupported on the connected Redis version) so callers can fall back.
-   * `null` is distinct from an empty reply, which is a valid result.
+   * Send a command and return its reply, or `null` when the command itself is
+   * unavailable (unknown/unsupported on the connected Redis version or proxy)
+   * so callers can fall back. `null` is distinct from an empty reply, which is a
+   * valid result. Any other error (permission, bad arguments, transient) is
+   * rethrown so it surfaces to the caller instead of triggering a silent
+   * fallback.
    */
   private async trySendCommand(
     client: RedisClient,
@@ -506,9 +509,17 @@ export class VectorSetService {
   ): Promise<string[] | null> {
     try {
       return (await client.sendCommand(command)) as string[];
-    } catch {
-      return null;
+    } catch (error) {
+      if (this.isUnsupportedCommandError(error)) {
+        return null;
+      }
+      throw error;
     }
+  }
+
+  private isUnsupportedCommandError(error: unknown): boolean {
+    const message = (error as ReplyError)?.message ?? '';
+    return message.includes(RedisErrorCodes.UnknownCommand);
   }
 
   /**

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -1,6 +1,12 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { catchAclError, catchMultiTransactionError } from 'src/utils';
 import { RedisErrorCodes } from 'src/constants';
+import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ReplyError } from 'src/models';
 import {
   BrowserToolKeysCommands,
@@ -135,7 +141,7 @@ export class VectorSetService {
         'Getting elements of the VectorSet data type stored at key.',
         clientMetadata,
       );
-      const { keyName, start, end, count } = dto;
+      const { keyName } = dto;
       const client: RedisClient =
         await this.databaseClientFactory.getOrCreateClient(clientMetadata);
 
@@ -146,32 +152,8 @@ export class VectorSetService {
         keyName,
       ])) as number;
 
-      const isVRangeSupported = await client.isFeatureSupported(
-        RedisFeature.VRangeCommand,
-      );
-
-      let elementNames: string[];
-      let nextCursor: string | undefined;
-
-      if (isVRangeSupported) {
-        elementNames = (await client.sendCommand([
-          BrowserToolVectorSetCommands.VRange,
-          keyName,
-          start || '-',
-          end || '+',
-          count,
-        ])) as string[];
-
-        if (elementNames.length === count && elementNames.length > 0) {
-          nextCursor = `(${elementNames[elementNames.length - 1]}`;
-        }
-      } else {
-        elementNames = (await client.sendCommand([
-          BrowserToolVectorSetCommands.VRandMember,
-          keyName,
-          count,
-        ])) as string[];
-      }
+      const { elementNames, nextCursor, isPaginationSupported } =
+        await this.listElementNames(client, dto);
 
       const elements: { name: string | Buffer; attributes?: string }[] =
         elementNames.map((name) => ({ name }));
@@ -188,7 +170,7 @@ export class VectorSetService {
         keyName,
         total,
         nextCursor,
-        isPaginationSupported: isVRangeSupported,
+        isPaginationSupported,
         elements,
       });
     } catch (error) {
@@ -452,6 +434,80 @@ export class VectorSetService {
         throw error;
       }
       throw catchAclError(error);
+    }
+  }
+
+  /**
+   * Resolve the element names for `getElements`, preferring the ordered,
+   * paginated VRANGE and falling back to the unordered VRANDMEMBER when VRANGE
+   * is unavailable. When neither command can list the elements, throws so the
+   * caller surfaces a server error.
+   */
+  private async listElementNames(
+    client: RedisClient,
+    dto: GetVectorSetElementsDto,
+  ): Promise<{
+    elementNames: string[];
+    nextCursor?: string;
+    isPaginationSupported: boolean;
+  }> {
+    const { keyName, start, end, count } = dto;
+
+    const vRangeCommand: RedisClientCommand = [
+      BrowserToolVectorSetCommands.VRange,
+      keyName,
+      start || '-',
+      end || '+',
+      count,
+    ];
+    const vRangeResult = await this.trySendCommand(client, vRangeCommand);
+    if (vRangeResult !== null) {
+      const nextCursor =
+        vRangeResult.length === count && vRangeResult.length > 0
+          ? `(${vRangeResult[vRangeResult.length - 1]}`
+          : undefined;
+
+      return {
+        elementNames: vRangeResult,
+        nextCursor,
+        isPaginationSupported: true,
+      };
+    }
+
+    const vRandMemberCommand: RedisClientCommand = [
+      BrowserToolVectorSetCommands.VRandMember,
+      keyName,
+      count,
+    ];
+    const vRandMemberResult = await this.trySendCommand(
+      client,
+      vRandMemberCommand,
+    );
+    if (vRandMemberResult !== null) {
+      return { elementNames: vRandMemberResult, isPaginationSupported: false };
+    }
+
+    throw new InternalServerErrorException(
+      ERROR_MESSAGES.UNABLE_TO_LIST_VECTOR_SET_ELEMENTS([
+        `${vRangeCommand[0]}`,
+        `${vRandMemberCommand[0]}`,
+      ]),
+    );
+  }
+
+  /**
+   * Send a command and return its reply, or `null` when the command is rejected
+   * (e.g. unsupported on the connected Redis version) so callers can fall back.
+   * `null` is distinct from an empty reply, which is a valid result.
+   */
+  private async trySendCommand(
+    client: RedisClient,
+    command: RedisClientCommand,
+  ): Promise<string[] | null> {
+    try {
+      return (await client.sendCommand(command)) as string[];
+    } catch {
+      return null;
     }
   }
 

--- a/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
+++ b/redisinsight/api/src/modules/browser/vector-set/vector-set.service.ts
@@ -489,8 +489,8 @@ export class VectorSetService {
 
     throw new InternalServerErrorException(
       ERROR_MESSAGES.UNABLE_TO_LIST_VECTOR_SET_ELEMENTS([
-        `${vRangeCommand[0]}`,
-        `${vRandMemberCommand[0]}`,
+        `${BrowserToolVectorSetCommands.VRange}`,
+        `${BrowserToolVectorSetCommands.VRandMember}`,
       ]),
     );
   }

--- a/redisinsight/api/src/modules/redis/client/redis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/redis.client.ts
@@ -57,7 +57,6 @@ export type RedisClientCommandReply =
 export enum RedisFeature {
   HashFieldsExpiration = 'HashFieldsExpiration',
   UnlinkCommand = 'UnlinkCommand',
-  VRangeCommand = 'VRangeCommand',
   VsimWithAttribs = 'VsimWithAttribs',
   ArrayCommands = 'ArrayCommands',
 }
@@ -185,9 +184,6 @@ export abstract class RedisClient extends EventEmitter2 {
       case RedisFeature.UnlinkCommand:
         // UNLINK command was introduced in Redis 4.0.0
         return this.isRedisVersionAtLeast('4.0.0');
-      case RedisFeature.VRangeCommand:
-        // VRANGE command was introduced in Redis 8.4
-        return this.isRedisVersionAtLeast('8.4');
       case RedisFeature.VsimWithAttribs:
         // VSIM WITHATTRIBS option is broken on 8.0.0–8.0.2 and was fixed in 8.0.3
         return this.isRedisVersionAtLeast('8.0.3');


### PR DESCRIPTION
## Description

Vector Set element listing now tries `VRANGE` (ordered + paginated) and falls back to `VRANDMEMBER` (unordered) when `VRANGE` isn't available, instead of choosing the command from a Redis version check.

The old `isRedisVersionAtLeast('8.4')` check was wrong on Redis Cloud/Enterprise: they report engine 8.4 (so the check passed) but the DMC proxy doesn't whitelist `VRANGE`, so listing failed with an unknown-command error. The runtime fallback works regardless of where the database runs; if neither command can list the elements, the API returns a 500.

<img width="2588" height="1724" alt="image (8)" src="https://github.com/user-attachments/assets/6a16b2b7-f4a9-4ab4-a006-26ed21c77460" />

## Testing

`vector-set.service.spec.ts` updated — all 69 tests pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser API behavior for vector-set listing on proxied/managed Redis; fallback is narrower (unknown command only), which is safer than version guessing but alters who gets pagination vs random samples.
> 
> **Overview**
> Vector Set **element listing** no longer picks `VRANGE` vs `VRANDMEMBER` from a Redis **8.4 version** check. It **tries `VRANGE` first** (ordered, paginated, `nextCursor`), and only falls back to **`VRANDMEMBER`** when Redis returns an **unknown command** for `VRANGE`—fixing cases like Redis Cloud where the engine reports 8.4 but the proxy does not expose `VRANGE`.
> 
> **`listElementNames`** and **`trySendCommand`** centralize that behavior: unknown-command errors yield `null` for fallback; **ACL, wrong-type, and other errors are rethrown** (no silent fallback). If **both** list commands are unavailable, the API returns **500** with **`UNABLE_TO_LIST_VECTOR_SET_ELEMENTS`**. **`RedisFeature.VRangeCommand`** is removed from the Redis client.
> 
> Tests now cover unknown-command fallback, non-fallback on permission errors, and the dual-failure 500 path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329cef84f76b0e6fac947cdfe4fc4725fdea4964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


