### PR TITLE
RI-8223 Add ARDEL and ARDELRANGE array delete endpoints

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Array/Delete Elements.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Delete Elements.bru
@@ -1,0 +1,55 @@
+meta {
+  name: Delete Elements
+  type: http
+  seq: 13
+}
+
+delete {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array/elements
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "readings",
+    "indexes": ["0", "3", "5"]
+  }
+}
+
+docs {
+  # ARDEL (delete elements by index)
+
+  Delete one or more elements by index — `ARDEL key index [index …]`. Indexes
+  pointing at an empty slot contribute 0 to the deleted count. Deleting the
+  last element removes the key.
+
+  ## Request body
+
+  | Field     | Type     | Notes                                              |
+  |-----------|----------|----------------------------------------------------|
+  | `keyName` | string   | The Array key name.                                |
+  | `indexes` | string[] | One or more unsigned 64-bit integers as strings.   |
+
+  ## Response
+
+  `200 OK`
+
+  ```json
+  { "affected": "2" }
+  ```
+
+  `affected` is the count actually deleted (decimal string).
+
+  ## Errors
+
+  | Status | When |
+  |--------|------|
+  | `400`  | Key holds a non-array type, or an index is not a valid u64 string. |
+  | `403`  | User has no permission for `ARDEL`. |
+  | `404`  | Key does not exist. |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Array/Delete Range.bru
+++ b/redisinsight/api/bruno/RedisInsight/Array/Delete Range.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Delete Range
+  type: http
+  seq: 14
+}
+
+delete {
+  url: {{API_URL}}/databases/{{DB_INSTANCE_ID}}/array/range
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "keyName": "readings",
+    "start": "0",
+    "end": "1"
+  }
+}
+
+docs {
+  # ARDELRANGE (delete an inclusive range)
+
+  Delete an inclusive range of elements — `ARDELRANGE key start end`. A reversed
+  range (`start > end`) deletes the same inclusive window. Deleting the last
+  element removes the key.
+
+  ## Request body
+
+  | Field     | Type   | Notes                                              |
+  |-----------|--------|----------------------------------------------------|
+  | `keyName` | string | The Array key name.                                |
+  | `start`   | string | Range start (inclusive). Unsigned 64-bit integer.  |
+  | `end`     | string | Range end (inclusive). Unsigned 64-bit integer.    |
+
+  ## Response
+
+  `200 OK`
+
+  ```json
+  { "affected": "2" }
+  ```
+
+  `affected` is the count of populated elements deleted in the range (decimal
+  string).
+
+  ## Errors
+
+  | Status | When |
+  |--------|------|
+  | `400`  | Key holds a non-array type, or a bound is not a valid u64 string. |
+  | `403`  | User has no permission for `ARDELRANGE`. |
+  | `404`  | Key does not exist. |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
+++ b/redisinsight/api/src/modules/browser/array/__tests__/array.factory.ts
@@ -7,6 +7,8 @@ import {
   ArrayElementDto,
   ArrayGrepCriteria,
   CreateArrayWithExpireDto,
+  DeleteArrayElementsDto,
+  DeleteArrayRangeDto,
   GetArraySearchDto,
   GetArraySearchResponse,
   SetArrayElementDto,
@@ -71,3 +73,17 @@ export const getArraySearchResponseFactory =
       { index: '6', value: Buffer.from('21.9') },
     ],
   }));
+
+export const deleteArrayElementsDtoFactory =
+  Factory.define<DeleteArrayElementsDto>(() => ({
+    keyName: arrayKeyName(),
+    indexes: ['0'],
+  }));
+
+export const deleteArrayRangeDtoFactory = Factory.define<DeleteArrayRangeDto>(
+  () => ({
+    keyName: arrayKeyName(),
+    start: '0',
+    end: '3',
+  }),
+);

--- a/redisinsight/api/src/modules/browser/array/array.controller.ts
+++ b/redisinsight/api/src/modules/browser/array/array.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   HttpCode,
   Post,
   UseInterceptors,
@@ -20,6 +21,9 @@ import {
   AggregateArrayDto,
   AggregateArrayResponse,
   CreateArrayWithExpireDto,
+  DeleteArrayElementsDto,
+  DeleteArrayRangeDto,
+  DeleteArrayResponse,
   GetArrayCountResponse,
   GetArrayElementDto,
   GetArrayElementResponse,
@@ -224,5 +228,41 @@ export class ArrayController extends BrowserBaseController {
     @Body() dto: AggregateArrayDto,
   ): Promise<AggregateArrayResponse> {
     return this.arrayService.aggregate(clientMetadata, dto);
+  }
+
+  @Delete('/elements')
+  @ApiOperation({
+    description:
+      'Delete one or more elements by index (ARDEL key index [index …]). ' +
+      'Indexes pointing at an empty slot contribute 0 to the deleted count. ' +
+      'Deleting the last element removes the key.',
+  })
+  @ApiRedisParams()
+  @ApiBody({ type: DeleteArrayElementsDto })
+  @ApiOkResponse({ type: DeleteArrayResponse })
+  @ApiQueryRedisStringEncoding()
+  async deleteElements(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: DeleteArrayElementsDto,
+  ): Promise<DeleteArrayResponse> {
+    return this.arrayService.deleteElements(clientMetadata, dto);
+  }
+
+  @Delete('/range')
+  @ApiOperation({
+    description:
+      'Delete an inclusive range of elements (ARDELRANGE key start end). ' +
+      'A reversed range (start > end) deletes the same inclusive window. ' +
+      'Deleting the last element removes the key.',
+  })
+  @ApiRedisParams()
+  @ApiBody({ type: DeleteArrayRangeDto })
+  @ApiOkResponse({ type: DeleteArrayResponse })
+  @ApiQueryRedisStringEncoding()
+  async deleteRange(
+    @BrowserClientMetadata() clientMetadata: ClientMetadata,
+    @Body() dto: DeleteArrayRangeDto,
+  ): Promise<DeleteArrayResponse> {
+    return this.arrayService.deleteRange(clientMetadata, dto);
   }
 }

--- a/redisinsight/api/src/modules/browser/array/array.service.spec.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.spec.ts
@@ -24,6 +24,8 @@ import {
   aggregateArrayDtoFactory,
   createContiguousArrayDtoFactory,
   createSparseArrayDtoFactory,
+  deleteArrayElementsDtoFactory,
+  deleteArrayRangeDtoFactory,
   getArraySearchDtoFactory,
   getArraySearchResponseFactory,
   setArrayElementDtoFactory,
@@ -908,6 +910,161 @@ describe('ArrayService', () => {
           mockBrowserClientMetadata,
           mockGetArrayMultiElementsDto,
         ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleteElements', () => {
+    // keyName matches mockKeyDto so the shared key-existence stub resolves.
+    const dto = deleteArrayElementsDtoFactory.build({
+      keyName: mockKeyDto.keyName,
+      indexes: ['0', '1', '3'],
+    });
+
+    beforeEach(() => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArDel,
+          dto.keyName,
+          ...dto.indexes,
+        ])
+        .mockResolvedValue('2');
+    });
+
+    it('should delete via ARDEL key index... and return the affected count', async () => {
+      const result = await service.deleteElements(
+        mockBrowserClientMetadata,
+        dto,
+      );
+      expect(result).toEqual({ affected: '2' });
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArDel,
+        dto.keyName,
+        ...dto.indexes,
+      ]);
+    });
+
+    it('should reject when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(0);
+      await expect(
+        service.deleteElements(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should rethrow BadRequest on WrongType', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'ARDEL',
+      };
+      when(client.sendCommand)
+        .calledWith(expect.arrayContaining([BrowserToolArrayCommands.ArDel]))
+        .mockRejectedValue(replyError);
+      await expect(
+        service.deleteElements(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should map ACL error to Forbidden', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARDEL',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+      await expect(
+        service.deleteElements(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleteRange', () => {
+    // keyName matches mockKeyDto so the shared key-existence stub resolves.
+    const dto = deleteArrayRangeDtoFactory.build({
+      keyName: mockKeyDto.keyName,
+      start: '0',
+      end: '3',
+    });
+
+    beforeEach(() => {
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArDelRange,
+          dto.keyName,
+          dto.start,
+          dto.end,
+        ])
+        .mockResolvedValue('2');
+    });
+
+    it('should delete via ARDELRANGE key start end and return the affected count', async () => {
+      const result = await service.deleteRange(mockBrowserClientMetadata, dto);
+      expect(result).toEqual({ affected: '2' });
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArDelRange,
+        dto.keyName,
+        dto.start,
+        dto.end,
+      ]);
+    });
+
+    it('should forward reversed ranges (start > end) to Redis as-is', async () => {
+      const reversed = deleteArrayRangeDtoFactory.build({
+        keyName: mockKeyDto.keyName,
+        start: '3',
+        end: '0',
+      });
+      when(client.sendCommand)
+        .calledWith([
+          BrowserToolArrayCommands.ArDelRange,
+          reversed.keyName,
+          reversed.start,
+          reversed.end,
+        ])
+        .mockResolvedValue('2');
+
+      await service.deleteRange(mockBrowserClientMetadata, reversed);
+
+      expect(client.sendCommand).toHaveBeenCalledWith([
+        BrowserToolArrayCommands.ArDelRange,
+        reversed.keyName,
+        '3',
+        '0',
+      ]);
+    });
+
+    it('should reject when key does not exist', async () => {
+      when(client.sendCommand)
+        .calledWith([BrowserToolKeysCommands.Exists, mockKeyDto.keyName])
+        .mockResolvedValue(0);
+      await expect(
+        service.deleteRange(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should rethrow BadRequest on WrongType', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisWrongTypeError,
+        command: 'ARDELRANGE',
+      };
+      when(client.sendCommand)
+        .calledWith(
+          expect.arrayContaining([BrowserToolArrayCommands.ArDelRange]),
+        )
+        .mockRejectedValue(replyError);
+      await expect(
+        service.deleteRange(mockBrowserClientMetadata, dto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should map ACL error to Forbidden', async () => {
+      const replyError: ReplyError = {
+        ...mockRedisNoPermError,
+        command: 'ARDELRANGE',
+      };
+      client.sendCommand.mockRejectedValue(replyError);
+      await expect(
+        service.deleteRange(mockBrowserClientMetadata, dto),
       ).rejects.toThrow(ForbiddenException);
     });
   });

--- a/redisinsight/api/src/modules/browser/array/array.service.ts
+++ b/redisinsight/api/src/modules/browser/array/array.service.ts
@@ -33,6 +33,9 @@ import {
   ArrayElement,
   ArraySearchElement,
   CreateArrayWithExpireDto,
+  DeleteArrayElementsDto,
+  DeleteArrayRangeDto,
+  DeleteArrayResponse,
   GetArrayCountResponse,
   GetArrayElementDto,
   GetArrayElementResponse,
@@ -566,6 +569,77 @@ export class ArrayService {
         error,
         clientMetadata,
       );
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
+  public async deleteElements(
+    clientMetadata: ClientMetadata,
+    dto: DeleteArrayElementsDto,
+  ): Promise<DeleteArrayResponse> {
+    try {
+      this.logger.debug('Deleting array elements.', clientMetadata);
+      const { keyName, indexes } = dto;
+      const client =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      await checkIfKeyNotExists(keyName, client);
+
+      // ARDEL returns the count actually deleted; indexes at empty slots
+      // count 0. Deleting the last element removes the key server-side.
+      const reply = await client.sendCommand([
+        BrowserToolArrayCommands.ArDel,
+        keyName,
+        ...indexes,
+      ]);
+
+      this.logger.debug('Succeed to delete array elements.', clientMetadata);
+      return plainToInstance(DeleteArrayResponse, {
+        affected: toRequiredIndexString(reply),
+      });
+    } catch (error) {
+      this.logger.error(
+        'Failed to delete array elements.',
+        error,
+        clientMetadata,
+      );
+      if (error?.message?.includes(RedisErrorCodes.WrongType)) {
+        throw new BadRequestException(error.message);
+      }
+      throw catchAclError(error);
+    }
+  }
+
+  public async deleteRange(
+    clientMetadata: ClientMetadata,
+    dto: DeleteArrayRangeDto,
+  ): Promise<DeleteArrayResponse> {
+    try {
+      this.logger.debug('Deleting array range.', clientMetadata);
+      const { keyName, start, end } = dto;
+
+      // No |end - start| span cap here (unlike ARGETRANGE): ARDELRANGE deletes
+      // populated elements in the index window server-side and returns only a
+      // count. A reversed range (start > end) is valid and forwarded as-is.
+      const client =
+        await this.databaseClientFactory.getOrCreateClient(clientMetadata);
+      await checkIfKeyNotExists(keyName, client);
+
+      const reply = await client.sendCommand([
+        BrowserToolArrayCommands.ArDelRange,
+        keyName,
+        start,
+        end,
+      ]);
+
+      this.logger.debug('Succeed to delete array range.', clientMetadata);
+      return plainToInstance(DeleteArrayResponse, {
+        affected: toRequiredIndexString(reply),
+      });
+    } catch (error) {
+      this.logger.error('Failed to delete array range.', error, clientMetadata);
       if (error?.message?.includes(RedisErrorCodes.WrongType)) {
         throw new BadRequestException(error.message);
       }

--- a/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/delete.array-elements.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import { IsArrayIndex } from 'src/common/decorators';
+import { ArrayMaxSize, ArrayMinSize, IsArray } from 'class-validator';
+import { ARRAY_RANGE_MAX_ELEMENTS } from 'src/modules/browser/array/constants';
+
+export class DeleteArrayElementsDto extends KeyDto {
+  @ApiProperty({
+    description:
+      'Indexes to delete (ARDEL). Each index is an unsigned 64-bit integer as ' +
+      'string. Indexes pointing at an empty slot contribute 0 to the deleted ' +
+      `count. At most ${ARRAY_RANGE_MAX_ELEMENTS.toLocaleString('en-US')} ` +
+      'indexes per call — ARDEL is O(N) in the number of indexes, the same ' +
+      'per-call cap as ARMGET.',
+    type: String,
+    isArray: true,
+    example: ['0', '5', '42'],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(ARRAY_RANGE_MAX_ELEMENTS)
+  @IsArrayIndex({ each: true })
+  indexes: string[];
+}

--- a/redisinsight/api/src/modules/browser/array/dto/delete.array-range.dto.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/delete.array-range.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { KeyDto } from 'src/modules/browser/keys/dto';
+import { IsArrayIndex } from 'src/common/decorators';
+
+export class DeleteArrayRangeDto extends KeyDto {
+  @ApiProperty({
+    description:
+      'Start index of the range to delete (inclusive). Unsigned 64-bit integer ' +
+      'as string.',
+    type: String,
+    example: '0',
+  })
+  @IsArrayIndex()
+  start: string;
+
+  @ApiProperty({
+    description:
+      'End index of the range to delete (inclusive). Unsigned 64-bit integer as ' +
+      'string. A reversed range (start > end) is valid and deletes the same ' +
+      'inclusive window.',
+    type: String,
+    example: '99',
+  })
+  @IsArrayIndex()
+  end: string;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/delete.array.response.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/delete.array.response.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteArrayResponse {
+  @ApiProperty({
+    description:
+      'Count of elements actually deleted. Unsigned 64-bit integer as string. ' +
+      'Indexes pointing at an empty slot contribute 0.',
+    type: String,
+    example: '2',
+  })
+  affected: string;
+}

--- a/redisinsight/api/src/modules/browser/array/dto/index.ts
+++ b/redisinsight/api/src/modules/browser/array/dto/index.ts
@@ -15,3 +15,6 @@ export * from './aggregate.array.dto';
 export * from './aggregate.array.response';
 export * from './get.array-search.dto';
 export * from './get.array-search.response';
+export * from './delete.array-elements.dto';
+export * from './delete.array-range.dto';
+export * from './delete.array.response';

--- a/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
+++ b/redisinsight/api/src/modules/browser/constants/browser-tool-commands.ts
@@ -126,6 +126,8 @@ export enum BrowserToolArrayCommands {
   ArNext = 'arnext',
   ArOp = 'arop',
   ArGrep = 'argrep',
+  ArDel = 'ardel',
+  ArDelRange = 'ardelrange',
 }
 
 export type BrowserToolCommands =

--- a/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
+++ b/redisinsight/api/src/modules/redis/client/ioredis/ioredis.client.ts
@@ -57,6 +57,8 @@ export abstract class IoredisClient extends RedisClient {
     client.addBuiltinCommand(BrowserToolArrayCommands.ArScan);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArNext);
     client.addBuiltinCommand(BrowserToolArrayCommands.ArGrep);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArDel);
+    client.addBuiltinCommand(BrowserToolArrayCommands.ArDelRange);
   }
 
   static prepareCommandOptions(options: IRedisClientCommandOptions): any {

--- a/redisinsight/api/test/api/array/DELETE-databases-id-array-elements.test.ts
+++ b/redisinsight/api/test/api/array/DELETE-databases-id-array-elements.test.ts
@@ -1,0 +1,225 @@
+import {
+  expect,
+  describe,
+  it,
+  before,
+  deps,
+  Joi,
+  requirements,
+  generateInvalidDataTestCases,
+  validateInvalidDataTestCase,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).delete(
+    `/${constants.API.DATABASES}/${instanceId}/array/elements`,
+  );
+
+// Per-item indexes are validated by @IsArrayIndex({ each: true }), which emits
+// a single combined message ("<field> must be an integer string between 0 and
+// 18446744073709551614") for any non-canonical item. Override the per-rule Joi
+// messages with a label-less substring so the harness's contains check passes.
+const ARRAY_INDEX_MSG = 'must be an integer string between';
+
+const dataSchema = Joi.object({
+  keyName: Joi.string().allow('').required(),
+  indexes: Joi.array()
+    .items(Joi.string().messages({ 'string.base': ARRAY_INDEX_MSG }))
+    .min(1)
+    .required()
+    .messages({ 'any.required': ARRAY_INDEX_MSG }),
+}).strict();
+
+const validInputData = {
+  keyName: constants.getRandomString(),
+  indexes: ['0'],
+};
+
+const responseSchema = Joi.object()
+  .keys({ affected: Joi.string().required() })
+  .required();
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARDEL/ARMSET/ARGET/ARCOUNT are Redis 8.8 preview commands with no typed
+// ioredis method; assert array state through the generic `call`.
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+const arcount = (key: string) => rte.client.call('ARCOUNT', key);
+
+// Seed shape mirrors the canonical `readings` fixture: indexes 0,1,5 populated,
+// gaps at 2,3,4 (logical length 6, count 3).
+const seedSparse = (key: string) =>
+  rte.client.call('ARMSET', key, '0', '20.1', '1', '20.4', '5', '21.4');
+
+describe('DELETE /databases/:instanceId/array/elements', () => {
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Validation', () => {
+    generateInvalidDataTestCases(dataSchema, validInputData).map(
+      validateInvalidDataTestCase(endpoint, dataSchema),
+    );
+
+    [
+      {
+        name: 'Should reject an empty indexes array (ArrayMinSize)',
+        data: { keyName: constants.getRandomString(), indexes: [] },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject a non-decimal index in the list',
+        data: {
+          keyName: constants.getRandomString(),
+          indexes: ['0', 'abc', '2'],
+        },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an index outside u64 in the list',
+        data: {
+          keyName: constants.getRandomString(),
+          indexes: ['0', '18446744073709551616'],
+        },
+        statusCode: 400,
+      },
+      {
+        // 2^64-1 is reserved by Redis as the "no-index" sentinel; a single
+        // bad item must invalidate the whole request (per-item @IsArrayIndex).
+        name: 'Should reject when any index equals the reserved 2^64-1 sentinel',
+        data: {
+          keyName: constants.getRandomString(),
+          indexes: ['0', '18446744073709551615', '5'],
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Main', () => {
+    it('Should delete populated indexes and count an empty-slot index as 0', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // 0 and 5 are populated; 3 is a gap, so the deleted count is 2.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, indexes: ['0', '3', '5'] },
+        responseSchema,
+        responseBody: { affected: '2' },
+      });
+
+      expect(await arget(keyName, '0')).to.eql(null);
+      expect(await arget(keyName, '5')).to.eql(null);
+      // Only index 1 survives.
+      expect(await arcount(keyName)).to.eql(1);
+    });
+
+    it('Should count a repeated index only once', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Index 0 is populated but listed twice; it is deleted once and counts 1.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, indexes: ['0', '0'] },
+        responseSchema,
+        responseBody: { affected: '1' },
+      });
+
+      expect(await arget(keyName, '0')).to.eql(null);
+      expect(await arcount(keyName)).to.eql(2);
+    });
+
+    it('Should remove the key when the last element is deleted', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('ARSET', keyName, '0', 'only');
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, indexes: ['0'] },
+        responseSchema,
+        responseBody: { affected: '1' },
+      });
+
+      // Deleting the last element removes the key (server behaviour).
+      expect(await rte.client.exists(keyName)).to.eql(0);
+    });
+
+    [
+      {
+        name: 'Should return BadRequest if key holds a non-array type',
+        data: { keyName: constants.TEST_STRING_KEY_1, indexes: ['0'] },
+        statusCode: 400,
+        before: () => rte.data.generateKeys(true),
+        after: async () => {
+          // The non-array key must be left untouched.
+          expect(await rte.client.get(constants.TEST_STRING_KEY_1)).to.eql(
+            constants.TEST_STRING_VALUE_1,
+          );
+        },
+      },
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), indexes: ['0'] },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), indexes: ['0'] },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('ACL', () => {
+    requirements('rte.acl');
+    before(async () => rte.data.setAclUserRules('~* +@all'));
+
+    const aclEndpoint = () => endpoint(constants.TEST_INSTANCE_ACL_ID);
+    const aclKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should delete the element for an authorised user',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, indexes: ['0'] },
+        responseSchema,
+        responseBody: { affected: '1' },
+        before: async () => {
+          await rte.data.setAclUserRules('~* +@all');
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+        },
+      },
+      {
+        name: 'Should throw error if no permissions for "ardel" command',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, indexes: ['0'] },
+        statusCode: 403,
+        responseBody: { statusCode: 403, error: 'Forbidden' },
+        // beforeEach() wipes the key between tests; reseed via the root client
+        // (the ACL rule below only affects the API request's user).
+        before: async () => {
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+          await rte.data.setAclUserRules('~* +@all -ardel');
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/array/DELETE-databases-id-array-range.test.ts
+++ b/redisinsight/api/test/api/array/DELETE-databases-id-array-range.test.ts
@@ -1,0 +1,225 @@
+import {
+  expect,
+  describe,
+  it,
+  before,
+  deps,
+  Joi,
+  requirements,
+  generateInvalidDataTestCases,
+  validateInvalidDataTestCase,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).delete(
+    `/${constants.API.DATABASES}/${instanceId}/array/range`,
+  );
+
+// `start` and `end` are validated by @IsArrayIndex on the API side, which emits
+// a single combined message ("<field> must be an integer string between 0 and
+// 18446744073709551614") for any non-canonical input. Override the per-rule Joi
+// messages with a label-less substring so the harness's contains check passes.
+const ARRAY_INDEX_MSG = 'must be an integer string between';
+
+const dataSchema = Joi.object({
+  keyName: Joi.string().allow('').required(),
+  start: Joi.string().required().messages({
+    'string.base': ARRAY_INDEX_MSG,
+    'any.required': ARRAY_INDEX_MSG,
+  }),
+  end: Joi.string().required().messages({
+    'string.base': ARRAY_INDEX_MSG,
+    'any.required': ARRAY_INDEX_MSG,
+  }),
+}).strict();
+
+const validInputData = {
+  keyName: constants.getRandomString(),
+  start: '0',
+  end: '5',
+};
+
+const responseSchema = Joi.object()
+  .keys({ affected: Joi.string().required() })
+  .required();
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// ARDELRANGE/ARMSET/ARGET/ARCOUNT are Redis 8.8 preview commands with no typed
+// ioredis method; assert array state through the generic `call`.
+const arget = (key: string, index: string) =>
+  rte.client.call('ARGET', key, index);
+const arcount = (key: string) => rte.client.call('ARCOUNT', key);
+
+// Seed shape mirrors the canonical `readings` fixture: indexes 0,1,5 populated,
+// gaps at 2,3,4 (logical length 6, count 3).
+const seedSparse = (key: string) =>
+  rte.client.call('ARMSET', key, '0', '20.1', '1', '20.4', '5', '21.4');
+
+describe('DELETE /databases/:instanceId/array/range', () => {
+  requirements('rte.version>=8.8');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Validation', () => {
+    generateInvalidDataTestCases(dataSchema, validInputData).map(
+      validateInvalidDataTestCase(endpoint, dataSchema),
+    );
+
+    [
+      {
+        name: 'Should reject a non-decimal bound',
+        data: { keyName: constants.getRandomString(), start: '0', end: 'abc' },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject a bound outside u64',
+        data: {
+          keyName: constants.getRandomString(),
+          start: '0',
+          end: '18446744073709551616',
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Main', () => {
+    it('Should delete an inclusive range and return the deleted count', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Range 0..1 covers both populated low indexes; index 5 is untouched.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, start: '0', end: '1' },
+        responseSchema,
+        responseBody: { affected: '2' },
+      });
+
+      expect(await arget(keyName, '0')).to.eql(null);
+      expect(await arget(keyName, '1')).to.eql(null);
+      expect(await arcount(keyName)).to.eql(1);
+    });
+
+    it('Should count only populated slots inside the range', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // Range 2..4 is all gaps; nothing is deleted.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, start: '2', end: '4' },
+        responseSchema,
+        responseBody: { affected: '0' },
+      });
+
+      expect(await arcount(keyName)).to.eql(3);
+    });
+
+    it('Should accept a reversed range (start > end) and delete the same window', async () => {
+      const keyName = constants.getRandomString();
+      await seedSparse(keyName);
+
+      // 1..0 reversed is the same inclusive 0..1 window.
+      await validateApiCall({
+        endpoint,
+        data: { keyName, start: '1', end: '0' },
+        responseSchema,
+        responseBody: { affected: '2' },
+      });
+
+      expect(await arcount(keyName)).to.eql(1);
+    });
+
+    it('Should remove the key when the range covers the last element', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('ARSET', keyName, '0', 'only');
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, start: '0', end: '0' },
+        responseSchema,
+        responseBody: { affected: '1' },
+      });
+
+      // Deleting the last element removes the key (server behaviour).
+      expect(await rte.client.exists(keyName)).to.eql(0);
+    });
+
+    [
+      {
+        name: 'Should return BadRequest if key holds a non-array type',
+        data: { keyName: constants.TEST_STRING_KEY_1, start: '0', end: '5' },
+        statusCode: 400,
+        before: () => rte.data.generateKeys(true),
+        after: async () => {
+          // The non-array key must be left untouched.
+          expect(await rte.client.get(constants.TEST_STRING_KEY_1)).to.eql(
+            constants.TEST_STRING_VALUE_1,
+          );
+        },
+      },
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), start: '0', end: '5' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), start: '0', end: '5' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('ACL', () => {
+    requirements('rte.acl');
+    before(async () => rte.data.setAclUserRules('~* +@all'));
+
+    const aclEndpoint = () => endpoint(constants.TEST_INSTANCE_ACL_ID);
+    const aclKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should delete the range for an authorised user',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, start: '0', end: '0' },
+        responseSchema,
+        responseBody: { affected: '1' },
+        before: async () => {
+          await rte.data.setAclUserRules('~* +@all');
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+        },
+      },
+      {
+        name: 'Should throw error if no permissions for "ardelrange" command',
+        endpoint: aclEndpoint,
+        data: { keyName: aclKey, start: '0', end: '0' },
+        statusCode: 403,
+        responseBody: { statusCode: 403, error: 'Forbidden' },
+        // beforeEach() wipes the key between tests; reseed via the root client
+        // (the ACL rule below only affects the API request's user).
+        before: async () => {
+          await rte.client.call('ARSET', aclKey, '0', 'seed');
+          await rte.data.setAclUserRules('~* +@all -ardelrange');
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});


### PR DESCRIPTION
# What

Backend slice (S1) of the array **Delete** vertical (RI-8223, parent RI-8174). Adds the two element-delete endpoints; whole-key delete already uses the existing `DEL` flow, and the UI (per-element, multi-select, range) lands in follow-up slices on this ticket.

- `DELETE /array/elements` → **ARDEL** `key index [index …]` — delete elements by index. An index pointing at an empty slot contributes 0 to the count.
- `DELETE /array/range` → **ARDELRANGE** `key start end` — delete an inclusive range; a reversed range (`start > end`) deletes the same window.
- Both return `{ "affected": "<count>" }` as a **decimal string** (u64 contract, consistent with ARLEN/ARCOUNT). Deleting the last element removes the key (server behaviour).
- `ARDEL` / `ARDELRANGE` registered as builtin commands so they work in pipelines.

# Testing

- `yarn test:api` — array service unit tests pass: count returned, empty-slot index counts 0, reversed range forwarded as-is, missing key → 404, wrong-type → 400, ACL → 403.
- Integration tests (`rte.version>=8.8`) for both endpoints: empty-slot counts 0, inclusive + reversed range, **last-element delete removes the key**, exact `affected` string, plus 400 / 404 / 403 paths.
- Bruno entries added for both endpoints.
- `yarn lint` clean; API `yarn type-check` adds zero new errors.

---

Part of RI-8223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive Redis mutations on array keys, but behavior mirrors existing array browser endpoints with validation, existence checks, and ACL mapping.
> 
> **Overview**
> Adds backend support for deleting Redis Array elements via two new **DELETE** routes, mapping to Redis 8.8 **ARDEL** and **ARDELRANGE**.
> 
> **`DELETE /array/elements`** accepts `keyName` and `indexes` (u64 strings, capped like **ARMGET**), runs **ARDEL**, and returns `{ affected: "<count>" }`. Empty slots add 0 to the count; removing the last element drops the key.
> 
> **`DELETE /array/range`** accepts inclusive `start`/`end` (reversed ranges forwarded as-is), runs **ARDELRANGE**, and returns the same `affected` shape.
> 
> **ARDEL** / **ARDELRANGE** are registered as ioredis builtin commands for pipeline use. DTO validation, key-existence checks, wrong-type → 400, and ACL → 403 match other browser array operations. Bruno requests and Redis 8.8+ integration tests cover sparse arrays, last-key removal, and ACL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0181b5cd31714478fc21d65c97d06f8634875e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->