### PR TITLE
ci(e2e): alert on any non-success nightly + run E2E on dependency PRs

### DIFF
--- a/.github/workflows/tests-e2e-playwright-v2.yml
+++ b/.github/workflows/tests-e2e-playwright-v2.yml
@@ -41,13 +41,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HAS_E2E_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-tests') }}
           HAS_RUN_ALL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
+          HAS_DEPENDENCIES_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           elif [[ "$EVENT_NAME" == "schedule" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if [[ "$HAS_E2E_LABEL" == "true" || "$HAS_RUN_ALL_LABEL" == "true" ]]; then
+            if [[ "$HAS_E2E_LABEL" == "true" || "$HAS_RUN_ALL_LABEL" == "true" || "$HAS_DEPENDENCIES_LABEL" == "true" ]]; then
               echo "should_run=true" >> $GITHUB_OUTPUT
             else
               echo "should_run=false" >> $GITHUB_OUTPUT
@@ -115,7 +116,7 @@ jobs:
       environment: ${{ inputs.environment || 'staging' }}
       debug: ${{ inputs.debug || false }}
 
-  # Slack notification on nightly failures only
+  # Alert on any non-success nightly result (incl. 'cancelled' from a timeout).
   notify-slack:
     name: Notify Slack on nightly failure
     needs:
@@ -128,12 +129,12 @@ jobs:
     if: |
       always() &&
       github.event_name == 'schedule' &&
-      (needs.lint.result == 'failure' ||
-       needs.build-docker.result == 'failure' ||
-       needs.build-linux.result == 'failure' ||
-       needs.e2e-dev-chromium.result == 'failure' ||
-       needs.e2e-docker.result == 'failure' ||
-       needs.e2e-electron.result == 'failure')
+      (needs.lint.result != 'success' ||
+       needs.build-docker.result != 'success' ||
+       needs.build-linux.result != 'success' ||
+       needs.e2e-dev-chromium.result != 'success' ||
+       needs.e2e-docker.result != 'success' ||
+       needs.e2e-electron.result != 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
@@ -143,7 +144,7 @@ jobs:
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |
             channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
-            text: "<!here> *Nightly E2E failure* — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            text: "<!here> *Nightly E2E did not succeed* — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
             attachments:
               - color: "#cc0000"
                 title: "${{ github.workflow }}"


### PR DESCRIPTION
# What

Two visibility/coverage fixes for the **E2E Playwright Tests (v2)** workflow, following the nightly install-hang incident:

- **Alert on any non-success nightly** — `notify-slack` now fires when any job result is `!= 'success'` (was `'failure'` only). A job killed by `timeout-minutes` reports `cancelled`, not `failure`, so the 1h install-hang timeouts went unnoticed for 9 nights with no Slack alert. Message text updated accordingly.
- **Run E2E on dependency PRs** — `check-trigger` now runs the suite when a PR carries the `dependencies` label (dependabot), alongside `e2e-tests` / `run-all-tests`. Dependency bumps are exactly how the Node 24.16 + Playwright install-hang regression reached the nightly, so this catches such regressions pre-merge.

Workflow-config only — no change to how the individual test jobs execute.

# Testing

YAML validated. The non-success alert path exercises on the next nightly (or any run that doesn't fully succeed); the `dependencies`-label trigger exercises when such a PR is labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow YAML only; broader PR E2E runs and slightly noisier nightly Slack if jobs are skipped or cancelled for benign reasons.
> 
> **Overview**
> Updates **E2E Playwright Tests (v2)** workflow triggers and nightly alerting only.
> 
> **Dependency PRs:** `check-trigger` now sets `should_run` when a PR has the `dependencies` label (in addition to `e2e-tests` and `run-all-tests`), so Dependabot-style bumps can run the full E2E suite before merge.
> 
> **Nightly Slack:** `notify-slack` on scheduled runs now fires when any listed job result is **not** `success` (previously only `failure`). That covers `cancelled` outcomes from timeouts—e.g. install hangs that never reported as failure. The Slack headline text is changed from “failure” to “did not succeed.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1775ec97fef2586ffa1da46f8bad20e2a55baae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->