### PR TITLE
ci: check i18n locale files for duplicate keys

### DIFF
--- a/.github/workflows/i18n-locale-check.yml
+++ b/.github/workflows/i18n-locale-check.yml
@@ -1,0 +1,22 @@
+name: i18n locales
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'redisinsight/ui/src/i18n/locales/**'
+
+jobs:
+  duplicate-keys:
+    runs-on: ubuntu-latest
+    name: Check duplicate i18n keys
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check i18n locale files for duplicate keys
+        run: yarn i18n:check

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:defaults": "yarn --cwd redisinsight/api build:defaults",
     "generate:api-client": "node ./scripts/generate-api-client.js",
     "i18n:extract": "i18next-cli extract",
+    "i18n:check": "node ./scripts/check-i18n-locales.js",
     "build:statics": "yarn build:defaults && sh ./scripts/build-statics.sh",
     "build:statics:win": "yarn build:defaults && ./scripts/build-statics.cmd",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir redisinsight",

--- a/scripts/check-i18n-locales.js
+++ b/scripts/check-i18n-locales.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Fails if any i18n locale file contains a DUPLICATE KEY.
+ *
+ * JSON silently keeps only the last occurrence of a duplicate key, so a stray
+ * dup would shadow a translation with no error at parse/build time. Locale files
+ * are flat (keySeparator/nsSeparator are false) and machine-formatted one key
+ * per line, so a line scan reliably finds duplicates. Duplicate *values* are
+ * expected (many error codes share the same text) and are never checked.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const LOCALES_DIR = path.join(
+  __dirname,
+  '..',
+  'redisinsight',
+  'ui',
+  'src',
+  'i18n',
+  'locales',
+);
+
+// Matches a leading  "some.key":  at the start of a line (after indentation).
+const KEY_RE = /^\s*"((?:\\.|[^"\\])*)"\s*:/;
+
+let hasDuplicates = false;
+
+const files = fs
+  .readdirSync(LOCALES_DIR)
+  .filter((file) => file.endsWith('.json'));
+
+files.forEach((file) => {
+  const filePath = path.join(LOCALES_DIR, file);
+  const text = fs.readFileSync(filePath, 'utf8');
+
+  // Sanity check: the file must still be valid JSON.
+  JSON.parse(text);
+
+  const firstSeenLine = new Map();
+  const duplicates = new Map();
+
+  text.split('\n').forEach((line, index) => {
+    const match = line.match(KEY_RE);
+    if (!match) {
+      return;
+    }
+    const key = match[1];
+    if (firstSeenLine.has(key)) {
+      if (!duplicates.has(key)) {
+        duplicates.set(key, [firstSeenLine.get(key)]);
+      }
+      duplicates.get(key).push(index + 1);
+    } else {
+      firstSeenLine.set(key, index + 1);
+    }
+  });
+
+  const relPath = path.relative(path.join(__dirname, '..'), filePath);
+  if (duplicates.size) {
+    hasDuplicates = true;
+    console.error(`\n✗ ${relPath}: ${duplicates.size} duplicate key(s):`);
+    duplicates.forEach((lines, key) => {
+      console.error(`    "${key}" — lines ${lines.join(', ')}`);
+    });
+  } else {
+    console.log(`✓ ${relPath}: no duplicate keys (${firstSeenLine.size} keys)`);
+  }
+});
+
+if (hasDuplicates) {
+  console.error(
+    '\nDuplicate i18n keys detected. JSON keeps only the last occurrence, ' +
+      'so the earlier value is silently dropped — remove the duplicate.',
+  );
+  process.exit(1);
+}
+
+console.log('\nNo duplicate i18n keys found.');


### PR DESCRIPTION
# What

Adds a CI guard that fails when an i18n locale file contains a **duplicate key**.

JSON silently keeps only the *last* occurrence of a duplicate key, so a stray dup
(easy to introduce when hand-editing `en.json` / `bg.json`) would shadow a
translation with no build or parse error. With 300+ flat keys edited by hand, this
catches the mistake at PR time.

- `scripts/check-i18n-locales.js` — dependency-free; scans `redisinsight/ui/src/i18n/locales/*.json`, validates JSON, and fails listing any duplicate key with its line numbers. Duplicate *values* are expected (many error codes share text) and are never checked.
- `package.json` — `yarn i18n:check`.
- `.github/workflows/i18n-locale-check.yml` — runs `yarn i18n:check` on PRs that touch `redisinsight/ui/src/i18n/locales/**`.

# Testing

- `yarn i18n:check` passes on the current locales.
- Injecting a duplicate key makes it exit non-zero and report the key + line numbers; reverting restores a clean run.

## Success

<img width="807" height="191" alt="image" src="https://github.com/user-attachments/assets/d20a7b73-ba57-48e4-a865-74f12d679e29" />

## Error

<img width="1010" height="265" alt="image" src="https://github.com/user-attachments/assets/68e27a9d-2d4d-4f59-9061-ffdc8194d74e" />

---

Part of RI-8268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and developer tooling only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Adds a **PR-time guard** so duplicate keys in `redisinsight/ui/src/i18n/locales/*.json` fail CI instead of silently overwriting earlier translations (JSON keeps only the last key).
> 
> A new **`scripts/check-i18n-locales.js`** script (no extra deps) parses each locale file, scans one-key-per-line entries for repeated keys, and exits non-zero with key names and line numbers. **`yarn i18n:check`** in `package.json` runs it locally.
> 
> **`.github/workflows/i18n-locale-check.yml`** runs that check on pull requests that change locale files (also callable via `workflow_dispatch` / `workflow_call`). Duplicate *values* are intentionally ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f64ccedc93a2f6a7eeb0995a30422ae3b66466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->