### PR TITLE
fix(api): drop .d.ts hunks from ioredis patch so it survives the e2e build

### DIFF
--- a/redisinsight/api/patches/ioredis+5.3.2.patch
+++ b/redisinsight/api/patches/ioredis+5.3.2.patch
@@ -1,23 +1,3 @@
-diff --git a/node_modules/ioredis/built/Command.d.ts b/node_modules/ioredis/built/Command.d.ts
-index ea90aa2..ca28897 100644
---- a/node_modules/ioredis/built/Command.d.ts
-+++ b/node_modules/ioredis/built/Command.d.ts
-@@ -6,6 +6,7 @@ interface CommandOptions {
-      * Set the encoding of the reply, by default buffer will be returned.
-      */
-     replyEncoding?: BufferEncoding | null;
-+    integerReply?: "number" | "bigint";
-     errorStack?: Error;
-     keyPrefix?: string;
-     /**
-@@ -75,6 +76,7 @@ export default class Command implements Respondable {
-     resolve: (result: any) => void;
-     promise: Promise<any>;
-     private replyEncoding;
-+    integerReply?: "number" | "bigint";
-     private errorStack;
-     private bufferMode;
-     private callback;
 diff --git a/node_modules/ioredis/built/Command.js b/node_modules/ioredis/built/Command.js
 index 40cd1a6..aad90af 100644
 --- a/node_modules/ioredis/built/Command.js
@@ -30,22 +10,6 @@ index 40cd1a6..aad90af 100644
          this.errorStack = options.errorStack;
          this.args = args.flat();
          this.callback = callback;
-diff --git a/node_modules/ioredis/built/DataHandler.d.ts b/node_modules/ioredis/built/DataHandler.d.ts
-index 93e97d9..24fe877 100644
---- a/node_modules/ioredis/built/DataHandler.d.ts
-+++ b/node_modules/ioredis/built/DataHandler.d.ts
-@@ -26,7 +26,11 @@ interface ParserOptions {
- }
- export default class DataHandler {
-     private redis;
-+    private parser;
-+    private stringNumbers;
-     constructor(redis: DataHandledable, parserOptions: ParserOptions);
-+    private updateIntegerReplyMode;
-+    private convertIntegerReply;
-     private returnFatalError;
-     private returnError;
-     private returnReply;
 diff --git a/node_modules/ioredis/built/DataHandler.js b/node_modules/ioredis/built/DataHandler.js
 index 1db1848..f985ed5 100644
 --- a/node_modules/ioredis/built/DataHandler.js


### PR DESCRIPTION
# What

The E2E **Build Docker** [job](https://github.com/redis/RedisInsight/actions/runs/28576245174/job/84737578292) was failing with `patch-package: "Failed to apply patch for package ioredis"`.

Root cause: RI-8296 (#6100) added `patches/ioredis+5.3.2.patch`, which modifies ioredis' `built/*.d.ts` files. `.github/build/build_modules.sh` installs the API (patch applies), then runs `yarn autoclean` with `.yarnclean.prod` — whose `*.ts` rule also deletes `*.d.ts` — and then re-installs, re-running `patch-package`. With the target `.d.ts` files stripped by autoclean, patch-package can no longer apply the patch and the build fails. (The host workspace build passes because it never autocleans.)

Fix: drop the two type-only `.d.ts` hunks and keep only the runtime `Command.js` / `DataHandler.js` changes. The `.d.ts` additions are unused by our build — `prepareCommandOptions` returns `any`, and `RedisClient` defines its own `integerReply` type, so nothing type-checks against ioredis' `CommandOptions`. patch-package is then idempotent across the autoclean → reinstall cycle.

# Testing

- Reproduced the full install → autoclean → reinstall sequence locally; the `.js`-only patch applies cleanly on both passes (`ioredis@5.3.2 ✔`).
- CI on this branch: the previously-red **Build Docker** job is now green, and `type-check / tsc baselines`, `Build API`, `Build Linux`, and `docker-build` all pass — confirming no type or runtime impact outside the patch.
- Link to succesfull Docker build: https://github.com/redis/RedisInsight/actions/runs/28583728882/job/84762367552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to the patch file; runtime ioredis bigint behavior is unchanged and CI already validated type-check and Docker build.
> 
> **Overview**
> Fixes **Build Docker** failures where `patch-package` could not re-apply the `ioredis+5.3.2` patch after `yarn autoclean` (`.yarnclean.prod` removes `*.d.ts`, including patched `built/*.d.ts` targets).
> 
> The patch is trimmed to **runtime-only** changes in `Command.js` and `DataHandler.js` (still wiring `integerReply` / `bigint` handling). The removed `Command.d.ts` / `DataHandler.d.ts` hunks were type-only and unused by the API build, so behavior is unchanged while the patch stays applyable on install → autoclean → reinstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c54001b30f54a1a0f0cd91c1ef612465eac306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->