### PR TITLE
RI-8174 Make dev-array flag overridable via local config.json

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3.94,
+  "version": 4,
   "features": {
     "redisDataIntegration": {
       "flag": true,
@@ -144,8 +144,8 @@
       "perc": [[0, 100]]
     },
     "dev-array": {
-      "flag": false,
-      "perc": [[0, 100]]
+      "flag": true,
+      "perc": [[0, 0]]
     },
     "prodMode": {
       "flag": true,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -105,7 +105,10 @@ export class FeatureFlagProvider {
     );
     this.strategies.set(
       KnownFeatures.DevArray,
-      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
+      new SwitchableFlagStrategy(
+        this.featuresConfigService,
+        this.settingsService,
+      ),
     );
     this.strategies.set(
       KnownFeatures.ProdMode,


### PR DESCRIPTION
# What

Make the `dev-array` feature flag overridable per machine. It now uses `SwitchableFlagStrategy` with `flag: true` + `perc: [[0, 0]]`, which resolves to **off for everyone by default** and can be enabled locally via `~/.redis-insight/config.json`:

```json
{ "features": { "dev-array": true } }
```

This lets the in-progress Array feature be toggled on for testers without rebuilding or fighting the version-gated config sync (`getCustomConfig()` is read fresh at resolution time, so it's immune to the version gate). Config `version` is bumped `3.94 → 4` so the change propagates on the next sync.

No behavior change for anyone not opting in: with no override, `dev-array` resolves to `false` exactly as before.

# Testing

- `yarn type-check` passes (no new errors on ui/api/desktop).
- Default (no `config.json` override): `dev-array` resolves `false` for all users.
- Add `{ "features": { "dev-array": true } }` to `~/.redis-insight/config.json`, restart → Array key type shows (on a Redis ≥ 8.8 server); remove it → hidden.

---

Part of RI-8174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to an opt-in dev feature flag; default resolution stays off without a local override.
> 
> **Overview**
> The **`dev-array`** feature flag is switched from **`CommonFlagStrategy`** to **`SwitchableFlagStrategy`**, matching other dev flags that can be toggled per machine via **`~/.redis-insight/config.json`** (`features["dev-array"]`).
> 
> Shipped defaults change to **`flag: true`** with **`perc: [[0, 0]]`**, so the flag stays **off for everyone** unless a local override turns it on. **`features-config.json`** **`version`** is bumped **3.94 → 4** so clients pick up the new defaults on the next sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c24fc17cfa3638b870da291b81aceec8691e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->