### PR TITLE
ci: make unit coverage comment step non-fatal

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,6 +27,7 @@ jobs:
         id: findPr
 
       - uses: ArtiomTr/jest-coverage-report-action@v2
+        continue-on-error: true
         with:
           prnumber: ${{ steps.findPr.outputs.number }}
           coverage-file: report/coverage/report.json


### PR DESCRIPTION
# What

I noticed the `jest-coverage-report-action` step in the unit coverage job
intermittently fails on a transient GitHub API error (e.g. `Premature close`
while fetching the PR). Posting the coverage comment is purely informational,
so it shouldn't fail the whole pipeline.

Added `continue-on-error: true` to that step so a flaky comment-posting call
surfaces as a step warning instead of failing the job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that only affects failure behavior for an optional PR comment step; no application or security impact.
> 
> **Overview**
> Unit test coverage jobs will no longer fail when the informational PR coverage comment cannot be posted.
> 
> The `jest-coverage-report-action` step in the **coverage-unit** workflow now sets **`continue-on-error: true`**, so transient GitHub API errors (e.g. connection drops while fetching the PR) surface as a step warning instead of failing the whole pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa95c5cf933a6d0d4534bb3d583cffbdc3d4703f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->