### PR TITLE
feat(api): emit resource on interpolated error exceptions (RI-8268)

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Error Codes/Already Exists (resource).bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/Already Exists (resource).bru
@@ -1,0 +1,60 @@
+meta {
+  name: Already Exists (resource)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_URL}}/databases
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "errorcode-resource-demo",
+    "host": "localhost",
+    "port": 6379,
+    "cloudDetails": {
+      "cloudId": 1,
+      "subscriptionId": 1,
+      "subscriptionType": "fixed"
+    }
+  }
+}
+
+docs {
+  # DatabaseAlreadyExists — errorCode 11200 (with `resource`)
+
+  Creating a **cloud** database whose unique fields (host, port, username,
+  password, certs) match one that already exists returns `409`. The
+  `resource` block carries the structured context a client needs to both
+  translate the message and act on it — here, the existing database id.
+
+  **To trigger:** send this request twice (the first creates the database,
+  the second collides), or use cloud details that match a database you
+  already have.
+
+  ## Expected response (409)
+
+  ```
+  {
+    "message": "The database already exists.",
+    "statusCode": 409,
+    "error": "DatabaseAlreadyExists",
+    "errorCode": 11200,
+    "resource": {
+      "databaseId": "a1b2c3d4-0000-0000-0000-000000000000"
+    }
+  }
+  ```
+
+  This is the shape Task 4 standardises: a stable `errorCode` plus raw vars
+  in `resource`, with the English `message` kept as the fallback. The client
+  looks up the translated template by `errorCode` and fills it from
+  `resource`.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/Connection Failed (custom code).bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/Connection Failed (custom code).bru
@@ -1,0 +1,45 @@
+meta {
+  name: Connection Failed (custom code)
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_URL}}/databases/test
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "errorcode-demo",
+    "host": "localhost",
+    "port": 1111
+  }
+}
+
+docs {
+  # RedisConnectionFailed — errorCode 10900
+
+  Tries to connect to a host/port with nothing listening, so the API fails
+  to connect. Demonstrates a **custom exception that carries a specific
+  `errorCode`** — the client translates by that code; `message` is the
+  English fallback.
+
+  ## Expected response (~424)
+
+  ```
+  {
+    "message": "Could not connect to localhost:1111, please check ...",
+    "statusCode": 424,
+    "error": "RedisConnectionFailedException",
+    "errorCode": 10900
+  }
+  ```
+
+  > A refused port may surface a related subclass (e.g. timeout → 10901).
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/Import Unparseable File (resource filename).bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/Import Unparseable File (resource filename).bru
@@ -1,0 +1,50 @@
+meta {
+  name: Import Unparseable File (resource filename)
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{API_URL}}/databases/import
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file: @file(Error Codes/fixtures/broken-import.txt)
+}
+
+docs {
+  # DatabaseImportUnableToParseFile — errorCode 11706 (with `resource`)
+
+  Uploads a file that isn't a valid database export, so `parseFile` yields
+  no importable array and the service throws
+  `UnableToParseDatabaseImportFileException`. The exception now carries the
+  **filename structurally** in `resource.filename` (the same value baked
+  into `message`), so the client can localize `Unable to parse {{filename}}.`
+
+  Bruno resolves the `@file()` path relative to the **collection root**
+  (`redisinsight/api/bruno/RedisInsight/`), so the fixture lives at
+  `Error Codes/fixtures/broken-import.txt`.
+
+  ## Expected response (400)
+
+  ```
+  {
+    "message": "Unable to parse broken-import.txt",
+    "statusCode": 400,
+    "error": "Unable To Parse Database Import File",
+    "errorCode": 11706,
+    "resource": {
+      "filename": "broken-import.txt"
+    }
+  }
+  ```
+
+  > Filenames longer than 50 chars are truncated with `...` in both
+  > `message` and `resource.filename`.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/Not Found (generic code).bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/Not Found (generic code).bru
@@ -1,0 +1,36 @@
+meta {
+  name: Not Found (generic code)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_URL}}/databases/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: inherit
+}
+
+docs {
+  # GenericNotFound — errorCode 12404
+
+  Fetches a database by an id that does not exist. The handler throws a
+  built-in Nest `NotFoundException` (no specific code). The
+  `GlobalExceptionFilter` injects a **status-based generic code** (12_000 +
+  HTTP status, so 404 -> 12404) so even un-coded errors are translatable.
+  `message` stays the English fallback.
+
+  ## Expected response (404)
+
+  ```
+  {
+    "message": "Invalid database instance id.",
+    "statusCode": 404,
+    "error": "Not Found",
+    "errorCode": 12404
+  }
+  ```
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/Validation Error.bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/Validation Error.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Validation Error
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{API_URL}}/databases/test
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "errorcode-demo",
+    "host": "localhost",
+    "port": "not-a-number"
+  }
+}
+
+docs {
+  # ValidationError — errorCode 12100
+
+  Sends a body that fails class-validator (`port` is not a number). The
+  `GlobalExceptionFilter` detects the array `message` shape and injects a
+  dedicated **ValidationError** code, leaving the per-field messages intact.
+
+  ## Expected response (400)
+
+  ```
+  {
+    "message": [
+      "port must be a number conforming to the specified constraints"
+    ],
+    "statusCode": 400,
+    "error": "Bad Request",
+    "errorCode": 12100
+  }
+  ```
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/fixtures/broken-import.txt
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/fixtures/broken-import.txt
@@ -1,0 +1,1 @@
+this is not a valid RedisInsight database export

--- a/redisinsight/api/bruno/RedisInsight/Error Codes/folder.bru
+++ b/redisinsight/api/bruno/RedisInsight/Error Codes/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Error Codes
+}

--- a/redisinsight/api/src/common/exceptions/validation.exception.ts
+++ b/redisinsight/api/src/common/exceptions/validation.exception.ts
@@ -1,3 +1,13 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
-export class ValidationException extends BadRequestException {}
+export class ValidationException extends BadRequestException {
+  constructor(message = 'Bad request') {
+    super({
+      statusCode: HttpStatus.BAD_REQUEST,
+      error: 'Bad Request',
+      message,
+      errorCode: CustomErrorCodes.ValidationError,
+    });
+  }
+}

--- a/redisinsight/api/src/common/middlewares/body-parser.middleware.spec.ts
+++ b/redisinsight/api/src/common/middlewares/body-parser.middleware.spec.ts
@@ -1,0 +1,49 @@
+import { HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
+import bodyParserErrorHandler from './body-parser.middleware';
+
+const mockResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as unknown as Response & {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+};
+
+describe('bodyParserErrorHandler', () => {
+  it('stamps a generic errorCode on the 413 entity.too.large response', () => {
+    const res = mockResponse();
+    const next = jest.fn();
+
+    bodyParserErrorHandler(
+      { type: 'entity.too.large', name: 'PayloadTooLargeError' } as any,
+      {} as Request,
+      res,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.PAYLOAD_TOO_LARGE,
+        errorCode: 12_000 + HttpStatus.PAYLOAD_TOO_LARGE,
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('delegates non-payload errors to next()', () => {
+    const res = mockResponse();
+    const next = jest.fn();
+    const err = new Error('other');
+
+    bodyParserErrorHandler(err as any, {} as Request, res, next);
+
+    expect(next).toHaveBeenCalledWith(err);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});

--- a/redisinsight/api/src/common/middlewares/body-parser.middleware.ts
+++ b/redisinsight/api/src/common/middlewares/body-parser.middleware.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { PayloadTooLargeException, HttpStatus } from '@nestjs/common';
+import { stampErrorCode } from 'src/exceptions/error-code.util';
 import { Config, get } from 'src/utils';
 
 const serverConfig = get('server') as Config['server'];
@@ -26,7 +27,7 @@ export default (
         'Access-Control-Allow-Credentials',
         `${serverConfig.cors.credentials}`,
       )
-      .json(exception.getResponse());
+      .json(stampErrorCode(exception));
   }
 
   next(err);

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -86,4 +86,14 @@ export enum CustomErrorCodes {
   TunnelConnectionLost = 11_601,
   UnableToCreateTunnel = 11_602,
   UnableToCreateLocalServer = 11_603,
+
+  // Encryption [11800, 11899]
+  EncryptionServiceError = 11_800,
+  KeyDecryptionError = 11_801,
+  KeyEncryptionError = 11_802,
+  KeyUnavailable = 11_803,
+  KeytarDecryptionError = 11_804,
+  KeytarEncryptionError = 11_805,
+  KeytarUnavailable = 11_806,
+  UnsupportedEncryptionStrategy = 11_807,
 }

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -114,4 +114,16 @@ export enum CustomErrorCodes {
   // Misc / server [11900, 11999]
   UnableToFetchRemoteConfig = 11_900,
   ClientNotFound = 11_901,
+
+  // Generic fallbacks (injected by GlobalExceptionFilter); last 3 digits
+  // mirror the HTTP status, i.e. 12_000 + status [12400, 12599]
+  GenericBadRequest = 12_400,
+  GenericUnauthorized = 12_401,
+  GenericForbidden = 12_403,
+  GenericNotFound = 12_404,
+  GenericConflict = 12_409,
+  GenericServerError = 12_500,
+
+  // Validation, class-validator failures [12100, 12199]
+  ValidationError = 12_100,
 }

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -96,4 +96,17 @@ export enum CustomErrorCodes {
   KeytarEncryptionError = 11_805,
   KeytarUnavailable = 11_806,
   UnsupportedEncryptionStrategy = 11_807,
+
+  // Database Import [11700, 11799]
+  DatabaseImportInvalidSshBody = 11_700,
+  DatabaseImportInvalidSshPrivateKeyBody = 11_701,
+  DatabaseImportInvalidCaCertificateBody = 11_702,
+  DatabaseImportInvalidClientCertificateBody = 11_703,
+  DatabaseImportInvalidClientPrivateKey = 11_704,
+  DatabaseImportInvalidCertificateName = 11_705,
+  DatabaseImportUnableToParseFile = 11_706,
+  DatabaseImportNoFileProvided = 11_707,
+  DatabaseImportSizeLimitExceeded = 11_708,
+  DatabaseImportInvalidCompressor = 11_709,
+  DatabaseImportSshAgentsNotSupported = 11_710,
 }

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -80,6 +80,7 @@ export enum CustomErrorCodes {
   RdiStartPipelineFailure = 11_408,
   RdiStopPipelineFailure = 11_409,
   RdiBadRequest = 11_410,
+  RdiTimeout = 11_411,
 
   // SSH [11600, 11699]
   UnableToCreateSshConnection = 11_600,

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -80,4 +80,10 @@ export enum CustomErrorCodes {
   RdiStartPipelineFailure = 11_408,
   RdiStopPipelineFailure = 11_409,
   RdiBadRequest = 11_410,
+
+  // SSH [11600, 11699]
+  UnableToCreateSshConnection = 11_600,
+  TunnelConnectionLost = 11_601,
+  UnableToCreateTunnel = 11_602,
+  UnableToCreateLocalServer = 11_603,
 }

--- a/redisinsight/api/src/constants/custom-error-codes.ts
+++ b/redisinsight/api/src/constants/custom-error-codes.ts
@@ -110,4 +110,8 @@ export enum CustomErrorCodes {
   DatabaseImportSizeLimitExceeded = 11_708,
   DatabaseImportInvalidCompressor = 11_709,
   DatabaseImportSshAgentsNotSupported = 11_710,
+
+  // Misc / server [11900, 11999]
+  UnableToFetchRemoteConfig = 11_900,
+  ClientNotFound = 11_901,
 }

--- a/redisinsight/api/src/exceptions/error-code.util.ts
+++ b/redisinsight/api/src/exceptions/error-code.util.ts
@@ -1,0 +1,35 @@
+import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
+
+// Generic fallback code: 12_000 + HTTP status (404 -> 12_404).
+export const GENERIC_ERROR_CODE_BASE = 12_000;
+
+const resolveErrorCode = (status: number, message: unknown): number =>
+  Array.isArray(message)
+    ? CustomErrorCodes.ValidationError
+    : GENERIC_ERROR_CODE_BASE + status;
+
+// Additively stamp an errorCode onto an HttpException's serialized body. Shared
+// by GlobalExceptionFilter and paths that serialize exceptions directly (e.g.
+// the body-parser middleware).
+export const stampErrorCode = (
+  exception: HttpException,
+): Record<string, unknown> => {
+  const status = exception.getStatus();
+  const res = exception.getResponse();
+
+  // String responses serialize as { statusCode, message }; rebuild as an object.
+  if (typeof res === 'string') {
+    return {
+      statusCode: status,
+      message: res,
+      errorCode: resolveErrorCode(status, res),
+    };
+  }
+
+  const body = res as Record<string, unknown>;
+  if (body.errorCode === undefined) {
+    body.errorCode = resolveErrorCode(status, body.message);
+  }
+  return body;
+};

--- a/redisinsight/api/src/exceptions/global-exception.filter.spec.ts
+++ b/redisinsight/api/src/exceptions/global-exception.filter.spec.ts
@@ -1,0 +1,109 @@
+import { BaseExceptionFilter } from '@nestjs/core';
+import {
+  ArgumentsHost,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
+import { GlobalExceptionFilter } from './global-exception.filter';
+
+const mockHost = (url = '/api/databases'): ArgumentsHost =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ url }),
+      getResponse: () => ({ status: () => ({ json: () => undefined }) }),
+    }),
+  }) as unknown as ArgumentsHost;
+
+const errorCodeOf = (exception: HttpException): unknown =>
+  (exception.getResponse() as Record<string, unknown>).errorCode;
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+  let superCatch: jest.SpyInstance;
+
+  beforeEach(() => {
+    filter = new GlobalExceptionFilter();
+    // Skip the real BaseExceptionFilter serialization (needs an http adapter).
+    superCatch = jest
+      .spyOn(BaseExceptionFilter.prototype, 'catch')
+      .mockReturnValue(undefined as never);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('maps each known status to its generic error code', () => {
+    const cases: [HttpException, CustomErrorCodes][] = [
+      [new BadRequestException('x'), CustomErrorCodes.GenericBadRequest],
+      [new UnauthorizedException('x'), CustomErrorCodes.GenericUnauthorized],
+      [new ForbiddenException('x'), CustomErrorCodes.GenericForbidden],
+      [new NotFoundException('x'), CustomErrorCodes.GenericNotFound],
+      [new ConflictException('x'), CustomErrorCodes.GenericConflict],
+    ];
+
+    cases.forEach(([exception, code]) => {
+      filter.catch(exception, mockHost());
+      expect(errorCodeOf(exception)).toBe(code);
+    });
+    expect(superCatch).toHaveBeenCalledTimes(cases.length);
+  });
+
+  it('computes 12_000 + status for other HttpExceptions (e.g. 500)', () => {
+    const exception = new InternalServerErrorException('boom');
+    filter.catch(exception, mockHost());
+    expect(errorCodeOf(exception)).toBe(CustomErrorCodes.GenericServerError);
+  });
+
+  it('upgrades a string HttpException response to an object with a code', () => {
+    const exception = new HttpException('Invalid subscription id', 400);
+    filter.catch(exception, mockHost());
+    // string responses are rebuilt, so inspect the exception delegated to super
+    const delegated = superCatch.mock.calls[0][0] as HttpException;
+    expect(delegated.getResponse()).toEqual({
+      statusCode: 400,
+      message: 'Invalid subscription id',
+      errorCode: CustomErrorCodes.GenericBadRequest,
+    });
+  });
+
+  it('uses ValidationError when message is an array (class-validator)', () => {
+    const exception = new BadRequestException([
+      'port must be a number conforming to the specified constraints',
+    ]);
+    filter.catch(exception, mockHost());
+    expect(errorCodeOf(exception)).toBe(CustomErrorCodes.ValidationError);
+  });
+
+  it('does not overwrite an existing custom errorCode', () => {
+    const exception = new HttpException(
+      {
+        message: 'The database already exists.',
+        statusCode: 409,
+        error: 'DatabaseAlreadyExists',
+        errorCode: CustomErrorCodes.DatabaseAlreadyExists,
+      },
+      409,
+    );
+    filter.catch(exception, mockHost());
+    expect(errorCodeOf(exception)).toBe(CustomErrorCodes.DatabaseAlreadyExists);
+  });
+
+  it('leaves non-HttpException errors untouched', () => {
+    expect(() =>
+      filter.catch(new Error('unexpected'), mockHost()),
+    ).not.toThrow();
+    expect(superCatch).toHaveBeenCalled();
+  });
+
+  it('does not inject a code for the static-asset branch', () => {
+    const exception = new NotFoundException('x');
+    filter.catch(exception, mockHost('/static/plugins/foo.js'));
+    expect(errorCodeOf(exception)).toBeUndefined();
+    expect(superCatch).not.toHaveBeenCalled();
+  });
+});

--- a/redisinsight/api/src/exceptions/global-exception.filter.ts
+++ b/redisinsight/api/src/exceptions/global-exception.filter.ts
@@ -1,6 +1,10 @@
 import { BaseExceptionFilter } from '@nestjs/core';
-import { ArgumentsHost, Logger } from '@nestjs/common';
+import { ArgumentsHost, HttpException, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { CustomErrorCodes } from 'src/constants';
+
+// Generic fallback code: 12_000 + HTTP status (404 -> 12_404).
+const GENERIC_ERROR_CODE_BASE = 12_000;
 
 export class GlobalExceptionFilter extends BaseExceptionFilter {
   private staticServerLogger = new Logger('GlobalExceptionFilter');
@@ -21,6 +25,41 @@ export class GlobalExceptionFilter extends BaseExceptionFilter {
       });
     }
 
-    return super.catch(exception, host);
+    return super.catch(this.withErrorCode(exception), host);
+  }
+
+  // Stamp an errorCode onto any HttpException that lacks one (additive;
+  // exceptions with their own code are left untouched).
+  private withErrorCode(exception: Error): Error {
+    if (!(exception instanceof HttpException)) {
+      return exception;
+    }
+
+    const status = exception.getStatus();
+    const res = exception.getResponse();
+
+    // String responses serialize as { statusCode, message } — rebuild as an
+    // object so the errorCode can be attached.
+    if (typeof res === 'string') {
+      return new HttpException(
+        {
+          statusCode: status,
+          message: res,
+          errorCode: GENERIC_ERROR_CODE_BASE + status,
+        },
+        status,
+      );
+    }
+
+    if (res !== null && typeof res === 'object') {
+      const body = res as Record<string, unknown>;
+      if (body.errorCode === undefined) {
+        body.errorCode = Array.isArray(body.message)
+          ? CustomErrorCodes.ValidationError
+          : GENERIC_ERROR_CODE_BASE + status;
+      }
+    }
+
+    return exception;
   }
 }

--- a/redisinsight/api/src/exceptions/global-exception.filter.ts
+++ b/redisinsight/api/src/exceptions/global-exception.filter.ts
@@ -1,10 +1,7 @@
 import { BaseExceptionFilter } from '@nestjs/core';
 import { ArgumentsHost, HttpException, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { CustomErrorCodes } from 'src/constants';
-
-// Generic fallback code: 12_000 + HTTP status (404 -> 12_404).
-const GENERIC_ERROR_CODE_BASE = 12_000;
+import { stampErrorCode } from './error-code.util';
 
 export class GlobalExceptionFilter extends BaseExceptionFilter {
   private staticServerLogger = new Logger('GlobalExceptionFilter');
@@ -28,36 +25,17 @@ export class GlobalExceptionFilter extends BaseExceptionFilter {
     return super.catch(this.withErrorCode(exception), host);
   }
 
-  // Stamp an errorCode onto any HttpException that lacks one (additive;
-  // exceptions with their own code are left untouched).
   private withErrorCode(exception: Error): Error {
     if (!(exception instanceof HttpException)) {
       return exception;
     }
 
-    const status = exception.getStatus();
-    const res = exception.getResponse();
+    const body = stampErrorCode(exception);
 
-    // String responses serialize as { statusCode, message } — rebuild as an
-    // object so the errorCode can be attached.
-    if (typeof res === 'string') {
-      return new HttpException(
-        {
-          statusCode: status,
-          message: res,
-          errorCode: GENERIC_ERROR_CODE_BASE + status,
-        },
-        status,
-      );
-    }
-
-    if (res !== null && typeof res === 'object') {
-      const body = res as Record<string, unknown>;
-      if (body.errorCode === undefined) {
-        body.errorCode = Array.isArray(body.message)
-          ? CustomErrorCodes.ValidationError
-          : GENERIC_ERROR_CODE_BASE + status;
-      }
+    // String responses can't carry a code; rebuild. Object responses are
+    // mutated in place, so the original exception stands.
+    if (typeof exception.getResponse() === 'string') {
+      return new HttpException(body, exception.getStatus());
     }
 
     return exception;

--- a/redisinsight/api/src/modules/cloud/auth/exceptions/cloud-oauth.missed-required-data.exception.ts
+++ b/redisinsight/api/src/modules/cloud/auth/exceptions/cloud-oauth.missed-required-data.exception.ts
@@ -11,11 +11,14 @@ export class CloudOauthMissedRequiredDataException extends HttpException {
     message = ERROR_MESSAGES.CLOUD_OAUTH_MISSED_REQUIRED_DATA,
     options?: HttpExceptionOptions,
   ) {
+    const hasDetail =
+      message && message !== ERROR_MESSAGES.CLOUD_OAUTH_MISSED_REQUIRED_DATA;
     const response = {
       message,
       statusCode: HttpStatus.BAD_REQUEST,
       error: 'CloudOauthMissedRequiredData',
       errorCode: CustomErrorCodes.CloudOauthMissedRequiredData,
+      ...(hasDetail ? { resource: { detail: message } } : {}),
     };
 
     super(response, response.statusCode, options);

--- a/redisinsight/api/src/modules/cloud/job/exceptions/cloud-job-unexpected-error.exception.ts
+++ b/redisinsight/api/src/modules/cloud/job/exceptions/cloud-job-unexpected-error.exception.ts
@@ -11,11 +11,14 @@ export class CloudJobUnexpectedErrorException extends HttpException {
     message = ERROR_MESSAGES.CLOUD_JOB_UNEXPECTED_ERROR,
     options?: HttpExceptionOptions,
   ) {
+    const hasDetail =
+      message && message !== ERROR_MESSAGES.CLOUD_JOB_UNEXPECTED_ERROR;
     const response = {
       message,
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       error: 'CloudJobUnexpectedError',
       errorCode: CustomErrorCodes.CloudJobUnexpectedError,
+      ...(hasDetail ? { resource: { detail: message } } : {}),
       // cause: options?.cause, // todo: check
     };
 

--- a/redisinsight/api/src/modules/database-import/database-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.ts
@@ -153,9 +153,7 @@ export class DatabaseImportService {
         if (filename.length > 50) {
           filename = `${filename.slice(0, 50)}...`;
         }
-        throw new UnableToParseDatabaseImportFileException(
-          `Unable to parse ${filename}`,
-        );
+        throw new UnableToParseDatabaseImportFileException(filename);
       }
 
       let response = {

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-ca-certificate-body.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-ca-certificate-body.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidCaCertificateBodyException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_CA_BODY) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidCaCertificateBody,
       error: 'Invalid Ca Certificate Body',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-certificate-name.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-certificate-name.exception.ts
@@ -1,5 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidCertificateNameException extends HttpException {
   constructor(
@@ -8,6 +9,7 @@ export class InvalidCertificateNameException extends HttpException {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidCertificateName,
       error: 'Invalid Certificate Name',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-client-certificate-body.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-client-certificate-body.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidClientCertificateBodyException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_CERTIFICATE_BODY) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidClientCertificateBody,
       error: 'Invalid Client Certificate Body',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-client-private-key.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-client-private-key.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidClientPrivateKeyException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_PRIVATE_KEY) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidClientPrivateKey,
       error: 'Invalid Client Private Key',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-compressor.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-compressor.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidCompressorException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_COMPRESSOR) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidCompressor,
       error: 'Invalid compressor',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-ssh-body.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-ssh-body.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidSshBodyException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_SSH_BODY) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidSshBody,
       error: 'Invalid SSH body',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/invalid-ssh-private-key-body.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/invalid-ssh-private-key-body.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class InvalidSshPrivateKeyBodyException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.INVALID_SSH_PRIVATE_KEY_BODY) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportInvalidSshPrivateKeyBody,
       error: 'Invalid SSH Private Key Body',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/no-database-import-file-provided.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/no-database-import-file-provided.exception.ts
@@ -1,10 +1,12 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class NoDatabaseImportFileProvidedException extends HttpException {
   constructor(message: string = 'No import file provided') {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportNoFileProvided,
       error: 'No Database Import File Provided',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/size-limit-exceeded-database-import-file.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/size-limit-exceeded-database-import-file.exception.ts
@@ -1,10 +1,12 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class SizeLimitExceededDatabaseImportFileException extends HttpException {
   constructor(message: string = 'Invalid import file') {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportSizeLimitExceeded,
       error: 'Invalid Database Import File',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/ssh-agents-are-not-supported.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/ssh-agents-are-not-supported.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class SshAgentsAreNotSupportedException extends HttpException {
   constructor(message: string = ERROR_MESSAGES.SSH_AGENTS_ARE_NOT_SUPPORTED) {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportSshAgentsNotSupported,
       error: 'Ssh Agents Are Not Supported',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/unable-to-parse-database-import-file.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/unable-to-parse-database-import-file.exception.ts
@@ -1,10 +1,12 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class UnableToParseDatabaseImportFileException extends HttpException {
   constructor(message: string = 'Unable to parse import file') {
     const response = {
       message,
       statusCode: 400,
+      errorCode: CustomErrorCodes.DatabaseImportUnableToParseFile,
       error: 'Unable To Parse Database Import File',
     };
 

--- a/redisinsight/api/src/modules/database-import/exceptions/unable-to-parse-database-import-file.exception.ts
+++ b/redisinsight/api/src/modules/database-import/exceptions/unable-to-parse-database-import-file.exception.ts
@@ -2,12 +2,15 @@ import { HttpException } from '@nestjs/common';
 import { CustomErrorCodes } from 'src/constants';
 
 export class UnableToParseDatabaseImportFileException extends HttpException {
-  constructor(message: string = 'Unable to parse import file') {
+  constructor(filename?: string) {
     const response = {
-      message,
+      message: filename
+        ? `Unable to parse ${filename}`
+        : 'Unable to parse import file',
       statusCode: 400,
       errorCode: CustomErrorCodes.DatabaseImportUnableToParseFile,
       error: 'Unable To Parse Database Import File',
+      ...(filename ? { resource: { filename } } : {}),
     };
 
     super(response, 400);

--- a/redisinsight/api/src/modules/encryption/exceptions/encryption-service-error.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/encryption-service-error.exception.ts
@@ -1,4 +1,5 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class EncryptionServiceErrorException extends HttpException {
   constructor(
@@ -6,6 +7,7 @@ export class EncryptionServiceErrorException extends HttpException {
       message: 'Encryption service error',
       name: 'EncryptionServiceError',
       statusCode: 500,
+      errorCode: CustomErrorCodes.EncryptionServiceError,
     },
     status = 500,
   ) {

--- a/redisinsight/api/src/modules/encryption/exceptions/key-decryption-error.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/key-decryption-error.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeyDecryptionErrorException extends EncryptionServiceErrorException {
   constructor(message = 'Unable to decrypt data') {
@@ -7,6 +8,7 @@ export class KeyDecryptionErrorException extends EncryptionServiceErrorException
         message,
         name: 'KeyDecryptionError',
         statusCode: 500,
+        errorCode: CustomErrorCodes.KeyDecryptionError,
       },
       500,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/key-encryption-error.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/key-encryption-error.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeyEncryptionErrorException extends EncryptionServiceErrorException {
   constructor(message = 'Unable to encrypt data') {
@@ -7,6 +8,7 @@ export class KeyEncryptionErrorException extends EncryptionServiceErrorException
         message,
         name: 'KeyEncryptionError',
         statusCode: 500,
+        errorCode: CustomErrorCodes.KeyEncryptionError,
       },
       500,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/key-unavailable.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/key-unavailable.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeyUnavailableException extends EncryptionServiceErrorException {
   constructor(message = 'Encryption key unavailable') {
@@ -7,6 +8,7 @@ export class KeyUnavailableException extends EncryptionServiceErrorException {
         message,
         name: 'KeyUnavailable',
         statusCode: 503,
+        errorCode: CustomErrorCodes.KeyUnavailable,
       },
       503,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/keytar-decryption-error.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/keytar-decryption-error.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeytarDecryptionErrorException extends EncryptionServiceErrorException {
   constructor(message = 'Unable to decrypt data with Keytar') {
@@ -7,6 +8,7 @@ export class KeytarDecryptionErrorException extends EncryptionServiceErrorExcept
         message,
         name: 'KeytarDecryptionError',
         statusCode: 500,
+        errorCode: CustomErrorCodes.KeytarDecryptionError,
       },
       500,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/keytar-encryption-error.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/keytar-encryption-error.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeytarEncryptionErrorException extends EncryptionServiceErrorException {
   constructor(message = 'Unable to encrypt data with Keytar') {
@@ -7,6 +8,7 @@ export class KeytarEncryptionErrorException extends EncryptionServiceErrorExcept
         message,
         name: 'KeytarEncryptionError',
         statusCode: 500,
+        errorCode: CustomErrorCodes.KeytarEncryptionError,
       },
       500,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/keytar-unavailable.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/keytar-unavailable.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class KeytarUnavailableException extends EncryptionServiceErrorException {
   constructor(message = 'Keytar unavailable') {
@@ -7,6 +8,7 @@ export class KeytarUnavailableException extends EncryptionServiceErrorException 
         message,
         name: 'KeytarUnavailable',
         statusCode: 503,
+        errorCode: CustomErrorCodes.KeytarUnavailable,
       },
       503,
     );

--- a/redisinsight/api/src/modules/encryption/exceptions/unsupported-encryption-strategy.exception.ts
+++ b/redisinsight/api/src/modules/encryption/exceptions/unsupported-encryption-strategy.exception.ts
@@ -1,4 +1,5 @@
 import { EncryptionServiceErrorException } from 'src/modules/encryption/exceptions/encryption-service-error.exception';
+import { CustomErrorCodes } from 'src/constants';
 
 export class UnsupportedEncryptionStrategyException extends EncryptionServiceErrorException {
   constructor(message = 'Unsupported encryption strategy') {
@@ -7,6 +8,7 @@ export class UnsupportedEncryptionStrategyException extends EncryptionServiceErr
         message,
         name: 'UnsupportedEncryptionStrategy',
         statusCode: 500,
+        errorCode: CustomErrorCodes.UnsupportedEncryptionStrategy,
       },
       500,
     );

--- a/redisinsight/api/src/modules/feature/exceptions/unable-to-fetch-remote-config.exception.ts
+++ b/redisinsight/api/src/modules/feature/exceptions/unable-to-fetch-remote-config.exception.ts
@@ -1,4 +1,5 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class UnableToFetchRemoteConfigException extends HttpException {
   constructor(
@@ -6,6 +7,7 @@ export class UnableToFetchRemoteConfigException extends HttpException {
       message: 'Unable to fetch remote config',
       name: 'UnableToFetchRemoteConfigException',
       statusCode: 500,
+      errorCode: CustomErrorCodes.UnableToFetchRemoteConfig,
     },
     status = 500,
   ) {

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.bad-request.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.bad-request.exception.ts
@@ -11,12 +11,14 @@ export class RdiPipelineBadRequestException extends HttpException {
     message = ERROR_MESSAGES.BAD_REQUEST,
     options?: HttpExceptionOptions & { details?: unknown },
   ) {
+    const hasDetail = message && message !== ERROR_MESSAGES.BAD_REQUEST;
     const response = {
       message,
       statusCode: HttpStatus.BAD_REQUEST,
       error: 'RdiBadRequest',
       errorCode: CustomErrorCodes.RdiBadRequest,
       detail: options?.details,
+      ...(hasDetail ? { resource: { detail: message } } : {}),
     };
 
     super(response, response.statusCode, options);

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.error.handler.spec.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.error.handler.spec.ts
@@ -157,6 +157,7 @@ describe('wrapRdiPipelineError', () => {
       message: errorMessages.INTERNAL_SERVER_ERROR,
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       error: 'RdiInternalServerError',
+      errorCode: CustomErrorCodes.RdiInternalServerError,
     });
   });
 });

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.error.handler.spec.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.error.handler.spec.ts
@@ -37,6 +37,7 @@ describe('wrapRdiPipelineError', () => {
       statusCode: HttpStatus.UNAUTHORIZED,
       error: 'RdiUnauthorized',
       errorCode: CustomErrorCodes.RdiUnauthorized,
+      resource: { detail: result.message },
     });
   });
 
@@ -76,6 +77,7 @@ describe('wrapRdiPipelineError', () => {
       statusCode: HttpStatus.FORBIDDEN,
       error: 'RdiForbidden',
       errorCode: CustomErrorCodes.RdiForbidden,
+      resource: { detail: result.message },
     });
   });
 

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.forbidden.exception.spec.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.forbidden.exception.spec.ts
@@ -24,6 +24,7 @@ describe('RdiPipelineForbiddenException', () => {
       message: customMessage,
       error: 'RdiForbidden',
       errorCode: CustomErrorCodes.RdiForbidden,
+      resource: { detail: customMessage },
     });
   });
 });

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.forbidden.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.forbidden.exception.ts
@@ -11,11 +11,13 @@ export class RdiPipelineForbiddenException extends HttpException {
     message = ERROR_MESSAGES.FORBIDDEN,
     options?: HttpExceptionOptions & { details?: unknown },
   ) {
+    const hasDetail = message && message !== ERROR_MESSAGES.FORBIDDEN;
     const response = {
       message,
       statusCode: HttpStatus.FORBIDDEN,
       error: 'RdiForbidden',
       errorCode: CustomErrorCodes.RdiForbidden,
+      ...(hasDetail ? { resource: { detail: message } } : {}),
     };
 
     super(response, response.statusCode, options);

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.internal-server-error.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.internal-server-error.exception.ts
@@ -11,11 +11,14 @@ export class RdiPipelineInternalServerErrorException extends HttpException {
     message = ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
     options?: HttpExceptionOptions,
   ) {
+    const hasDetail =
+      message && message !== ERROR_MESSAGES.INTERNAL_SERVER_ERROR;
     const response = {
       message,
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       errorCode: CustomErrorCodes.RdiInternalServerError,
       error: 'RdiInternalServerError',
+      ...(hasDetail ? { resource: { detail: message } } : {}),
     };
 
     super(response, HttpStatus.INTERNAL_SERVER_ERROR, options);

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.internal-server-error.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.internal-server-error.exception.ts
@@ -4,6 +4,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class RdiPipelineInternalServerErrorException extends HttpException {
   constructor(
@@ -13,6 +14,7 @@ export class RdiPipelineInternalServerErrorException extends HttpException {
     const response = {
       message,
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      errorCode: CustomErrorCodes.RdiInternalServerError,
       error: 'RdiInternalServerError',
     };
 

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.not-found.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.not-found.exception.ts
@@ -9,7 +9,10 @@ import ERROR_MESSAGES from 'src/constants/error-messages';
 export class RdiPipelineNotFoundException extends HttpException {
   constructor(
     message = ERROR_MESSAGES.BAD_REQUEST,
-    options?: HttpExceptionOptions & { details?: unknown },
+    options?: HttpExceptionOptions & {
+      details?: unknown;
+      resource?: Record<string, unknown>;
+    },
   ) {
     const response = {
       message,
@@ -17,6 +20,7 @@ export class RdiPipelineNotFoundException extends HttpException {
       error: 'RdiNotFound',
       errorCode: CustomErrorCodes.RdiNotFound,
       details: options?.details,
+      ...(options?.resource ? { resource: options.resource } : {}),
     };
     super(response, response.statusCode, options);
   }

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.timeout-error.exception.spec.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.timeout-error.exception.spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 import errorMessages from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 import { RdiPipelineTimeoutException } from './rdi-pipeline.timeout-error.exception';
 
 describe('RdiPipelineTimeoutException', () => {
@@ -8,6 +9,7 @@ describe('RdiPipelineTimeoutException', () => {
     expect(exception.getStatus()).toBe(HttpStatus.REQUEST_TIMEOUT);
     expect(exception.getResponse()).toEqual({
       statusCode: HttpStatus.REQUEST_TIMEOUT,
+      errorCode: CustomErrorCodes.RdiTimeout,
       message: errorMessages.RDI_TIMEOUT_ERROR,
       error: 'Timeout Error',
     });
@@ -19,6 +21,7 @@ describe('RdiPipelineTimeoutException', () => {
     expect(exception.getStatus()).toBe(HttpStatus.REQUEST_TIMEOUT);
     expect(exception.getResponse()).toEqual({
       statusCode: HttpStatus.REQUEST_TIMEOUT,
+      errorCode: CustomErrorCodes.RdiTimeout,
       message: customMessage,
       error: 'Timeout Error',
     });

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.timeout-error.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.timeout-error.exception.ts
@@ -1,11 +1,13 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { CustomErrorCodes } from 'src/constants';
 
 export class RdiPipelineTimeoutException extends HttpException {
   constructor(message = ERROR_MESSAGES.RDI_TIMEOUT_ERROR) {
     super(
       {
         statusCode: HttpStatus.REQUEST_TIMEOUT,
+        errorCode: CustomErrorCodes.RdiTimeout,
         message,
         error: 'Timeout Error',
       },

--- a/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.unauthorized.exception.ts
+++ b/redisinsight/api/src/modules/rdi/exceptions/rdi-pipeline.unauthorized.exception.ts
@@ -11,11 +11,13 @@ export class RdiPipelineUnauthorizedException extends HttpException {
     message = ERROR_MESSAGES.UNAUTHORIZED,
     options?: HttpExceptionOptions & { details?: unknown },
   ) {
+    const hasDetail = message && message !== ERROR_MESSAGES.UNAUTHORIZED;
     const response = {
       message,
       statusCode: HttpStatus.UNAUTHORIZED,
       error: 'RdiUnauthorized',
       errorCode: CustomErrorCodes.RdiUnauthorized,
+      ...(hasDetail ? { resource: { detail: message } } : {}),
     };
 
     super(response, response.statusCode, options);

--- a/redisinsight/api/src/modules/rdi/rdi.service.ts
+++ b/redisinsight/api/src/modules/rdi/rdi.service.ts
@@ -52,7 +52,12 @@ export class RdiService {
     const rdi = await this.repository.get(id);
 
     if (!rdi) {
-      throw new RdiPipelineNotFoundException(`RDI with id ${id} was not found`);
+      throw new RdiPipelineNotFoundException(
+        `RDI with id ${id} was not found`,
+        {
+          resource: { id },
+        },
+      );
     }
 
     return rdi;

--- a/redisinsight/api/src/modules/redis/exceptions/client-not-found-error.exception.ts
+++ b/redisinsight/api/src/modules/redis/exceptions/client-not-found-error.exception.ts
@@ -1,4 +1,5 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 
 export class ClientNotFoundErrorException extends HttpException {
   constructor(
@@ -6,6 +7,7 @@ export class ClientNotFoundErrorException extends HttpException {
       message: 'Client not found or it has been disconnected.',
       name: 'ClientNotFoundError',
       statusCode: 404,
+      errorCode: CustomErrorCodes.ClientNotFound,
     },
     status = 404,
   ) {

--- a/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-failed.exception.ts
+++ b/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-failed.exception.ts
@@ -22,11 +22,16 @@ export class RedisConnectionFailedException extends HttpException {
     let response: Record<string, any>;
 
     if (isString(message)) {
+      // Expose the underlying error as a structured detail so the UI can
+      // localize the framing and interpolate it.
+      const hasDetail =
+        message && message !== ERROR_MESSAGES.REDIS_CONNECTION_FAILED;
       response = {
         message,
         error: 'RedisConnectionFailedException',
         statusCode: RedisConnectionFailedStatusCode,
         errorCode: CustomErrorCodes.RedisConnectionFailed,
+        ...(hasDetail ? { resource: { detail: message } } : {}),
       };
     } else {
       response = message;

--- a/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-incorrect-certificate.exception.ts
+++ b/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-incorrect-certificate.exception.ts
@@ -7,16 +7,14 @@ import {
 } from 'src/modules/redis/exceptions/connection/redis-connection-failed.exception';
 
 export class RedisConnectionIncorrectCertificateException extends RedisConnectionFailedException {
-  constructor(
-    message: string = ERROR_MESSAGES.INCORRECT_CERTIFICATES('this host'),
-    options?: HttpExceptionOptions,
-  ) {
+  constructor(url: string = 'this host', options?: HttpExceptionOptions) {
     super(
       {
-        message,
+        message: ERROR_MESSAGES.INCORRECT_CERTIFICATES(url),
         error: 'RedisConnectionIncorrectCertificateException',
         statusCode: RedisConnectionFailedStatusCode,
         errorCode: CustomErrorCodes.RedisConnectionIncorrectCertificate,
+        resource: { url },
       },
       options,
     );

--- a/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-unavailable.exception.ts
+++ b/redisinsight/api/src/modules/redis/exceptions/connection/redis-connection-unavailable.exception.ts
@@ -7,16 +7,14 @@ import {
 } from 'src/modules/redis/exceptions/connection/redis-connection-failed.exception';
 
 export class RedisConnectionUnavailableException extends RedisConnectionFailedException {
-  constructor(
-    message: string = ERROR_MESSAGES.INCORRECT_DATABASE_URL('this host'),
-    options?: HttpExceptionOptions,
-  ) {
+  constructor(url: string = 'this host', options?: HttpExceptionOptions) {
     super(
       {
-        message,
+        message: ERROR_MESSAGES.INCORRECT_DATABASE_URL(url),
         error: 'RedisConnectionUnavailableException',
         statusCode: RedisConnectionFailedStatusCode,
         errorCode: CustomErrorCodes.RedisConnectionUnavailable,
+        resource: { url },
       },
       options,
     );

--- a/redisinsight/api/src/modules/ssh/exceptions/tunnel-connection-lost.exception.ts
+++ b/redisinsight/api/src/modules/ssh/exceptions/tunnel-connection-lost.exception.ts
@@ -1,5 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import { sanitizeMessage } from '../utils';
+import { CustomErrorCodes } from 'src/constants';
 
 export class TunnelConnectionLostException extends HttpException {
   constructor(message = '') {
@@ -10,6 +11,7 @@ export class TunnelConnectionLostException extends HttpException {
         message: `${prepend} ${sanitizedMessage}`,
         name: 'TunnelConnectionLostException',
         statusCode: 500,
+        errorCode: CustomErrorCodes.TunnelConnectionLost,
       },
       500,
     );

--- a/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-local-server.exception.ts
+++ b/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-local-server.exception.ts
@@ -1,5 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import { sanitizeMessage } from '../utils';
+import { CustomErrorCodes } from 'src/constants';
 
 export class UnableToCreateLocalServerException extends HttpException {
   constructor(message = '') {
@@ -10,6 +11,7 @@ export class UnableToCreateLocalServerException extends HttpException {
         message: `${prepend} ${sanitizedMessage}`,
         name: 'UnableToCreateLocalServerException',
         statusCode: 500,
+        errorCode: CustomErrorCodes.UnableToCreateLocalServer,
       },
       500,
     );

--- a/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-ssh-connection.exception.ts
+++ b/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-ssh-connection.exception.ts
@@ -1,4 +1,5 @@
 import { HttpException } from '@nestjs/common';
+import { CustomErrorCodes } from 'src/constants';
 import { sanitizeMessage } from '../utils';
 
 export class UnableToCreateSshConnectionException extends HttpException {
@@ -10,6 +11,7 @@ export class UnableToCreateSshConnectionException extends HttpException {
         message: `${prepend} ${sanitizedMessage}`,
         name: 'UnableToCreateSshConnectionException',
         statusCode: 503,
+        errorCode: CustomErrorCodes.UnableToCreateSshConnection,
       },
       503,
     );

--- a/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-tunnel.exception.ts
+++ b/redisinsight/api/src/modules/ssh/exceptions/unable-to-create-tunnel.exception.ts
@@ -1,5 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import { sanitizeMessage } from '../utils';
+import { CustomErrorCodes } from 'src/constants';
 
 export class UnableToCreateTunnelException extends HttpException {
   constructor(message = '') {
@@ -10,6 +11,7 @@ export class UnableToCreateTunnelException extends HttpException {
         message: `${prepend} ${sanitizedMessage}`,
         name: 'UnableToCreateTunnelException',
         statusCode: 500,
+        errorCode: CustomErrorCodes.UnableToCreateTunnel,
       },
       500,
     );

--- a/redisinsight/api/src/utils/catch-redis-errors.spec.ts
+++ b/redisinsight/api/src/utils/catch-redis-errors.spec.ts
@@ -14,7 +14,6 @@ import {
 } from 'src/utils/catch-redis-errors';
 import { ReplyError } from 'src/models';
 import { CertificatesErrorCodes, RedisErrorCodes } from 'src/constants';
-import ERROR_MESSAGES from 'src/constants/error-messages';
 import {
   BadRequestException,
   ForbiddenException,
@@ -71,30 +70,22 @@ describe('catch-redis-errors', () => {
       },
       {
         error: new Error(RedisErrorCodes.ConnectionRefused),
-        output: new RedisConnectionUnavailableException(
-          ERROR_MESSAGES.INCORRECT_DATABASE_URL(urlPlaceholder),
-        ),
+        output: new RedisConnectionUnavailableException(urlPlaceholder),
       },
       {
         error: new Error(RedisErrorCodes.ConnectionNotFound),
-        output: new RedisConnectionUnavailableException(
-          ERROR_MESSAGES.INCORRECT_DATABASE_URL(urlPlaceholder),
-        ),
+        output: new RedisConnectionUnavailableException(urlPlaceholder),
       },
       {
         error: new Error(RedisErrorCodes.DNSTimeoutError),
-        output: new RedisConnectionUnavailableException(
-          ERROR_MESSAGES.INCORRECT_DATABASE_URL(urlPlaceholder),
-        ),
+        output: new RedisConnectionUnavailableException(urlPlaceholder),
       },
       {
         error: {
           message: 'some message',
           code: RedisErrorCodes.ConnectionReset,
         },
-        output: new RedisConnectionUnavailableException(
-          ERROR_MESSAGES.INCORRECT_DATABASE_URL(urlPlaceholder),
-        ),
+        output: new RedisConnectionUnavailableException(urlPlaceholder),
       },
       {
         error: {
@@ -102,7 +93,7 @@ describe('catch-redis-errors', () => {
           code: CertificatesErrorCodes.IncorrectCertificates,
         },
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
@@ -111,7 +102,7 @@ describe('catch-redis-errors', () => {
           code: CertificatesErrorCodes.DepthZeroSelfSignedCert,
         },
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
@@ -120,7 +111,7 @@ describe('catch-redis-errors', () => {
           code: CertificatesErrorCodes.SelfSignedCertInChain,
         },
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
@@ -129,31 +120,31 @@ describe('catch-redis-errors', () => {
           code: CertificatesErrorCodes.OSSLError,
         },
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
         error: new Error('SSL error'),
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
         error: new Error(CertificatesErrorCodes.OSSLError),
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
         error: new Error(CertificatesErrorCodes.IncorrectCertificates),
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
       {
         error: new Error('ERR unencrypted connection is prohibited'),
         output: new RedisConnectionIncorrectCertificateException(
-          ERROR_MESSAGES.INCORRECT_CERTIFICATES(urlPlaceholder),
+          urlPlaceholder,
         ),
       },
     ])('should handle %j', ({ error, output }) => {

--- a/redisinsight/api/src/utils/catch-redis-errors.ts
+++ b/redisinsight/api/src/utils/catch-redis-errors.ts
@@ -94,18 +94,14 @@ export const getRedisConnectionException = (
       error?.code === RedisErrorCodes.ConnectionReset
     ) {
       return new RedisConnectionUnavailableException(
-        ERROR_MESSAGES.INCORRECT_DATABASE_URL(
-          errorPlaceholder || `${host}:${port}`,
-        ),
+        errorPlaceholder || `${host}:${port}`,
         { cause: error },
       );
     }
 
     if (isCertError(error)) {
       return new RedisConnectionIncorrectCertificateException(
-        ERROR_MESSAGES.INCORRECT_CERTIFICATES(
-          errorPlaceholder || `${host}:${port}`,
-        ),
+        errorPlaceholder || `${host}:${port}`,
         { cause: error },
       );
     }

--- a/redisinsight/api/test/api/rdi/GET-rdi-id.test.ts
+++ b/redisinsight/api/test/api/rdi/GET-rdi-id.test.ts
@@ -48,6 +48,7 @@ describe('GET /rdi/:id', () => {
           statusCode: 404,
           error: 'RdiNotFound',
           errorCode: 11405,
+          resource: { id: notExistedRdiId },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/PATCH-rdi-id.test.ts
+++ b/redisinsight/api/test/api/rdi/PATCH-rdi-id.test.ts
@@ -105,6 +105,7 @@ describe('PATCH /rdi/:id', () => {
           statusCode: 401,
           error: 'RdiUnauthorized',
           errorCode: 11402,
+          resource: { detail: 'Unauthorized' },
         },
         before: () => {
           loginNock.reply(401, {

--- a/redisinsight/api/test/api/rdi/POST-rdi.test.ts
+++ b/redisinsight/api/test/api/rdi/POST-rdi.test.ts
@@ -100,6 +100,7 @@ describe('POST /rdi', () => {
           statusCode: 401,
           error: 'RdiUnauthorized',
           errorCode: 11402,
+          resource: { detail: 'Unauthorized' },
         },
       },
     ].forEach(mainCheckFn);

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-config-template-pipelineType-dbType.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-config-template-pipelineType-dbType.test.ts
@@ -77,6 +77,7 @@ describe('GET /rdi/:id/pipeline/config/template/:pipelineType/:dbType', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-job-functions.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-job-functions.test.ts
@@ -67,6 +67,7 @@ describe('GET /rdi/:id/pipeline/job-functions', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-job-template-pipelineType.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-job-template-pipelineType.test.ts
@@ -76,6 +76,7 @@ describe('GET /rdi/:id/pipeline/job/template/:pipelineType', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-schema.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-schema.test.ts
@@ -72,6 +72,7 @@ describe('GET /rdi/:id/pipeline/schema', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-status.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-status.test.ts
@@ -135,6 +135,7 @@ describe('GET /rdi/:id/pipeline/status', () => {
             errorCode: 11402,
             message: 'Unauthorized',
             statusCode: 401,
+            resource: { detail: 'Unauthorized' },
           });
         },
         before: async () => {
@@ -197,6 +198,7 @@ describe('GET /rdi/:id/pipeline/status', () => {
             errorCode: 11402,
             message: 'Unauthorized',
             statusCode: 401,
+            resource: { detail: 'Unauthorized' },
           });
         },
         before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-strategies.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline-strategies.test.ts
@@ -67,6 +67,7 @@ describe('GET /rdi/:id/pipeline/strategies', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/GET-rdi-id-pipeline.test.ts
@@ -111,6 +111,7 @@ describe('GET /rdi/:id/pipeline/', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/POST-rdi-id-pipeline-dry-run-job.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/POST-rdi-id-pipeline-dry-run-job.test.ts
@@ -109,6 +109,7 @@ describe('POST /rdi/:id/pipeline/dry-run-job', () => {
           errorCode: 11402,
           message: 'Unauthorized',
           statusCode: 401,
+          resource: { detail: 'Unauthorized' },
         });
       },
       before: async () => {

--- a/redisinsight/api/test/api/rdi/pipeline/POST-rdi-id-pipeline-test-connections.test.ts
+++ b/redisinsight/api/test/api/rdi/pipeline/POST-rdi-id-pipeline-test-connections.test.ts
@@ -189,6 +189,7 @@ describe('POST /rdi/:id/pipeline/test-connections', () => {
             errorCode: 11402,
             message: 'Unauthorized',
             statusCode: 401,
+            resource: { detail: 'Unauthorized' },
           });
         },
         before: async () => {


### PR DESCRIPTION
## What

Exposes the runtime value(s) baked into freeform error `message` strings as a structured `resource` object, so the UI can look up a translated template by `errorCode` and interpolate the value.

The English `message` stays on every exception (backwards-compatible for the VS Code plugin / non-i18n consumers); we only **add** `resource`.

### Structured (`resource: { <var> }`)
| Code | Exception | `resource` |
|------|-----------|-----------|
| 10904 | `RedisConnectionUnavailable` | `{ url }` |
| 10907 | `RedisConnectionIncorrectCertificate` | `{ url }` |
| 11706 | `DatabaseImportUnableToParseFile` | `{ filename }` |

## Example payload

`DatabaseImportUnableToParseFile` (11706):

```json
{
  "message": "Unable to parse my-databases.json",
  "statusCode": 400,
  "error": "Unable To Parse Database Import File",
  "errorCode": 11706,
  "resource": { "filename": "my-databases.json" }
}
```

## Tests

Extended the exception/handler specs to assert `resource` alongside `message`/`errorCode` (structured `url`, freeform-with-detail present, freeform-default omitted).

## Notes

- Frontend PR #6142 (locale `.message` with `{{url}}`/`{{filename}}`/`{{detail}}`) consumes this and depends on it being live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON fields on error responses with broad test updates; no auth or data-path behavior changes beyond richer error metadata.
> 
> **Overview**
> Adds an optional **`resource`** object to API error payloads so clients can localize by `errorCode` and interpolate values, while keeping the existing English **`message`** unchanged.
> 
> **Structured fields:** Redis connection unavailable/incorrect-certificate exceptions now take a **`url`** argument and include `resource: { url }`. Database import parse failures pass **`filename`** (truncated like the message) and expose `resource: { filename }`. Missing RDI instances attach `resource: { id }` from `RdiService.get`.
> 
> **Freeform detail:** When the message differs from the default template, several exceptions add `resource: { detail: message }` (cloud OAuth/job errors, RDI pipeline auth/forbidden/bad-request/internal errors, and generic Redis connection failures with a custom string).
> 
> **Call sites & tests:** `catch-redis-errors` and import service call sites were updated for the new constructor shapes. Bruno documents the import 11706 response; API/unit/RDI integration tests assert the new `resource` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53741ec87562790ef030adac41bd4038f0dc1b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


