### PR TITLE
#5543 Fix home database table scrolling

### DIFF
--- a/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.tsx
+++ b/redisinsight/ui/src/pages/home/components/databases-list/DatabasesList.tsx
@@ -40,7 +40,7 @@ const DatabasesList = () => {
         defaultPagination={getDefaultPagination()}
         onPaginationChange={handlePaginationChange}
         defaultSorting={DEFAULT_SORTING}
-        maxHeight="60rem" // this enables vertical scroll
+        style={{ maxHeight: '100%' }}
       />
       <BulkItemsActions items={selectedInstances} onClose={resetRowSelection} />
     </>

--- a/redisinsight/ui/src/pages/home/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/styles.module.scss
@@ -8,9 +8,14 @@
   padding: 1px 16px 16px !important;
 
   :global {
+    .RI-page-body {
+      min-height: 0;
+    }
+
     .homePage {
-      height: calc(100% - 60px);
-      overflow-y: auto;
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: hidden;
       /* Inset on all sides so table card chrome is not clipped by this scrollport */
       padding: 1px;
     }


### PR DESCRIPTION
# What
Fixes the Redis Databases table on the Home screen so users can scroll through the full database list.

The table previously used a fixed `maxHeight="60rem"` value, which could overflow the available page area and cause lower rows to be clipped on smaller screens. This change lets the table use the available Home page height and keeps vertical overflow inside the table viewport.

The Home page layout was also adjusted so the page body and database list container can shrink correctly within the available viewport height. This allows the Redis UI table’s internal scroller to handle long database lists instead of the page clipping the table content.

Closes #5543

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Home-page layout and table height styling only; no auth, data, or API changes.
> 
> **Overview**
> Fixes clipped rows on the Home Redis Databases table by sizing the table to the available page height instead of a fixed **60rem** cap.
> 
> **`DatabasesList`** passes `style={{ maxHeight: '100%' }}` to the shared **`Table`** so height follows its flex parent rather than overflowing on shorter viewports.
> 
> **Home layout CSS** adds `min-height: 0` on **`.RI-page-body`** and switches **`.homePage`** from `height: calc(100% - 60px)` with page-level `overflow-y: auto` to a flex child (`flex: 1 1 auto`, `min-height: 0`, `overflow: hidden`) so the list area shrinks within the viewport and the table’s internal scroller owns vertical overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e563987b6ec4494a2accfcc03519ad50faebc108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->