### PR TITLE
RI-8222: Add array append endpoint

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Array/Append Element.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Append Element.bru
@@ -1,0 +1,54 @@
+meta {
+  name: Append Element
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array/append
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "readings",
+    "value": "22.3"
+  }
+}
+
+docs {
+  # Append element (ARSET at end)
+
+  Append a value to the end of the array. The end index is computed
+  server-side (current `ARLEN`), so no index is supplied. The key must already
+  exist (append targets an existing array).
+
+  ## Request body
+
+  | Field     | Type   | Notes                                    |
+  |-----------|--------|------------------------------------------|
+  | `keyName` | string | The Array key name.                      |
+  | `value`   | string | Value to append at the end.              |
+
+  ## Response
+
+  ```
+  {
+    "keyName": "readings",
+    "index": "7"
+  }
+  ```
+
+  ## Errors
+
+  | Status | When |
+  |--------|------|
+  | `400`  | Key holds a non-array type. |
+  | `403`  | User has no permission for the underlying commands. |
+  | `404`  | Key does not exist. |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/src/constants/error-messages.ts
+++ b/redisinsight/api/src/constants/error-messages.ts
@@ -81,6 +81,8 @@ export default {
   ARRAY_RANGE_TOO_LARGE: (max: number) =>
     `Requested range exceeds the maximum of ${numberWithSpaces(max)} elements per call. Narrow the range and try again.`,
   ARRAY_MATCH_VALUE_REQUIRED: 'value is required for MATCH operation.',
+  ARRAY_IS_FULL:
+    'The array has reached the maximum index (2^64-2), so there is no position left to append to.',
   REMOVING_MULTIPLE_ELEMENTS_NOT_SUPPORT: () =>
     'Removing multiple elements is available for Redis databases v. 6.2 or later.',
   SCAN_PER_KEY_TYPE_NOT_SUPPORT: () =>

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -10,6 +10,7 @@ import {
   GetArraySearchDto,
   GetArraySearchResponse,
   SetArrayElementDto,
+  AppendArrayElementDto,
 } from 'src/modules/browser/array/dto';
 
 const arrayKeyName = () => Buffer.from(`array:${faker.string.alphanumeric(6)}`);
@@ -44,6 +45,12 @@ export const setArrayElementDtoFactory = Factory.define<SetArrayElementDto>(
     value: arrayValue(),
   }),
 );
+
+export const appendArrayElementDtoFactory =
+  Factory.define<AppendArrayElementDto>(() => ({
+    keyName: arrayKeyName(),
+    value: arrayValue(),
+  }));
 
 export const aggregateArrayDtoFactory = Factory.define<AggregateArrayDto>(
   () => ({

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -34,6 +34,8 @@ import {
   GetArraySearchDto,
   GetArraySearchResponse,
   SetArrayElementDto,
+  AppendArrayElementDto,
+  AppendArrayElementResponse,
 } from 'src/modules/browser/array/dto';
 
 @ApiTags('Browser: Array')
@@ -73,6 +75,25 @@ export class ArrayController extends BrowserBaseController {
     @Body() dto: SetArrayElementDto,
   ): Promise<void> {
     return this.arrayService.setElement(clientMetadata, dto);
+  }
+
+  @Post('/append')
+  @HttpCode(200)
+  @ApiOperation({
+    description:
+      'Append a value to the end of the array. The end index is computed ' +
+      'server-side (current length); no index is supplied. Returns the index ' +
+      'written. The key must already exist.',
+  })
+  @ApiRedisParams()
+  @ApiBody({ type: AppendArrayElementDto })
+  @ApiOkResponse({ type: AppendArrayElementResponse })
+  @ApiQueryRedisStringEncoding()
+  async appendElement(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: AppendArrayElementDto,
+  ): Promise<AppendArrayElementResponse> {
+    return this.arrayService.appendElement(clientMetadata, dto);
   }
 
   @Post('/get-range')

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -27,6 +27,7 @@ import {
   getArraySearchDtoFactory,
   getArraySearchResponseFactory,
   setArrayElementDtoFactory,
+  appendArrayElementDtoFactory,
 } from 'src/modules/browser/array/__tests__/array.factory';
 import {
   mockArrayCount,
@@ -847,6 +848,87 @@ describe('ArrayService', () => {
       await expect(
         service.search(mockBrowserClientMetadata, mockGetArraySearchDto),
       ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('appendElement', () => {
+    // keyName matches mockKeyDto so the shared key-existence stub resolves.
+    const dto = appendArrayElementDtoFactory.build({
+      keyName: mockKeyDto.keyName,
+    });
+
+    it('should append at the current length (ARLEN then ARSET) and return the index', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolArrayCommands.ArLen, dto.keyName])
+        .mockResolvedValue(7);
+
+      const result = await service.appendElement(
+        mockBrowserClientMetadata,
+        dto,
+      );
+
+      expect(result).toEqual({ keyName: dto.keyName, index: '7' });
+      // Writes at the length read by ARLEN, passing the index as a string so
+      // the append stays precise once ioredis returns 64-bit integers
+      // losslessly (RI-8296).
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArSet,
+        dto.keyName,
+        '7',
+        dto.value,
+      ]);
+    });
+
+    it('should reject when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, dto.keyName])
+        .mockResolvedValue(0);
+      await expect(
+        service.appendElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject with BadRequest when the array is full (ARLEN === 2^64-1)', async () => {
+      // Top index already 2^64-2, so the next index is the reserved 2^64-1 —
+      // guard it before ARSET rather than letting Redis 500.
+      when(client.sendCommand)
+        .calledWith([BrowserToolArrayCommands.ArLen, dto.keyName])
+        .mockResolvedValue('18446744073709551615');
+
+      await expect(
+        service.appendElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(client.sendCommand).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          BrowserToolArrayCommands.ArSet,
+          dto.keyName,
+          '18446744073709551615',
+        ]),
+      );
+    });
+
+    it('should rethrow BadRequest on WrongType', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'ARLEN',
+      };
+      when(client.sendCommand)
+        .calledWith([BrowserToolArrayCommands.ArLen, dto.keyName])
+        .mockRejectedValue(replyError);
+      await expect(
+        service.appendElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should map ACL error to Forbidden', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARSET',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+      await expect(
+        service.appendElement(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -21,6 +21,7 @@ import {
 } from 'src/modules/browser/utils';
 import { KeyDto } from 'src/modules/browser/keys/dto';
 import { ARRAY_RANGE_MAX_ELEMENTS } from 'src/modules/browser/array/constants';
+import { isValidArrayIndex } from 'src/common/utils/array-index.helper';
 import {
   toIndexString,
   toRequiredIndexString,
@@ -47,6 +48,8 @@ import {
   GetArraySearchDto,
   GetArraySearchResponse,
   SetArrayElementDto,
+  AppendArrayElementDto,
+  AppendArrayElementResponse,
 } from 'src/modules/browser/array/dto';
 
 @Injectable()
@@ -531,6 +534,60 @@ export class ArrayService {
       this.logger.debug('Succeed to set array element.', clientMetadata);
     } catch (error) {
       this.logger.error('Failed to set array element.', error, clientMetadata);
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
+  public async appendElement(
+    clientMetadata: ClientMetadata,
+    dto: AppendArrayElementDto,
+  ): Promise<AppendArrayElementResponse> {
+    try {
+      this.logger.debug('Appending array element.', clientMetadata);
+      const { keyName, value } = dto;
+      const client =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      // Append targets an existing array, so the key must already exist.
+      await checkIfKeyNotExists(keyName, client);
+
+      // Append-to-end = ARSET at the current length. Read the length, then
+      // write there. Not wrapped in a transaction (the client has no
+      // MULTI/WATCH yet), so concurrent appends can race on the same length —
+      // acceptable for the desktop GUI. The index stays a string, so the write
+      // is precise once ioredis returns 64-bit integers losslessly (RI-8296).
+      const index = toRequiredIndexString(
+        await client.sendCommand([BrowserToolArrayCommands.ArLen, keyName]),
+      );
+
+      // A full array (top index already 2^64-2) reports length 2^64-1 — the
+      // reserved index ARSET rejects with "invalid array index". Surface it as
+      // a clean 400 rather than letting it fall through as a 500.
+      if (!isValidArrayIndex(index)) {
+        throw new BadRequestException(ERROR_MESSAGES.ARRAY_IS_FULL);
+      }
+
+      await client.sendCommand([
+        BrowserToolArrayCommands.ArSet,
+        keyName,
+        index,
+        value,
+      ]);
+
+      this.logger.debug('Succeed to append array element.', clientMetadata);
+      return plainToInstance(AppendArrayElementResponse, {
+        keyName,
+        index,
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to append array element.',
+        error,
+        clientMetadata,
+      );
+      if (error instanceof BadRequestException) throw error;
       if (error?.message?.includes(RedisErrorCodes.WrongType)) {
         throw new BadRequestException(error.message);
       }

--- a/redisinsight/api/src/modules/browser/array/dto/append.array-element.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/append.array-element.dto.ts
@@ -1,0 +1,20 @@
+import { IsDefined } from 'class-validator';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import {
+  ApiRedisString,
+  IsRedisString,
+  RedisStringType,
+} from 'src/common/decorators';
+import { RedisString } from 'src/common/constants';
+
+/**
+ * Appends a value to the end of the array. The end index is computed
+ * server-side (current ARLEN), so no index is supplied.
+ */
+export class AppendArrayElementDto extends KeyDto {
+  @ApiRedisString('Value to append at the end of the array')
+  @IsDefined()
+  @IsRedisString()
+  @RedisStringType()
+  value: RedisString;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/append.array-element.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/append.array-element.response.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { KeyResponse } from 'src/modules/browser/keys/dto';
+
+export class AppendArrayElementResponse extends KeyResponse {
+  @ApiProperty({
+    description:
+      'Index the value was appended at (the array length before the append). ' +
+      'Unsigned 64-bit integer as string.',
+    type: String,
+    example: '7',
+  })
+  index: string;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -6,6 +6,8 @@ export * from './get.array-scan.response';
 export * from './get.array-element.dto';
 export * from './get.array-element.response';
 export * from './set.array-element.dto';
+export * from './append.array-element.dto';
+export * from './append.array-element.response';
 export * from './get.array-multi-elements.dto';
 export * from './get.array-multi-elements.response';
 export * from './get.array-length.response';

--- a/redisinsight/api/test/api/array/POST-databases-id-array-append.test.ts
+++ b/redisinsight/api/test/api/array/POST-databases-id-array-append.test.ts
@@ -1,0 +1,218 @@
+import {
+  expect,
+  describe,
+  it,
+  before,
+  deps,
+  Joi,
+  requirements,
+  generateInvalidDataTestCases,
+  validateInvalidDataTestCase,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(
+    `/${constants.API.DATABASES}/${instanceId}/array/append`,
+  );
+
+const dataSchema = Joi.object({
+  keyName: Joi.string().allow('').required(),
+  value: Joi.string().required(),
+}).strict();
+
+const validInputData = {
+  keyName: constants.getRandomString(),
+  value: constants.getRandomString(),
+};
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARSET/ARMSET/ARLEN/ARCOUNT are Redis 8.8 preview commands with no typed
+// ioredis method; assert array state through the generic `call`.
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+const arlen = (key: string) => rte.client.call('ARLEN', key);
+
+// Seed shape mirrors the canonical `readings` fixture: indexes 0,1,5 populated,
+// gaps at 2,3,4 (logical length 6) — so the end index is 6.
+const seedSparse = (key: string) =>
+  rte.client.call('ARMSET', key, '0', '20.1', '1', '20.4', '5', '21.4');
+
+describe('POST /databases/:instanceId/array/append', () => {
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Validation', () => {
+    generateInvalidDataTestCases(dataSchema, validInputData).map(
+      validateInvalidDataTestCase(endpoint, dataSchema),
+    );
+  });
+
+  describe('Main', () => {
+    it('Should append at the end (index = current length) and grow length', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, value: 'appended' },
+        responseBody: { keyName, index: '6' },
+      });
+
+      expect(await arget(keyName, '6')).to.eql('appended');
+      expect(await arlen(keyName)).to.eql(7);
+    });
+
+    it('Should place consecutive appends at increasing indexes', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, value: 'first' },
+        responseBody: { keyName, index: '6' },
+      });
+      await validateApiCall({
+        endpoint,
+        data: { keyName, value: 'second' },
+        responseBody: { keyName, index: '7' },
+      });
+
+      expect(await arget(keyName, '6')).to.eql('first');
+      expect(await arget(keyName, '7')).to.eql('second');
+      expect(await arlen(keyName)).to.eql(8);
+    });
+
+    it('Should append a value sent as encoding=buffer byte-for-byte', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      await validateApiCall({
+        endpoint,
+        query: { encoding: 'buffer' },
+        data: {
+          keyName,
+          value: { type: 'Buffer', data: [...Buffer.from('20.5')] },
+        },
+      });
+
+      expect(await arget(keyName, '6')).to.eql('20.5');
+    });
+
+    // Above 2^53 ioredis parses the ARLEN reply as a JS number and drops the
+    // low bit, so append derives the wrong end index. This is purely the
+    // integer-transport limitation tracked by RI-8296 (ioredis
+    // `stringNumbers`); the service keeps the index as a string, so it flips
+    // green once the client returns 64-bit integers losslessly. Skipped until.
+    it.skip('Should append precisely above 2^53 (needs ioredis 64-bit int fix — RI-8296)', async () => {
+      const keyName = constants.getRandomString();
+      // Length becomes 2^53 + 1 (9007199254740993) — odd, not representable as
+      // a JS double, so a rounded read would collide with the seeded element.
+      await rte.client.call('ARSET', keyName, '9007199254740992', 'base');
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, value: 'appended' },
+        responseBody: { keyName, index: '9007199254740993' },
+      });
+
+      expect(await arget(keyName, '9007199254740992')).to.eql('base');
+      expect(await arget(keyName, '9007199254740993')).to.eql('appended');
+    });
+
+    it('Should return BadRequest when the array is full (no index left to append)', async () => {
+      const keyName = constants.getRandomString();
+      // Top index = 2^64-2 (max valid) → length 2^64-1, the reserved index.
+      await rte.client.call('ARSET', keyName, '18446744073709551614', 'top');
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, value: 'overflow' },
+        statusCode: 400,
+      });
+
+      // The full array is left untouched.
+      expect(await arget(keyName, '18446744073709551614')).to.eql('top');
+    });
+
+    [
+      {
+        name: 'Should return BadRequest if key holds a non-array type',
+        data: { keyName: constants.TEST_STRING_KEY_1, value: 'x' },
+        statusCode: 400,
+        before: () => rte.data.generateKeys(true),
+        after: async () => {
+          // The non-array key must be left untouched.
+          expect(await rte.client.get(constants.TEST_STRING_KEY_1)).to.eql(
+            constants.TEST_STRING_VALUE_1,
+          );
+        },
+      },
+      {
+        // Append targets an existing array; the service guards a missing key
+        // as a 404 rather than creating one.
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), value: 'x' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), value: 'x' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('ACL', () => {
+    requirements('rte.acl');
+    before(async () => rte.data.setAclUserRules('~* +@all'));
+
+    const aclEndpoint = () => endpoint(constants.TEST_INSTANCE_ACL_ID);
+    const aclKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should append for an authorised user',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, value: 'authorised' },
+        before: async () => {
+          await rte.data.setAclUserRules('~* +@all');
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+        },
+        after: async () => {
+          expect(await arget(aclKey, '1')).to.eql('authorised');
+        },
+      },
+      {
+        name: 'Should throw error if no permissions for "arset" command',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, value: 'x' },
+        statusCode: 403,
+        responseBody: { statusCode: 403, error: 'Forbidden' },
+        // beforeEach() wipes the key between tests; reseed via the root client
+        // (the ACL rule below only affects the API request's user). Append
+        // performs ARSET, so removing it triggers NOPERM.
+        before: async () => {
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+          await rte.data.setAclUserRules('~* +@all -arset');
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});


### PR DESCRIPTION
# What

Adds `POST /databases/:id/array/append` for the array Modify vertical: appends a
value to the end of an array. The end index is computed server-side (current
`ARLEN`) — the client sends only `keyName` + `value` — and the written index is
returned. The key must already exist (404 otherwise); `WRONGTYPE` → 400, ACL
denial → 403.

### Design notes

- **Read-then-set, not a Lua script.** Append = `ARLEN` then `ARSET key <len> value`.
  An EVAL approach was rejected: Lua numbers are doubles, so it rounds the index
  *inside the script* above 2⁵³ and corrupts the write — a loss the upcoming
  ioredis fix could never repair.
- **Big-int index contract.** The index is a decimal string end-to-end and is
  passed to `ARSET` as a string, so the write stays precise. Above 2⁵³ the only
  imprecision is ioredis parsing the `ARLEN` reply as a JS number — the transport
  limitation tracked by **RI-8296** (`stringNumbers`). The integration test for
  that case is `skip`ped and will flip green once ioredis is fixed, with no code
  change.
- **Not transactional.** The client has no `MULTI`/`WATCH` yet (`sendMulti` is a
  TODO), so two concurrent appends can race on the same length. Acceptable for
  the desktop GUI, and still fresher than a UI-cached length.
- `ARINSERT` is intentionally not used (its cursor starts at 0 on ARSET/ARMSET-built
  arrays, so it overwrites from the front; cursor positioning needs `ARSEEK`, v2).

# Testing

- Service unit tests: append returns the index, `ARLEN`→`ARSET` call shape,
  404 / 400 / 403 paths.
- Integration suite vs **redis:8.8** (320 passing, 1 pending): append at end,
  consecutive appends, `encoding=buffer`, non-array → 400, missing key/instance →
  404, ACL authorised + `-arset` → 403, and the skipped >2⁵³ precision case.
- Bruno request added under `Array/Append Element`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New write path to live Redis data with a non-transactional ARLEN→ARSET sequence (concurrent appends can race); otherwise mirrors existing array modify patterns and error handling.
> 
> **Overview**
> Adds **`POST /databases/:id/array/append`** so clients can append to an existing Redis array with only `keyName` and `value`. The server reads **`ARLEN`**, writes at that index via **`ARSET`**, and returns **`{ keyName, index }`** (index as a decimal string).
> 
> **Behavior and errors:** Missing key → **404**; wrong type → **400**; ACL → **403**. When length is **`2^64-1`** (no valid append index), the API returns **400** with **`ARRAY_IS_FULL`** instead of hitting Redis with an invalid index.
> 
> **Tests & docs:** Service unit tests, Redis 8.8 integration tests (including buffer encoding, full-array guard, ACL on `arset`), a test factory, and a Bruno request under **Array/Append Element**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05cd432bad92dcb096fdd6f09c4363c839ac14cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->