### PR TITLE
fix(e2e): bump Playwright to 1.61.1 to fix install hang on Node 24.16

### DIFF
--- a/tests/e2e-playwright/package-lock.json
+++ b/tests/e2e-playwright/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.18.1",
         "@typescript-eslint/parser": "^8.18.1",
@@ -240,13 +240,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1995,13 +1995,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tests/e2e-playwright/package.json
+++ b/tests/e2e-playwright/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.1",
     "@typescript-eslint/parser": "^8.18.1",


### PR DESCRIPTION
# What

The nightly **E2E Playwright Tests (v2)** workflow has been hanging at `playwright install` ("Downloading Chromium…") and hitting the 1h job timeout every night since ~2026-06-23 — silently, because a `timeout-minutes` kill is a `cancelled` result and the Slack alert only fires on `failure`.

Root cause: Node was bumped to 24.16.0 ([#6008](https://github.com/redis/RedisInsight/pull/6008)), and **Playwright 1.57.0's browser installer hangs after download on Node 24.16.0** — a known Node zip-extraction (`extract-zip`/`yauzl`) regression that also affected Cypress. Fixed upstream in **Playwright 1.60.0** ([microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000), [#40998](https://github.com/microsoft/playwright/issues/40998); no backport to 1.57.x).

This bumps `@playwright/test` 1.57.0 → **1.61.1**. The lockfile change also invalidates the stale `~/.cache/ms-playwright` browser cache, forcing a clean 1.61.1 install.

A more defensive alternative that bypasses Playwright's downloader entirely (curl-based install) is kept on branch `fix/e2e-playwright-cdn-install-hang` as a fallback.

# Testing

Triggered the E2E workflow on this branch ([run 28571097465](https://github.com/redis/RedisInsight/actions/runs/28571097465)) on a fresh cache-miss: the browser install completed successfully in ~30s (vs the prior 1h hang) and the Playwright tests ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only E2E dependency bump with no application runtime changes; main effect is restored nightly E2E installs on Node 24.16.
> 
> **Overview**
> Bumps **`@playwright/test`** (and locked **`playwright`** / **`playwright-core`**) from **1.57.0** to **1.61.1** in `tests/e2e-playwright` only, so `playwright install` no longer hangs after browser download on **Node 24.16** (upstream fix from 1.60.0+).
> 
> The **`package-lock.json`** update also changes the hash used by CI’s Playwright browser cache (`.github/actions/setup-e2e-playwright`), forcing a fresh browser install aligned with 1.61.1 instead of reusing a 1.57.0 cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2293072167dd798412d2a5e365476412f45a1c54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->