### PR TITLE
RI-8303 Add copy system info button to settings

### DIFF
--- a/redisinsight/api/src/__mocks__/server.ts
+++ b/redisinsight/api/src/__mocks__/server.ts
@@ -25,6 +25,7 @@ export const mockGetServerInfoResponse = Object.assign(
     appVersion: SERVER_CONFIG.appVersion,
     buildCommitSha: SERVER_CONFIG.buildCommitSha,
     osPlatform: process.platform,
+    osArch: process.arch,
     buildType: SERVER_CONFIG.buildType,
     appType: AppType.Docker,
     encryptionStrategies: [EncryptionStrategy.PLAIN, EncryptionStrategy.KEYTAR],

--- a/redisinsight/api/src/modules/server/dto/server.dto.ts
+++ b/redisinsight/api/src/modules/server/dto/server.dto.ts
@@ -38,6 +38,13 @@ export class GetServerInfoResponse {
   osPlatform: string;
 
   @ApiProperty({
+    description: 'The operating system CPU architecture.',
+    type: String,
+    example: 'x64',
+  })
+  osArch: string;
+
+  @ApiProperty({
     description: 'Application build type.',
     type: String,
     example: 'ELECTRON',

--- a/redisinsight/api/src/modules/server/local.server.service.spec.ts
+++ b/redisinsight/api/src/modules/server/local.server.service.spec.ts
@@ -102,6 +102,7 @@ describe('LocalServerService', () => {
         sessionId: expect.any(Number),
         packageType: undefined, // should be undefined for non-electron applications
       });
+      expect(result.osArch).toEqual(process.arch);
     });
     it('should throw ServerInfoNotFoundException', async () => {
       serverRepository.getOrCreate.mockResolvedValue(null);

--- a/redisinsight/api/src/modules/server/local.server.service.ts
+++ b/redisinsight/api/src/modules/server/local.server.service.ts
@@ -57,6 +57,7 @@ export class LocalServerService extends ServerService {
         appVersion: SERVER_CONFIG.appVersion,
         buildCommitSha: SERVER_CONFIG.buildCommitSha,
         osPlatform: process.platform,
+        osArch: process.arch,
         buildType: SERVER_CONFIG.buildType,
         appType: ServerService.getAppType(SERVER_CONFIG.buildType),
         encryptionStrategies:

--- a/redisinsight/api/test/api/info/GET-info.test.ts
+++ b/redisinsight/api/test/api/info/GET-info.test.ts
@@ -11,6 +11,7 @@ const responseSchema = Joi.object()
     appVersion: Joi.string().required(),
     buildCommitSha: Joi.string().optional(),
     osPlatform: Joi.string().required(),
+    osArch: Joi.string().required(),
     buildType: Joi.string()
       .valid('ELECTRON', 'DOCKER_ON_PREMISE', 'REDIS_STACK')
       .required(),
@@ -39,6 +40,7 @@ describe('GET /info', () => {
       responseSchema,
       checkFn: ({ body }) => {
         expect(body.osPlatform).to.eql(process.platform);
+        expect(body.osArch).to.eql(process.arch);
       },
     },
   ].map(mainCheckFn);

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -1,5 +1,6 @@
 {
   "settings.advancedWarning": "Разширените настройки трябва да се променят само ако разбирате тяхното въздействие.",
+  "settings.copyDiagnostics": "Копиране на системна информация",
   "settings.title": "Настройки",
   "settings.language.label": "Изберете езика, използван в Redis Insight:",
   "settings.language.title": "Език",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -1,5 +1,6 @@
 {
   "settings.advancedWarning": "Advanced settings should only be changed if you understand their impact.",
+  "settings.copyDiagnostics": "Copy system info",
   "settings.title": "Settings",
   "settings.language.label": "Specifies the language used in Redis Insight:",
   "settings.language.title": "Language",

--- a/redisinsight/ui/src/mocks/factories/app/GetServerInfoResponse.factory.ts
+++ b/redisinsight/ui/src/mocks/factories/app/GetServerInfoResponse.factory.ts
@@ -1,0 +1,18 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { AppType, GetServerInfoResponse, PackageType } from 'apiClient'
+
+export const GetServerInfoResponseFactory =
+  Factory.define<GetServerInfoResponse>(() => ({
+    id: faker.string.uuid(),
+    createDateTime: faker.date.past().toISOString(),
+    appVersion: faker.system.semver(),
+    buildCommitSha: faker.git.commitSha(),
+    osPlatform: faker.helpers.arrayElement(['darwin', 'linux', 'win32']),
+    osArch: faker.helpers.arrayElement(['x64', 'arm64']),
+    buildType: 'ELECTRON',
+    appType: AppType.Electron,
+    packageType: PackageType.Mas,
+    encryptionStrategies: [],
+    sessionId: faker.number.int(),
+  }))

--- a/redisinsight/ui/src/pages/settings/SettingsPage.tsx
+++ b/redisinsight/ui/src/pages/settings/SettingsPage.tsx
@@ -35,6 +35,7 @@ import {
   AdvancedSettings,
   AppVersion,
   CloudSettings,
+  CopyDiagnostics,
   ThemeSettings,
   WorkbenchSettings,
 } from './components'
@@ -186,6 +187,7 @@ const SettingsPage = () => {
             </RICollapsibleNavGroup>
           </Col>
           <AppVersion />
+          <CopyDiagnostics />
         </PageContentBody>
       </PageBody>
     </Page>

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/CopyDiagnostics.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/CopyDiagnostics.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render, screen, fireEvent } from 'uiSrc/utils/test-utils'
+import { appServerInfoSelector } from 'uiSrc/slices/app/info'
+import { handleCopy } from 'uiSrc/utils'
+import { GetServerInfoResponseFactory } from 'uiSrc/mocks/factories/app/GetServerInfoResponse.factory'
+
+import { CopyDiagnostics } from './CopyDiagnostics'
+import { formatDiagnostics } from './formatDiagnostics'
+
+jest.mock('uiSrc/slices/app/info', () => ({
+  ...jest.requireActual('uiSrc/slices/app/info'),
+  appServerInfoSelector: jest.fn().mockReturnValue(null),
+}))
+
+jest.mock('uiSrc/utils', () => ({
+  ...jest.requireActual('uiSrc/utils'),
+  handleCopy: jest.fn(),
+}))
+
+const mockedHandleCopy = jest.mocked(handleCopy)
+
+const renderComponent = (
+  server: unknown = GetServerInfoResponseFactory.build(),
+) => {
+  ;(appServerInfoSelector as jest.Mock).mockReturnValue(server)
+  return render(<CopyDiagnostics />)
+}
+
+describe('CopyDiagnostics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render the copy diagnostics control when server info is available', () => {
+    renderComponent()
+
+    expect(screen.getByText('Copy system info')).toBeInTheDocument()
+    expect(screen.getByTestId('copy-diagnostics-btn')).toBeInTheDocument()
+  })
+
+  it('should copy the formatted diagnostics to clipboard when clicked', () => {
+    const server = GetServerInfoResponseFactory.build()
+    renderComponent(server)
+
+    fireEvent.click(screen.getByTestId('copy-diagnostics-btn'))
+
+    expect(mockedHandleCopy).toHaveBeenCalledWith(formatDiagnostics(server))
+  })
+
+  it('should not render when server info is null', () => {
+    renderComponent(null)
+
+    expect(screen.queryByTestId('copy-diagnostics-btn')).not.toBeInTheDocument()
+  })
+
+  it('should not render when appVersion is missing', () => {
+    renderComponent({})
+
+    expect(screen.queryByTestId('copy-diagnostics-btn')).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/CopyDiagnostics.tsx
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/CopyDiagnostics.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { useTranslation } from 'uiSrc/i18n'
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { appServerInfoSelector } from 'uiSrc/slices/app/info'
+import { CopyButton } from 'uiSrc/components/copy-button'
+import { Text } from 'uiSrc/components/base/text'
+import { Row } from 'uiSrc/components/base/layout/flex'
+
+import { formatDiagnostics } from './formatDiagnostics'
+
+export const CopyDiagnostics = () => {
+  const { t } = useTranslation()
+  const server = useAppSelector(appServerInfoSelector)
+
+  if (!server?.appVersion) return null
+
+  const label = t('settings.copyDiagnostics')
+
+  return (
+    <Row
+      align="center"
+      gap="s"
+      grow={false}
+      data-testid="settings-copy-diagnostics"
+    >
+      <Text size="s" color="secondary">
+        {label}
+      </Text>
+      <CopyButton
+        copy={formatDiagnostics(server)}
+        withTooltip={false}
+        aria-label={label}
+        data-testid="copy-diagnostics"
+      />
+    </Row>
+  )
+}

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.spec.ts
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.spec.ts
@@ -18,7 +18,7 @@ describe('formatDiagnostics', () => {
     expect(formatDiagnostics(server)).toEqual(
       [
         '```',
-        'RedisInsight diagnostics',
+        'Redis Insight diagnostics',
         'App version:   3.6.0',
         'Build commit:  a1b2c3d',
         'OS:            darwin (arm64)',

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.spec.ts
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.spec.ts
@@ -1,0 +1,50 @@
+import { AppType, GetServerInfoResponse, PackageType } from 'apiClient'
+import { GetServerInfoResponseFactory } from 'uiSrc/mocks/factories/app/GetServerInfoResponse.factory'
+
+import { formatDiagnostics } from './formatDiagnostics'
+
+const server = GetServerInfoResponseFactory.build({
+  appVersion: '3.6.0',
+  buildCommitSha: 'a1b2c3d4e5f6',
+  osPlatform: 'darwin',
+  osArch: 'arm64',
+  buildType: 'ELECTRON',
+  appType: AppType.Electron,
+  packageType: PackageType.Mas,
+})
+
+describe('formatDiagnostics', () => {
+  it('should format all fields into an aligned fenced code block', () => {
+    expect(formatDiagnostics(server)).toEqual(
+      [
+        '```',
+        'RedisInsight diagnostics',
+        'App version:   3.6.0',
+        'Build commit:  a1b2c3d',
+        'OS:            darwin (arm64)',
+        'Build type:    ELECTRON',
+        'App type:      ELECTRON',
+        'Package type:  mas',
+        '```',
+      ].join('\n'),
+    )
+  })
+
+  it('should omit the build commit line when buildCommitSha is absent', () => {
+    const result = formatDiagnostics({ ...server, buildCommitSha: undefined })
+
+    expect(result).not.toContain('Build commit:')
+    expect(result).toContain('App version:   3.6.0')
+    expect(result).toContain('OS:            darwin (arm64)')
+  })
+
+  it('should omit the package type line when packageType is absent', () => {
+    const result = formatDiagnostics({
+      ...server,
+      packageType: undefined,
+    } as unknown as GetServerInfoResponse)
+
+    expect(result).not.toContain('Package type:')
+    expect(result).toContain('App type:      ELECTRON')
+  })
+})

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.ts
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.ts
@@ -1,7 +1,7 @@
 import { GetServerInfoResponse } from 'apiClient'
 
 const CODE_FENCE = '```'
-const HEADER = 'RedisInsight diagnostics'
+const HEADER = 'Redis Insight diagnostics'
 const LABEL_COLUMN_WIDTH = 15
 const BUILD_COMMIT_SHA_LENGTH = 7
 

--- a/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.ts
+++ b/redisinsight/ui/src/pages/settings/components/copy-diagnostics/formatDiagnostics.ts
@@ -1,0 +1,29 @@
+import { GetServerInfoResponse } from 'apiClient'
+
+const CODE_FENCE = '```'
+const HEADER = 'RedisInsight diagnostics'
+const LABEL_COLUMN_WIDTH = 15
+const BUILD_COMMIT_SHA_LENGTH = 7
+
+/**
+ * Builds the clipboard payload for the Settings copy button: a fenced code
+ * block of environment info ready to paste into a GitHub issue. Rows with an
+ * empty value (build commit on dev builds, package type off Electron) are
+ * dropped so each runtime flavor produces a clean block.
+ */
+export const formatDiagnostics = (server: GetServerInfoResponse): string => {
+  const rows: [string, string | undefined][] = [
+    ['App version:', server.appVersion],
+    ['Build commit:', server.buildCommitSha?.slice(0, BUILD_COMMIT_SHA_LENGTH)],
+    ['OS:', `${server.osPlatform} (${server.osArch})`],
+    ['Build type:', server.buildType],
+    ['App type:', server.appType],
+    ['Package type:', server.packageType],
+  ]
+
+  const lines = rows
+    .filter(([, value]) => Boolean(value))
+    .map(([label, value]) => `${label.padEnd(LABEL_COLUMN_WIDTH)}${value}`)
+
+  return [CODE_FENCE, HEADER, ...lines, CODE_FENCE].join('\n')
+}

--- a/redisinsight/ui/src/pages/settings/components/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/index.ts
@@ -4,6 +4,7 @@ import WorkbenchSettings from './workbench-settings'
 import CloudSettings from './cloud-settings'
 import GeneralSettings from './general-settings'
 import ThemeSettings from './theme-settings'
+import { CopyDiagnostics } from './copy-diagnostics/CopyDiagnostics'
 
 export {
   AdvancedSettings,
@@ -12,4 +13,5 @@ export {
   CloudSettings,
   GeneralSettings,
   ThemeSettings,
+  CopyDiagnostics,
 }


### PR DESCRIPTION
# What

Adds a **Copy system info** control to the Settings page. It copies runtime
diagnostics to the clipboard as a fenced code block, ready to paste straight
into a GitHub issue:

```
RedisInsight diagnostics
App version:   <version>
Build commit:  <sha7>
OS:            <platform> (<arch>)
Build type:    <buildType>
App type:      <appType>
Package type:  <packageType>
```

- Rows with an empty value are dropped, so each runtime flavor (dev build,
  non-Electron, etc.) produces a clean block.
- Exposes a new `osArch` field on `GET /info` so the payload can report the CPU
  architecture alongside the OS platform.

## Screenshots
<img width="828" height="382" alt="image" src="https://github.com/user-attachments/assets/48c665b3-2bf0-4171-bc21-1a974106a9e9" />

<img width="878" height="390" alt="image" src="https://github.com/user-attachments/assets/97a8988d-3790-416b-8f7f-f0aa352e25b4" />

## Example copied output

```
Redis Insight diagnostics
App version:   3.6.0
Build commit:  1903399
OS:            darwin (arm64)
Build type:    DOCKER_ON_PREMISE
App type:      ELECTRON
```

# Testing

- `formatDiagnostics` unit tests: full block, plus the build-commit and
  package-type omission cases.
- `CopyDiagnostics` component tests: renders when server info is present,
  copies the formatted payload on click, hides when info is missing.
- API: extended `GET /info` integration test + Joi schema and the
  `LocalServerService` unit spec to cover `osArch`.

Gates run locally: `yarn lint`, `yarn type-check` (no new errors), UI + API
unit specs green.

---

Closes RI-8303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API field and a read-only Settings clipboard action; no auth, persistence, or sensitive data handling changes.
> 
> **Overview**
> Adds a **Copy system info** control on Settings (below app version) that copies a fenced **Redis Insight diagnostics** block to the clipboard for pasting into GitHub issues. The payload is built from existing `GET /info` data via `formatDiagnostics`, with optional rows (short build SHA, package type) omitted when empty.
> 
> **`GET /info`** now includes **`osArch`** (`process.arch`) alongside `osPlatform`, wired through the DTO, `LocalServerService`, mocks, and API/UI tests.
> 
> New UI pieces: `CopyDiagnostics`, `formatDiagnostics`, a `GetServerInfoResponse` test factory, and `settings.copyDiagnostics` strings (en/bg). The control hides when server info or `appVersion` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8a34afcc2d233fe7ab745f4a6e8c965335c9c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->