### PR TITLE
RI-8222 Add "Add element" to the array View tab

### DIFF
--- a/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.constants.ts
+++ b/redisinsight/ui/src/components/production-write-confirmation/ProductionWriteConfirmationProvider.constants.ts
@@ -20,6 +20,7 @@ export enum BrowserConfirmationCommandId {
   AddListElements = 'browser:add-list-elements',
   AddSetMembers = 'browser:add-set-members',
   AddHashFields = 'browser:add-hash-fields',
+  AddArrayElements = 'browser:add-array-elements',
   AddStreamEntry = 'browser:add-stream-entry',
   RenameKey = 'browser:rename-key',
   ChangeTtl = 'browser:change-ttl',

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -85,6 +85,7 @@ enum ApiEndpoints {
   ARRAY_AGGREGATE = 'array/aggregate',
   ARRAY_SEARCH = 'array/search',
   ARRAY_SET_ELEMENT = 'array/set-element',
+  ARRAY_APPEND = 'array/append',
 
   STREAMS = 'streams',
   STREAMS_ENTRIES = 'streams/entries',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/ArrayDetails.tsx
@@ -15,10 +15,12 @@ import * as S from './ArrayDetails.styles'
 
 export interface Props extends KeyDetailsHeaderProps {
   keyProp: RedisResponseBuffer | null
+  onOpenAddItemPanel?: () => void
+  onCloseAddItemPanel?: () => void
 }
 
 const ArrayDetails = (props: Props) => {
-  const { keyProp } = props
+  const { keyProp, onOpenAddItemPanel, onCloseAddItemPanel } = props
 
   const [activeTab, setActiveTab] = useState<ArrayDetailsTab>(
     DEFAULT_ARRAY_DETAILS_TAB,
@@ -34,6 +36,8 @@ const ArrayDetails = (props: Props) => {
         <ViewTab
           keyProp={keyProp}
           isActive={activeTab === ArrayDetailsTab.View}
+          onOpenAddItemPanel={onOpenAddItemPanel}
+          onCloseAddItemPanel={onCloseAddItemPanel}
         />
       </S.TabSlot>
       <S.TabSlot $hidden={activeTab !== ArrayDetailsTab.Search}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
@@ -11,6 +11,10 @@ export const INVALID_INDEX_MESSAGE =
 export const ADD_BUTTON_LABEL = 'Add'
 export const CANCEL_BUTTON_LABEL = 'Cancel'
 export const MOVE_TO_ELEMENT_LABEL = 'Move to the added element'
+export const MOVE_TO_ELEMENT_HINT =
+  'When enabled, the View moves to show the element you just added. This is ' +
+  'useful for an append or a new index that lands outside the current range, ' +
+  'which would otherwise stay hidden.'
 
 export const CONFIRM_TITLE = 'Add element to a production database?'
 export const CONFIRM_DESCRIPTION =

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
@@ -10,6 +10,7 @@ export const INVALID_INDEX_MESSAGE =
   'Index must be an integer string between 0 and 18446744073709551614'
 export const ADD_BUTTON_LABEL = 'Add'
 export const CANCEL_BUTTON_LABEL = 'Cancel'
+export const MOVE_TO_ELEMENT_LABEL = 'Move to the added element'
 
 export const CONFIRM_TITLE = 'Add element to a production database?'
 export const CONFIRM_DESCRIPTION =

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.constants.ts
@@ -1,0 +1,17 @@
+export const ARRAY_ADD_FORM_TEST_ID = 'array-add-form'
+
+export const VALUE_LABEL = 'Value'
+export const INDEX_LABEL = 'Index'
+export const INDEX_PLACEHOLDER = 'Leave empty to append to the end'
+export const INDEX_HINT =
+  'Leave empty to append the value to the end of the array. Enter an index to ' +
+  'set the value at that exact position (overwriting any existing value there).'
+export const INVALID_INDEX_MESSAGE =
+  'Index must be an integer string between 0 and 18446744073709551614'
+export const ADD_BUTTON_LABEL = 'Add'
+export const CANCEL_BUTTON_LABEL = 'Cancel'
+
+export const CONFIRM_TITLE = 'Add element to a production database?'
+export const CONFIRM_DESCRIPTION =
+  'You are about to add an element to a key on a production database.'
+export const CONFIRM_BUTTON_TEXT = 'Add'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -124,6 +124,32 @@ describe('ArrayAddForm', () => {
     expect(onReveal).not.toHaveBeenCalled()
   })
 
+  it('honors a "move to element" toggle made while the write is in flight', async () => {
+    let resolvePost: (value: unknown) => void = () => {}
+    apiService.post = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve
+        }),
+    )
+    const onReveal = jest.fn()
+    renderForm(jest.fn(), onReveal)
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    // User unchecks the box before the POST resolves — the success handler must
+    // read the live flag, not the value captured when Add was confirmed.
+    fireEvent.click(screen.getByTestId('array-add-form-move-to-element'))
+    await act(async () => {
+      resolvePost({ status: 200, data: { index: '42' } })
+    })
+
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
   it('does not close the panel if the form unmounted before the write resolved', async () => {
     // Hold the write open so we can unmount (key switch + fresh panel) first.
     let resolvePost: (value: unknown) => void = () => {}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -66,6 +66,16 @@ describe('ArrayAddForm', () => {
     expect(screen.getByTestId('array-add-form-index')).toBeInTheDocument()
   })
 
+  it('renders the move-to-element checkbox with an info tooltip', () => {
+    renderForm()
+    expect(
+      screen.getByTestId('array-add-form-move-to-element'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('array-add-form-move-to-element-info'),
+    ).toBeInTheDocument()
+  })
+
   it('appends (POST /array/append) when the index is left empty', async () => {
     const closePanel = jest.fn()
     renderForm(closePanel)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -66,6 +66,21 @@ describe('ArrayAddForm', () => {
     expect(screen.getByTestId('array-add-form-index')).toBeInTheDocument()
   })
 
+  it('disables the submit button while a write is in flight', () => {
+    const busyState = {
+      ...stateWithKeySelected,
+      browser: {
+        ...stateWithKeySelected.browser,
+        array: { ...stateWithKeySelected.browser.array, updating: true },
+      },
+    }
+    render(<ArrayAddForm closePanel={jest.fn()} />, {
+      store: mockStore(busyState),
+    })
+
+    expect(screen.getByTestId('array-add-form-submit')).toBeDisabled()
+  })
+
   it('renders the move-to-element checkbox with an info tooltip', () => {
     renderForm()
     expect(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -66,16 +66,22 @@ describe('ArrayAddForm', () => {
     expect(screen.getByTestId('array-add-form-index')).toBeInTheDocument()
   })
 
-  it('disables the submit button while a write is in flight', () => {
-    const busyState = {
+  it('disables the submit button while refresh is locked (write in flight or a cell editor open)', () => {
+    const lockedState = {
       ...stateWithKeySelected,
       browser: {
         ...stateWithKeySelected.browser,
-        array: { ...stateWithKeySelected.browser.array, updating: true },
+        keys: {
+          ...stateWithKeySelected.browser.keys,
+          selectedKey: {
+            ...stateWithKeySelected.browser.keys.selectedKey,
+            isRefreshDisabled: true,
+          },
+        },
       },
     }
     render(<ArrayAddForm closePanel={jest.fn()} />, {
-      store: mockStore(busyState),
+      store: mockStore(lockedState),
     })
 
     expect(screen.getByTestId('array-add-form-submit')).toBeDisabled()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -13,6 +13,23 @@ import { stringToBuffer } from 'uiSrc/utils'
 
 import { ArrayAddForm } from './ArrayAddForm'
 
+// Capture the confirmation callback so a test can defer/replay it (the real
+// modal outlives the panel). By default it fires immediately, matching the
+// non-production provider the other tests rely on.
+let capturedOnConfirm: (() => void) | undefined
+const mockRequestConfirmation = jest.fn(
+  ({ onConfirm }: { onConfirm: () => void }) => {
+    capturedOnConfirm = onConfirm
+    onConfirm()
+  },
+)
+jest.mock('uiSrc/components/production-write-confirmation', () => ({
+  ...jest.requireActual('uiSrc/components/production-write-confirmation'),
+  useProductionWriteConfirmation: () => ({
+    requestConfirmation: mockRequestConfirmation,
+  }),
+}))
+
 const keyBuffer = stringToBuffer('mykey')
 
 // The form reads the write key from the selected key's data (selectedKeyData),
@@ -195,6 +212,30 @@ describe('ArrayAddForm', () => {
 
     // The stale success callback must not close the now-current panel.
     expect(closePanel).not.toHaveBeenCalled()
+  })
+
+  it('does not write from a discarded panel when confirmed after unmount', async () => {
+    apiService.post = jest.fn().mockResolvedValue({ status: 200, data: {} })
+    // Capture the confirmation without firing it — the modal outlives the panel.
+    mockRequestConfirmation.mockImplementationOnce(
+      ({ onConfirm }: { onConfirm: () => void }) => {
+        capturedOnConfirm = onConfirm
+      },
+    )
+    const { unmount } = renderForm()
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    // The panel is discarded (key switch) before the user presses Confirm.
+    unmount()
+    await act(async () => {
+      capturedOnConfirm?.()
+    })
+
+    expect(findCall('array/append')).toBeUndefined()
   })
 
   it('sets at index (POST /array/set-element) when an index is provided', async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { act, fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
+import {
+  act,
+  fireEvent,
+  initialStateDefault,
+  mockStore,
+  render,
+  screen,
+  waitFor,
+} from 'uiSrc/utils/test-utils'
 import { apiService } from 'uiSrc/services'
 import { stringToBuffer } from 'uiSrc/utils'
 
@@ -7,8 +15,29 @@ import { ArrayAddForm } from './ArrayAddForm'
 
 const keyProp = stringToBuffer('mykey')
 
+// The form's key must be the live selected key, otherwise applyArrayWriteResult
+// suppresses the success side effects (onSuccess/closePanel) as a stale write.
+const stateWithKeySelected = {
+  ...initialStateDefault,
+  app: {
+    ...initialStateDefault.app,
+    context: {
+      ...initialStateDefault.app.context,
+      browser: {
+        ...initialStateDefault.app.context.browser,
+        keyList: {
+          ...initialStateDefault.app.context.browser.keyList,
+          selectedKey: keyProp,
+        },
+      },
+    },
+  },
+}
+
 const renderForm = (closePanel = jest.fn()) =>
-  render(<ArrayAddForm keyProp={keyProp} closePanel={closePanel} />)
+  render(<ArrayAddForm keyProp={keyProp} closePanel={closePanel} />, {
+    store: mockStore(stateWithKeySelected),
+  })
 
 const findCall = (fragment: string) =>
   (apiService.post as jest.Mock).mock.calls.find(([url]) =>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -71,6 +71,32 @@ describe('ArrayAddForm', () => {
     expect(closePanel).toHaveBeenCalled()
   })
 
+  it('does not close the panel if the form unmounted before the write resolved', async () => {
+    // Hold the write open so we can unmount (key switch + fresh panel) first.
+    let resolvePost: (value: unknown) => void = () => {}
+    apiService.post = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePost = resolve
+        }),
+    )
+    const closePanel = jest.fn()
+    const { unmount } = renderForm(closePanel)
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    unmount()
+    await act(async () => {
+      resolvePost({ status: 200, data: {} })
+    })
+
+    // The stale success callback must not close the now-current panel.
+    expect(closePanel).not.toHaveBeenCalled()
+  })
+
   it('sets at index (POST /array/set-element) when an index is provided', async () => {
     renderForm()
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { act, fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
+import { apiService } from 'uiSrc/services'
+import { stringToBuffer } from 'uiSrc/utils'
+
+import { ArrayAddForm } from './ArrayAddForm'
+
+const keyProp = stringToBuffer('mykey')
+
+const renderForm = (closePanel = jest.fn()) =>
+  render(<ArrayAddForm keyProp={keyProp} closePanel={closePanel} />)
+
+const findCall = (fragment: string) =>
+  (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+    (url as string).includes(fragment),
+  )
+
+describe('ArrayAddForm', () => {
+  beforeEach(() => {
+    apiService.post = jest.fn().mockResolvedValue({ status: 200, data: {} })
+  })
+
+  it('renders the value and index inputs', () => {
+    renderForm()
+    expect(screen.getByTestId('array-add-form-value')).toBeInTheDocument()
+    expect(screen.getByTestId('array-add-form-index')).toBeInTheDocument()
+  })
+
+  it('appends (POST /array/append) when the index is left empty', async () => {
+    const closePanel = jest.fn()
+    renderForm(closePanel)
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    await waitFor(() => {
+      expect(findCall('array/append')).toBeTruthy()
+    })
+    expect(findCall('array/set-element')).toBeFalsy()
+    expect(closePanel).toHaveBeenCalled()
+  })
+
+  it('sets at index (POST /array/set-element) when an index is provided', async () => {
+    renderForm()
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.change(screen.getByTestId('array-add-form-index'), {
+      target: { value: '5' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    await waitFor(() => {
+      const call = findCall('array/set-element')
+      expect(call).toBeTruthy()
+      expect((call?.[1] as { index: string }).index).toBe('5')
+    })
+    expect(findCall('array/append')).toBeFalsy()
+  })
+
+  it('disables Add for a non-canonical index', () => {
+    renderForm()
+
+    act(() => {
+      fireEvent.change(screen.getByTestId('array-add-form-index'), {
+        target: { value: '007' },
+      })
+    })
+
+    expect(screen.getByTestId('array-add-form-submit')).toBeDisabled()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -45,8 +45,8 @@ const stateWithKeySelected = {
   },
 }
 
-const renderForm = (closePanel = jest.fn()) =>
-  render(<ArrayAddForm closePanel={closePanel} />, {
+const renderForm = (closePanel = jest.fn(), onReveal = jest.fn()) =>
+  render(<ArrayAddForm closePanel={closePanel} onReveal={onReveal} />, {
     store: mockStore(stateWithKeySelected),
   })
 
@@ -80,6 +80,38 @@ describe('ArrayAddForm', () => {
     })
     expect(findCall('array/set-element')).toBeFalsy()
     expect(closePanel).toHaveBeenCalled()
+  })
+
+  it('reveals the added element on success when "move to element" is checked', async () => {
+    apiService.post = jest
+      .fn()
+      .mockResolvedValue({ status: 200, data: { index: '42' } })
+    const onReveal = jest.fn()
+    renderForm(jest.fn(), onReveal)
+
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    await waitFor(() => expect(onReveal).toHaveBeenCalledWith('42'))
+  })
+
+  it('does not reveal when "move to element" is unchecked', async () => {
+    apiService.post = jest
+      .fn()
+      .mockResolvedValue({ status: 200, data: { index: '42' } })
+    const onReveal = jest.fn()
+    renderForm(jest.fn(), onReveal)
+
+    fireEvent.click(screen.getByTestId('array-add-form-move-to-element'))
+    fireEvent.change(screen.getByTestId('array-add-form-value'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByTestId('array-add-form-submit'))
+
+    await waitFor(() => expect(findCall('array/append')).toBeTruthy())
+    expect(onReveal).not.toHaveBeenCalled()
   })
 
   it('does not close the panel if the form unmounted before the write resolved', async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.spec.tsx
@@ -13,12 +13,23 @@ import { stringToBuffer } from 'uiSrc/utils'
 
 import { ArrayAddForm } from './ArrayAddForm'
 
-const keyProp = stringToBuffer('mykey')
+const keyBuffer = stringToBuffer('mykey')
 
-// The form's key must be the live selected key, otherwise applyArrayWriteResult
-// suppresses the success side effects (onSuccess/closePanel) as a stale write.
+// The form reads the write key from the selected key's data (selectedKeyData),
+// and applyArrayWriteResult gates the success side effects (onSuccess/
+// closePanel) on the live browser-context selection — seed both to the key.
 const stateWithKeySelected = {
   ...initialStateDefault,
+  browser: {
+    ...initialStateDefault.browser,
+    keys: {
+      ...initialStateDefault.browser.keys,
+      selectedKey: {
+        ...initialStateDefault.browser.keys.selectedKey,
+        data: { name: keyBuffer } as any,
+      },
+    },
+  },
   app: {
     ...initialStateDefault.app,
     context: {
@@ -27,7 +38,7 @@ const stateWithKeySelected = {
         ...initialStateDefault.app.context.browser,
         keyList: {
           ...initialStateDefault.app.context.browser.keyList,
-          selectedKey: keyProp,
+          selectedKey: keyBuffer,
         },
       },
     },
@@ -35,7 +46,7 @@ const stateWithKeySelected = {
 }
 
 const renderForm = (closePanel = jest.fn()) =>
-  render(<ArrayAddForm keyProp={keyProp} closePanel={closePanel} />, {
+  render(<ArrayAddForm closePanel={closePanel} />, {
     store: mockStore(stateWithKeySelected),
   })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -14,6 +14,7 @@ import { stringToSerializedBufferFormat } from 'uiSrc/utils'
 import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
+import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
@@ -32,6 +33,7 @@ import {
   INDEX_LABEL,
   INDEX_PLACEHOLDER,
   INVALID_INDEX_MESSAGE,
+  MOVE_TO_ELEMENT_LABEL,
   VALUE_LABEL,
 } from './ArrayAddForm.constants'
 import { ArrayAddFormProps } from './ArrayAddForm.types'
@@ -43,7 +45,7 @@ import { ArrayAddFormProps } from './ArrayAddForm.types'
  * length); providing one sets at that index (POST /array/set-element).
  * `ARINSERT` is intentionally not used — see docs/array-modify-vertical-plan.md.
  */
-export const ArrayAddForm = ({ closePanel }: ArrayAddFormProps) => {
+export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   const dispatch = useAppDispatch()
   const { viewFormat } = useAppSelector(selectedKeySelector)
   // Resolve the target key from the live selection (like the List/Hash add
@@ -56,6 +58,10 @@ export const ArrayAddForm = ({ closePanel }: ArrayAddFormProps) => {
 
   const [value, setValue] = useState('')
   const [index, setIndex] = useState('')
+  // Default on: an append lands past the current window, so without moving the
+  // View the new element would be invisible. Users who don't want the jump can
+  // opt out per add.
+  const [moveToElement, setMoveToElement] = useState(true)
 
   // A write resolves asynchronously and the slice still fires onSuccess while
   // its target key is selected. But the user may have closed this panel (key
@@ -76,9 +82,14 @@ export const ArrayAddForm = ({ closePanel }: ArrayAddFormProps) => {
   const indexInvalid =
     trimmedIndex.length > 0 && parseArrayIndex(trimmedIndex) !== trimmedIndex
 
-  const handleSuccess = () => {
+  const handleSuccess = (addedIndex?: string) => {
     if (!isMounted.current) {
       return
+    }
+    // Move the View to the new element before closing, so an append past the
+    // current window is actually shown (revealIndex no-ops if it's in view).
+    if (moveToElement && addedIndex) {
+      onReveal?.(addedIndex)
     }
     setValue('')
     setIndex('')
@@ -146,6 +157,19 @@ export const ArrayAddForm = ({ closePanel }: ArrayAddFormProps) => {
           </FlexItem>
         </Row>
       </EntryContent>
+
+      <Row gap="m" grow={false}>
+        <FlexItem grow={false}>
+          <Checkbox
+            id={`${TEST_ID}-move-to-element`}
+            name="move-to-element"
+            label={MOVE_TO_ELEMENT_LABEL}
+            checked={moveToElement}
+            onChange={(e) => setMoveToElement(e.target.checked)}
+            data-testid={`${TEST_ID}-move-to-element`}
+          />
+        </FlexItem>
+      </Row>
 
       <Row justify="end" gap="m" grow={false}>
         <FlexItem grow={false}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -6,6 +6,7 @@ import {
   selectedKeySelector,
 } from 'uiSrc/slices/browser/keys'
 import { appendArrayElement, addArrayElement } from 'uiSrc/slices/browser/array'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import {
   BrowserConfirmationCommandId,
   useProductionWriteConfirmation,
@@ -57,6 +58,10 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   const { name: selectedKey } = useAppSelector(selectedKeyDataSelector) ?? {
     name: undefined,
   }
+  // The instance/key active when Add is pressed. The thunk cancels the write if
+  // the live connection no longer matches — a confirmation left pending across
+  // a database switch must not write into the newly selected database.
+  const { id: instanceId } = useAppSelector(connectedInstanceSelector)
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   const [value, setValue] = useState('')
@@ -114,14 +119,23 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
         if (trimmedIndex.length === 0) {
           dispatch(
             appendArrayElement(
-              { key: selectedKey, value: serialized },
+              {
+                key: selectedKey,
+                value: serialized,
+                expectedInstanceId: instanceId,
+              },
               handleSuccess,
             ),
           )
         } else {
           dispatch(
             addArrayElement(
-              { key: selectedKey, index: trimmedIndex, value: serialized },
+              {
+                key: selectedKey,
+                index: trimmedIndex,
+                value: serialized,
+                expectedInstanceId: instanceId,
+              },
               handleSuccess,
             ),
           )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -70,6 +70,10 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   // View the new element would be invisible. Users who don't want the jump can
   // opt out per add.
   const [moveToElement, setMoveToElement] = useState(true)
+  // handleSuccess is captured by the thunk when Add is confirmed; read the flag
+  // from a ref so a toggle while the POST is in flight is honored.
+  const moveToElementRef = useRef(moveToElement)
+  moveToElementRef.current = moveToElement
 
   // A write resolves asynchronously and the slice still fires onSuccess while
   // its target key is selected. But the user may have closed this panel (key
@@ -96,7 +100,7 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
     }
     // Move the View to the new element before closing, so an append past the
     // current window is actually shown (revealIndex no-ops if it's in view).
-    if (moveToElement && addedIndex) {
+    if (moveToElementRef.current && addedIndex) {
       onReveal?.(addedIndex)
     }
     setValue('')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -36,8 +36,8 @@ import { ArrayAddFormProps } from './ArrayAddForm.types'
 /**
  * Content of the "Add element" slide-out panel (rendered inside the shared
  * `AddKeysContainer`, matching List / Vector Set). The index is optional:
- * leaving it empty appends to the end (POST /array/append, atomic ARSET at the
- * current length); providing one sets at that index (POST /array/set-element).
+ * leaving it empty appends to the end (POST /array/append, ARSET at the current
+ * length); providing one sets at that index (POST /array/set-element).
  * `ARINSERT` is intentionally not used — see docs/array-modify-vertical-plan.md.
  */
 export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
@@ -48,6 +48,19 @@ export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
   const [value, setValue] = useState('')
   const [index, setIndex] = useState('')
 
+  // A write resolves asynchronously and the slice still fires onSuccess while
+  // its target key is selected. But the user may have closed this panel (key
+  // switch, then reopened a fresh panel) before it resolved — this instance is
+  // unmounted, and running closePanel would discard the *current* panel. Ignore
+  // the callback once this form is gone.
+  const isMounted = useRef(true)
+  useEffect(
+    () => () => {
+      isMounted.current = false
+    },
+    [],
+  )
+
   // The index input is optional (empty → append). When provided it must be a
   // canonical decimal string, matching the backend @IsArrayIndex validator.
   const trimmedIndex = index.trim()
@@ -55,6 +68,9 @@ export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
     trimmedIndex.length > 0 && parseArrayIndex(trimmedIndex) !== trimmedIndex
 
   const handleSuccess = () => {
+    if (!isMounted.current) {
+      return
+    }
     setValue('')
     setIndex('')
     closePanel()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -5,7 +5,11 @@ import {
   selectedKeyDataSelector,
   selectedKeySelector,
 } from 'uiSrc/slices/browser/keys'
-import { appendArrayElement, addArrayElement } from 'uiSrc/slices/browser/array'
+import {
+  appendArrayElement,
+  addArrayElement,
+  arraySelector,
+} from 'uiSrc/slices/browser/array'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import {
   BrowserConfirmationCommandId,
@@ -47,7 +51,8 @@ import { ArrayAddFormProps } from './ArrayAddForm.types'
  * `AddKeysContainer`, matching List / Vector Set). The index is optional:
  * leaving it empty appends to the end (POST /array/append, ARSET at the current
  * length); providing one sets at that index (POST /array/set-element).
- * `ARINSERT` is intentionally not used — see docs/array-modify-vertical-plan.md.
+ * `ARINSERT` is intentionally not used: its cursor starts at 0 on arrays built
+ * via ARSET/ARMSET, so it would overwrite from the front instead of appending.
  */
 export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   const dispatch = useAppDispatch()
@@ -58,6 +63,10 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   const { name: selectedKey } = useAppSelector(selectedKeyDataSelector) ?? {
     name: undefined,
   }
+  // A write is in flight (this add or an inline edit). Disable submit so a
+  // second click can't dispatch a duplicate append/set when confirmations are
+  // bypassed (non-production db, or skipped for the session).
+  const { updating } = useAppSelector(arraySelector)
   // The instance/key active when Add is pressed. The thunk cancels the write if
   // the live connection no longer matches — a confirmation left pending across
   // a database switch must not write into the newly selected database.
@@ -217,7 +226,8 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
         <FlexItem grow={false}>
           <PrimaryButton
             onClick={handleAdd}
-            disabled={indexInvalid}
+            disabled={indexInvalid || updating}
+            loading={updating}
             data-testid={`${TEST_ID}-submit`}
           >
             {ADD_BUTTON_LABEL}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -56,16 +56,18 @@ import { ArrayAddFormProps } from './ArrayAddForm.types'
  */
 export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
   const dispatch = useAppDispatch()
-  const { viewFormat } = useAppSelector(selectedKeySelector)
+  const { viewFormat, isRefreshDisabled } = useAppSelector(selectedKeySelector)
   // Resolve the target key from the live selection (like the List/Hash add
   // panels), not a captured prop — so a confirm after switching keys writes to
   // the currently selected key rather than a stale one.
   const { name: selectedKey } = useAppSelector(selectedKeyDataSelector) ?? {
     name: undefined,
   }
-  // A write is in flight (this add or an inline edit). Disable submit so a
-  // second click can't dispatch a duplicate append/set when confirmations are
-  // bypassed (non-production db, or skipped for the session).
+  // `updating` drives the submit spinner (a write is genuinely in flight).
+  // isRefreshDisabled is the broader lock (an open cell editor OR updating): an
+  // add's reveal/refresh would move the loaded window and unmount an open
+  // editor, discarding its input — so block submit while it's set, which also
+  // stops a duplicate add when confirmations are bypassed.
   const { updating } = useAppSelector(arraySelector)
   // The instance/key active when Add is pressed. The thunk cancels the write if
   // the live connection no longer matches — a confirmation left pending across
@@ -226,7 +228,7 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
         <FlexItem grow={false}>
           <PrimaryButton
             onClick={handleAdd}
-            disabled={indexInvalid || updating}
+            disabled={indexInvalid || isRefreshDisabled}
             loading={updating}
             data-testid={`${TEST_ID}-submit`}
           >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -15,6 +15,8 @@ import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
+import { RiTooltip } from 'uiSrc/components'
+import { RiIcon } from 'uiSrc/components/base/icons'
 import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
@@ -33,6 +35,7 @@ import {
   INDEX_LABEL,
   INDEX_PLACEHOLDER,
   INVALID_INDEX_MESSAGE,
+  MOVE_TO_ELEMENT_HINT,
   MOVE_TO_ELEMENT_LABEL,
   VALUE_LABEL,
 } from './ArrayAddForm.constants'
@@ -131,16 +134,6 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
     <Col gap="m">
       <EntryContent gap="m" data-testid={TEST_ID}>
         <Row align="end" gap="m">
-          <FlexItem grow>
-            <FormField label={VALUE_LABEL}>
-              <TextInput
-                value={value}
-                onChange={setValue}
-                placeholder="Enter value"
-                data-testid={`${TEST_ID}-value`}
-              />
-            </FormField>
-          </FlexItem>
           <FlexItem>
             <FormField
               label={INDEX_LABEL}
@@ -155,10 +148,20 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
               />
             </FormField>
           </FlexItem>
+          <FlexItem grow>
+            <FormField label={VALUE_LABEL}>
+              <TextInput
+                value={value}
+                onChange={setValue}
+                placeholder="Enter value"
+                data-testid={`${TEST_ID}-value`}
+              />
+            </FormField>
+          </FlexItem>
         </Row>
       </EntryContent>
 
-      <Row gap="m" grow={false}>
+      <Row align="center" gap="s" grow={false}>
         <FlexItem grow={false}>
           <Checkbox
             id={`${TEST_ID}-move-to-element`}
@@ -168,6 +171,19 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
             onChange={(e) => setMoveToElement(e.target.checked)}
             data-testid={`${TEST_ID}-move-to-element`}
           />
+        </FlexItem>
+        <FlexItem grow={false}>
+          <RiTooltip
+            content={MOVE_TO_ELEMENT_HINT}
+            position="top"
+            anchorClassName="inline-flex"
+          >
+            <RiIcon
+              type="InfoIcon"
+              size="m"
+              data-testid={`${TEST_ID}-move-to-element-info`}
+            />
+          </RiTooltip>
         </FlexItem>
       </Row>
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react'
+
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { appendArrayElement, addArrayElement } from 'uiSrc/slices/browser/array'
+import {
+  BrowserConfirmationCommandId,
+  useProductionWriteConfirmation,
+} from 'uiSrc/components/production-write-confirmation'
+import { stringToSerializedBufferFormat } from 'uiSrc/utils'
+import { parseArrayIndex } from 'uiSrc/utils/arrayIndex'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { TextInput } from 'uiSrc/components/base/inputs'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import {
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+
+import { EntryContent } from '../../common/AddKeysContainer.styled'
+import {
+  ARRAY_ADD_FORM_TEST_ID as TEST_ID,
+  ADD_BUTTON_LABEL,
+  CANCEL_BUTTON_LABEL,
+  CONFIRM_BUTTON_TEXT,
+  CONFIRM_DESCRIPTION,
+  CONFIRM_TITLE,
+  INDEX_HINT,
+  INDEX_LABEL,
+  INDEX_PLACEHOLDER,
+  INVALID_INDEX_MESSAGE,
+  VALUE_LABEL,
+} from './ArrayAddForm.constants'
+import { ArrayAddFormProps } from './ArrayAddForm.types'
+
+/**
+ * Content of the "Add element" slide-out panel (rendered inside the shared
+ * `AddKeysContainer`, matching List / Vector Set). The index is optional:
+ * leaving it empty appends to the end (POST /array/append, atomic ARSET at the
+ * current length); providing one sets at that index (POST /array/set-element).
+ * `ARINSERT` is intentionally not used — see docs/array-modify-vertical-plan.md.
+ */
+export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
+  const dispatch = useAppDispatch()
+  const { viewFormat } = useAppSelector(selectedKeySelector)
+  const { requestConfirmation } = useProductionWriteConfirmation()
+
+  const [value, setValue] = useState('')
+  const [index, setIndex] = useState('')
+
+  // The index input is optional (empty → append). When provided it must be a
+  // canonical decimal string, matching the backend @IsArrayIndex validator.
+  const trimmedIndex = index.trim()
+  const indexInvalid =
+    trimmedIndex.length > 0 && parseArrayIndex(trimmedIndex) !== trimmedIndex
+
+  const handleSuccess = () => {
+    setValue('')
+    setIndex('')
+    closePanel()
+  }
+
+  const handleAdd = () => {
+    requestConfirmation({
+      title: CONFIRM_TITLE,
+      actionDescription: CONFIRM_DESCRIPTION,
+      confirmButtonText: CONFIRM_BUTTON_TEXT,
+      commandId: BrowserConfirmationCommandId.AddArrayElements,
+      disableConfirmationInput: true,
+      onConfirm: () => {
+        const serialized = stringToSerializedBufferFormat(viewFormat, value)
+        if (trimmedIndex.length === 0) {
+          dispatch(
+            appendArrayElement(
+              { key: keyProp, value: serialized },
+              handleSuccess,
+            ),
+          )
+        } else {
+          dispatch(
+            addArrayElement(
+              { key: keyProp, index: trimmedIndex, value: serialized },
+              handleSuccess,
+            ),
+          )
+        }
+      },
+    })
+  }
+
+  return (
+    <Col gap="m">
+      <EntryContent gap="m" data-testid={TEST_ID}>
+        <Row align="end" gap="m">
+          <FlexItem grow>
+            <FormField label={VALUE_LABEL}>
+              <TextInput
+                value={value}
+                onChange={setValue}
+                placeholder="Enter value"
+                data-testid={`${TEST_ID}-value`}
+              />
+            </FormField>
+          </FlexItem>
+          <FlexItem>
+            <FormField
+              label={INDEX_LABEL}
+              infoIconProps={{ content: INDEX_HINT }}
+            >
+              <TextInput
+                value={index}
+                onChange={setIndex}
+                placeholder={INDEX_PLACEHOLDER}
+                error={indexInvalid ? INVALID_INDEX_MESSAGE : undefined}
+                data-testid={`${TEST_ID}-index`}
+              />
+            </FormField>
+          </FlexItem>
+        </Row>
+      </EntryContent>
+
+      <Row justify="end" gap="m" grow={false}>
+        <FlexItem grow={false}>
+          <SecondaryButton
+            onClick={() => closePanel(true)}
+            data-testid={`${TEST_ID}-cancel`}
+          >
+            {CANCEL_BUTTON_LABEL}
+          </SecondaryButton>
+        </FlexItem>
+        <FlexItem grow={false}>
+          <PrimaryButton
+            onClick={handleAdd}
+            disabled={indexInvalid}
+            data-testid={`${TEST_ID}-submit`}
+          >
+            {ADD_BUTTON_LABEL}
+          </PrimaryButton>
+        </FlexItem>
+      </Row>
+    </Col>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -127,7 +127,10 @@ export const ArrayAddForm = ({ closePanel, onReveal }: ArrayAddFormProps) => {
       commandId: BrowserConfirmationCommandId.AddArrayElements,
       disableConfirmationInput: true,
       onConfirm: () => {
-        if (!selectedKey) {
+        // The confirmation modal outlives this panel: the user can switch keys
+        // (ViewTab closes/unmounts the panel) and return before confirming.
+        // Don't write from a discarded panel even if the same key is reselected.
+        if (!isMounted.current || !selectedKey) {
           return
         }
         const serialized = stringToSerializedBufferFormat(viewFormat, value)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
-import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import {
+  selectedKeyDataSelector,
+  selectedKeySelector,
+} from 'uiSrc/slices/browser/keys'
 import { appendArrayElement, addArrayElement } from 'uiSrc/slices/browser/array'
 import {
   BrowserConfirmationCommandId,
@@ -40,9 +43,15 @@ import { ArrayAddFormProps } from './ArrayAddForm.types'
  * length); providing one sets at that index (POST /array/set-element).
  * `ARINSERT` is intentionally not used — see docs/array-modify-vertical-plan.md.
  */
-export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
+export const ArrayAddForm = ({ closePanel }: ArrayAddFormProps) => {
   const dispatch = useAppDispatch()
   const { viewFormat } = useAppSelector(selectedKeySelector)
+  // Resolve the target key from the live selection (like the List/Hash add
+  // panels), not a captured prop — so a confirm after switching keys writes to
+  // the currently selected key rather than a stale one.
+  const { name: selectedKey } = useAppSelector(selectedKeyDataSelector) ?? {
+    name: undefined,
+  }
   const { requestConfirmation } = useProductionWriteConfirmation()
 
   const [value, setValue] = useState('')
@@ -84,18 +93,21 @@ export const ArrayAddForm = ({ keyProp, closePanel }: ArrayAddFormProps) => {
       commandId: BrowserConfirmationCommandId.AddArrayElements,
       disableConfirmationInput: true,
       onConfirm: () => {
+        if (!selectedKey) {
+          return
+        }
         const serialized = stringToSerializedBufferFormat(viewFormat, value)
         if (trimmedIndex.length === 0) {
           dispatch(
             appendArrayElement(
-              { key: keyProp, value: serialized },
+              { key: selectedKey, value: serialized },
               handleSuccess,
             ),
           )
         } else {
           dispatch(
             addArrayElement(
-              { key: keyProp, index: trimmedIndex, value: serialized },
+              { key: selectedKey, index: trimmedIndex, value: serialized },
               handleSuccess,
             ),
           )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
@@ -2,4 +2,8 @@ export interface ArrayAddFormProps {
   /** Closes the add panel. `isCancelled` distinguishes an explicit Cancel from
    *  a close-after-success (mirrors the other types' add panels). */
   closePanel: (isCancelled?: boolean) => void
+  /** Moves the View to show the added element (at `index`) when the user opts
+   *  in via the "move to element" checkbox — an append lands past the current
+   *  window, so it would otherwise stay hidden. */
+  onReveal?: (index: string) => void
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
@@ -1,0 +1,9 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface ArrayAddFormProps {
+  /** The array key being viewed; the element is added to it. */
+  keyProp: RedisResponseBuffer
+  /** Closes the add panel. `isCancelled` distinguishes an explicit Cancel from
+   *  a close-after-success (mirrors the other types' add panels). */
+  closePanel: (isCancelled?: boolean) => void
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/ArrayAddForm.types.ts
@@ -1,8 +1,4 @@
-import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-
 export interface ArrayAddFormProps {
-  /** The array key being viewed; the element is added to it. */
-  keyProp: RedisResponseBuffer
   /** Closes the add panel. `isCancelled` distinguishes an explicit Cancel from
    *  a close-after-success (mirrors the other types' add panels). */
   closePanel: (isCancelled?: boolean) => void

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-add-form/index.ts
@@ -1,0 +1,1 @@
+export { ArrayAddForm } from './ArrayAddForm'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/constants.ts
@@ -19,6 +19,12 @@ export const DEFAULT_RANGE_START = '0'
  */
 export const DEFAULT_RANGE_END = '9'
 
+/**
+ * Size of the window the View jumps to when revealing a just-added element
+ * that fell outside the current range (matches the 10-element default span).
+ */
+export const REVEAL_WINDOW_SIZE = 10
+
 /** Criteria pre-selected for a new predicate row on the Search tab. */
 export const DEFAULT_SEARCH_CRITERIA = ArrayGrepCriteria.Exact
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
@@ -256,5 +256,38 @@ describe('useArrayRangeQuery', () => {
       expect(result.current.start).toBe('0')
       expect(result.current.end).toBe('3')
     })
+
+    it('reveals without throwing when the range fields are non-numeric', () => {
+      const { result } = renderWithStore(keyBuffer)
+
+      act(() => {
+        result.current.setStart('abc')
+        result.current.setEnd('')
+      })
+      // Must not throw (it runs in the post-add success path) and should move
+      // to a valid window ending at the index, replacing the unusable bounds.
+      expect(() =>
+        act(() => {
+          result.current.revealIndex('100')
+        }),
+      ).not.toThrow()
+      expect(result.current.start).toBe('91')
+      expect(result.current.end).toBe('100')
+    })
+
+    it('is a no-op for a non-numeric index', () => {
+      const { result, store } = renderWithStore(keyBuffer)
+      store.clearActions()
+
+      act(() => {
+        result.current.revealIndex('not-an-index')
+      })
+
+      expect(result.current.start).toBe('0')
+      expect(result.current.end).toBe('9')
+      expect(
+        store.getActions().some((a) => a.type === setArrayActiveQuery.type),
+      ).toBe(false)
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
@@ -23,10 +23,14 @@ const buildState = (
   overrides: {
     selectedKeyType?: KeyTypes
     selectedKeyName?: ReturnType<typeof stringToBuffer> | null
+    activeQuery?: { start: string; end: string; showEmpty: boolean }
   } = {},
 ) => {
   const next = cloneDeep(initialStateDefault)
   next.browser.array = cloneDeep(initialStateArray)
+  if (overrides.activeQuery) {
+    next.browser.array.query = overrides.activeQuery
+  }
   next.browser.keys.selectedKey.data = overrides.selectedKeyName
     ? ({
         type: overrides.selectedKeyType ?? KeyTypes.Array,
@@ -243,29 +247,59 @@ describe('useArrayRangeQuery', () => {
     })
 
     it('clamps the window start to 0 near the beginning', () => {
-      const { result } = renderWithStore(keyBuffer)
+      const { result } = renderWithStore(
+        keyBuffer,
+        buildState({
+          selectedKeyName: keyBuffer,
+          activeQuery: { start: '50', end: '60', showEmpty: true },
+        }),
+      )
 
       act(() => {
-        result.current.setStart('50')
-        result.current.setEnd('60')
-      })
-      act(() => {
-        result.current.revealIndex('3') // below the moved window
+        result.current.revealIndex('3') // below the active window
       })
 
       expect(result.current.start).toBe('0')
       expect(result.current.end).toBe('3')
     })
 
-    it('reveals without throwing when the range fields are non-numeric', () => {
-      const { result } = renderWithStore(keyBuffer)
+    it('reveals against the active query, not the (possibly unrun) form range', () => {
+      // The form range would "cover" the index, but the active query — what
+      // refreshArray replays — does not, so the element must still be revealed.
+      const { result, store } = renderWithStore(
+        keyBuffer,
+        buildState({
+          selectedKeyName: keyBuffer,
+          activeQuery: { start: '0', end: '9', showEmpty: true },
+        }),
+      )
 
       act(() => {
-        result.current.setStart('abc')
-        result.current.setEnd('')
+        result.current.setStart('0')
+        result.current.setEnd('1000000') // canonical but unrun (over the cap)
       })
+      act(() => {
+        result.current.revealIndex('10')
+      })
+
+      expect(result.current.start).toBe('1')
+      expect(result.current.end).toBe('10')
+      expect(store.getActions()).toContainEqual(
+        setArrayActiveQuery({ start: '1', end: '10', showEmpty: true }),
+      )
+    })
+
+    it('reveals without throwing when the active bounds are non-numeric', () => {
+      const { result } = renderWithStore(
+        keyBuffer,
+        buildState({
+          selectedKeyName: keyBuffer,
+          activeQuery: { start: 'abc', end: '', showEmpty: true },
+        }),
+      )
+
       // Must not throw (it runs in the post-add success path) and should move
-      // to a valid window ending at the index, replacing the unusable bounds.
+      // to a valid window ending at the index.
       expect(() =>
         act(() => {
           result.current.revealIndex('100')

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
@@ -10,7 +10,10 @@ import {
 import { apiService } from 'uiSrc/services'
 import { KeyTypes } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
-import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
+import {
+  initialState as initialStateArray,
+  setArrayActiveQuery,
+} from 'uiSrc/slices/browser/array'
 import { useArrayRangeQuery } from './useArrayRangeQuery'
 
 const KEY = 'readings'
@@ -205,5 +208,53 @@ describe('useArrayRangeQuery', () => {
       url.includes('array/get-range'),
     )
     expect(call?.[1]).toEqual({ keyName: keyBuffer, start: '0', end: '9' })
+  })
+
+  describe('revealIndex', () => {
+    it('is a no-op when the index is already within the window', () => {
+      const { result, store } = renderWithStore(keyBuffer)
+      store.clearActions()
+
+      act(() => {
+        result.current.revealIndex('5') // default window is [0, 9]
+      })
+
+      expect(result.current.start).toBe('0')
+      expect(result.current.end).toBe('9')
+      expect(
+        store.getActions().some((a) => a.type === setArrayActiveQuery.type),
+      ).toBe(false)
+    })
+
+    it('moves the window to end at an index above the current range', () => {
+      const { result, store } = renderWithStore(keyBuffer)
+      store.clearActions()
+
+      act(() => {
+        result.current.revealIndex('100')
+      })
+
+      // A 10-element window ending at the added index.
+      expect(result.current.start).toBe('91')
+      expect(result.current.end).toBe('100')
+      expect(store.getActions()).toContainEqual(
+        setArrayActiveQuery({ start: '91', end: '100', showEmpty: true }),
+      )
+    })
+
+    it('clamps the window start to 0 near the beginning', () => {
+      const { result } = renderWithStore(keyBuffer)
+
+      act(() => {
+        result.current.setStart('50')
+        result.current.setEnd('60')
+      })
+      act(() => {
+        result.current.revealIndex('3') // below the moved window
+      })
+
+      expect(result.current.start).toBe('0')
+      expect(result.current.end).toBe('3')
+    })
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.spec.tsx
@@ -289,6 +289,30 @@ describe('useArrayRangeQuery', () => {
       )
     })
 
+    it('syncs showEmpty to the active query mode when revealing', () => {
+      const { result, store } = renderWithStore(
+        keyBuffer,
+        buildState({
+          selectedKeyName: keyBuffer,
+          activeQuery: { start: '0', end: '9', showEmpty: true },
+        }),
+      )
+
+      // Toggle the checkbox without running — the reveal fetches with the
+      // active mode, so the control must be reset to match it.
+      act(() => {
+        result.current.setShowEmpty(false)
+      })
+      act(() => {
+        result.current.revealIndex('100')
+      })
+
+      expect(result.current.showEmpty).toBe(true)
+      expect(store.getActions()).toContainEqual(
+        setArrayActiveQuery({ start: '91', end: '100', showEmpty: true }),
+      )
+    })
+
     it('reveals without throwing when the active bounds are non-numeric', () => {
       const { result } = renderWithStore(
         keyBuffer,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -19,6 +19,18 @@ import {
   REVEAL_WINDOW_SIZE,
 } from '../constants'
 
+// BigInt() throws on a non-numeric string. The range fields can hold a
+// half-typed / invalid value, so parse defensively — a throw here would run in
+// the post-add success path and abort the panel close + refresh after a write
+// that already succeeded.
+const toBigIntOrNull = (value: string): bigint | null => {
+  try {
+    return BigInt(value)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Owns the View / Browse tab query state for an array key: the inclusive
  * `start`/`end` bounds and the "show empty indexes" toggle that switches
@@ -144,11 +156,19 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   // new window and the form inputs stay in sync.
   const revealIndex = useCallback(
     (index: string) => {
-      const target = BigInt(index)
-      const lo = BigInt(start)
-      const hi = BigInt(end)
+      const target = toBigIntOrNull(index)
+      if (target === null) return
+
+      // If the range fields are valid and already cover the index, leave the
+      // window alone. When they can't be parsed, fall through and reveal — that
+      // also replaces the unusable bounds with a valid window ending at `index`.
+      const lo = toBigIntOrNull(start)
+      const hi = toBigIntOrNull(end)
       const withinWindow =
-        target >= (lo < hi ? lo : hi) && target <= (lo < hi ? hi : lo)
+        lo !== null &&
+        hi !== null &&
+        target >= (lo < hi ? lo : hi) &&
+        target <= (lo < hi ? hi : lo)
       if (withinWindow) return
 
       const span = BigInt(REVEAL_WINDOW_SIZE - 1)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -183,8 +183,12 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
 
       const span = BigInt(REVEAL_WINDOW_SIZE - 1)
       const nextStart = (target > span ? target - span : BigInt(0)).toString()
+      // Sync all three form controls to the query we just fetched — including
+      // showEmpty, so a toggled-but-unrun checkbox (and the command preview)
+      // can't be left showing a mode the reveal didn't actually use.
       setStart(nextStart)
       setEnd(index)
+      setShowEmpty(active.showEmpty)
       dispatch(
         setArrayActiveQuery({
           start: nextStart,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -50,6 +50,16 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
   const [showEmpty, setShowEmpty] = useState<boolean>(true)
 
+  // Latest-value refs so a stable revealIndex (held by the add form's captured
+  // success callback) reads the CURRENT bounds — the user may edit the range or
+  // toggle options while an add's POST is still in flight.
+  const startRef = useRef(start)
+  const endRef = useRef(end)
+  const showEmptyRef = useRef(showEmpty)
+  startRef.current = start
+  endRef.current = end
+  showEmptyRef.current = showEmpty
+
   // Manual + auto dispatches are gated on this so a quick click during a
   // key-switch can't fire ARGETRANGE/ARSCAN against a non-array key
   // (which the API rejects with WrongType).
@@ -159,11 +169,14 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
       const target = toBigIntOrNull(index)
       if (target === null) return
 
+      // Read the CURRENT bounds via refs, not closure values — this callback is
+      // captured by the add form when Add is pressed, but must reveal against
+      // the range the user has by the time the write resolves.
       // If the range fields are valid and already cover the index, leave the
       // window alone. When they can't be parsed, fall through and reveal — that
       // also replaces the unusable bounds with a valid window ending at `index`.
-      const lo = toBigIntOrNull(start)
-      const hi = toBigIntOrNull(end)
+      const lo = toBigIntOrNull(startRef.current)
+      const hi = toBigIntOrNull(endRef.current)
       const withinWindow =
         lo !== null &&
         hi !== null &&
@@ -175,9 +188,15 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
       const nextStart = (target > span ? target - span : BigInt(0)).toString()
       setStart(nextStart)
       setEnd(index)
-      dispatch(setArrayActiveQuery({ start: nextStart, end: index, showEmpty }))
+      dispatch(
+        setArrayActiveQuery({
+          start: nextStart,
+          end: index,
+          showEmpty: showEmptyRef.current,
+        }),
+      )
     },
-    [dispatch, start, end, showEmpty],
+    [dispatch],
   )
 
   return {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -6,13 +6,18 @@ import {
   arraySelector,
   fetchArrayRange,
   scanArrayRange,
+  setArrayActiveQuery,
   setArrayInitialState,
 } from 'uiSrc/slices/browser/array'
 import { selectedKeyDataSelector } from 'uiSrc/slices/browser/keys'
 import { isEqualBuffers } from 'uiSrc/utils'
 import { KeyTypes } from 'uiSrc/constants'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { DEFAULT_RANGE_END, DEFAULT_RANGE_START } from '../constants'
+import {
+  DEFAULT_RANGE_END,
+  DEFAULT_RANGE_START,
+  REVEAL_WINDOW_SIZE,
+} from '../constants'
 
 /**
  * Owns the View / Browse tab query state for an array key: the inclusive
@@ -132,6 +137,29 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     )
   }, [dispatch, isArrayKeyReady, keyProp])
 
+  // Move the window so `index` is visible — used after an add whose element
+  // lands outside the current range (e.g. an append at the new tail). No-op
+  // when it's already within the window. Sets the form bounds AND the slice's
+  // active query (without fetching) so the caller's refreshArray replays the
+  // new window and the form inputs stay in sync.
+  const revealIndex = useCallback(
+    (index: string) => {
+      const target = BigInt(index)
+      const lo = BigInt(start)
+      const hi = BigInt(end)
+      const withinWindow =
+        target >= (lo < hi ? lo : hi) && target <= (lo < hi ? hi : lo)
+      if (withinWindow) return
+
+      const span = BigInt(REVEAL_WINDOW_SIZE - 1)
+      const nextStart = (target > span ? target - span : BigInt(0)).toString()
+      setStart(nextStart)
+      setEnd(index)
+      dispatch(setArrayActiveQuery({ start: nextStart, end: index, showEmpty }))
+    },
+    [dispatch, start, end, showEmpty],
+  )
+
   return {
     start,
     end,
@@ -141,6 +169,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
     setShowEmpty,
     runQuery,
     resetQuery,
+    revealIndex,
     isArrayKeyReady,
     elements: data?.elements ?? [],
     loading,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/hooks/useArrayRangeQuery.ts
@@ -42,7 +42,7 @@ const toBigIntOrNull = (value: string): bigint | null => {
  */
 export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const dispatch = useAppDispatch()
-  const { loading, error } = useAppSelector(arraySelector)
+  const { loading, error, query } = useAppSelector(arraySelector)
   const data = useAppSelector(arrayDataSelector)
   const selectedKeyData = useAppSelector(selectedKeyDataSelector)
 
@@ -50,15 +50,12 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
   const [end, setEnd] = useState<string>(DEFAULT_RANGE_END)
   const [showEmpty, setShowEmpty] = useState<boolean>(true)
 
-  // Latest-value refs so a stable revealIndex (held by the add form's captured
-  // success callback) reads the CURRENT bounds — the user may edit the range or
-  // toggle options while an add's POST is still in flight.
-  const startRef = useRef(start)
-  const endRef = useRef(end)
-  const showEmptyRef = useRef(showEmpty)
-  startRef.current = start
-  endRef.current = end
-  showEmptyRef.current = showEmpty
+  // Latest-value ref for the *active* query (the one refreshArray replays after
+  // an add), so a stable revealIndex — held by the add form's captured success
+  // callback — decides visibility against what's actually displayed rather than
+  // the form inputs (which may hold an unrun / invalid range).
+  const activeQueryRef = useRef(query)
+  activeQueryRef.current = query
 
   // Manual + auto dispatches are gated on this so a quick click during a
   // key-switch can't fire ARGETRANGE/ARSCAN against a non-array key
@@ -169,14 +166,14 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
       const target = toBigIntOrNull(index)
       if (target === null) return
 
-      // Read the CURRENT bounds via refs, not closure values — this callback is
-      // captured by the add form when Add is pressed, but must reveal against
-      // the range the user has by the time the write resolves.
-      // If the range fields are valid and already cover the index, leave the
-      // window alone. When they can't be parsed, fall through and reveal — that
-      // also replaces the unusable bounds with a valid window ending at `index`.
-      const lo = toBigIntOrNull(startRef.current)
-      const hi = toBigIntOrNull(endRef.current)
+      // Decide visibility against the ACTIVE query (what refreshArray replays),
+      // not the form inputs — those can hold a canonical-but-unrun/invalid range
+      // (e.g. a span over the cap with Run disabled), so the element would be
+      // "within" a range that is never actually fetched. Only skip when the
+      // index truly falls inside the displayed window.
+      const active = activeQueryRef.current
+      const lo = toBigIntOrNull(active.start)
+      const hi = toBigIntOrNull(active.end)
       const withinWindow =
         lo !== null &&
         hi !== null &&
@@ -192,7 +189,7 @@ export const useArrayRangeQuery = (keyProp: RedisResponseBuffer | null) => {
         setArrayActiveQuery({
           start: nextStart,
           end: index,
-          showEmpty: showEmptyRef.current,
+          showEmpty: active.showEmpty,
         }),
       )
     },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.spec.tsx
@@ -22,28 +22,44 @@ jest.mock('uiSrc/services', () => ({
 
 const KEY = 'readings'
 const keyBuffer = stringToBuffer(KEY)
+const keyA = stringToBuffer('key-a')
+const keyB = stringToBuffer('key-b')
 
-const buildState = (elements: ArrayDataElement[]) => {
+const ADD_BTN = 'add-key-value-items-btn'
+const PANEL = 'array-add-form'
+
+// isArrayKeyReady requires the selected key to be an Array whose name matches
+// keyProp, so seed the store's selected key to the rendered one.
+const buildState = (
+  elements: ArrayDataElement[],
+  selectedKey: ReturnType<typeof stringToBuffer> = keyBuffer,
+) => {
   const next = cloneDeep(initialStateDefault)
   next.browser.array = cloneDeep(initialStateArray)
   next.browser.array.data = { ...next.browser.array.data, elements }
   next.browser.keys.selectedKey.loading = false
   next.browser.keys.selectedKey.data = {
     type: KeyTypes.Array,
-    name: keyBuffer,
+    name: selectedKey,
   } as any
   return next
 }
 
-const renderTab = (elements: ArrayDataElement[]) => {
-  const store = mockStore(buildState(elements))
+const renderView = (
+  keyProp: ReturnType<typeof stringToBuffer>,
+  props: Partial<React.ComponentProps<typeof ViewTab>> = {},
+  elements: ArrayDataElement[] = [],
+) => {
+  const store = mockStore(buildState(elements, keyProp))
   store.clearActions()
-  return render(<ViewTab keyProp={keyBuffer} isActive />, { store })
+  return render(<ViewTab keyProp={keyProp} isActive {...props} />, { store })
 }
 
 describe('ViewTab', () => {
   it('renders a per-row delete affordance for a populated element', () => {
-    renderTab([arrayElementWithValueFactory.build({ index: '7' })])
+    renderView(keyBuffer, {}, [
+      arrayElementWithValueFactory.build({ index: '7' }),
+    ])
 
     expect(screen.getByTestId('array-remove-btn-7-icon')).toBeInTheDocument()
   })
@@ -56,7 +72,9 @@ describe('ViewTab', () => {
       .fn()
       .mockResolvedValue({ status: 200, data: { keyName: KEY, count: '3' } })
 
-    renderTab([arrayElementWithValueFactory.build({ index: '7' })])
+    renderView(keyBuffer, {}, [
+      arrayElementWithValueFactory.build({ index: '7' }),
+    ])
 
     fireEvent.click(screen.getByTestId('array-remove-btn-7-icon'))
     fireEvent.click(await screen.findByTestId('array-remove-btn-7'))
@@ -79,7 +97,7 @@ describe('ViewTab', () => {
       .fn()
       .mockResolvedValue({ status: 200, data: { keyName: KEY, count: '0' } })
 
-    renderTab([
+    renderView(keyBuffer, {}, [
       arrayElementWithValueFactory.build({ index: '0' }),
       arrayElementWithValueFactory.build({ index: '5' }),
     ])
@@ -114,7 +132,7 @@ describe('ViewTab', () => {
       .fn()
       .mockResolvedValue({ status: 200, data: { keyName: KEY, elements: [] } })
 
-    renderTab([
+    renderView(keyBuffer, {}, [
       arrayElementWithValueFactory.build({ index: '0' }),
       arrayElementWithValueFactory.build({ index: '5' }),
     ])
@@ -129,5 +147,48 @@ describe('ViewTab', () => {
     expect(
       screen.queryByTestId('array-bulk-remove-btn-icon'),
     ).not.toBeInTheDocument()
+  })
+
+  it('opens the add panel and fires open telemetry', () => {
+    const onOpenAddItemPanel = jest.fn()
+    renderView(keyA, { onOpenAddItemPanel })
+
+    expect(screen.queryByTestId(PANEL)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId(ADD_BTN))
+
+    expect(onOpenAddItemPanel).toHaveBeenCalled()
+    expect(screen.getByTestId(PANEL)).toBeInTheDocument()
+  })
+
+  it('fires cancel telemetry and hides the panel on Cancel', () => {
+    const onCloseAddItemPanel = jest.fn()
+    renderView(keyA, { onCloseAddItemPanel })
+
+    fireEvent.click(screen.getByTestId(ADD_BTN))
+    fireEvent.click(screen.getByTestId(`${PANEL}-cancel`))
+
+    expect(onCloseAddItemPanel).toHaveBeenCalled()
+    expect(screen.queryByTestId(PANEL)).not.toBeInTheDocument()
+  })
+
+  it('closes the panel when the selected key changes', () => {
+    const { rerender } = renderView(keyA)
+
+    fireEvent.click(screen.getByTestId(ADD_BTN))
+    expect(screen.getByTestId(PANEL)).toBeInTheDocument()
+
+    rerender(<ViewTab keyProp={keyB} isActive />)
+    expect(screen.queryByTestId(PANEL)).not.toBeInTheDocument()
+  })
+
+  it('keeps the panel open when keyProp is a new buffer with the same bytes', () => {
+    const { rerender } = renderView(keyA)
+
+    fireEvent.click(screen.getByTestId(ADD_BTN))
+    expect(screen.getByTestId(PANEL)).toBeInTheDocument()
+
+    // Same key, fresh buffer object — a byte-exact compare must not close it.
+    rerender(<ViewTab keyProp={stringToBuffer('key-a')} isActive />)
+    expect(screen.getByTestId(PANEL)).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { FlexItem } from 'uiSrc/components/base/layout/flex'
+
+/** Subheader strip hosting the right-aligned "Add Elements" action, mirroring
+ *  VectorSetKeySubheader so the array view matches the other key types. */
+export const SubheaderContainer = styled(FlexItem)`
+  padding: ${({ theme }) =>
+    `${theme.core?.space.space150} ${theme.core?.space.space200} 0`};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -127,7 +127,7 @@ const ViewTab = ({
         )}
         {isAddPanelOpen && keyProp && (
           <AddKeysContainer>
-            <ArrayAddForm keyProp={keyProp} closePanel={closeAddPanel} />
+            <ArrayAddForm closePanel={closeAddPanel} />
           </AddKeysContainer>
         )}
       </S.TabBody>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -61,6 +61,7 @@ const ViewTab = ({
     setShowEmpty,
     runQuery,
     resetQuery,
+    revealIndex,
     isArrayKeyReady,
     elements,
     loading: rangeLoading,
@@ -127,7 +128,7 @@ const ViewTab = ({
         )}
         {isAddPanelOpen && keyProp && (
           <AddKeysContainer>
-            <ArrayAddForm closePanel={closeAddPanel} />
+            <ArrayAddForm closePanel={closeAddPanel} onReveal={revealIndex} />
           </AddKeysContainer>
         )}
       </S.TabBody>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -1,18 +1,56 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import AutoSizer from 'react-virtualized-auto-sizer'
 
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
-import { bufferToString } from 'uiSrc/utils'
+import { bufferToString, isEqualBuffers } from 'uiSrc/utils'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
 
 import { ArrayDetailsTable } from '../array-details-table'
 import { ArrayRangeForm } from '../array-range-form'
+import { ArrayAddForm } from '../array-add-form'
+import { AddKeysContainer } from '../../common/AddKeysContainer.styled'
 import { useArrayRangeQuery, useArrayElementActions } from '../hooks'
 import * as S from '../tabs.styles'
+import * as LS from './ViewTab.styles'
 import { ViewTabProps } from './ViewTab.types'
 
-const ViewTab = ({ keyProp, isActive }: ViewTabProps) => {
+const ADD_ELEMENTS_TITLE = 'Add Elements'
+
+const ViewTab = ({
+  keyProp,
+  isActive,
+  onOpenAddItemPanel,
+  onCloseAddItemPanel,
+}: ViewTabProps) => {
   const { loading, isRefreshDisabled } = useAppSelector(selectedKeySelector)
   const keyName = keyProp ? bufferToString(keyProp) : ''
+  const [isAddPanelOpen, setIsAddPanelOpen] = useState(false)
+  const prevKeyProp = useRef(keyProp)
+
+  // Close the panel when the selected key changes, otherwise a confirmed write
+  // from a panel left open could target the newly selected key. Compare bytes
+  // (not the decoded name) — distinct binary keys can decode to the same
+  // Unicode string and would otherwise leave a stale panel open.
+  useEffect(() => {
+    if (!isEqualBuffers(prevKeyProp.current, keyProp)) {
+      setIsAddPanelOpen(false)
+    }
+    prevKeyProp.current = keyProp
+  }, [keyProp])
+
+  const openAddPanel = () => {
+    setIsAddPanelOpen(true)
+    onOpenAddItemPanel?.()
+  }
+
+  const closeAddPanel = (isCancelled?: boolean) => {
+    setIsAddPanelOpen(false)
+    if (isCancelled) {
+      onCloseAddItemPanel?.()
+    }
+  }
 
   const {
     start,
@@ -58,6 +96,21 @@ const ViewTab = ({ keyProp, isActive }: ViewTabProps) => {
         onReset={handleReset}
         disabled={!isArrayKeyReady || isRefreshDisabled}
       />
+      {isArrayKeyReady && (
+        <LS.SubheaderContainer grow={false}>
+          <AutoSizer disableHeight>
+            {({ width = 0 }) => (
+              <Row style={{ width }} justify="end" align="center">
+                <AddItemsAction
+                  title={ADD_ELEMENTS_TITLE}
+                  width={width}
+                  openAddItemPanel={openAddPanel}
+                />
+              </Row>
+            )}
+          </AutoSizer>
+        </LS.SubheaderContainer>
+      )}
       <S.TabBody>
         {!loading && (
           <S.TabTableWrapper>
@@ -71,6 +124,11 @@ const ViewTab = ({ keyProp, isActive }: ViewTabProps) => {
               bulkDeleteConfig={bulkDeleteConfig}
             />
           </S.TabTableWrapper>
+        )}
+        {isAddPanelOpen && keyProp && (
+          <AddKeysContainer>
+            <ArrayAddForm keyProp={keyProp} closePanel={closeAddPanel} />
+          </AddKeysContainer>
         )}
       </S.TabBody>
     </>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.types.ts
@@ -5,4 +5,8 @@ export interface ViewTabProps {
   /** True when this is the visible tab — only the active tab's table drives
    *  the shared key-header refresh flag and keeps its editor open. */
   isActive: boolean
+  /** Telemetry hooks supplied by KeyDetails — fired when the add panel opens
+   *  and when it is dismissed via Cancel, matching the other key types. */
+  onOpenAddItemPanel?: () => void
+  onCloseAddItemPanel?: () => void
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -967,13 +967,20 @@ export function appendArrayElement(
   onFailAction?: () => void,
 ) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    const state = stateInit()
+    if (
+      !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
+    ) {
+      return
+    }
+    // Hold the same lock inline ARSET uses so the key-header refresh (and
+    // range/aggregate forms) pause while the write is in flight — otherwise a
+    // pre-write refreshKeyInfoAction could resolve after the add and repaint
+    // the header with stale Length/Count/Size.
+    latestEditRequestToken += 1
+    const requestToken = latestEditRequestToken
+    dispatch(setArrayUpdating(true))
     try {
-      const state = stateInit()
-      if (
-        !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
-      ) {
-        return
-      }
       const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status, data } = await apiService.post<{ index: string }>(
         arrayUrl(state, ApiEndpoints.ARRAY_APPEND),
@@ -993,6 +1000,12 @@ export function appendArrayElement(
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
       onFailAction?.()
+    } finally {
+      // Only the latest write releases the shared lock, so an add overlapping
+      // an edit (or another add) can't re-enable refresh while one is pending.
+      if (requestToken === latestEditRequestToken) {
+        dispatch(setArrayUpdating(false))
+      }
     }
   }
 }
@@ -1008,13 +1021,18 @@ export function addArrayElement(
   onFailAction?: () => void,
 ) {
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    const state = stateInit()
+    if (
+      !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
+    ) {
+      return
+    }
+    // See appendArrayElement: hold the shared updating lock so a pre-write key
+    // refresh can't resolve after the add and overwrite the header metadata.
+    latestEditRequestToken += 1
+    const requestToken = latestEditRequestToken
+    dispatch(setArrayUpdating(true))
     try {
-      const state = stateInit()
-      if (
-        !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
-      ) {
-        return
-      }
       const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status } = await apiService.post(
         arrayUrl(state, ApiEndpoints.ARRAY_SET_ELEMENT),
@@ -1034,6 +1052,10 @@ export function addArrayElement(
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
       onFailAction?.()
+    } finally {
+      if (requestToken === latestEditRequestToken) {
+        dispatch(setArrayUpdating(false))
+      }
     }
   }
 }

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -910,11 +910,19 @@ export function refreshArray(key: RedisString) {
  */
 function applyArrayWriteResult(
   key: RedisResponseBuffer,
+  startInstanceId: Maybe<string>,
   onSuccessAction?: () => void,
 ) {
   return (dispatch: AppDispatch, stateInit: () => RootState) => {
-    const selectedKey = appContextSelectedKey(stateInit())
-    if (!selectedKey || !isEqualBuffers(selectedKey, key)) {
+    const latest = stateInit()
+    const selectedKey = appContextSelectedKey(latest)
+    // The user may have switched key or database while the POST was in flight.
+    // Applying the result (closing the panel, refreshing) only makes sense when
+    // both still match, so a same-named key in another database can't be
+    // repainted as if the add happened there (mirrors the edit/delete thunks).
+    const sameInstance =
+      latest.connections.instances.connectedInstance?.id === startInstanceId
+    if (!sameInstance || !selectedKey || !isEqualBuffers(selectedKey, key)) {
       return
     }
     onSuccessAction?.()
@@ -936,13 +944,16 @@ export function appendArrayElement(
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
       const state = stateInit()
+      const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status } = await apiService.post(
         arrayUrl(state, ApiEndpoints.ARRAY_APPEND),
         { keyName: params.key, value: params.value },
         encodingParams(state),
       )
       if (isStatusSuccessful(status)) {
-        dispatch<any>(applyArrayWriteResult(params.key, onSuccessAction))
+        dispatch<any>(
+          applyArrayWriteResult(params.key, startInstanceId, onSuccessAction),
+        )
       }
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
@@ -964,13 +975,16 @@ export function addArrayElement(
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
       const state = stateInit()
+      const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status } = await apiService.post(
         arrayUrl(state, ApiEndpoints.ARRAY_SET_ELEMENT),
         { keyName: params.key, index: params.index, value: params.value },
         encodingParams(state),
       )
       if (isStatusSuccessful(status)) {
-        dispatch<any>(applyArrayWriteResult(params.key, onSuccessAction))
+        dispatch<any>(
+          applyArrayWriteResult(params.key, startInstanceId, onSuccessAction),
+        )
       }
     } catch (error) {
       dispatch(addErrorNotification(error as IAddInstanceErrorPayload))

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -881,9 +881,10 @@ export function refreshArray(key: RedisString) {
     // array's current contents instead of a value computed before the
     // refresh. `resetData: false` keeps the existing value on screen while
     // the recompute is in flight (no loader flash), mirroring the
-    // range/scan replay above. Only runs once an aggregate has actually
-    // been computed for this key (`hasResult` + a stored query).
-    if (aggregate.hasResult && aggregate.query) {
+    // range/scan replay above. Runs whenever a query is stored and either has
+    // a result or is still in flight — replaying aborts a pre-refresh AROP
+    // that would otherwise land later with a stale result.
+    if (aggregate.query && (aggregate.hasResult || aggregate.loading)) {
       dispatch(aggregateArray({ key, ...aggregate.query, resetData: false }))
     }
 

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -936,6 +936,27 @@ function applyArrayWriteResult(
 }
 
 /**
+ * True while the write's target still matches what it was when the user
+ * requested it: the same connected instance AND the same selected key. A
+ * pending production-write confirmation can fire after a database/key switch,
+ * and the POST URL is built from the live connection — so this stops a stale
+ * confirmation from writing the old form into the newly selected database/key.
+ */
+function isArrayWriteTargetCurrent(
+  state: RootState,
+  key: RedisResponseBuffer,
+  expectedInstanceId: Maybe<string>,
+) {
+  const currentInstanceId = state.connections.instances.connectedInstance?.id
+  const selectedKey = appContextSelectedKey(state)
+  return (
+    currentInstanceId === expectedInstanceId &&
+    !!selectedKey &&
+    isEqualBuffers(selectedKey, key)
+  )
+}
+
+/**
  * Append a value to the end of the array (POST /array/append → ARSET at the
  * current length). On success the displayed surface, counters, and key header
  * are refreshed so the new element appears.
@@ -948,6 +969,11 @@ export function appendArrayElement(
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
       const state = stateInit()
+      if (
+        !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
+      ) {
+        return
+      }
       const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status, data } = await apiService.post<{ index: string }>(
         arrayUrl(state, ApiEndpoints.ARRAY_APPEND),
@@ -984,6 +1010,11 @@ export function addArrayElement(
   return async (dispatch: AppDispatch, stateInit: () => RootState) => {
     try {
       const state = stateInit()
+      if (
+        !isArrayWriteTargetCurrent(state, params.key, params.expectedInstanceId)
+      ) {
+        return
+      }
       const startInstanceId = state.connections.instances.connectedInstance?.id
       const { status } = await apiService.post(
         arrayUrl(state, ApiEndpoints.ARRAY_SET_ELEMENT),

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -911,7 +911,8 @@ export function refreshArray(key: RedisString) {
 function applyArrayWriteResult(
   key: RedisResponseBuffer,
   startInstanceId: Maybe<string>,
-  onSuccessAction?: () => void,
+  index: Maybe<string>,
+  onSuccessAction?: (index?: string) => void,
 ) {
   return (dispatch: AppDispatch, stateInit: () => RootState) => {
     const latest = stateInit()
@@ -925,7 +926,10 @@ function applyArrayWriteResult(
     if (!sameInstance || !selectedKey || !isEqualBuffers(selectedKey, key)) {
       return
     }
-    onSuccessAction?.()
+    // Pass the landed index so the caller can reveal it: an append lands at the
+    // current length, which may be above the View's active upper bound. Runs
+    // before refreshArray so a range change here is what refreshArray replays.
+    onSuccessAction?.(index)
     dispatch<any>(refreshArray(key))
     dispatch<any>(refreshKeyInfoAction(key))
   }
@@ -945,14 +949,19 @@ export function appendArrayElement(
     try {
       const state = stateInit()
       const startInstanceId = state.connections.instances.connectedInstance?.id
-      const { status } = await apiService.post(
+      const { status, data } = await apiService.post<{ index: string }>(
         arrayUrl(state, ApiEndpoints.ARRAY_APPEND),
         { keyName: params.key, value: params.value },
         encodingParams(state),
       )
       if (isStatusSuccessful(status)) {
         dispatch<any>(
-          applyArrayWriteResult(params.key, startInstanceId, onSuccessAction),
+          applyArrayWriteResult(
+            params.key,
+            startInstanceId,
+            data?.index,
+            onSuccessAction,
+          ),
         )
       }
     } catch (error) {
@@ -983,7 +992,12 @@ export function addArrayElement(
       )
       if (isStatusSuccessful(status)) {
         dispatch<any>(
-          applyArrayWriteResult(params.key, startInstanceId, onSuccessAction),
+          applyArrayWriteResult(
+            params.key,
+            startInstanceId,
+            params.index,
+            onSuccessAction,
+          ),
         )
       }
     } catch (error) {

--- a/redisinsight/ui/src/slices/browser/array.ts
+++ b/redisinsight/ui/src/slices/browser/array.ts
@@ -36,6 +36,8 @@ import {
   FetchArrayScanParams,
   SearchArrayParams,
   UpdateArrayElementParams,
+  AppendArrayElementParams,
+  AddArrayElementParams,
 } from 'uiSrc/slices/interfaces/array'
 import { RedisString, RedisResponseBuffer } from 'uiSrc/slices/interfaces/app'
 import {
@@ -887,6 +889,92 @@ export function refreshArray(key: RedisString) {
 
     if (search.query) {
       dispatch(searchArray({ key, ...search.query }))
+    }
+  }
+}
+
+/**
+ * Apply a successful write's side effects — close/clear the panel
+ * (`onSuccessAction`) and replay the read surface + key header — but only if
+ * `key` is still the selected key. A write can resolve after the user moved to
+ * another key: `onSuccessAction` would close/clear the now-different panel, and
+ * refreshArray writes into the shared array slice (its range controller would
+ * abort the newly-selected key's load) while the header reads Length/Count/Size
+ * from the keys slice.
+ *
+ * The live selection is read from the browser context, not
+ * `keys.selectedKey.data` — fetchKeyInfo keeps the previous `data` in place
+ * while the newly clicked key loads, so that field is stale during the switch.
+ * Comparison is byte-exact (isEqualBuffers), since two distinct binary names
+ * can decode to the same Unicode string.
+ */
+function applyArrayWriteResult(
+  key: RedisResponseBuffer,
+  onSuccessAction?: () => void,
+) {
+  return (dispatch: AppDispatch, stateInit: () => RootState) => {
+    const selectedKey = appContextSelectedKey(stateInit())
+    if (!selectedKey || !isEqualBuffers(selectedKey, key)) {
+      return
+    }
+    onSuccessAction?.()
+    dispatch<any>(refreshArray(key))
+    dispatch<any>(refreshKeyInfoAction(key))
+  }
+}
+
+/**
+ * Append a value to the end of the array (POST /array/append → ARSET at the
+ * current length). On success the displayed surface, counters, and key header
+ * are refreshed so the new element appears.
+ */
+export function appendArrayElement(
+  params: AppendArrayElementParams,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { status } = await apiService.post(
+        arrayUrl(state, ApiEndpoints.ARRAY_APPEND),
+        { keyName: params.key, value: params.value },
+        encodingParams(state),
+      )
+      if (isStatusSuccessful(status)) {
+        dispatch<any>(applyArrayWriteResult(params.key, onSuccessAction))
+      }
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      onFailAction?.()
+    }
+  }
+}
+
+/**
+ * Add a value at an explicit index (POST /array/set-element → ARSET key index
+ * value). Used by the "Add element" form when the user points at an index.
+ * Refreshes the displayed surface, counters, and key header on success.
+ */
+export function addArrayElement(
+  params: AddArrayElementParams,
+  onSuccessAction?: () => void,
+  onFailAction?: () => void,
+) {
+  return async (dispatch: AppDispatch, stateInit: () => RootState) => {
+    try {
+      const state = stateInit()
+      const { status } = await apiService.post(
+        arrayUrl(state, ApiEndpoints.ARRAY_SET_ELEMENT),
+        { keyName: params.key, index: params.index, value: params.value },
+        encodingParams(state),
+      )
+      if (isStatusSuccessful(status)) {
+        dispatch<any>(applyArrayWriteResult(params.key, onSuccessAction))
+      }
+    } catch (error) {
+      dispatch(addErrorNotification(error as IAddInstanceErrorPayload))
+      onFailAction?.()
     }
   }
 }

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -167,6 +167,11 @@ export interface FetchArrayRangeParams {
 export interface AppendArrayElementParams {
   key: RedisResponseBuffer
   value: RedisString
+  /** Connected instance id when the add was requested. The write is cancelled
+   *  if the live connection no longer matches — a pending production-write
+   *  confirmation must not write into a database the user has since switched
+   *  to. */
+  expectedInstanceId?: string
 }
 
 /** Add a value at an explicit index (ARSET key index value). Index is a
@@ -175,6 +180,8 @@ export interface AddArrayElementParams {
   key: RedisResponseBuffer
   index: string
   value: RedisString
+  /** See AppendArrayElementParams.expectedInstanceId. */
+  expectedInstanceId?: string
 }
 
 export interface FetchArrayScanParams {

--- a/redisinsight/ui/src/slices/interfaces/array.ts
+++ b/redisinsight/ui/src/slices/interfaces/array.ts
@@ -7,7 +7,7 @@ import {
   GetArraySearchResponse,
   GetArrayScanResponse,
 } from 'apiClient'
-import { RedisString } from 'uiSrc/slices/interfaces/app'
+import { RedisResponseBuffer, RedisString } from 'uiSrc/slices/interfaces/app'
 
 /**
  * Mirror of the backend `ArrayAggregateOperation` enum (BE
@@ -159,6 +159,22 @@ export interface FetchArrayRangeParams {
   start: string
   end: string
   resetData?: boolean
+}
+
+/** Append a value to the end of the array (ARSET at the current length,
+ *  computed server-side). The key is always a buffer (the selected key), so
+ *  the stale-key guard can compare it byte-exactly with isEqualBuffers. */
+export interface AppendArrayElementParams {
+  key: RedisResponseBuffer
+  value: RedisString
+}
+
+/** Add a value at an explicit index (ARSET key index value). Index is a
+ *  numeric string per the unsigned-64-bit contract. */
+export interface AddArrayElementParams {
+  key: RedisResponseBuffer
+  index: string
+  value: RedisString
 }
 
 export interface FetchArrayScanParams {

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1102,10 +1102,11 @@ describe('array slice', () => {
     })
 
     describe('appendArrayElement', () => {
-      it('posts keyName/value to array/append, calls onSuccess, and refreshes', async () => {
-        apiService.post = jest
-          .fn()
-          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+      it('posts keyName/value to array/append, calls onSuccess with the landed index, and refreshes', async () => {
+        apiService.post = jest.fn().mockResolvedValue({
+          status: 200,
+          data: { keyName: mockKey, index: '6' },
+        })
         const onSuccess = jest.fn()
         const local = storeWithSelectedKey()
 
@@ -1118,7 +1119,9 @@ describe('array slice', () => {
         )
         expect(appendCall).toBeTruthy()
         expect(appendCall[1]).toEqual({ keyName: mockKeyBuffer, value: 'v' })
-        expect(onSuccess).toHaveBeenCalled()
+        // The append response's index is passed through so the caller can
+        // reveal the new element in the View.
+        expect(onSuccess).toHaveBeenCalledWith('6')
         // refreshArray re-reads length/count after the add.
         const lengthCall = (apiService.post as jest.Mock).mock.calls.find(
           ([url]) => url.includes('array/get-length'),
@@ -1232,7 +1235,8 @@ describe('array slice', () => {
           index: '5',
           value: 'v',
         })
-        expect(onSuccess).toHaveBeenCalled()
+        // The chosen index is passed through so the View can reveal it.
+        expect(onSuccess).toHaveBeenCalledWith('5')
         const lengthCall = (apiService.post as jest.Mock).mock.calls.find(
           ([url]) => url.includes('array/get-length'),
         )

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -43,6 +43,8 @@ import reducer, {
   fetchArrayLength,
   fetchArrayCount,
   refreshArray,
+  appendArrayElement,
+  addArrayElement,
   searchArray,
   updateArrayElementAction,
   fetchArrayNeighbours,
@@ -71,6 +73,29 @@ jest.mock('uiSrc/services', () => ({
 // friction with the generated DTO types (which model the Buffer branch as
 // `{ type: 'Buffer'; data: number[] }`).
 const mockKey = 'readings'
+// Buffer form for the write thunks: the selected-key guard compares buffers
+// (isEqualBuffers), exactly as the UI passes them in production.
+const mockKeyBuffer = stringToBuffer(mockKey)
+
+// A store whose live (browser-context) selected key is `name` — array writes
+// only apply their success side effects while that key is still selected.
+const storeWithSelectedKey = (name = mockKeyBuffer) =>
+  mockStore({
+    ...initialStateDefault,
+    app: {
+      ...initialStateDefault.app,
+      context: {
+        ...initialStateDefault.app.context,
+        browser: {
+          ...initialStateDefault.app.context.browser,
+          keyList: {
+            ...initialStateDefault.app.context.browser.keyList,
+            selectedKey: name,
+          },
+        },
+      },
+    },
+  })
 
 let store: typeof mockedStore
 let dateNow: jest.SpyInstance<number>
@@ -1073,6 +1098,143 @@ describe('array slice', () => {
           addErrorNotification(rejected as IAddInstanceErrorPayload),
           setArrayUpdating(false),
         ])
+      })
+    })
+
+    describe('appendArrayElement', () => {
+      it('posts keyName/value to array/append, calls onSuccess, and refreshes', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const onSuccess = jest.fn()
+        const local = storeWithSelectedKey()
+
+        await local.dispatch<any>(
+          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
+        )
+
+        const appendCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/append'),
+        )
+        expect(appendCall).toBeTruthy()
+        expect(appendCall[1]).toEqual({ keyName: mockKeyBuffer, value: 'v' })
+        expect(onSuccess).toHaveBeenCalled()
+        // refreshArray re-reads length/count after the add.
+        const lengthCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/get-length'),
+        )
+        expect(lengthCall).toBeTruthy()
+        // refreshKeyInfoAction re-reads the key header (Length/Count/Size).
+        const keyInfoCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('keys/get-info'),
+        )
+        expect(keyInfoCall).toBeTruthy()
+      })
+
+      it('skips the success side effects when the user has switched to another key', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const onSuccess = jest.fn()
+        // Live selection moved on before the append resolved.
+        const local = storeWithSelectedKey(stringToBuffer('another-key'))
+
+        await local.dispatch<any>(
+          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
+        )
+
+        // The write still happens…
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/append'),
+          ),
+        ).toBeTruthy()
+        // …but onSuccess (which closes/clears the now-different panel) and the
+        // stale refresh that would clobber the new key's view do not run.
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/get-length'),
+          ),
+        ).toBeUndefined()
+      })
+
+      it('notifies and calls onFail on error', async () => {
+        const rejected = {
+          response: { status: 500, data: { message: 'boom' } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(rejected)
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(
+          appendArrayElement(
+            { key: mockKeyBuffer, value: 'v' },
+            undefined,
+            onFail,
+          ),
+        )
+
+        expect(onFail).toHaveBeenCalled()
+        expect(store.getActions()).toContainEqual(
+          addErrorNotification(rejected as IAddInstanceErrorPayload),
+        )
+      })
+    })
+
+    describe('addArrayElement (set at index)', () => {
+      it('posts keyName/index/value to array/set-element, calls onSuccess, and refreshes', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const onSuccess = jest.fn()
+        const local = storeWithSelectedKey()
+
+        await local.dispatch<any>(
+          addArrayElement(
+            { key: mockKeyBuffer, index: '5', value: 'v' },
+            onSuccess,
+          ),
+        )
+
+        const setCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/set-element'),
+        )
+        expect(setCall).toBeTruthy()
+        expect(setCall[1]).toEqual({
+          keyName: mockKeyBuffer,
+          index: '5',
+          value: 'v',
+        })
+        expect(onSuccess).toHaveBeenCalled()
+        const lengthCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/get-length'),
+        )
+        expect(lengthCall).toBeTruthy()
+        const keyInfoCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('keys/get-info'),
+        )
+        expect(keyInfoCall).toBeTruthy()
+      })
+
+      it('notifies and calls onFail on error', async () => {
+        const rejected = {
+          response: { status: 500, data: { message: 'boom' } },
+        }
+        apiService.post = jest.fn().mockRejectedValue(rejected)
+        const onFail = jest.fn()
+
+        await store.dispatch<any>(
+          addArrayElement(
+            { key: mockKeyBuffer, index: '5', value: 'v' },
+            undefined,
+            onFail,
+          ),
+        )
+
+        expect(onFail).toHaveBeenCalled()
+        expect(store.getActions()).toContainEqual(
+          addErrorNotification(rejected as IAddInstanceErrorPayload),
+        )
       })
     })
 

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -76,12 +76,29 @@ const mockKey = 'readings'
 // Buffer form for the write thunks: the selected-key guard compares buffers
 // (isEqualBuffers), exactly as the UI passes them in production.
 const mockKeyBuffer = stringToBuffer(mockKey)
+// Connected instance id the add is requested against; the write is cancelled if
+// the live connection no longer matches `expectedInstanceId`.
+const mockInstanceId = 'instance-1'
 
-// A store whose live (browser-context) selected key is `name` — array writes
-// only apply their success side effects while that key is still selected.
-const storeWithSelectedKey = (name = mockKeyBuffer) =>
+// A store whose live (browser-context) selected key is `name` and connected
+// instance is `instanceId` — array writes only proceed/apply while both still
+// match what they were when the add was requested.
+const storeWithSelectedKey = (
+  name = mockKeyBuffer,
+  instanceId = mockInstanceId,
+) =>
   mockStore({
     ...initialStateDefault,
+    connections: {
+      ...initialStateDefault.connections,
+      instances: {
+        ...initialStateDefault.connections.instances,
+        connectedInstance: {
+          ...initialStateDefault.connections.instances.connectedInstance,
+          id: instanceId,
+        },
+      },
+    },
     app: {
       ...initialStateDefault.app,
       context: {
@@ -1111,7 +1128,14 @@ describe('array slice', () => {
         const local = storeWithSelectedKey()
 
         await local.dispatch<any>(
-          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
+          appendArrayElement(
+            {
+              key: mockKeyBuffer,
+              value: 'v',
+              expectedInstanceId: mockInstanceId,
+            },
+            onSuccess,
+          ),
         )
 
         const appendCall = (apiService.post as jest.Mock).mock.calls.find(
@@ -1134,53 +1158,85 @@ describe('array slice', () => {
         expect(keyInfoCall).toBeTruthy()
       })
 
-      it('skips the success side effects when the user has switched to another key', async () => {
+      it('cancels the write (no POST) when the selected key changed before confirming', async () => {
         apiService.post = jest
           .fn()
           .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
         const onSuccess = jest.fn()
-        // Live selection moved on before the append resolved.
+        // Selection moved to another key before the confirmation resolved.
         const local = storeWithSelectedKey(stringToBuffer('another-key'))
 
         await local.dispatch<any>(
-          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
+          appendArrayElement(
+            {
+              key: mockKeyBuffer,
+              value: 'v',
+              expectedInstanceId: mockInstanceId,
+            },
+            onSuccess,
+          ),
         )
 
-        // The write still happens…
+        // The stale confirmation must not write at all, and no side effects run.
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/append'),
+          ),
+        ).toBeUndefined()
+        expect(onSuccess).not.toHaveBeenCalled()
+      })
+
+      it('cancels the write (no POST) when the database changed before confirming', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const onSuccess = jest.fn()
+        // Live connection is a different database than when Add was pressed.
+        const local = storeWithSelectedKey(mockKeyBuffer, 'db-2')
+
+        await local.dispatch<any>(
+          appendArrayElement(
+            { key: mockKeyBuffer, value: 'v', expectedInstanceId: 'db-1' },
+            onSuccess,
+          ),
+        )
+
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/append'),
+          ),
+        ).toBeUndefined()
+        expect(onSuccess).not.toHaveBeenCalled()
+      })
+
+      it('skips the success side effects when the database changed mid-write', async () => {
+        // Passes the pre-write check (same db at dispatch), then the connection
+        // switches while the POST is in flight — the write landed on the old
+        // database, so its result must not repaint the new one.
+        const local = storeWithSelectedKey(mockKeyBuffer, 'db-1')
+        const onSuccess = jest.fn()
+
+        apiService.post = jest.fn().mockImplementation(async (url: string) => {
+          if (url.includes('array/append')) {
+            local.getState().connections.instances.connectedInstance.id = 'db-2'
+          }
+          return { status: 200, data: { keyName: mockKey } }
+        })
+
+        await local.dispatch<any>(
+          appendArrayElement(
+            { key: mockKeyBuffer, value: 'v', expectedInstanceId: 'db-1' },
+            onSuccess,
+          ),
+        )
+
+        // The write went out (pre-check passed)…
         expect(
           (apiService.post as jest.Mock).mock.calls.find(([url]) =>
             url.includes('array/append'),
           ),
         ).toBeTruthy()
-        // …but onSuccess (which closes/clears the now-different panel) and the
-        // stale refresh that would clobber the new key's view do not run.
-        expect(onSuccess).not.toHaveBeenCalled()
-        expect(
-          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
-            url.includes('array/get-length'),
-          ),
-        ).toBeUndefined()
-      })
-
-      it('skips the success side effects when the database changed mid-write', async () => {
-        // Same selected key name, but the connection switched while the POST
-        // was in flight — the write landed on the old database, so its result
-        // must not repaint the new one.
-        const state = cloneDeep(initialStateDefault)
-        state.app.context.browser.keyList.selectedKey = mockKeyBuffer
-        state.connections.instances.connectedInstance = { id: 'db-1' } as any
-        const local = mockStore(state)
-        const onSuccess = jest.fn()
-
-        apiService.post = jest.fn().mockImplementation(async () => {
-          state.connections.instances.connectedInstance = { id: 'db-2' } as any
-          return { status: 200, data: { keyName: mockKey } }
-        })
-
-        await local.dispatch<any>(
-          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
-        )
-
+        // …but the post-write guard suppresses the refresh for the new db.
         expect(onSuccess).not.toHaveBeenCalled()
         expect(
           (apiService.post as jest.Mock).mock.calls.find(([url]) =>
@@ -1195,17 +1251,22 @@ describe('array slice', () => {
         }
         apiService.post = jest.fn().mockRejectedValue(rejected)
         const onFail = jest.fn()
+        const local = storeWithSelectedKey()
 
-        await store.dispatch<any>(
+        await local.dispatch<any>(
           appendArrayElement(
-            { key: mockKeyBuffer, value: 'v' },
+            {
+              key: mockKeyBuffer,
+              value: 'v',
+              expectedInstanceId: mockInstanceId,
+            },
             undefined,
             onFail,
           ),
         )
 
         expect(onFail).toHaveBeenCalled()
-        expect(store.getActions()).toContainEqual(
+        expect(local.getActions()).toContainEqual(
           addErrorNotification(rejected as IAddInstanceErrorPayload),
         )
       })
@@ -1221,7 +1282,12 @@ describe('array slice', () => {
 
         await local.dispatch<any>(
           addArrayElement(
-            { key: mockKeyBuffer, index: '5', value: 'v' },
+            {
+              key: mockKeyBuffer,
+              index: '5',
+              value: 'v',
+              expectedInstanceId: mockInstanceId,
+            },
             onSuccess,
           ),
         )
@@ -1253,17 +1319,23 @@ describe('array slice', () => {
         }
         apiService.post = jest.fn().mockRejectedValue(rejected)
         const onFail = jest.fn()
+        const local = storeWithSelectedKey()
 
-        await store.dispatch<any>(
+        await local.dispatch<any>(
           addArrayElement(
-            { key: mockKeyBuffer, index: '5', value: 'v' },
+            {
+              key: mockKeyBuffer,
+              index: '5',
+              value: 'v',
+              expectedInstanceId: mockInstanceId,
+            },
             undefined,
             onFail,
           ),
         )
 
         expect(onFail).toHaveBeenCalled()
-        expect(store.getActions()).toContainEqual(
+        expect(local.getActions()).toContainEqual(
           addErrorNotification(rejected as IAddInstanceErrorPayload),
         )
       })

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1158,6 +1158,25 @@ describe('array slice', () => {
         expect(keyInfoCall).toBeTruthy()
       })
 
+      it('brackets the write with the updating lock (pauses key refresh)', async () => {
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = storeWithSelectedKey()
+
+        await local.dispatch<any>(
+          appendArrayElement({
+            key: mockKeyBuffer,
+            value: 'v',
+            expectedInstanceId: mockInstanceId,
+          }),
+        )
+
+        const actions = local.getActions()
+        expect(actions).toContainEqual(setArrayUpdating(true))
+        expect(actions).toContainEqual(setArrayUpdating(false))
+      })
+
       it('cancels the write (no POST) when the selected key changed before confirming', async () => {
         apiService.post = jest
           .fn()

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -752,6 +752,45 @@ describe('array slice', () => {
         })
       })
 
+      it('replays the AROP when one is still in flight (no result yet)', async () => {
+        // First AROP still loading (query stored, hasResult=false). A pre-add
+        // response would land stale, so refresh must abort + replay it.
+        apiService.post = jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { keyName: mockKey } })
+        const local = mockStore({
+          ...initialStateDefault,
+          browser: {
+            ...initialStateDefault.browser,
+            array: {
+              ...initialState,
+              aggregate: {
+                ...initialState.aggregate,
+                loading: true,
+                hasResult: false,
+                query: {
+                  start: '5',
+                  end: '15',
+                  operation: ArrayAggregateOperation.Sum,
+                },
+              },
+            },
+          },
+        })
+
+        await local.dispatch<any>(refreshArray(mockKey))
+
+        const aggregateCall = (apiService.post as jest.Mock).mock.calls.find(
+          ([url]) => url.includes('array/aggregate'),
+        )
+        expect(aggregateCall?.[1]).toEqual({
+          keyName: mockKey,
+          start: '5',
+          end: '15',
+          operation: ArrayAggregateOperation.Sum,
+        })
+      })
+
       it('does not replay AROP when no aggregate has been run', async () => {
         apiService.post = jest
           .fn()

--- a/redisinsight/ui/src/slices/tests/browser/array.spec.ts
+++ b/redisinsight/ui/src/slices/tests/browser/array.spec.ts
@@ -1159,6 +1159,33 @@ describe('array slice', () => {
         ).toBeUndefined()
       })
 
+      it('skips the success side effects when the database changed mid-write', async () => {
+        // Same selected key name, but the connection switched while the POST
+        // was in flight — the write landed on the old database, so its result
+        // must not repaint the new one.
+        const state = cloneDeep(initialStateDefault)
+        state.app.context.browser.keyList.selectedKey = mockKeyBuffer
+        state.connections.instances.connectedInstance = { id: 'db-1' } as any
+        const local = mockStore(state)
+        const onSuccess = jest.fn()
+
+        apiService.post = jest.fn().mockImplementation(async () => {
+          state.connections.instances.connectedInstance = { id: 'db-2' } as any
+          return { status: 200, data: { keyName: mockKey } }
+        })
+
+        await local.dispatch<any>(
+          appendArrayElement({ key: mockKeyBuffer, value: 'v' }, onSuccess),
+        )
+
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(
+          (apiService.post as jest.Mock).mock.calls.find(([url]) =>
+            url.includes('array/get-length'),
+          ),
+        ).toBeUndefined()
+      })
+
       it('notifies and calls onFail on error', async () => {
         const rejected = {
           response: { status: 500, data: { message: 'boom' } },


### PR DESCRIPTION
# What

Adds the **Add element** UI to the array key View tab, completing the Modify
vertical on the frontend. A right-aligned "Add Elements" action opens a slide-out
panel (reusing the shared `AddItemsAction` + `AddKeysContainer` chrome, so it
matches Lists / Vector Sets).

The panel takes a **value** and an **optional index**:

- **index left empty** → append to the end (`POST /array/append`)
- **index provided** → set at that index (`POST /array/set-element`)

An info icon next to the index field explains that leaving it empty appends to
the end. The index is validated against the canonical decimal form (matching the
backend `@IsArrayIndex`), and writes go through the production-write confirmation.

### Notes

- New slice thunks `appendArrayElement` / `addArrayElement`, both refreshing the
  key on success.
- The index is carried as a string throughout (unsigned 64-bit contract).

<img width="836" height="1133" alt="Screenshot 2026-06-29 at 16 47 49" src="https://github.com/user-attachments/assets/218401a7-619d-4f61-9653-3022baaa213a" />
<img width="836" height="1133" alt="Screenshot 2026-06-29 at 16 47 37" src="https://github.com/user-attachments/assets/a9ca7202-87b9-4815-ba65-a21f070308a9" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production database writes with careful stale-key/instance guards; complexity around async confirm, unmount, and shared array slice refresh increases regression surface but is heavily tested.
> 
> **Overview**
> Adds **Add Elements** on the array key **View** tab: a slide-out panel (same chrome as List/Vector Set) with optional **index** and **value**, production-write confirmation (`browser:add-array-elements`), and telemetry hooks wired from `KeyDetails`.
> 
> **Writes:** empty index → `POST /array/append`; index set → `POST /array/set-element`. New Redux thunks `appendArrayElement` / `addArrayElement` refresh the view and key header on success, with guards for key/database switches and stale confirmation callbacks. Optional **move to the added element** scrolls the range via new `revealIndex` on `useArrayRangeQuery` (10-element window, synced to the active query).
> 
> **Safety/UX:** panel closes on key change (byte compare); form blocks submit while refresh is locked; unmount ignores late success/confirm. `refreshArray` also replays an in-flight aggregate query so AROP doesn’t return stale after refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d8a185a66842a1e669ab3527f2336677cb4c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->