### PR TITLE
RI-8272 i18n: translate consent copy via agreement codes

### DIFF
--- a/redisinsight/api/src/constants/agreements-spec.json
+++ b/redisinsight/api/src/constants/agreements-spec.json
@@ -2,6 +2,7 @@
   "version": "1.0.6",
   "agreements": {
     "analytics": {
+      "code": "analytics",
       "defaultValue": false,
       "displayInSetting": true,
       "required": false,
@@ -15,6 +16,7 @@
       "description": "Help improve Redis Insight by sharing anonymous usage data. This helps us understand feature usage and make the app better. By enabling this, you agree to our "
     },
     "notifications": {
+      "code": "notifications",
       "defaultValue": false,
       "displayInSetting": true,
       "required": false,
@@ -24,8 +26,8 @@
       "category": "notifications",
       "since": "1.0.6",
       "title": "Notification",
-      "label": "Show notification",
-      "description": "Select to display notification. Otherwise, notifications are shown in the Notification Center."
+      "label": "Show notifications",
+      "description": "Select to display notifications. Otherwise, notifications are shown in the Notification Center."
     },
     "encryption": {
       "conditional": true,
@@ -34,6 +36,7 @@
 
       "options": {
         "true": {
+          "code": "encryptionEnabled",
           "defaultValue": true,
           "displayInSetting": false,
           "required": false,
@@ -47,6 +50,7 @@
           "description": "Select to encrypt sensitive information using system keychain. Otherwise, this information is stored locally in plain text, which may incur security risk."
         },
         "false": {
+          "code": "encryptionDisabled",
           "defaultValue": false,
           "displayInSetting": false,
           "required": false,
@@ -60,6 +64,7 @@
           "description": "Install or enable the system keychain to encrypt and securely store your sensitive information added before using the application. Otherwise, this information will be stored locally in plain text and may lead to security risks."
         },
         "stack_false": {
+          "code": "encryptionStackDisabled",
           "defaultValue": false,
           "displayInSetting": false,
           "required": false,
@@ -75,6 +80,7 @@
       }
     },
     "eula": {
+      "code": "eula",
       "defaultValue": false,
       "displayInSetting": false,
       "required": true,

--- a/redisinsight/api/src/modules/settings/models/agreements.interface.ts
+++ b/redisinsight/api/src/modules/settings/models/agreements.interface.ts
@@ -1,4 +1,5 @@
 export interface IAgreement {
+  code?: string;
   defaultValue?: boolean;
   displayInSetting?: boolean;
   required?: boolean;

--- a/redisinsight/api/src/modules/settings/settings.service.ts
+++ b/redisinsight/api/src/modules/settings/settings.service.ts
@@ -6,7 +6,7 @@ import {
   InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
-import { difference, isEmpty, map, cloneDeep } from 'lodash';
+import { difference, isEmpty, map, cloneDeep, forEach } from 'lodash';
 import { readFile } from 'fs-extra';
 import { join } from 'path';
 import * as AGREEMENTS_SPEC from 'src/constants/agreements-spec.json';
@@ -20,7 +20,10 @@ import { classToClass } from 'src/utils';
 import { AgreementsRepository } from 'src/modules/settings/repositories/agreements.repository';
 import { FeatureServerEvents } from 'src/modules/feature/constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { IAgreementSpecFile } from 'src/modules/settings/models/agreements.interface';
+import {
+  IAgreement,
+  IAgreementSpecFile,
+} from 'src/modules/settings/models/agreements.interface';
 import { SessionMetadata } from 'src/common/models';
 
 import { DatabaseDiscoveryService } from 'src/modules/database-discovery/database-discovery.service';
@@ -228,9 +231,19 @@ export class SettingsService {
   private async getAgreementsSpecFromFile(): Promise<IAgreementSpecFile> {
     try {
       if (SERVER_CONFIG.agreementsPath) {
-        return JSON.parse(
+        const spec: IAgreementSpecFile = JSON.parse(
           await readFile(join(__dirname, SERVER_CONFIG.agreementsPath), 'utf8'),
         );
+
+        // A custom spec (RI_AGREEMENTS_PATH) owns its consent/legal copy. Drop
+        // the i18n `code` fields (even if copied from the bundled spec) so the
+        // UI renders that text verbatim instead of the built-in translation.
+        forEach(spec?.agreements, (agreement: IAgreement) => {
+          delete agreement.code;
+          forEach(agreement?.options, (option) => delete option.code);
+        });
+
+        return spec;
       }
     } catch (e) {
       // ignore error

--- a/redisinsight/api/test/api/settings/GET-settings-agreements-spec.test.ts
+++ b/redisinsight/api/test/api/settings/GET-settings-agreements-spec.test.ts
@@ -6,6 +6,7 @@ const { server, request } = deps;
 const endpoint = () => request(server).get('/settings/agreements/spec');
 
 const agreementItemSchema = Joi.object().keys({
+  code: Joi.string().optional(),
   defaultValue: Joi.bool().required(),
   required: Joi.bool().required(),
   disabled: Joi.bool().required(),

--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.spec.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.spec.tsx
@@ -4,6 +4,7 @@ import ConsentOption from './ConsentOption'
 import { IConsent } from '../ConsentsSettings'
 
 const mockConsent: IConsent = {
+  code: 'test-consent',
   agreementName: 'analytics',
   title: 'Analytics',
   label: 'Share usage data',
@@ -119,6 +120,59 @@ describe('ConsentOption', () => {
       screen.getByText('Help us improve Redis Insight by sharing usage data.'),
     ).toBeInTheDocument()
     expect(screen.queryByText('Privacy Policy')).not.toBeInTheDocument()
+  })
+
+  it('should localize label and description by agreement code', () => {
+    const analyticsConsent = {
+      ...mockConsent,
+      code: 'analytics',
+      label: 'Share usage data',
+      description: 'Help us improve Redis Insight by sharing usage data.',
+    }
+
+    render(<ConsentOption {...defaultProps} consent={analyticsConsent} />)
+
+    // The spec-provided English is overridden by the api.agreement.analytics.* copy.
+    expect(screen.getByText('Usage Data')).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Help us improve Redis Insight by sharing usage data.',
+      ),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should keep server-provided copy when no code is sent (custom spec)', () => {
+    const customConsent = {
+      ...mockConsent,
+      code: undefined,
+      agreementName: 'analytics',
+      label: 'Custom usage data label',
+      description: 'Custom usage data description.',
+    }
+
+    render(<ConsentOption {...defaultProps} consent={customConsent} />)
+
+    // No code -> do not fall back to api.agreement.analytics.* built-in copy.
+    expect(screen.getByText('Custom usage data label')).toBeInTheDocument()
+    expect(
+      screen.getByText('Custom usage data description.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Usage Data')).not.toBeInTheDocument()
+  })
+
+  it('should not render a description (or the raw key) when the agreement has none', () => {
+    const eulaConsent = {
+      ...mockConsent,
+      code: 'eula',
+      description: undefined,
+    }
+
+    render(<ConsentOption {...defaultProps} consent={eulaConsent} />)
+
+    // Missing description + missing key must not leak the i18n key string.
+    expect(
+      screen.queryByText('api.agreement.eula.description'),
+    ).not.toBeInTheDocument()
   })
 
   it('should render disabled switch when consent is disabled', () => {

--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.tsx
@@ -6,6 +6,7 @@ import { Spacer } from 'uiSrc/components/base/layout/spacer'
 
 import { Text } from 'uiSrc/components/base/text'
 import { SwitchInput } from 'uiSrc/components/base/inputs'
+import { useTranslation } from 'uiSrc/i18n'
 
 import { ItemDescription } from './components'
 import { IConsent } from '../ConsentsSettings'
@@ -27,14 +28,30 @@ const ConsentOption = (props: Props) => {
     withoutSpacer = false,
   } = props
 
+  const { t } = useTranslation()
+
+  // Localize the backend-supplied copy by its stable agreement code, falling
+  // back to the English text shipped in the spec (mirrors the error-code i18n).
+  const label = consent.code
+    ? t(`api.agreement.${consent.code}.label` as never, {
+        defaultValue: consent.label,
+      })
+    : consent.label
+  const description =
+    consent.code && consent.description
+      ? t(`api.agreement.${consent.code}.description` as never, {
+          defaultValue: consent.description,
+        })
+      : consent.description
+
   return (
     <FlexItem key={consent.agreementName} grow>
-      {isSettingsPage && consent.description && (
+      {isSettingsPage && description && (
         <>
           <Spacer size="s" />
           <Text size="M" color="primary">
             <ItemDescription
-              description={consent.description}
+              description={description}
               withLink={consent.linkToPrivacyPolicy}
             />
           </Text>
@@ -55,14 +72,14 @@ const ConsentOption = (props: Props) => {
         </FlexItem>
         <FlexItem>
           <Text size="M" color="primary">
-            {parse(consent.label)}
+            {parse(label)}
           </Text>
-          {!isSettingsPage && consent.description && (
+          {!isSettingsPage && description && (
             <>
               <Spacer size="xs" />
               <Text size="s" color="secondary">
                 <ItemDescription
-                  description={consent.description}
+                  description={description}
                   withLink={consent.linkToPrivacyPolicy}
                 />
               </Text>

--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Link } from 'uiSrc/components/base/link/Link'
 import { EXTERNAL_LINKS, UTM_MEDIUMS } from 'uiSrc/constants/links'
 import { getUtmExternalLink } from 'uiSrc/utils/links'
+import { useTranslation } from 'uiSrc/i18n'
 
 interface ItemDescriptionProps {
   description: string
@@ -12,25 +13,29 @@ interface ItemDescriptionProps {
 export const ItemDescription = ({
   description,
   withLink,
-}: ItemDescriptionProps) => (
-  <>
-    {description && parse(description)}
-    {withLink && (
-      <>
-        <Link
-          variant="inline"
-          target="_blank"
-          color="secondary"
-          size="S"
-          href={getUtmExternalLink(EXTERNAL_LINKS.legalPrivacyPolicy, {
-            medium: UTM_MEDIUMS.App,
-            campaign: 'telemetry',
-          })}
-        >
-          Privacy Policy
-        </Link>
-        .
-      </>
-    )}
-  </>
-)
+}: ItemDescriptionProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {description && parse(description)}
+      {withLink && (
+        <>
+          <Link
+            variant="inline"
+            target="_blank"
+            color="secondary"
+            size="S"
+            href={getUtmExternalLink(EXTERNAL_LINKS.legalPrivacyPolicy, {
+              medium: UTM_MEDIUMS.App,
+              campaign: 'telemetry',
+            })}
+          >
+            {t('common.privacyPolicy')}
+          </Link>
+          .
+        </>
+      )}
+    </>
+  )
+}

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -29,6 +29,7 @@ interface Values {
 }
 
 export interface IConsent {
+  code?: string
   defaultValue: boolean
   displayInSetting: boolean
   required: boolean

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -1,4 +1,8 @@
 {
+  "api.agreement.analytics.description": "Помогнете за подобряването на Redis Insight, като споделяте анонимни данни за употреба. Това ни помага да разберем използването на функциите и да направим приложението по-добро. Активирайки това, се съгласявате с нашата ",
+  "api.agreement.analytics.label": "Данни за употреба",
+  "api.agreement.notifications.description": "Изберете, за да се показват известия. В противен случай известията се показват в Центъра за известия.",
+  "api.agreement.notifications.label": "Показвай известия",
   "api.error.code.11000.message": "Опитайте да рестартирате Redis Insight.",
   "api.error.code.11000.title": "Сървърна грешка",
   "api.error.code.11001.message": "Влезте отново, за да продължите работа с Redis Cloud.",
@@ -44,6 +48,7 @@
   "browser.array.delete.range.trigger": "Изтриване на диапазон",
   "browser.array.delete.row.message": "Този елемент ще бъде премахнат за постоянно от масива.",
   "browser.array.delete.row.title": "Изтриване на елемент",
+  "common.privacyPolicy": "Политика за поверителност",
   "notification.error.arrayBulkDeleteLimit.message": "Можете да изтриете най-много {{max}} елемента наведнъж. Изчистете част от селекцията и опитайте отново.",
   "notification.error.arrayBulkDeleteLimit.title": "Избрани са твърде много елементи",
   "notification.error.button.copied": "Копирано",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "api.agreement.analytics.description": "Help improve Redis Insight by sharing anonymous usage data. This helps us understand feature usage and make the app better. By enabling this, you agree to our ",
+  "api.agreement.analytics.label": "Usage Data",
+  "api.agreement.notifications.description": "Select to display notifications. Otherwise, notifications are shown in the Notification Center.",
+  "api.agreement.notifications.label": "Show notifications",
   "api.error.code.11000.message": "Try restarting Redis Insight.",
   "api.error.code.11000.title": "Server error",
   "api.error.code.11001.message": "Sign in again to continue working with Redis Cloud.",
@@ -44,6 +48,7 @@
   "browser.array.delete.range.trigger": "Delete range",
   "browser.array.delete.row.message": "This element will be permanently removed from the array.",
   "browser.array.delete.row.title": "Delete element",
+  "common.privacyPolicy": "Privacy Policy",
   "notification.error.arrayBulkDeleteLimit.message": "You can delete up to {{max}} elements at once. Clear some of the selection and try again.",
   "notification.error.arrayBulkDeleteLimit.title": "Too many elements selected",
   "notification.error.button.copied": "Copied",

--- a/tests/e2e-playwright/pages/settings/SettingsPage.ts
+++ b/tests/e2e-playwright/pages/settings/SettingsPage.ts
@@ -68,7 +68,7 @@ export class SettingsPage extends BasePage {
     this.themeDropdown = page.getByRole('combobox', { name: /color theme/i });
     this.notificationSwitch = page
       .locator('div')
-      .filter({ hasText: /^Show notification$/ })
+      .filter({ hasText: /^Show notifications$/ })
       .locator('..')
       .getByRole('switch');
     this.dateFormatRadioPreselected = page.getByRole('radio', { name: 'Pre-selected formats' });


### PR DESCRIPTION
# What

Translate the **consent** copy (Notifications & Privacy sections) that https://github.com/redis/RedisInsight/pull/6154 left out because it isn't authored in the UI — it comes from the backend agreements spec.

Approach mirrors the existing **error-code** i18n contract:
- **Backend** — each agreement in `agreements-spec.json` gets a stable `code` (`analytics`, `notifications`, the `encryption` options, `eula`) 
- **Frontend** — `ConsentOption` localizes `api.agreement.<code>.{label,description}` with the spec's English as the `defaultValue` fallback. Falls back to the agreement name when no code is sent, so it degrades gracefully against older API builds.

Translations added for `analytics` + `notifications` (the consents shown in Settings); `encryption`/`eula` get codes and fall back to English until translated later — no further backend work needed.

# Screenshots (EN | BG)

| Section | English | Български |
|---|---|---|
| **Privacy** (Usage Data consent) | <img width="792" height="246" alt="en-consent-privacy" src="https://github.com/user-attachments/assets/d16c36e9-9050-43e1-bad3-8564a0aa4276" />|<img width="792" height="265" alt="bg-consent-privacy" src="https://github.com/user-attachments/assets/81825e62-8f4b-4451-8680-e9ee1ae17efd" /> |
| **General** (Notifications consent) |<img width="792" height="678" alt="en-consent-general" src="https://github.com/user-attachments/assets/002c97e3-8b4b-429d-ad61-8465b1707bb2" />|<img width="792" height="678" alt="bg-consent-general" src="https://github.com/user-attachments/assets/e14242f8-600d-4968-b82c-68c0586af61d" /> |

# Testing

- Manual: open Settings, toggle Language EN↔BG; the Usage Data & Show notification consent labels/descriptions + Privacy Policy link translate.

---

Closes RI-8272

Related community requests: #605, #1317, #1883, #2040, #2137, #2181, #2213, #2417, #2550, #2590, #2695, #2715, #2716, #2727, #2828, #2912, #2943, #2945, #3081, #3141, #3142, #3319, #3411, #3601, #3625, #3628, #3663, #3671, #3812, #3815, #4150, #4182, #4408, #4664, #4672, #4744, #5052, #5967

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer i18n and optional API metadata only; custom agreement paths explicitly opt out of translation. No change to consent storage or legal acceptance logic.
> 
> **Overview**
> Adds **i18n for consent text** that comes from the backend agreements spec (usage data, notifications, etc.), using the same pattern as error-code translations.
> 
> **Backend:** Each agreement in `agreements-spec.json` gets an optional stable **`code`** (`analytics`, `notifications`, encryption variants, `eula`). The notifications label/copy is updated to **“Show notifications”** (plural). When a **custom agreements file** is loaded via `RI_AGREEMENTS_PATH`, `settings.service` **strips `code`** from the parsed spec so the UI shows that legal copy verbatim instead of built-in locale strings.
> 
> **Frontend:** `ConsentOption` resolves label/description via `api.agreement.<code>.{label,description}` with spec English as `defaultValue`; without `code`, it keeps server text (custom spec / older API). `ItemDescription` uses `common.privacyPolicy` for the link. **EN/BG** locale entries cover analytics and notifications; encryption/eula codes fall back to English until translated.
> 
> Tests and Playwright settings page selectors are updated for the new notification label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3aad38ca971b869015c3de90225718fcaa38415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->