### PR TITLE
RI-8279 Add language picker in settings

### DIFF
--- a/redisinsight/api/bruno/RedisInsight/Settings/Get Settings.bru
+++ b/redisinsight/api/bruno/RedisInsight/Settings/Get Settings.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Get Settings
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_URL}}/settings
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get Settings
+
+  Fetches the current application settings via `GET /settings`. Use this to
+  confirm the `language` value persisted after calling **Update Language**.
+
+  ## Response
+
+  Returns `200 OK` with the full settings object:
+
+  ```
+  {
+    "theme": "DARK",
+    "language": "bg",
+    "dateFormat": null,
+    "timezone": null,
+    "scanThreshold": 10000,
+    "batchSize": 5,
+    "acceptTermsAndConditionsOverwritten": false,
+    "agreements": { "version": "1.0.0", "eula": true, "analytics": true }
+  }
+  ```
+
+  `language` is `null` until a user sets it.
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Settings/Update Language.bru
+++ b/redisinsight/api/bruno/RedisInsight/Settings/Update Language.bru
@@ -1,0 +1,79 @@
+meta {
+  name: Update Language
+  type: http
+  seq: 1
+}
+
+patch {
+  url: {{API_URL}}/settings
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "language": "bg"
+  }
+}
+
+docs {
+  # Update Language
+
+  Sets the application display language via `PATCH /settings`. The value is
+  persisted in the agnostic user-settings config (the same JSON blob that
+  stores `theme`, `dateFormat`, and `timezone`) and is applied app-wide on the
+  next load by the UI.
+
+  The example above switches the UI to Bulgarian (`bg`). Send `"en"` to switch
+  back to English.
+
+  ## Request Body
+
+  All fields are optional — send only the ones you want to change.
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `language` | string | Locale code to apply. Currently supported: `en`, `bg`. Unknown codes fall back to `en` at render time. |
+  | `theme` | string (optional) | Color theme, e.g. `DARK`, `LIGHT`, `SYSTEM`. |
+  | `dateFormat` | string (optional) | Applied date format. |
+  | `timezone` | string (optional) | `local` or `UTC`. |
+  | `scanThreshold` | number (optional) | Scan threshold (min 500). |
+  | `batchSize` | number (optional) | Workbench pipeline batch size. |
+
+  ## Response
+
+  Returns `200 OK` with the full, updated settings object, including the new
+  `language`:
+
+  ```
+  {
+    "theme": "DARK",
+    "language": "bg",
+    "dateFormat": null,
+    "timezone": null,
+    "scanThreshold": 10000,
+    "batchSize": 5,
+    "acceptTermsAndConditionsOverwritten": false,
+    "agreements": { "version": "1.0.0", "eula": true, "analytics": true }
+  }
+  ```
+
+  ## Notes
+
+  - The language **picker** in Settings is gated behind the switchable
+    `dev-language` feature flag (off by default; overridable on via
+    `~/.redis-insight/config.json`). This API endpoint accepts `language`
+    regardless of the flag — the flag only controls UI visibility.
+  - `language` defaults to `null` for users who have never set it; the UI then
+    uses the default language (`en`) or the `?lang=` query-param override.
+
+  ## Error Responses
+
+  | Status | Condition |
+  |--------|-----------|
+  | `400` | Validation failed (e.g. `language` is not a string). |
+}
+
+settings {
+  encodeUrl: true
+}

--- a/redisinsight/api/bruno/RedisInsight/Settings/folder.bru
+++ b/redisinsight/api/bruno/RedisInsight/Settings/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Settings
+}

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -3,7 +3,8 @@
   "features": {
     "dev-language": {
       "flag": true,
-      "perc": [[0, 0]]
+      "perc": [[0, 0]],
+      "filters": []
     },
     "redisDataIntegration": {
       "flag": true,

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,6 +1,10 @@
 {
-  "version": 4,
+  "version": 5,
   "features": {
+    "dev-language": {
+      "flag": true,
+      "perc": [[0, 0]]
+    },
     "redisDataIntegration": {
       "flag": true,
       "perc": [[0, 100]],

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -39,6 +39,7 @@ export enum KnownFeatures {
   VectorSet = 'vectorSet',
   DevArray = 'dev-array',
   ProdMode = 'prodMode',
+  DevLanguage = 'dev-language',
 }
 
 export interface IFeatureFlag {

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -95,4 +95,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.ProdMode,
     storage: FeatureStorage.Database,
   },
+  [KnownFeatures.DevLanguage]: {
+    name: KnownFeatures.DevLanguage,
+    storage: FeatureStorage.Database,
+  },
 };

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -114,6 +114,13 @@ export class FeatureFlagProvider {
       KnownFeatures.ProdMode,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
+    this.strategies.set(
+      KnownFeatures.DevLanguage,
+      new SwitchableFlagStrategy(
+        this.featuresConfigService,
+        this.settingsService,
+      ),
+    );
   }
 
   getStrategy(name: string): FeatureFlagStrategy {

--- a/redisinsight/api/src/modules/settings/dto/settings.dto.ts
+++ b/redisinsight/api/src/modules/settings/dto/settings.dto.ts
@@ -91,6 +91,15 @@ export class GetAppSettingsResponse {
   theme: string = null;
 
   @ApiProperty({
+    description: 'Applied application language.',
+    type: String,
+    example: 'en',
+  })
+  @Expose()
+  @Default(null)
+  language: string | null = null;
+
+  @ApiProperty({
     description: 'Applied application date format',
     type: String,
     example: 'yyyy-mm-dd',
@@ -161,6 +170,15 @@ export class UpdateSettingsDto {
   @IsOptional()
   @IsString()
   theme?: string;
+
+  @ApiPropertyOptional({
+    description: 'Application language.',
+    type: String,
+    example: 'en',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string;
 
   @ApiPropertyOptional({
     description: 'Application date format.',

--- a/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.analytics.spec.ts
@@ -138,6 +138,7 @@ describe('SettingsAnalytics', () => {
       dateFormat: null,
       timezone: null,
       theme: null,
+      language: null,
     };
     it('should emit [SETTINGS_KEYS_TO_SCAN_CHANGED] event', async () => {
       service.sendSettingsUpdatedEvent(

--- a/redisinsight/api/src/modules/settings/settings.service.spec.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.spec.ts
@@ -111,6 +111,7 @@ describe('SettingsService', () => {
 
       expect(result).toEqual({
         theme: null,
+        language: null,
         scanThreshold: REDIS_SCAN_CONFIG.scanThreshold,
         batchSize: WORKBENCH_CONFIG.countBatch,
         dateFormat: null,
@@ -130,6 +131,7 @@ describe('SettingsService', () => {
 
       expect(result).toEqual({
         ...mockSettings.data,
+        language: null,
         acceptTermsAndConditionsOverwritten: false,
         agreements: {
           version: mockAgreements.version,

--- a/redisinsight/api/test/api/settings/GET-settings.test.ts
+++ b/redisinsight/api/test/api/settings/GET-settings.test.ts
@@ -20,6 +20,7 @@ const endpoint = () => request(server).get('/settings');
 const responseSchema = Joi.object()
   .keys({
     theme: Joi.string().allow(null).required(),
+    language: Joi.string().allow(null),
     scanThreshold: Joi.number().required(),
     batchSize: Joi.number().required(),
     dateFormat: Joi.string().allow(null),

--- a/redisinsight/api/test/api/settings/PATCH-settings.test.ts
+++ b/redisinsight/api/test/api/settings/PATCH-settings.test.ts
@@ -20,6 +20,7 @@ const endpoint = () => request(server).patch('/settings');
 const responseSchema = Joi.object()
   .keys({
     theme: Joi.string().allow(null).required(),
+    language: Joi.string().allow(null),
     scanThreshold: Joi.number().required(),
     batchSize: Joi.number().required(),
     dateFormat: Joi.string().allow(null),

--- a/redisinsight/api/test/helpers/constants.ts
+++ b/redisinsight/api/test/helpers/constants.ts
@@ -23,6 +23,7 @@ const APP_DEFAULT_SETTINGS = {
   scanThreshold: 10000,
   batchSize: 5,
   theme: null,
+  language: null,
   dateFormat: null,
   timezone: null,
   agreements: null,

--- a/redisinsight/ui/src/components/config/Config.tsx
+++ b/redisinsight/ui/src/components/config/Config.tsx
@@ -41,6 +41,7 @@ import { fetchDBSettings } from 'uiSrc/slices/app/db-settings'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { DatabaseSettingsData } from 'uiSrc/slices/interfaces'
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
+import i18n from 'uiSrc/i18n'
 
 const SETTINGS_PAGE_PATH = '/settings'
 const Config = () => {
@@ -113,6 +114,7 @@ const Config = () => {
   useEffect(() => {
     if (config) {
       checkAndSetTheme()
+      checkAndSetLanguage()
     }
   }, [config])
 
@@ -217,6 +219,13 @@ const Config = () => {
     const theme = config?.theme
     if (theme && localStorageService.get(BrowserStorageItem.theme) !== theme)
       changeTheme(theme)
+  }
+
+  const checkAndSetLanguage = () => {
+    const language = config?.language
+    if (language && i18n.language !== language) {
+      i18n.changeLanguage(language)
+    }
   }
 
   return null

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -17,4 +17,5 @@ export enum FeatureFlags {
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
   prodMode = 'prodMode',
+  devLanguage = 'dev-language',
 }

--- a/redisinsight/ui/src/i18n/i18n.constants.ts
+++ b/redisinsight/ui/src/i18n/i18n.constants.ts
@@ -8,3 +8,9 @@ export const DEFAULT_LANGUAGE: SupportedLanguage = 'en'
 
 // The single namespace all keys live under (also augmented in i18next.d.ts).
 export const DEFAULT_NAMESPACE = 'translation'
+
+// Human-readable names for the language switcher, keyed by locale code.
+export const LANGUAGE_NAMES: Record<SupportedLanguage, string> = {
+  en: 'English',
+  bg: 'Български',
+}

--- a/redisinsight/ui/src/i18n/index.ts
+++ b/redisinsight/ui/src/i18n/index.ts
@@ -6,5 +6,6 @@ export {
   SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
   DEFAULT_NAMESPACE,
+  LANGUAGE_NAMES,
   type SupportedLanguage,
 } from './i18n.constants'

--- a/redisinsight/ui/src/pages/settings/SettingsPage.tsx
+++ b/redisinsight/ui/src/pages/settings/SettingsPage.tsx
@@ -31,11 +31,13 @@ import { Text } from 'uiSrc/components/base/text'
 import { Loader, RICollapsibleNavGroup } from 'uiSrc/components/base/display'
 import { Col } from 'uiSrc/components/base/layout/flex'
 import { useTranslation } from 'uiSrc/i18n'
+import { isDevLanguageEnabledSelector } from 'uiSrc/slices/app/features'
 import {
   AdvancedSettings,
   AppVersion,
   CloudSettings,
   CopyDiagnostics,
+  LanguageSettings,
   ThemeSettings,
   WorkbenchSettings,
 } from './components'
@@ -46,6 +48,7 @@ const SettingsPage = () => {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
   const { loading: settingsLoading } = useAppSelector(userSettingsSelector)
+  const isLanguageEnabled = useAppSelector(isDevLanguageEnabledSelector)
 
   const initialOpenSection = globalThis.location.hash || ''
 
@@ -69,6 +72,7 @@ const SettingsPage = () => {
   const Appearance = () => (
     <>
       <ThemeSettings />
+      {isLanguageEnabled && <LanguageSettings />}
       <ConsentsNotifications />
       <Divider />
       <Spacer />

--- a/redisinsight/ui/src/pages/settings/components/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/index.ts
@@ -4,6 +4,7 @@ import WorkbenchSettings from './workbench-settings'
 import CloudSettings from './cloud-settings'
 import GeneralSettings from './general-settings'
 import ThemeSettings from './theme-settings'
+import LanguageSettings from './language-settings'
 import { CopyDiagnostics } from './copy-diagnostics/CopyDiagnostics'
 
 export {
@@ -13,5 +14,6 @@ export {
   CloudSettings,
   GeneralSettings,
   ThemeSettings,
+  LanguageSettings,
   CopyDiagnostics,
 }

--- a/redisinsight/ui/src/pages/settings/components/language-settings/LanguageSettings.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/language-settings/LanguageSettings.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { cloneDeep } from 'lodash'
+import {
+  cleanup,
+  mockedStore,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  waitForRedisUiSelectVisible,
+} from 'uiSrc/utils/test-utils'
+import { DEFAULT_LANGUAGE, LANGUAGE_NAMES } from 'uiSrc/i18n'
+import { updateUserConfigSettingsAction } from 'uiSrc/slices/user/user-settings'
+
+import LanguageSettings from './LanguageSettings'
+
+jest.mock('uiSrc/i18n', () => {
+  const actual = jest.requireActual('uiSrc/i18n')
+  return {
+    __esModule: true,
+    ...actual,
+    default: { language: 'en', changeLanguage: jest.fn() },
+  }
+})
+
+jest.mock('uiSrc/slices/user/user-settings', () => {
+  const original = jest.requireActual('uiSrc/slices/user/user-settings')
+  return {
+    ...original,
+    updateUserConfigSettingsAction: jest.fn(() => ({ type: 'TEST_ACTION' })),
+  }
+})
+
+const i18n = require('uiSrc/i18n').default
+
+let store: typeof mockedStore
+
+describe('LanguageSettings', () => {
+  beforeEach(() => {
+    cleanup()
+    store = cloneDeep(mockedStore)
+    store.clearActions()
+    jest.clearAllMocks()
+  })
+
+  it('should render', () => {
+    expect(render(<LanguageSettings />)).toBeTruthy()
+  })
+
+  it('should render the default language selected when there is no previous config', async () => {
+    render(<LanguageSettings />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(LANGUAGE_NAMES[DEFAULT_LANGUAGE]),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('should change language and persist it on selection', async () => {
+    render(<LanguageSettings />, { store })
+
+    await userEvent.click(screen.getByTestId('select-language'))
+    await waitForRedisUiSelectVisible()
+
+    await waitFor(() => {
+      expect(screen.getByText(LANGUAGE_NAMES.bg)).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText(LANGUAGE_NAMES.bg))
+
+    expect(i18n.changeLanguage).toHaveBeenCalledWith('bg')
+    expect(updateUserConfigSettingsAction).toHaveBeenCalledWith({
+      language: 'bg',
+    })
+  })
+})

--- a/redisinsight/ui/src/pages/settings/components/language-settings/LanguageSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/language-settings/LanguageSettings.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react'
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import {
+  updateUserConfigSettingsAction,
+  userSettingsSelector,
+} from 'uiSrc/slices/user/user-settings'
+import i18n, {
+  DEFAULT_LANGUAGE,
+  LANGUAGE_NAMES,
+  SUPPORTED_LANGUAGES,
+} from 'uiSrc/i18n'
+import {
+  defaultValueRender,
+  RiSelect,
+  RiSelectOption,
+} from 'uiSrc/components/base/forms/select/RiSelect'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { Title } from 'uiSrc/components/base/text'
+
+const options: RiSelectOption[] = SUPPORTED_LANGUAGES.map((language) => ({
+  value: language,
+  inputDisplay: LANGUAGE_NAMES[language],
+}))
+
+const LanguageSettings = () => {
+  const dispatch = useAppDispatch()
+  const { config } = useAppSelector(userSettingsSelector)
+  const [selectedLanguage, setSelectedLanguage] = useState<string>(
+    config?.language ?? i18n.language ?? DEFAULT_LANGUAGE,
+  )
+
+  useEffect(() => {
+    if (config?.language) {
+      setSelectedLanguage(config.language)
+    }
+  }, [config])
+
+  const onChange = (value: string) => {
+    if (value === selectedLanguage) {
+      return
+    }
+    setSelectedLanguage(value)
+    i18n.changeLanguage(value)
+    dispatch(updateUserConfigSettingsAction({ language: value }))
+  }
+
+  return (
+    <form>
+      <Title size="XS">Language</Title>
+      <Spacer size="m" />
+      <FormField label="Specifies the display language:">
+        <Spacer size="m" />
+        <RiSelect
+          valueRender={defaultValueRender}
+          options={options}
+          value={selectedLanguage}
+          onChange={onChange}
+          data-testid="select-language"
+        />
+      </FormField>
+      <Spacer size="xl" />
+    </form>
+  )
+}
+
+export default LanguageSettings

--- a/redisinsight/ui/src/pages/settings/components/language-settings/index.ts
+++ b/redisinsight/ui/src/pages/settings/components/language-settings/index.ts
@@ -1,0 +1,3 @@
+import LanguageSettings from './LanguageSettings'
+
+export default LanguageSettings

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -80,6 +80,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.prodMode]: {
         flag: false,
       },
+      [FeatureFlags.devLanguage]: {
+        flag: false,
+      },
     },
   },
 }
@@ -246,6 +249,15 @@ export const isDevArrayEnabledSelector = (state: RootState): boolean => {
 
   const features = state.app.features.featureFlags.features
   return features[FeatureFlags.devArray]?.flag ?? false
+}
+
+export const isDevLanguageEnabledSelector = (state: RootState): boolean => {
+  if (isDevelopment) {
+    return true
+  }
+
+  const features = state.app.features.featureFlags.features
+  return features[FeatureFlags.devLanguage]?.flag ?? false
 }
 
 export default appFeaturesSlice.reducer


### PR DESCRIPTION
# What

Adds a **Language** picker to Settings → General so users can switch the app's display language (currently English / Bulgarian). The choice is persisted to the user settings config (new `language` field), applied at runtime via `i18n.changeLanguage`, and re-applied app-wide on startup.

### Enabling it locally (packaged / prod build)

The picker is **hidden behind the `dev-language` feature flag** while translations are still incomplete — off for end users by default, and auto-enabled in dev builds.

To force it on, add to your local RedisInsight `config.json` (in the app home dir):

```json
{
  "features": {
    "dev-language": true
  }
}
```

Set it to `false` to force off, or omit the key for the default (off). In `yarn dev` you don't need this — the picker is auto-enabled in development.

# Testing

- Settings → General shows a **Language** dropdown (in a dev build, or with the override above).
- Selecting `Български` → UI strings switch and `PATCH /settings` fires with `{ "language": "bg" }`.
- Reload → language persists (re-applied on startup).

Bruno requests for the settings API are under `bruno/RedisInsight/Settings/`.

# Preview

https://github.com/user-attachments/assets/7602879e-a729-430b-a2f2-52d743aca914

---

Closes #RI-8279


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User preference stored like theme; picker is gated behind dev-language with no auth or data-model changes beyond an optional settings field.
> 
> **Overview**
> Adds a **persisted display language** (`language` on `GET`/`PATCH /settings`) and wires the UI to apply it via **i18n** on change and at startup in `Config`.
> 
> Settings → General gets a **Language** dropdown (`en` / `bg`) when the switchable **`dev-language`** feature flag is on (auto-on in dev; off in prod unless overridden in local config). Selection calls `i18n.changeLanguage` and persists with `updateUserConfigSettingsAction`.
> 
> Also exports **`LANGUAGE_NAMES`** for the switcher, registers the flag on API/UI, bumps `features-config.json`, and adds Bruno requests plus test/schema updates for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e71ba285ef3a91fd7d972de712b58a0a92b8948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->