### PR TITLE
RI-8294 Add nearby-elements context band to the array Search tab

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import userEvent from '@testing-library/user-event'
 import { render, screen } from 'uiSrc/utils/test-utils'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 import {
@@ -91,5 +92,34 @@ describe('ArrayDetailsTable', () => {
     // a nullish-only fallback would leave the table blank on an empty range.
     renderComponent([], false, '')
     expect(screen.getByText('No elements in range')).toBeInTheDocument()
+  })
+
+  it('renders an expanded panel when a row is expanded via row click', async () => {
+    const user = userEvent.setup()
+    render(
+      <ArrayDetailsTable
+        elements={[arrayElementWithValueFactory.build({ index: '7' })]}
+        loading={false}
+        expandRowOnClick
+        getIsRowExpandable={() => true}
+        renderExpandedRow={(row) => (
+          <div data-testid={`expanded-${row.original.index}`}>panel</div>
+        )}
+      />,
+    )
+
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    expect(await screen.findByTestId('expanded-7')).toBeInTheDocument()
+  })
+
+  it('renders no expand affordance when expansion props are omitted', () => {
+    render(
+      <ArrayDetailsTable
+        elements={[arrayElementWithValueFactory.build({ index: '7' })]}
+        loading={false}
+      />,
+    )
+    expect(screen.queryByTestId('expanded-7')).not.toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
-import { Table } from 'uiSrc/components/base/layout/table'
+import { Table, TableProps } from 'uiSrc/components/base/layout/table'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 
 export const Container = styled(FlexItem)`
   display: flex;
@@ -10,6 +11,8 @@ export const Container = styled(FlexItem)`
   padding: ${({ theme }) => theme.core?.space.space200};
 `
 
+// `styled(Table)` widens the row generic to `object` and drops the
+// `ArrayDataElement`-typed expansion callbacks; the trailing cast pins it back.
 export const StyledTable = styled(Table)`
   scrollbar-width: thin;
   max-height: 100%;
@@ -19,4 +22,4 @@ export const StyledTable = styled(Table)`
   [data-role='table-scroller'] {
     scrollbar-width: thin;
   }
-`
+` as unknown as (props: TableProps<ArrayDataElement>) => JSX.Element

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -28,7 +28,14 @@ import * as S from './ArrayDetailsTable.styles'
  * verticals (see docs/redis-array-type-initiative.md §6 Tasks 6-7).
  */
 const ArrayDetailsTable = memo(
-  ({ elements, loading, error }: ArrayDetailsTableProps) => {
+  ({
+    elements,
+    loading,
+    error,
+    renderExpandedRow,
+    getIsRowExpandable,
+    expandRowOnClick,
+  }: ArrayDetailsTableProps) => {
     const { compressor = null } = useAppSelector(
       connectedInstanceSelector,
     ) as unknown as { compressor: Nullable<KeyValueCompressor> }
@@ -59,6 +66,9 @@ const ArrayDetailsTable = memo(
           stripedRows
           minWidth={TABLE_MIN_WIDTH}
           emptyState={emptyState}
+          renderExpandedRow={renderExpandedRow}
+          getIsRowExpandable={getIsRowExpandable}
+          expandRowOnClick={expandRowOnClick}
           data-testid={`${TEST_ID}-table`}
         />
       </S.Container>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.types.ts
@@ -1,4 +1,6 @@
+import { ReactNode } from 'react'
 import { KeyValueCompressor, KeyValueFormat } from 'uiSrc/constants'
+import { Row } from 'uiSrc/components/base/layout/table'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 import { Nullable } from 'uiSrc/utils'
 
@@ -9,6 +11,12 @@ export interface ArrayDetailsTableProps {
    *  doesn't misleadingly read "No elements in range" when the request
    *  errored. The slice still also raises a toast via `addErrorNotification`. */
   error?: string
+  /** Search context band only. Renders an expanded panel under each row;
+   *  omitted on the View / Aggregate tabs, which then show no expand
+   *  affordance. */
+  renderExpandedRow?: (row: Row<ArrayDataElement>) => ReactNode
+  getIsRowExpandable?: (rowData: ArrayDataElement) => boolean
+  expandRowOnClick?: boolean
 }
 
 /**

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.constants.ts
@@ -18,8 +18,7 @@ export const APPLIES_TO_ALL_LABEL = 'applies to all'
 
 export const OPTIONS_LABEL = 'Options'
 export const OPTIONS_HINT =
-  'Range limits the index window (blank = whole array). NOCASE matches ' +
-  'case-insensitively, WITHVALUES returns values, LIMIT caps the result count.'
+  'Refine which elements are searched and how matches are shown.'
 export const RANGE_LABEL = 'Range'
 export const RANGE_TO_LABEL = 'to'
 export const START_PLACEHOLDER = '-'
@@ -27,6 +26,17 @@ export const END_PLACEHOLDER = '+'
 export const NOCASE_LABEL = 'NOCASE'
 export const WITHVALUES_LABEL = 'WITHVALUES'
 export const LIMIT_LABEL = 'LIMIT'
+export const CONTEXT_LABEL = 'Context'
+export const CONTEXT_PREFIX = '±'
+
+/** Per-option (i) hints rendered next to each control. */
+export const RANGE_HINT =
+  'Limits the index window searched (blank = whole array).'
+export const NOCASE_HINT = 'Match case-insensitively.'
+export const WITHVALUES_HINT = "Return each match's value, not just its index."
+export const LIMIT_HINT = 'Cap the number of matches returned.'
+export const CONTEXT_HINT =
+  'When expanding a match, also show ±N neighbouring elements.'
 
 export const INVALID_INDEX_MESSAGE =
   'Index must be a valid 64-bit unsigned integer'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { fireEvent, render, screen, userEvent } from 'uiSrc/utils/test-utils'
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'uiSrc/utils/test-utils'
 import {
   ArrayCombinator,
   ArrayGrepCriteria,
@@ -24,6 +30,8 @@ const defaultProps: ArraySearchFormProps = {
   onChangePredicate: jest.fn(),
   onChangeCombinator: jest.fn(),
   onChangeOptions: jest.fn(),
+  context: { enabled: false, count: 5 },
+  onChangeContext: jest.fn(),
   onRun: jest.fn(),
   onReset: jest.fn(),
 }
@@ -181,6 +189,75 @@ describe('ArraySearchForm', () => {
         />,
       )
       expect(screen.getByTestId(`${TEST_ID}-limit`)).toBeEnabled()
+    })
+  })
+
+  describe('context', () => {
+    // The context control lives inside the collapsed Options section, so each
+    // test must expand it before the controls exist in the DOM.
+    const openOptions = () =>
+      fireEvent.click(screen.getByTestId(`${TEST_ID}-options-toggle`))
+
+    it('keeps the context input disabled until the toggle is ticked', () => {
+      const { rerender } = renderComponent()
+      openOptions()
+      // Off by default → input present (so layout is stable) but disabled.
+      expect(screen.getByTestId(`${TEST_ID}-context`)).toBeDisabled()
+
+      rerender(
+        <ArraySearchForm
+          {...defaultProps}
+          context={{ enabled: true, count: 5 }}
+        />,
+      )
+      expect(screen.getByTestId(`${TEST_ID}-context`)).toBeEnabled()
+    })
+
+    it('enables context when the toggle is ticked', () => {
+      const onChangeContext = jest.fn()
+      renderComponent({ onChangeContext })
+      openOptions()
+
+      fireEvent.click(screen.getByTestId(`${TEST_ID}-context-toggle`))
+
+      expect(onChangeContext).toHaveBeenCalledWith({ enabled: true })
+    })
+
+    it('shows the passed count and clamps a typed value above the max to 50', async () => {
+      const user = userEvent.setup()
+      renderComponent({ context: { enabled: true, count: 5 } })
+      openOptions()
+
+      const input = screen.getByTestId(`${TEST_ID}-context`)
+      // redis-ui NumericInput renders a text input, so the DOM value is a
+      // string.
+      expect(input).toHaveValue('5')
+
+      // redis-ui's `autoValidate` clamps onChange, but the field text only
+      // settles to the clamped value on blur — so '99' stays verbatim while
+      // typing and resolves to '50' once the input blurs.
+      await user.clear(input)
+      await user.type(input, '99')
+      await user.tab()
+
+      await waitFor(() => {
+        expect(input).toHaveValue('50')
+      })
+    })
+
+    it('reports a new count via onChangeContext', () => {
+      const onChangeContext = jest.fn()
+      renderComponent({
+        context: { enabled: true, count: 5 },
+        onChangeContext,
+      })
+      openOptions()
+
+      fireEvent.change(screen.getByTestId(`${TEST_ID}-context`), {
+        target: { value: '8' },
+      })
+
+      expect(onChangeContext).toHaveBeenCalledWith({ count: 8 })
     })
   })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { ToggleButton } from 'uiSrc/components/base/forms/buttons'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
 
@@ -31,12 +32,29 @@ export const NarrowInputBox = styled(Row)`
   width: 110px;
 `
 
+/** Hairline rule between the index-window row and the flags row. */
+export const OptionsDivider = styled(Row)`
+  border-top: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+`
+
 /**
  * Fixed minimum width so the action row doesn't reflow when the selected
  * criteria label changes width (Exact / Match / Glob / Regex).
  */
 export const CriteriaSelect = styled(RiSelect)`
   min-width: 85px;
+`
+
+/**
+ * Option checkbox with its label's trailing padding removed so a following
+ * InfoHint hugs the text. That padding is on the inner `<label>`, not the
+ * className-bearing root, so it must be targeted as a descendant.
+ */
+export const InlineCheckbox = styled(Checkbox)`
+  & label {
+    padding-inline-end: 0;
+    padding-right: 0;
+  }
 `
 
 /**

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
@@ -8,7 +8,6 @@ import {
   PrimaryButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { ButtonGroup } from 'uiSrc/components/base/forms/button-group/ButtonGroup'
-import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import {
   DeleteIcon,
   PlusIcon,
@@ -16,7 +15,7 @@ import {
   RiIcon,
 } from 'uiSrc/components/base/icons'
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
-import { TextInput } from 'uiSrc/components/base/inputs'
+import { NumericInput, TextInput } from 'uiSrc/components/base/inputs'
 import { Text } from 'uiSrc/components/base/text'
 import {
   ArrayCombinator,
@@ -24,7 +23,11 @@ import {
 } from 'uiSrc/slices/interfaces/array'
 
 import { CommandPreview } from '../command-preview'
-import { DEFAULT_LIMIT } from '../constants'
+import {
+  CONTEXT_COUNT_MAX,
+  CONTEXT_COUNT_MIN,
+  DEFAULT_LIMIT,
+} from '../constants'
 import { quoteRedisArgument } from '../utils'
 import {
   ADD_PREDICATE_ARIA,
@@ -32,13 +35,18 @@ import {
   ARRAY_GREP_CRITERIA_OPTIONS,
   ARRAY_SEARCH_FORM_TEST_ID as TEST_ID,
   COMBINATOR_ARIA,
+  CONTEXT_HINT,
+  CONTEXT_LABEL,
+  CONTEXT_PREFIX,
   REMOVE_PREDICATE_ARIA,
   END_PLACEHOLDER,
   INVALID_INDEX_MESSAGE,
   INVALID_LIMIT_MESSAGE,
+  LIMIT_HINT,
   LIMIT_LABEL,
   MATCH_BY_HINT,
   MATCH_BY_LABEL,
+  NOCASE_HINT,
   NOCASE_LABEL,
   OPTIONS_HINT,
   OPTIONS_LABEL,
@@ -46,6 +54,7 @@ import {
   PREVIEW_TOGGLE_HIDE_TOOLTIP,
   PREVIEW_TOGGLE_LABEL,
   PREVIEW_TOGGLE_SHOW_TOOLTIP,
+  RANGE_HINT,
   RANGE_LABEL,
   RANGE_TO_LABEL,
   RESET_ARIA_LABEL,
@@ -53,6 +62,7 @@ import {
   RUN_BUTTON_LABEL,
   START_PLACEHOLDER,
   VALUE_PLACEHOLDER,
+  WITHVALUES_HINT,
   WITHVALUES_LABEL,
 } from './ArraySearchForm.constants'
 import { ArraySearchFormProps } from './ArraySearchForm.types'
@@ -80,6 +90,8 @@ export const ArraySearchForm = ({
   onChangePredicate,
   onChangeCombinator,
   onChangeOptions,
+  context,
+  onChangeContext,
   onRun,
   onReset,
   disabled = false,
@@ -120,7 +132,7 @@ export const ArraySearchForm = ({
 
   return (
     <S.FormContainer data-testid={TEST_ID} gap="m" grow={false}>
-      <Row align="center" gap="s" grow={false}>
+      <Row align="center" gap="xs" grow={false}>
         <FlexItem grow={false}>
           <Text size="s">{MATCH_BY_LABEL}</Text>
         </FlexItem>
@@ -219,7 +231,7 @@ export const ArraySearchForm = ({
       <Col gap="m" grow={false}>
         {/* Compact disclosure: chevron + "Options" on the left, the add-row
             "+" on the right, the option fields below once expanded. */}
-        <Row align="center" gap="s" grow={false}>
+        <Row align="center" gap="xs" grow={false}>
           <FlexItem grow={false}>
             <EmptyButton
               onClick={() => setOptionsOpen((open) => !open)}
@@ -259,78 +271,159 @@ export const ArraySearchForm = ({
 
         {optionsOpen && (
           <Col gap="m" grow={false}>
-            <Row align="center" gap="s">
+            <Row align="center" gap="xl">
               <FlexItem grow={false}>
-                <Text size="s">{RANGE_LABEL}</Text>
+                <Row align="center" gap="s" grow={false}>
+                  <FlexItem grow={false}>
+                    <Row align="center" gap="xs" grow={false}>
+                      <FlexItem grow={false}>
+                        <Text size="s">{RANGE_LABEL}</Text>
+                      </FlexItem>
+                      <FlexItem grow={false}>
+                        <InfoHint content={RANGE_HINT} />
+                      </FlexItem>
+                    </Row>
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <S.NarrowInputBox>
+                      <TextInput
+                        value={options.start}
+                        onChange={(start) => onChangeOptions({ start })}
+                        placeholder={START_PLACEHOLDER}
+                        error={startInvalid ? INVALID_INDEX_MESSAGE : undefined}
+                        disabled={disabled}
+                        data-testid={`${TEST_ID}-start`}
+                      />
+                    </S.NarrowInputBox>
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <Text size="s">{RANGE_TO_LABEL}</Text>
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <S.NarrowInputBox>
+                      <TextInput
+                        value={options.end}
+                        onChange={(end) => onChangeOptions({ end })}
+                        placeholder={END_PLACEHOLDER}
+                        error={endInvalid ? INVALID_INDEX_MESSAGE : undefined}
+                        disabled={disabled}
+                        data-testid={`${TEST_ID}-end`}
+                      />
+                    </S.NarrowInputBox>
+                  </FlexItem>
+                </Row>
               </FlexItem>
               <FlexItem grow={false}>
-                <S.NarrowInputBox>
-                  <TextInput
-                    value={options.start}
-                    onChange={(start) => onChangeOptions({ start })}
-                    placeholder={START_PLACEHOLDER}
-                    error={startInvalid ? INVALID_INDEX_MESSAGE : undefined}
-                    disabled={disabled}
-                    data-testid={`${TEST_ID}-start`}
-                  />
-                </S.NarrowInputBox>
+                <Row align="center" gap="s" grow={false}>
+                  <FlexItem grow={false}>
+                    <Row align="center" gap="xs" grow={false}>
+                      <FlexItem grow={false}>
+                        <S.InlineCheckbox
+                          id={`${TEST_ID}-context-toggle`}
+                          name="array-search-context-toggle"
+                          label={CONTEXT_LABEL}
+                          checked={context.enabled}
+                          onChange={(e) =>
+                            onChangeContext({ enabled: e.target.checked })
+                          }
+                          disabled={disabled}
+                          data-testid={`${TEST_ID}-context-toggle`}
+                        />
+                      </FlexItem>
+                      <FlexItem grow={false}>
+                        <InfoHint content={CONTEXT_HINT} />
+                      </FlexItem>
+                    </Row>
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <Text size="s">{CONTEXT_PREFIX}</Text>
+                  </FlexItem>
+                  {/* Always rendered so ticking Context doesn't shift the row;
+                      it just becomes editable once the toggle is on. */}
+                  <FlexItem grow={false}>
+                    <S.NarrowInputBox>
+                      <NumericInput
+                        autoValidate
+                        min={CONTEXT_COUNT_MIN}
+                        max={CONTEXT_COUNT_MAX}
+                        value={context.count}
+                        onChange={(next) =>
+                          onChangeContext({
+                            count: Number(next ?? CONTEXT_COUNT_MIN),
+                          })
+                        }
+                        disabled={disabled || !context.enabled}
+                        data-testid={`${TEST_ID}-context`}
+                      />
+                    </S.NarrowInputBox>
+                  </FlexItem>
+                </Row>
               </FlexItem>
-              <FlexItem grow={false}>
-                <Text size="s">{RANGE_TO_LABEL}</Text>
-              </FlexItem>
-              <FlexItem grow={false}>
-                <S.NarrowInputBox>
-                  <TextInput
-                    value={options.end}
-                    onChange={(end) => onChangeOptions({ end })}
-                    placeholder={END_PLACEHOLDER}
-                    error={endInvalid ? INVALID_INDEX_MESSAGE : undefined}
-                    disabled={disabled}
-                    data-testid={`${TEST_ID}-end`}
-                  />
-                </S.NarrowInputBox>
-              </FlexItem>
+              <FlexItem grow />
             </Row>
+
+            <S.OptionsDivider grow={false} />
 
             <Row align="center" gap="xl">
               <FlexItem grow={false}>
-                <Checkbox
-                  id={`${TEST_ID}-nocase`}
-                  name="array-search-nocase"
-                  label={NOCASE_LABEL}
-                  checked={options.nocase}
-                  onChange={(e) =>
-                    onChangeOptions({ nocase: e.target.checked })
-                  }
-                  disabled={disabled}
-                  data-testid={`${TEST_ID}-nocase`}
-                />
+                <Row align="center" gap="xs" grow={false}>
+                  <FlexItem grow={false}>
+                    <S.InlineCheckbox
+                      id={`${TEST_ID}-nocase`}
+                      name="array-search-nocase"
+                      label={NOCASE_LABEL}
+                      checked={options.nocase}
+                      onChange={(e) =>
+                        onChangeOptions({ nocase: e.target.checked })
+                      }
+                      disabled={disabled}
+                      data-testid={`${TEST_ID}-nocase`}
+                    />
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <InfoHint content={NOCASE_HINT} />
+                  </FlexItem>
+                </Row>
               </FlexItem>
               <FlexItem grow={false}>
-                <Checkbox
-                  id={`${TEST_ID}-withvalues`}
-                  name="array-search-withvalues"
-                  label={WITHVALUES_LABEL}
-                  checked={options.withValues}
-                  onChange={(e) =>
-                    onChangeOptions({ withValues: e.target.checked })
-                  }
-                  disabled={disabled}
-                  data-testid={`${TEST_ID}-withvalues`}
-                />
+                <Row align="center" gap="xs" grow={false}>
+                  <FlexItem grow={false}>
+                    <S.InlineCheckbox
+                      id={`${TEST_ID}-withvalues`}
+                      name="array-search-withvalues"
+                      label={WITHVALUES_LABEL}
+                      checked={options.withValues}
+                      onChange={(e) =>
+                        onChangeOptions({ withValues: e.target.checked })
+                      }
+                      disabled={disabled}
+                      data-testid={`${TEST_ID}-withvalues`}
+                    />
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <InfoHint content={WITHVALUES_HINT} />
+                  </FlexItem>
+                </Row>
               </FlexItem>
               <FlexItem grow={false}>
-                <Checkbox
-                  id={`${TEST_ID}-limit-toggle`}
-                  name="array-search-limit-toggle"
-                  label={LIMIT_LABEL}
-                  checked={options.limitEnabled}
-                  onChange={(e) =>
-                    onChangeOptions({ limitEnabled: e.target.checked })
-                  }
-                  disabled={disabled}
-                  data-testid={`${TEST_ID}-limit-toggle`}
-                />
+                <Row align="center" gap="xs" grow={false}>
+                  <FlexItem grow={false}>
+                    <S.InlineCheckbox
+                      id={`${TEST_ID}-limit-toggle`}
+                      name="array-search-limit-toggle"
+                      label={LIMIT_LABEL}
+                      checked={options.limitEnabled}
+                      onChange={(e) =>
+                        onChangeOptions({ limitEnabled: e.target.checked })
+                      }
+                      disabled={disabled}
+                      data-testid={`${TEST_ID}-limit-toggle`}
+                    />
+                  </FlexItem>
+                  <FlexItem grow={false}>
+                    <InfoHint content={LIMIT_HINT} />
+                  </FlexItem>
+                </Row>
               </FlexItem>
               {/* Always rendered so ticking LIMIT doesn't shift the row; the
                   pre-filled default just becomes editable once enabled. */}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
@@ -349,7 +349,9 @@ export const ArraySearchForm = ({
                         value={context.count}
                         onChange={(next) =>
                           onChangeContext({
-                            count: Number(next ?? CONTEXT_COUNT_MIN),
+                            count: Math.round(
+                              Number(next ?? CONTEXT_COUNT_MIN),
+                            ),
                           })
                         }
                         disabled={disabled || !context.enabled}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.types.ts
@@ -4,6 +4,16 @@ import {
   ArraySearchOptions,
 } from 'uiSrc/slices/interfaces/array'
 
+/**
+ * Per-match context window shown when a result row is expanded: a toggle plus
+ * the ±N neighbour count. A display concern, kept separate from `options` so
+ * it never enters the ARGREP command.
+ */
+export type ContextOption = {
+  enabled: boolean
+  count: number
+}
+
 export interface ArraySearchFormProps {
   /**
    * Key name rendered in the preview command. Optional so the form can be
@@ -22,6 +32,8 @@ export interface ArraySearchFormProps {
   onChangePredicate: (index: number, patch: Partial<ArrayGrepPredicate>) => void
   onChangeCombinator: (combinator: ArrayCombinator) => void
   onChangeOptions: (patch: Partial<ArraySearchOptions>) => void
+  context: ContextOption
+  onChangeContext: (patch: Partial<ContextOption>) => void
   onRun: () => void
   /**
    * Optional reset hook — restores form defaults and clears prior results.

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -54,3 +54,14 @@ export const ARRAY_DETAILS_TAB_LABELS: Record<ArrayDetailsTab, string> = {
   [ArrayDetailsTab.Search]: 'Search',
   [ArrayDetailsTab.Aggregate]: 'Aggregate',
 }
+
+/**
+ * Context is opt-in: rows aren't expandable until the user enables it, so the
+ * neighbour band never fetches for a match the user didn't ask to expand.
+ */
+export const DEFAULT_CONTEXT_ENABLED = false
+/** Default ± neighbours shown when a search match is expanded. */
+export const DEFAULT_CONTEXT_COUNT = 2
+export const CONTEXT_COUNT_MIN = 0
+/** Upper bound on the context window so an expand can't request a huge range. */
+export const CONTEXT_COUNT_MAX = 50

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -65,3 +65,9 @@ export const DEFAULT_CONTEXT_COUNT = 2
 export const CONTEXT_COUNT_MIN = 0
 /** Upper bound on the context window so an expand can't request a huge range. */
 export const CONTEXT_COUNT_MAX = 50
+
+/** Seed/reset value for the Search tab's Context option. */
+export const DEFAULT_CONTEXT = {
+  enabled: DEFAULT_CONTEXT_ENABLED,
+  count: DEFAULT_CONTEXT_COUNT,
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { apiService } from 'uiSrc/services'
+import { render, screen, waitFor } from 'uiSrc/utils/test-utils'
+import { mockArrayKeyBuffer } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
+import { NeighbourBand } from './NeighbourBand'
+import { NeighbourBandProps } from './NeighbourBand.types'
+
+jest.mock('uiSrc/services', () => ({
+  ...jest.requireActual('uiSrc/services'),
+}))
+
+const keyBuffer = mockArrayKeyBuffer
+
+const defaultProps: NeighbourBandProps = {
+  keyProp: keyBuffer,
+  matchIndex: '41',
+  count: 1,
+}
+
+const renderBand = (propsOverride?: Partial<NeighbourBandProps>) =>
+  render(<NeighbourBand {...defaultProps} {...propsOverride} />)
+
+const mockRange = (elements: (string | null)[]) => {
+  apiService.post = jest.fn().mockResolvedValue({
+    status: 200,
+    data: { keyName: keyBuffer, elements },
+  })
+}
+
+describe('NeighbourBand', () => {
+  it('fetches and renders the ±count neighbours, highlighting the match', async () => {
+    mockRange(['v40', 'v41', 'v42'])
+    renderBand({ matchIndex: '41', count: 1 })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('array-context-band-41')).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByTestId('array-context-band-match-41'),
+    ).toBeInTheDocument()
+  })
+
+  it('requests a non-negative start when the match is near index 0', async () => {
+    mockRange(['v0', 'v1', 'v2'])
+    renderBand({ matchIndex: '2', count: 5 })
+
+    // Wait for the settled band so the trailing state update is flushed.
+    await screen.findByTestId('array-context-band-2')
+    const [, body] = (apiService.post as jest.Mock).mock.calls[0]
+    expect(body.start).toBe('0')
+  })
+
+  it('shows an inline error when the fetch fails', async () => {
+    apiService.post = jest.fn().mockResolvedValue({ status: 500, data: null })
+    renderBand({ matchIndex: '41', count: 1 })
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('array-context-band-error-41'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('refetches with a wider range when count grows', async () => {
+    mockRange(['v40', 'v41', 'v42'])
+    const { rerender } = renderBand({ matchIndex: '41', count: 1 })
+    // Let the first fetch settle into the DOM before widening the window.
+    await screen.findByTestId('array-context-band-row-40')
+    expect(apiService.post).toHaveBeenCalledTimes(1)
+
+    mockRange(['v38', 'v39', 'v40', 'v41', 'v42', 'v43', 'v44'])
+    rerender(<NeighbourBand {...defaultProps} matchIndex="41" count={3} />)
+
+    // The wider range's outermost neighbour confirms the refetch landed.
+    await screen.findByTestId('array-context-band-row-38')
+    const last = (apiService.post as jest.Mock).mock.calls.at(-1)
+    expect(last?.[1]).toEqual({
+      keyName: keyBuffer,
+      start: '38',
+      end: '44',
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+const INDEX_COLUMN_MIN_WIDTH = '120px'
+const VALUE_COLUMN_MIN_WIDTH = '160px'
+
+export const Band = styled(Col)`
+  padding: ${({ theme }) => theme.core.space.space050};
+`
+
+export const BandRow = styled.div<
+  React.HTMLAttributes<HTMLDivElement> & { $match?: boolean }
+>`
+  display: grid;
+  grid-template-columns:
+    minmax(${INDEX_COLUMN_MIN_WIDTH}, 1fr)
+    minmax(${VALUE_COLUMN_MIN_WIDTH}, 2fr);
+  gap: ${({ theme }) => theme.core.space.space100};
+  padding: ${({ theme }) => theme.core.space.space050};
+  background: ${({ theme, $match }) =>
+    $match ? theme.semantic.color.background.neutral200 : 'transparent'};
+`
+
+export const Message = styled(Col)`
+  padding: ${({ theme }) => theme.core.space.space100};
+  color: ${({ theme }) => theme.semantic.color.text.neutral600};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { fetchArrayNeighbours } from 'uiSrc/slices/browser/array'
+import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+import { getNeighbourRange } from 'uiSrc/utils/arrayIndex'
+import { DEFAULT_ERROR_MESSAGE, Nullable } from 'uiSrc/utils'
+import { KeyValueCompressor } from 'uiSrc/constants'
+
+import { ARRAY_TABLE_LOADING_MESSAGE } from '../../array-details-table/constants'
+import {
+  ArrayIndexCell,
+  ArrayValueCell,
+} from '../../array-details-table/components'
+import { NeighbourBandProps } from './NeighbourBand.types'
+import * as S from './NeighbourBand.styles'
+
+const TEST_ID_PREFIX = 'array-context-band'
+
+/**
+ * Expanded panel rendered under a search match. Fetches the ±count index
+ * window around `matchIndex`, holds the result in local state (writes
+ * nothing to the shared array slice), and highlights the matched row.
+ * Refetches when `count` changes and aborts the in-flight request on
+ * unmount / dependency change via a per-instance `AbortController`.
+ */
+export const NeighbourBand = ({
+  keyProp,
+  matchIndex,
+  count,
+}: NeighbourBandProps) => {
+  const dispatch = useAppDispatch()
+  const { compressor = null } = useAppSelector(
+    connectedInstanceSelector,
+  ) as unknown as { compressor: Nullable<KeyValueCompressor> }
+  const { viewFormat } = useAppSelector(selectedKeySelector)
+
+  const [elements, setElements] = useState<ArrayDataElement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const { start, end } = getNeighbourRange(matchIndex, count)
+    setLoading(true)
+    setError('')
+
+    dispatch(
+      fetchArrayNeighbours({ key: keyProp, start, end }, controller.signal),
+    )
+      .then((result) => {
+        if (controller.signal.aborted) return
+        setElements(result)
+        setLoading(false)
+      })
+      .catch((e) => {
+        if (axios.isCancel(e) || controller.signal.aborted) return
+        setError(e?.message || DEFAULT_ERROR_MESSAGE)
+        setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [dispatch, keyProp, matchIndex, count])
+
+  if (loading) {
+    return (
+      <S.Message data-testid={`${TEST_ID_PREFIX}-loading-${matchIndex}`}>
+        {ARRAY_TABLE_LOADING_MESSAGE}
+      </S.Message>
+    )
+  }
+
+  if (error) {
+    return (
+      <S.Message data-testid={`${TEST_ID_PREFIX}-error-${matchIndex}`}>
+        {error}
+      </S.Message>
+    )
+  }
+
+  return (
+    <S.Band data-testid={`${TEST_ID_PREFIX}-${matchIndex}`}>
+      {elements.map((el) => {
+        const isMatch = el.index === matchIndex
+        return (
+          <S.BandRow
+            key={el.index}
+            $match={isMatch}
+            data-testid={
+              isMatch
+                ? `${TEST_ID_PREFIX}-match-${matchIndex}`
+                : `${TEST_ID_PREFIX}-row-${el.index}`
+            }
+          >
+            <ArrayIndexCell index={el.index} />
+            <ArrayValueCell
+              index={el.index}
+              value={el.value}
+              compressor={compressor}
+              viewFormat={viewFormat}
+            />
+          </S.BandRow>
+        )
+      })}
+    </S.Band>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import axios from 'axios'
 
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
@@ -42,28 +42,39 @@ export const NeighbourBand = ({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  // Identifies the requested window. A response is applied only if it still
+  // matches the latest request, so a slow fetch for a previous ±N count can't
+  // overwrite the band once the count changed — the effect's abort cleanup is
+  // deferred and may not have run yet when that stale response settles.
+  const requestKey = `${matchIndex}:${count}`
+  const latestRequestKey = useRef(requestKey)
+  latestRequestKey.current = requestKey
+
   useEffect(() => {
     const controller = new AbortController()
     const { start, end } = getNeighbourRange(matchIndex, count)
     setLoading(true)
     setError('')
 
+    const isStale = () =>
+      controller.signal.aborted || latestRequestKey.current !== requestKey
+
     dispatch(
       fetchArrayNeighbours({ key: keyProp, start, end }, controller.signal),
     )
       .then((result) => {
-        if (controller.signal.aborted) return
+        if (isStale()) return
         setElements(result)
         setLoading(false)
       })
       .catch((e) => {
-        if (axios.isCancel(e) || controller.signal.aborted) return
+        if (axios.isCancel(e) || isStale()) return
         setError(e?.message || DEFAULT_ERROR_MESSAGE)
         setLoading(false)
       })
 
     return () => controller.abort()
-  }, [dispatch, keyProp, matchIndex, count])
+  }, [dispatch, keyProp, matchIndex, count, requestKey])
 
   if (loading) {
     return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.types.ts
@@ -1,0 +1,9 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface NeighbourBandProps {
+  keyProp: RedisResponseBuffer
+  /** Decimal-string index of the matched element (band centre). */
+  matchIndex: string
+  /** Neighbours to fetch on each side of the match. */
+  count: number
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/index.ts
@@ -1,0 +1,1 @@
+export { NeighbourBand } from './NeighbourBand'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
+import userEvent from '@testing-library/user-event'
 import {
+  fireEvent,
   initialStateDefault,
   mockStore,
   render,
@@ -8,10 +10,15 @@ import {
 } from 'uiSrc/utils/test-utils'
 import { KeyTypes } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
+import { apiService } from 'uiSrc/services'
 import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
 import { ArraySearchState } from 'uiSrc/slices/interfaces/array'
 import { arrayElementWithValueFactory } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
 import SearchTab from './SearchTab'
+
+jest.mock('uiSrc/services', () => ({
+  ...jest.requireActual('uiSrc/services'),
+}))
 
 const KEY = 'readings'
 const keyBuffer = stringToBuffer(KEY)
@@ -101,5 +108,66 @@ describe('SearchTab', () => {
     renderTab({ loaded: true, loading: false, error: '', data: [] })
 
     expect(screen.getByText('No elements in range')).toBeInTheDocument()
+  })
+
+  it('expands a match to show its neighbour band once context is enabled', async () => {
+    const user = userEvent.setup()
+    apiService.post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        keyName: KEY,
+        elements: [
+          'v2',
+          'v3',
+          'v4',
+          'v5',
+          'v6',
+          'v7',
+          'v8',
+          'v9',
+          'v10',
+          'v11',
+          'v12',
+        ],
+      },
+    })
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    // Context is off by default, so the row isn't expandable yet — open the
+    // Options section and tick the Context toggle before clicking the match.
+    // fireEvent on the toggles sidesteps the redis-ui control's
+    // `pointer-events: none` wrapper that blocks userEvent's pointer guard.
+    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    expect(
+      await screen.findByTestId('array-context-band-7'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('array-context-band-match-7')).toBeInTheDocument()
+  })
+
+  it('does not expand a match while context is off (default)', async () => {
+    const user = userEvent.setup()
+    const post = jest.fn()
+    apiService.post = post
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    // Default state: context disabled → clicking the row must not expand it.
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    expect(screen.queryByTestId('array-context-band-7')).not.toBeInTheDocument()
+    expect(post).not.toHaveBeenCalled()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -7,6 +7,7 @@ import {
   mockStore,
   render,
   screen,
+  waitFor,
 } from 'uiSrc/utils/test-utils'
 import { KeyTypes } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
@@ -188,5 +189,55 @@ describe('SearchTab', () => {
     fireEvent.click(screen.getByTestId('array-search-form-reset'))
 
     expect(screen.getByTestId('array-search-form-context')).toBeDisabled()
+  })
+
+  it('collapses the neighbour band when Context is toggled off', async () => {
+    const user = userEvent.setup()
+    apiService.post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { keyName: KEY, elements: ['v6', 'v7', 'v8'] },
+    })
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+    expect(
+      await screen.findByTestId('array-context-band-7'),
+    ).toBeInTheDocument()
+
+    // Toggling Context off must unmount the band (and stop its fetch), not
+    // leave an already-expanded match still showing it.
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('array-context-band-7'),
+      ).not.toBeInTheDocument(),
+    )
+  })
+
+  it('resets Context to off when the selected key changes', () => {
+    const { rerender } = renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+    expect(screen.getByRole('checkbox', { name: 'Context' })).toBeChecked()
+
+    // The tab stays mounted across key switches; selecting another key resets
+    // Context to its default rather than inheriting the previous key's.
+    rerender(<SearchTab keyProp={stringToBuffer('other-key')} />)
+
+    expect(screen.getByRole('checkbox', { name: 'Context' })).not.toBeChecked()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -170,4 +170,23 @@ describe('SearchTab', () => {
     expect(screen.queryByTestId('array-context-band-7')).not.toBeInTheDocument()
     expect(post).not.toHaveBeenCalled()
   })
+
+  it('resets context to its default when the form is reset', () => {
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    // Enabling Context enables its count input; reset must turn it back off
+    // (context state lives in SearchTab, not the query hook's resetQuery).
+    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+    expect(screen.getByTestId('array-search-form-context')).toBeEnabled()
+
+    fireEvent.click(screen.getByTestId('array-search-form-reset'))
+
+    expect(screen.getByTestId('array-search-form-context')).toBeDisabled()
+  })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -1,14 +1,15 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
-import { bufferToString } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import { bufferToString, isEqualBuffers } from 'uiSrc/utils'
 
 import { ArrayDetailsTable } from '../array-details-table'
 import { ArraySearchForm } from '../array-search-form'
 import { ContextOption } from '../array-search-form/ArraySearchForm.types'
 import { useArraySearchQuery } from '../hooks'
-import { DEFAULT_CONTEXT_COUNT, DEFAULT_CONTEXT_ENABLED } from '../constants'
+import { DEFAULT_CONTEXT } from '../constants'
 import * as S from '../tabs.styles'
 import { NeighbourBand } from './NeighbourBand'
 import { SearchTabProps } from './SearchTab.types'
@@ -19,12 +20,21 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
 
   // Context is a display concern (±N neighbours on expand), off by default so
   // result rows aren't expandable until the user opts in.
-  const [context, setContext] = useState<ContextOption>({
-    enabled: DEFAULT_CONTEXT_ENABLED,
-    count: DEFAULT_CONTEXT_COUNT,
-  })
+  const [context, setContext] = useState<ContextOption>(DEFAULT_CONTEXT)
   const onChangeContext = (patch: Partial<ContextOption>) =>
     setContext((c) => ({ ...c, ...patch }))
+
+  // Context is SearchTab-owned and the tab stays mounted across key switches,
+  // so reset it on a real key change — otherwise a new key inherits the
+  // previous key's toggle/count (the query hook resets only its own state).
+  const lastKeyRef = useRef<RedisResponseBuffer | null>(null)
+  useEffect(() => {
+    if (!keyProp) return
+    if (lastKeyRef.current && isEqualBuffers(lastKeyRef.current, keyProp))
+      return
+    lastKeyRef.current = keyProp
+    setContext(DEFAULT_CONTEXT)
+  }, [keyProp])
 
   const {
     predicates,
@@ -47,10 +57,7 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
   // Context lives here, not in the query hook, so the form's reset must
   // restore it too — otherwise reset leaves rows expandable at the old count.
   const handleReset = () => {
-    setContext({
-      enabled: DEFAULT_CONTEXT_ENABLED,
-      count: DEFAULT_CONTEXT_COUNT,
-    })
+    setContext(DEFAULT_CONTEXT)
     resetQuery()
   }
 
@@ -87,7 +94,7 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
               expandRowOnClick
               getIsRowExpandable={() => context.enabled && !!keyProp}
               renderExpandedRow={(row) =>
-                keyProp ? (
+                context.enabled && keyProp ? (
                   <NeighbourBand
                     keyProp={keyProp}
                     matchIndex={row.original.index}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -44,6 +44,16 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
     loaded,
   } = useArraySearchQuery(keyProp)
 
+  // Context lives here, not in the query hook, so the form's reset must
+  // restore it too — otherwise reset leaves rows expandable at the old count.
+  const handleReset = () => {
+    setContext({
+      enabled: DEFAULT_CONTEXT_ENABLED,
+      count: DEFAULT_CONTEXT_COUNT,
+    })
+    resetQuery()
+  }
+
   return (
     <>
       <ArraySearchForm
@@ -60,7 +70,7 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
         context={context}
         onChangeContext={onChangeContext}
         onRun={runSearch}
-        onReset={resetQuery}
+        onReset={handleReset}
         disabled={!isArrayKeyReady}
       />
       <S.TabBody>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -6,13 +6,25 @@ import { bufferToString } from 'uiSrc/utils'
 
 import { ArrayDetailsTable } from '../array-details-table'
 import { ArraySearchForm } from '../array-search-form'
+import { ContextOption } from '../array-search-form/ArraySearchForm.types'
 import { useArraySearchQuery } from '../hooks'
+import { DEFAULT_CONTEXT_COUNT, DEFAULT_CONTEXT_ENABLED } from '../constants'
 import * as S from '../tabs.styles'
+import { NeighbourBand } from './NeighbourBand'
 import { SearchTabProps } from './SearchTab.types'
 
 const SearchTab = ({ keyProp }: SearchTabProps) => {
   const { loading: keyLoading } = useAppSelector(selectedKeySelector)
   const keyName = keyProp ? bufferToString(keyProp) : ''
+
+  // Context is a display concern (±N neighbours on expand), off by default so
+  // result rows aren't expandable until the user opts in.
+  const [context, setContext] = useState<ContextOption>({
+    enabled: DEFAULT_CONTEXT_ENABLED,
+    count: DEFAULT_CONTEXT_COUNT,
+  })
+  const onChangeContext = (patch: Partial<ContextOption>) =>
+    setContext((c) => ({ ...c, ...patch }))
 
   const {
     predicates,
@@ -45,6 +57,8 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
         onChangePredicate={updatePredicate}
         onChangeCombinator={setCombinator}
         onChangeOptions={updateOptions}
+        context={context}
+        onChangeContext={onChangeContext}
         onRun={runSearch}
         onReset={resetQuery}
         disabled={!isArrayKeyReady}
@@ -60,6 +74,17 @@ const SearchTab = ({ keyProp }: SearchTabProps) => {
               elements={elements}
               loading={loading}
               error={error}
+              expandRowOnClick
+              getIsRowExpandable={() => context.enabled && !!keyProp}
+              renderExpandedRow={(row) =>
+                keyProp ? (
+                  <NeighbourBand
+                    keyProp={keyProp}
+                    matchIndex={row.original.index}
+                    count={context.count}
+                  />
+                ) : null
+              }
             />
           </S.TabTableWrapper>
         )}

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -478,6 +478,34 @@ export function searchArray(params: SearchArrayParams) {
   }
 }
 
+/**
+ * Fetches the ±N context window for one search match via ARGETRANGE and
+ * returns the normalized elements. Writes nothing into the shared array
+ * slice — the View tab owns `data.elements`; the search context band holds
+ * this result in local component state. Pass an AbortSignal so a re-expand,
+ * context-count change, or unmount can cancel the request.
+ */
+export function fetchArrayNeighbours(
+  params: { key: RedisString; start: string; end: string },
+  signal?: AbortSignal,
+) {
+  return async (
+    _dispatch: AppDispatch,
+    stateInit: () => RootState,
+  ): Promise<ArrayDataElement[]> => {
+    const state = stateInit()
+    const { data, status } = await apiService.post<GetArrayRangeResponse>(
+      arrayUrl(state, ApiEndpoints.ARRAY_GET_RANGE),
+      { keyName: params.key, start: params.start, end: params.end },
+      { ...encodingParams(state), signal },
+    )
+    if (!isStatusSuccessful(status)) {
+      throw new Error(DEFAULT_ERROR_MESSAGE)
+    }
+    return expandRangeElements(params.start, params.end, data.elements)
+  }
+}
+
 export function fetchArrayLength(key: RedisString) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -36,6 +36,7 @@ import reducer, {
   fetchArrayCount,
   refreshArray,
   searchArray,
+  fetchArrayNeighbours,
 } from '../../browser/array'
 import { arrayGrepPredicateFactory } from 'uiSrc/mocks/factories/browser/array/arrayGrepPredicate.factory'
 import { updateSelectedKeyRefreshTime } from '../../browser/keys'
@@ -843,6 +844,56 @@ describe('array slice', () => {
         const [, , config] = (apiService.post as jest.Mock).mock.calls[0]
         expect(config?.signal).toBeInstanceOf(AbortSignal)
         expect(store.getActions()).toEqual([loadArraySearch({ predicates })])
+      })
+    })
+
+    describe('fetchArrayNeighbours', () => {
+      it('resolves normalized elements without dispatching slice actions', async () => {
+        const data = { keyName: mockKey, elements: ['a', null, 'c'] }
+        apiService.post = jest.fn().mockResolvedValue({ status: 200, data })
+
+        const result = await store.dispatch<any>(
+          fetchArrayNeighbours({ key: mockKey, start: '37', end: '39' }),
+        )
+
+        expect(result).toEqual([
+          { index: '37', value: 'a' },
+          { index: '38', value: null },
+          { index: '39', value: 'c' },
+        ])
+        // Writes nothing into the shared View-tab slice.
+        expect(store.getActions()).toEqual([])
+      })
+
+      it('sends the clamped range and the abort signal', async () => {
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: { keyName: mockKey, elements: [] },
+        })
+        const controller = new AbortController()
+
+        await store.dispatch<any>(
+          fetchArrayNeighbours(
+            { key: mockKey, start: '0', end: '5' },
+            controller.signal,
+          ),
+        )
+
+        const [, body, config] = (apiService.post as jest.Mock).mock.calls[0]
+        expect(body).toEqual({ keyName: mockKey, start: '0', end: '5' })
+        expect(config.signal).toBe(controller.signal)
+      })
+
+      it('throws on a non-success status', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 304, data: null })
+
+        await expect(
+          store.dispatch<any>(
+            fetchArrayNeighbours({ key: mockKey, start: '0', end: '5' }),
+          ),
+        ).rejects.toThrow(DEFAULT_ERROR_MESSAGE)
       })
     })
   })

--- a/redisinsight/ui/src/utils/arrayIndex.ts
+++ b/redisinsight/ui/src/utils/arrayIndex.ts
@@ -47,8 +47,12 @@ export const getNeighbourRange = (
   index: string,
   count: number,
 ): { start: string; end: string } => {
+  // Coerce count to a non-negative integer: a fractional/NaN value would make
+  // BigInt() throw and break the caller mid-render.
+  const span = BigInt(
+    Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0,
+  )
   const center = BigInt(index)
-  const span = BigInt(count)
   const lower = center - span
   const upper = center + span
   return {

--- a/redisinsight/ui/src/utils/arrayIndex.ts
+++ b/redisinsight/ui/src/utils/arrayIndex.ts
@@ -37,3 +37,22 @@ export const parseArrayIndex = (input: unknown): string | null => {
 
 export const isValidArrayIndex = (input: unknown): boolean =>
   parseArrayIndex(input) !== null
+
+/**
+ * Inclusive ±count index window around a match, for the search context
+ * band. Clamps the lower bound at 0 (no negative indexes) and the upper
+ * bound at ARRAY_INDEX_MAX. All math in BigInt to stay exact past 2^53.
+ */
+export const getNeighbourRange = (
+  index: string,
+  count: number,
+): { start: string; end: string } => {
+  const center = BigInt(index)
+  const span = BigInt(count)
+  const lower = center - span
+  const upper = center + span
+  return {
+    start: (lower < BigInt(0) ? BigInt(0) : lower).toString(),
+    end: (upper > ARRAY_INDEX_MAX ? ARRAY_INDEX_MAX : upper).toString(),
+  }
+}

--- a/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
+++ b/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
@@ -78,5 +78,14 @@ describe('arrayIndex', () => {
         end: '9007199254740995',
       })
     })
+
+    it('truncates a fractional count instead of throwing in BigInt', () => {
+      expect(getNeighbourRange('42', 1.5)).toEqual({ start: '41', end: '43' })
+    })
+
+    it('treats a non-finite or negative count as 0', () => {
+      expect(getNeighbourRange('42', NaN)).toEqual({ start: '42', end: '42' })
+      expect(getNeighbourRange('42', -3)).toEqual({ start: '42', end: '42' })
+    })
   })
 })

--- a/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
+++ b/redisinsight/ui/src/utils/tests/arrayIndex.spec.ts
@@ -3,6 +3,7 @@ import {
   isValidArrayIndex,
   parseArrayIndex,
 } from 'uiSrc/utils'
+import { getNeighbourRange } from 'uiSrc/utils/arrayIndex'
 
 describe('arrayIndex', () => {
   it('should expose the max valid Redis array index (2^64 - 2)', () => {
@@ -49,6 +50,33 @@ describe('arrayIndex', () => {
     })
     it('should return false for non-string input', () => {
       expect(isValidArrayIndex(42)).toEqual(false)
+    })
+  })
+
+  describe('getNeighbourRange', () => {
+    it('returns ±count around the index', () => {
+      expect(getNeighbourRange('42', 5)).toEqual({ start: '37', end: '47' })
+    })
+
+    it('clamps the lower bound at 0 (never negative)', () => {
+      expect(getNeighbourRange('3', 5)).toEqual({ start: '0', end: '8' })
+    })
+
+    it('returns just the match for count 0', () => {
+      expect(getNeighbourRange('42', 0)).toEqual({ start: '42', end: '42' })
+    })
+
+    it('caps the upper bound at ARRAY_INDEX_MAX', () => {
+      const { start, end } = getNeighbourRange(ARRAY_INDEX_MAX.toString(), 5)
+      expect(end).toBe(ARRAY_INDEX_MAX.toString())
+      expect(start).toBe((ARRAY_INDEX_MAX - BigInt(5)).toString())
+    })
+
+    it('stays exact for indexes beyond 2^53 (BigInt math)', () => {
+      expect(getNeighbourRange('9007199254740993', 2)).toEqual({
+        start: '9007199254740991',
+        end: '9007199254740995',
+      })
     })
   })
 })


### PR DESCRIPTION
# What

Adds the **Context** option to the array Search tab (Slice 4 of the ARGREP search vertical, parent RI-8221). It's opt-in via a toggle in the Search **Options** section (off by default): once enabled, expanding a result row shows ±N neighbouring elements around the match, with the matched row highlighted and the count adjustable.

- Neighbours are fetched via the existing `ARGETRANGE` endpoint into **local component state** — the View tab's array slice is left untouched.
- The ±N index window is computed in **BigInt**, clamped at 0 and capped at `ARRAY_INDEX_MAX`, so no negative or out-of-range index is ever requested (u64-as-string contract).
- `ArrayDetailsTable` gains optional row-expansion passthrough; the View / Aggregate tabs are unchanged (no expansion props → no expand affordance).
- Options panel reorganized: Range + Context on one row, a divider, then NOCASE / WITHVALUES / LIMIT — each with its own `(i)` hint.

# Testing

- `yarn test` — 200 array-details / slice / util tests pass, including: clamp-at-0, BigInt-exact-past-2^53, thunk writes nothing to the slice, off-by-default ⇒ no expand and no fetch, and refetch-on-count-change.
- `yarn lint` clean; `yarn type-check` adds zero new errors.
- Manual: open an array key (behind `dev-array`) → **Search** → run a query → expand **Options**, tick **Context** → expand a match to see the ±N band (matched row highlighted); toggle Context off → rows are no longer expandable.

| Light | Dark |
| --- | --- |
| <img width="999" height="441" alt="image" src="https://github.com/user-attachments/assets/59838a04-a721-4d97-9b4d-cb31a2496df4" /> | <img width="1002" height="470" alt="image" src="https://github.com/user-attachments/assets/fe2da56e-b8ed-461a-8079-4c0cd77603bb" />  |
| <img width="993" height="757" alt="image" src="https://github.com/user-attachments/assets/549f8fcc-9065-4049-8b90-ef6621d83645" /> | <img width="997" height="756" alt="image" src="https://github.com/user-attachments/assets/073e806c-739e-443a-a84f-af15bb4bed27" />|
| <img width="995" height="946" alt="image" src="https://github.com/user-attachments/assets/0d0dc682-fd2c-400c-b072-21d5c21763ed" /> | <img width="997" height="909" alt="image" src="https://github.com/user-attachments/assets/8ce72eef-9765-4a8c-a66b-a176789f0093" />|

---

Closes #RI-8294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds on-demand ARGETRANGE fetches and row expansion only on Search; neighbour loads are isolated from the View slice with abort/clamp safeguards, but wrong range math could still stress large windows (capped at ±50).
> 
> **Overview**
> Adds an opt-in **Context** control to the array **Search** tab so users can expand a match row and see **±N** neighbouring elements (matched row highlighted), without changing ARGREP itself.
> 
> **Search form & state:** New `Context` toggle and count (capped at 50) live in **Options**, separate from search `options` so they never appear in the command preview. The options panel is reorganized (Range + Context on one row, divider, then NOCASE / WITHVALUES / LIMIT) with per-control **InfoHint** tooltips. `SearchTab` owns context state (off by default), resets it on form reset and key switch, and only enables row expansion when Context is on.
> 
> **Table & neighbour fetch:** `ArrayDetailsTable` optionally forwards row-expansion props to the shared `Table`; View/Aggregate tabs omit them. Expanding a row renders **`NeighbourBand`**, which calls a new **`fetchArrayNeighbours`** thunk (`ARGETRANGE`) into **local state** only (View-tab `data.elements` untouched), with abort + stale-response guards. Index windows use new **`getNeighbourRange`** (BigInt, clamped at 0 and max u64).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddfbfc1f2c1c479e55681cc206c5d06e24b0a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->