### PR TITLE
RI-8300: Array Search tab: surface Context option and indicate expandable rows

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -20,7 +20,11 @@ const indexColumn: ColumnDef<ArrayDataElement> = {
   enableSorting: false,
   enableResizing: true,
   cell: ({ row }: CellContext<ArrayDataElement, unknown>) => (
-    <ArrayIndexCell index={row.original.index} />
+    <ArrayIndexCell
+      index={row.original.index}
+      canExpand={row.getCanExpand()}
+      isExpanded={row.getIsExpanded()}
+    />
   ),
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { RiIcon } from 'uiSrc/components/base/icons'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
 import { Text } from 'uiSrc/components/base/text'
 import { formatLongName } from 'uiSrc/utils'
@@ -12,21 +14,43 @@ const TEST_ID_PREFIX = 'array-details-table-index'
  * Renders an array slot's index with a tooltip showing the full value —
  * indexes can be up to 20 digits (2^64-1), which need truncation in the
  * cell but should remain copyable from the tooltip.
+ *
+ * When the row is expandable (Search tab with Context on) a disclosure
+ * chevron precedes the index, pointing down while expanded and right while
+ * collapsed.
  */
-export const ArrayIndexCell = ({ index }: ArrayIndexCellProps) => (
-  <Text
-    component="div"
-    color="secondary"
-    style={{ maxWidth: '100%' }}
-    data-testid={`${TEST_ID_PREFIX}-${index}`}
-  >
-    <RiTooltip
-      title="Index"
-      position="bottom"
-      anchorClassName="truncateText"
-      content={formatLongName(index)}
-    >
-      <span className="truncateText">{index}</span>
-    </RiTooltip>
-  </Text>
+export const ArrayIndexCell = ({
+  index,
+  canExpand,
+  isExpanded,
+}: ArrayIndexCellProps) => (
+  <Row align="center" gap="xs" grow={false}>
+    {canExpand && (
+      <FlexItem grow={false}>
+        <RiIcon
+          size="m"
+          color="currentColor"
+          type={isExpanded ? 'ChevronDownIcon' : 'ChevronRightIcon'}
+          data-testid={`${TEST_ID_PREFIX}-${index}-expander`}
+        />
+      </FlexItem>
+    )}
+    <FlexItem grow style={{ minWidth: 0 }}>
+      <Text
+        component="div"
+        color="secondary"
+        style={{ maxWidth: '100%' }}
+        data-testid={`${TEST_ID_PREFIX}-${index}`}
+      >
+        <RiTooltip
+          title="Index"
+          position="bottom"
+          anchorClassName="truncateText"
+          content={formatLongName(index)}
+        >
+          <span className="truncateText">{index}</span>
+        </RiTooltip>
+      </Text>
+    </FlexItem>
+  </Row>
 )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayIndexCell.types.ts
@@ -1,4 +1,8 @@
 export interface ArrayIndexCellProps {
   /** Decimal-string index (BigInt-as-string contract). */
   index: string
+  /** Show a disclosure chevron before the index (expandable Search rows). */
+  canExpand?: boolean
+  /** Chevron direction: down when the row is expanded, right when collapsed. */
+  isExpanded?: boolean
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.spec.tsx
@@ -193,14 +193,9 @@ describe('ArraySearchForm', () => {
   })
 
   describe('context', () => {
-    // The context control lives inside the collapsed Options section, so each
-    // test must expand it before the controls exist in the DOM.
-    const openOptions = () =>
-      fireEvent.click(screen.getByTestId(`${TEST_ID}-options-toggle`))
-
+    // Context is always visible, so no need to expand Options first.
     it('keeps the context input disabled until the toggle is ticked', () => {
       const { rerender } = renderComponent()
-      openOptions()
       // Off by default → input present (so layout is stable) but disabled.
       expect(screen.getByTestId(`${TEST_ID}-context`)).toBeDisabled()
 
@@ -216,7 +211,6 @@ describe('ArraySearchForm', () => {
     it('enables context when the toggle is ticked', () => {
       const onChangeContext = jest.fn()
       renderComponent({ onChangeContext })
-      openOptions()
 
       fireEvent.click(screen.getByTestId(`${TEST_ID}-context-toggle`))
 
@@ -226,7 +220,6 @@ describe('ArraySearchForm', () => {
     it('shows the passed count and clamps a typed value above the max to 50', async () => {
       const user = userEvent.setup()
       renderComponent({ context: { enabled: true, count: 5 } })
-      openOptions()
 
       const input = screen.getByTestId(`${TEST_ID}-context`)
       // redis-ui NumericInput renders a text input, so the DOM value is a
@@ -251,7 +244,6 @@ describe('ArraySearchForm', () => {
         context: { enabled: true, count: 5 },
         onChangeContext,
       })
-      openOptions()
 
       fireEvent.change(screen.getByTestId(`${TEST_ID}-context`), {
         target: { value: '8' },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-search-form/ArraySearchForm.tsx
@@ -228,6 +228,49 @@ export const ArraySearchForm = ({
         ))}
       </Col>
 
+      <Row align="center" gap="s" grow={false}>
+        <FlexItem grow={false}>
+          <Row align="center" gap="xs" grow={false}>
+            <FlexItem grow={false}>
+              <S.InlineCheckbox
+                id={`${TEST_ID}-context-toggle`}
+                name="array-search-context-toggle"
+                label={CONTEXT_LABEL}
+                checked={context.enabled}
+                onChange={(e) => onChangeContext({ enabled: e.target.checked })}
+                disabled={disabled}
+                data-testid={`${TEST_ID}-context-toggle`}
+              />
+            </FlexItem>
+            <FlexItem grow={false}>
+              <InfoHint content={CONTEXT_HINT} />
+            </FlexItem>
+          </Row>
+        </FlexItem>
+        <FlexItem grow={false}>
+          <Text size="s">{CONTEXT_PREFIX}</Text>
+        </FlexItem>
+        {/* Always rendered so ticking Context doesn't shift the row; it just
+            becomes editable once the toggle is on. */}
+        <FlexItem grow={false}>
+          <S.NarrowInputBox>
+            <NumericInput
+              autoValidate
+              min={CONTEXT_COUNT_MIN}
+              max={CONTEXT_COUNT_MAX}
+              value={context.count}
+              onChange={(next) =>
+                onChangeContext({
+                  count: Math.round(Number(next ?? CONTEXT_COUNT_MIN)),
+                })
+              }
+              disabled={disabled || !context.enabled}
+              data-testid={`${TEST_ID}-context`}
+            />
+          </S.NarrowInputBox>
+        </FlexItem>
+      </Row>
+
       <Col gap="m" grow={false}>
         {/* Compact disclosure: chevron + "Options" on the left, the add-row
             "+" on the right, the option fields below once expanded. */}
@@ -308,54 +351,6 @@ export const ArraySearchForm = ({
                         error={endInvalid ? INVALID_INDEX_MESSAGE : undefined}
                         disabled={disabled}
                         data-testid={`${TEST_ID}-end`}
-                      />
-                    </S.NarrowInputBox>
-                  </FlexItem>
-                </Row>
-              </FlexItem>
-              <FlexItem grow={false}>
-                <Row align="center" gap="s" grow={false}>
-                  <FlexItem grow={false}>
-                    <Row align="center" gap="xs" grow={false}>
-                      <FlexItem grow={false}>
-                        <S.InlineCheckbox
-                          id={`${TEST_ID}-context-toggle`}
-                          name="array-search-context-toggle"
-                          label={CONTEXT_LABEL}
-                          checked={context.enabled}
-                          onChange={(e) =>
-                            onChangeContext({ enabled: e.target.checked })
-                          }
-                          disabled={disabled}
-                          data-testid={`${TEST_ID}-context-toggle`}
-                        />
-                      </FlexItem>
-                      <FlexItem grow={false}>
-                        <InfoHint content={CONTEXT_HINT} />
-                      </FlexItem>
-                    </Row>
-                  </FlexItem>
-                  <FlexItem grow={false}>
-                    <Text size="s">{CONTEXT_PREFIX}</Text>
-                  </FlexItem>
-                  {/* Always rendered so ticking Context doesn't shift the row;
-                      it just becomes editable once the toggle is on. */}
-                  <FlexItem grow={false}>
-                    <S.NarrowInputBox>
-                      <NumericInput
-                        autoValidate
-                        min={CONTEXT_COUNT_MIN}
-                        max={CONTEXT_COUNT_MAX}
-                        value={context.count}
-                        onChange={(next) =>
-                          onChangeContext({
-                            count: Math.round(
-                              Number(next ?? CONTEXT_COUNT_MIN),
-                            ),
-                          })
-                        }
-                        disabled={disabled || !context.enabled}
-                        data-testid={`${TEST_ID}-context`}
                       />
                     </S.NarrowInputBox>
                   </FlexItem>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -154,11 +154,8 @@ describe('SearchTab', () => {
       data: [arrayElementWithValueFactory.build({ index: '7' })],
     })
 
-    // Context is off by default, so the row isn't expandable yet — open the
-    // Options section and tick the Context toggle before clicking the match.
-    // fireEvent on the toggles sidesteps the redis-ui control's
-    // `pointer-events: none` wrapper that blocks userEvent's pointer guard.
-    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
+    // Context is off by default — enable it so the row can expand. fireEvent
+    // sidesteps the redis-ui control's `pointer-events: none` wrapper.
     fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
 
     await user.click(screen.getByTestId('array-details-table-index-7'))
@@ -197,7 +194,6 @@ describe('SearchTab', () => {
 
     // Enabling Context enables its count input; reset must turn it back off
     // (context state lives in SearchTab, not the query hook's resetQuery).
-    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
     fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
     expect(screen.getByTestId('array-search-form-context')).toBeEnabled()
 
@@ -243,7 +239,6 @@ describe('SearchTab', () => {
       data: [arrayElementWithValueFactory.build({ index: '7' })],
     })
 
-    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
     fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
     await user.click(screen.getByTestId('array-details-table-index-7'))
     expect(
@@ -269,7 +264,6 @@ describe('SearchTab', () => {
       data: [arrayElementWithValueFactory.build({ index: '7' })],
     })
 
-    fireEvent.click(screen.getByTestId('array-search-form-options-toggle'))
     fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
     expect(screen.getByRole('checkbox', { name: 'Context' })).toBeChecked()
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -184,6 +184,57 @@ describe('SearchTab', () => {
     expect(post).not.toHaveBeenCalled()
   })
 
+  it('shows no disclosure chevron on match rows while context is off', () => {
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    expect(
+      screen.queryByTestId('array-details-table-index-7-expander'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a collapsed chevron on match rows once context is on', () => {
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+
+    expect(
+      screen.getByTestId('array-details-table-index-7-expander'),
+    ).toHaveAttribute('aria-label', 'Chevron Right')
+  })
+
+  it('flips the chevron to expanded when a match row is opened', async () => {
+    const user = userEvent.setup()
+    apiService.post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { keyName: KEY, elements: ['v6', 'v7', 'v8'] },
+    })
+    renderTab({
+      loaded: true,
+      loading: false,
+      error: '',
+      data: [arrayElementWithValueFactory.build({ index: '7' })],
+    })
+
+    fireEvent.click(screen.getByTestId('array-search-form-context-toggle'))
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('array-details-table-index-7-expander'),
+      ).toHaveAttribute('aria-label', 'Chevron Down'),
+    )
+  })
+
   it('resets context to its default when the form is reset', () => {
     renderTab({
       loaded: true,


### PR DESCRIPTION
# What

Two polish items for the array Search tab (part of RI-8174):

- **Context moved out of Options** — the Context toggle + `±N` count input now
  live on their own always-visible row, instead of being hidden inside the
  collapsible "Options" section.
- **Expandable-row affordance** — when Context is on, a disclosure chevron
  appears before the index in each match row (right when collapsed, down when
  expanded), so it's clear the row can be opened to reveal its neighbour band.
  No chevron shows when Context is off or on the View/Aggregate tabs.

## Default (context is OFF, no expand functionality)

<img width="710" height="786" alt="Screenshot 2026-07-06 at 15 14 12" src="https://github.com/user-attachments/assets/a6ea1ee9-e021-4be7-b4c3-9bdb561d3dcf" />

## Context is ON, no expanded rows

<img width="710" height="786" alt="Screenshot 2026-07-06 at 15 14 19" src="https://github.com/user-attachments/assets/1023b6b8-c4da-43e2-b685-bbb9ab1b1257" />

## Context is ON, and a row is expanded

<img width="710" height="786" alt="Screenshot 2026-07-06 at 15 14 01" src="https://github.com/user-attachments/assets/8d82fed7-c564-41bf-a642-5da0bcde0bd0" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Browser UI-only layout and affordance changes in the array key-details Search tab; no API, auth, or data-path changes.
> 
> **Overview**
> **Context** on the array Search tab is no longer buried in the collapsible **Options** section. The Context checkbox, hint, `±N` count field, and related layout now sit on a dedicated always-visible row above Options, so users can enable neighbour bands without expanding Options first.
> 
> **Expandable match rows** get a visual affordance: `ArrayIndexCell` accepts optional `canExpand` / `isExpanded` from the table row and shows a disclosure chevron (right collapsed, down expanded) only when the row can expand—i.e. Search with Context on. `ArrayDetailsTable.config` wires `row.getCanExpand()` and `row.getIsExpanded()` into the index column.
> 
> Tests drop the old “open Options before Context” steps and add Search tab coverage for chevron presence, direction, and expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7819a91072d5073739ae894e1076ce79fb4fc499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->