### PR TITLE
feat(connection): allow editing host when editing a connection

### DIFF
--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -1341,8 +1341,8 @@ describe('InstanceForm', () => {
         />,
       )
 
-      // Host is not shown in edit mode (shown as info above form)
-      expect(screen.queryByTestId('host')).not.toBeInTheDocument()
+      // Host is shown but disabled for Azure databases
+      expect(screen.getByTestId('host')).toBeDisabled()
       // Port, username, password should be disabled
       expect(screen.getByTestId('port')).toBeDisabled()
       expect(screen.getByTestId('username')).toBeDisabled()
@@ -1381,8 +1381,8 @@ describe('InstanceForm', () => {
         />,
       )
 
-      // Host is not shown in edit mode (shown as info above form)
-      expect(screen.queryByTestId('host')).not.toBeInTheDocument()
+      // Host is shown and editable for non-Azure databases in edit mode
+      expect(screen.getByTestId('host')).not.toBeDisabled()
       // Port, username, password should NOT be disabled for non-Azure databases
       expect(screen.getByTestId('port')).not.toBeDisabled()
       expect(screen.getByTestId('username')).not.toBeDisabled()

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -63,7 +63,7 @@ const EditConnection = (props: Props) => {
             formik={formik}
             showFields={{
               alias: true,
-              host: (!isEditMode || isCloneMode) && !isFromCloud,
+              host: !isFromCloud,
               port: !isFromCloud,
               timeout: true,
             }}


### PR DESCRIPTION
Previously the host field was hidden entirely when editing a saved connection (shown only when adding or cloning). Show it in edit mode so the host can be changed. Cloud (Connect redirect) still hides host/port, and Azure-sourced databases keep host disabled via AZURE_READONLY_FIELDS.

# What
<!-- Briefly explain what have you changed in the code and any tech decisions that were made. -->

# Testing
Manual tested and verified.