### PR TITLE
Fix type-check regression from stricter match() inference

### DIFF
--- a/redisinsight/api/.tscheck.rec.json
+++ b/redisinsight/api/.tscheck.rec.json
@@ -1206,9 +1206,6 @@
   "src/modules/redis-sentinel/redis-sentinel.analytics.ts": {
     "TS18048": 1
   },
-  "src/modules/redis/client/ioredis/cluster.ioredis.client.ts": {
-    "TS2488": 1
-  },
   "src/modules/redis/client/ioredis/ioredis.client.ts": {
     "TS2345": 2,
     "TS2532": 1

--- a/redisinsight/api/src/modules/browser/utils/clusterCursor.ts
+++ b/redisinsight/api/src/modules/browser/utils/clusterCursor.ts
@@ -24,7 +24,11 @@ export const parseClusterCursor = (cursor: string): IScannerNodeKeys[] => {
 
   nodeStrings.forEach((item: string) => {
     const [address, nextCursor] = item.split(CURSOR_SEPARATOR);
-    const [, host, port] = address.match(/(.+):(\d+)$/);
+    const match = address.match(/(.+):(\d+)$/);
+    if (!match) {
+      return;
+    }
+    const [, host, port] = match;
 
     // ignore nodes with cursor -1 (fully scanned)
     if (parseInt(nextCursor, 10) >= 0) {

--- a/redisinsight/api/src/modules/redis/client/ioredis/cluster.ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/cluster.ioredis.client.ts
@@ -34,11 +34,14 @@ export class ClusterIoredisClient extends IoredisClient {
           });
 
           if (natAddressString) {
-            const [, natHost, natPort] = natAddressString.match(/(.+):(\d+)$/);
-            natAddress = {
-              natHost,
-              natPort: +natPort,
-            };
+            const natMatch = natAddressString.match(/(.+):(\d+)$/);
+            if (natMatch) {
+              const [, natHost, natPort] = natMatch;
+              natAddress = {
+                natHost,
+                natPort: +natPort,
+              };
+            }
           }
         }
 

--- a/redisinsight/desktop/.tscheck.rec.json
+++ b/redisinsight/desktop/.tscheck.rec.json
@@ -74,64 +74,45 @@
   "../ui/src/pages/browser/modules/key-details/components/rejson-details/utils/utils.ts": {
     "TS2307": 1
   },
-  "../ui/src/slices/analytics/clusterDetails.ts": {
-    "TS2345": 1
-  },
-  "../ui/src/slices/analytics/dbAnalysis.ts": {
-    "TS2345": 4
-  },
-  "../ui/src/slices/analytics/slowlog.ts": {
-    "TS2345": 4
-  },
-  "../ui/src/slices/app/info.ts": {
-    "TS2345": 1
-  },
-  "../ui/src/slices/app/plugins.ts": {
-    "TS2345": 1
-  },
   "../ui/src/slices/app/redis-commands.ts": {
-    "TS2345": 2
-  },
-  "../ui/src/slices/browser/bulkActions.ts": {
-    "TS2345": 2
+    "TS2345": 1
   },
   "../ui/src/slices/browser/hash.ts": {
     "TS2322": 2,
-    "TS2345": 17,
+    "TS2345": 4,
     "TS2769": 1
   },
   "../ui/src/slices/browser/keys.ts": {
     "TS2322": 1,
-    "TS2345": 9,
     "TS2741": 1
   },
   "../ui/src/slices/browser/list.ts": {
     "TS2322": 5,
-    "TS2345": 18,
+    "TS2345": 6,
     "TS2769": 1
   },
   "../ui/src/slices/browser/redisearch.ts": {
     "TS2322": 1,
     "TS2339": 2,
-    "TS2345": 10,
+    "TS2345": 5,
     "TS2769": 1
   },
   "../ui/src/slices/browser/rejson.ts": {
-    "TS2345": 8
+    "TS2345": 1
   },
   "../ui/src/slices/browser/set.ts": {
     "TS2322": 2,
-    "TS2345": 14
+    "TS2345": 4
   },
   "../ui/src/slices/browser/stream.ts": {
     "TS2322": 4,
     "TS2339": 1,
-    "TS2345": 30,
+    "TS2345": 13,
     "TS2698": 1,
     "TS2739": 1
   },
   "../ui/src/slices/browser/string.ts": {
-    "TS2345": 7,
+    "TS2345": 1,
     "TS2741": 1
   },
   "../ui/src/slices/browser/vectorSet.ts": {
@@ -140,37 +121,22 @@
   },
   "../ui/src/slices/browser/zset.ts": {
     "TS2322": 3,
-    "TS2345": 22
+    "TS2345": 4
   },
   "../ui/src/slices/cli/cli-output.ts": {
-    "TS2345": 2
-  },
-  "../ui/src/slices/cli/cli-settings.ts": {
-    "TS2345": 5
-  },
-  "../ui/src/slices/content/create-redis-buttons.ts": {
     "TS2345": 1
   },
   "../ui/src/slices/instances/caCerts.ts": {
-    "TS2345": 5
-  },
-  "../ui/src/slices/instances/clientCerts.ts": {
-    "TS2345": 4
-  },
-  "../ui/src/slices/instances/cloud.ts": {
-    "TS2345": 5
-  },
-  "../ui/src/slices/instances/cluster.ts": {
-    "TS2345": 5
+    "TS2345": 1
   },
   "../ui/src/slices/instances/instances.ts": {
     "TS2322": 1,
     "TS2339": 2,
-    "TS2345": 14
+    "TS2345": 1
   },
   "../ui/src/slices/instances/sentinel.ts": {
     "TS2322": 1,
-    "TS2345": 6
+    "TS2345": 3
   },
   "../ui/src/slices/interfaces/hash.ts": {
     "TS2430": 1
@@ -181,48 +147,16 @@
   "../ui/src/slices/interfaces/zset.ts": {
     "TS2430": 1
   },
-  "../ui/src/slices/oauth/cloud.ts": {
-    "TS2345": 9
-  },
-  "../ui/src/slices/panels/aiAssistant.ts": {
-    "TS2345": 3
-  },
-  "../ui/src/slices/pubsub/pubsub.ts": {
-    "TS2345": 1
-  },
-  "../ui/src/slices/rdi/dryRun.ts": {
-    "TS2345": 1
-  },
   "../ui/src/slices/rdi/instances.ts": {
     "TS2322": 2,
     "TS2339": 1,
-    "TS2345": 8
-  },
-  "../ui/src/slices/rdi/pipeline.ts": {
-    "TS2345": 7
-  },
-  "../ui/src/slices/rdi/statistics.ts": {
-    "TS2345": 1
-  },
-  "../ui/src/slices/rdi/testConnections.ts": {
-    "TS2345": 1
-  },
-  "../ui/src/slices/recommendations/recommendations.ts": {
-    "TS2345": 3
-  },
-  "../ui/src/slices/user/user-settings.ts": {
-    "TS2345": 1
+    "TS2345": 2
   },
   "../ui/src/slices/workbench/wb-custom-tutorials.ts": {
-    "TS2339": 1,
-    "TS2345": 3
+    "TS2339": 1
   },
   "../ui/src/slices/workbench/wb-results.ts": {
-    "TS2322": 1,
-    "TS2345": 6
-  },
-  "../ui/src/slices/workbench/wb-tutorials.ts": {
-    "TS2345": 1
+    "TS2322": 1
   },
   "../ui/src/telemetry/telemetryUtils.ts": {
     "TS7053": 1


### PR DESCRIPTION
# What

`yarn type-check` was failing on main after the typeorm 0.3.29 / socket.io
bumps tightened type inference, surfacing latent strict-null errors where
`String.match()` results (`RegExpMatchArray | null`) were destructured
directly:

> TS2488: Type 'RegExpMatchArray | null' must have a '[Symbol.iterator]()'
> method that returns an iterator.

- Guard the match before destructuring in both affected API files —
  `clusterCursor.ts` (cursor parser) and `cluster.ioredis.client.ts`
  (NAT address parsing). `host`/`port` stay typed as `string`.
- Refresh the api/desktop TS baselines: the same bumps regenerated
  `api-client` and lowered recorded error counts that were never updated.

These were the only two `.match()`-destructure sites in the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small null-safety guards in cluster cursor and NAT parsing; baseline JSON only affects recorded type-check debt, not runtime behavior for valid inputs.
> 
> **Overview**
> Restores **`yarn type-check`** after stricter inference from dependency bumps (e.g. typeorm / socket.io) exposed **TS2488** on direct destructuring of `RegExpMatchArray | null`.
> 
> **Runtime/type fixes:** **`parseClusterCursor`** and the ioredis **cluster NAT map** parser now assign `match` / `natMatch`, return or skip when there is no match, then destructure so `host`/`port` stay correctly narrowed.
> 
> **Baselines:** Updates **`redisinsight/api/.tscheck.rec.json`** (drops the fixed `cluster.ioredis.client` entry) and **`redisinsight/desktop/.tscheck.rec.json`** to reflect lower recorded error counts after regenerated **`api-client`** and related typing changes—not new product logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b777c3f6ba3c5729d68c582b18031e9055ef04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->