### PR TITLE
RI-8300 Show empty array values as "Empty"

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -69,15 +69,15 @@ describe('ArrayDetailsTable', () => {
     ).toHaveTextContent('18446744073709551610')
   })
 
-  it('shows "(empty)" for null values (gap-preserving range)', () => {
+  it('shows "Empty" for null values (gap-preserving range)', () => {
     renderComponent([arrayElementFactory.build({ index: '3' })])
 
     expect(screen.getByTestId('array-details-table-empty-3')).toHaveTextContent(
-      '(empty)',
+      'Empty',
     )
   })
 
-  it('shows "(empty)" when value is undefined (JSON-dropped key edge case)', () => {
+  it('shows "Empty" when value is undefined (JSON-dropped key edge case)', () => {
     renderComponent([
       arrayElementFactory.build({
         index: '4',
@@ -86,7 +86,7 @@ describe('ArrayDetailsTable', () => {
     ])
 
     expect(screen.getByTestId('array-details-table-empty-4')).toHaveTextContent(
-      '(empty)',
+      'Empty',
     )
   })
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+import { Text } from 'uiSrc/components/base/text'
+
+export const EmptyValue = styled(Text)`
+  color: ${({ theme }) => theme.semantic.color.text.neutral500};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { Text } from 'uiSrc/components/base/text'
 import {
   TEXT_DISABLED_COMPRESSED_VALUE,
   TEXT_DISABLED_FORMATTER_EDITING,
@@ -27,12 +26,13 @@ import {
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
 import { ArrayValueCellProps } from './ArrayValueCell.types'
+import * as S from './ArrayValueCell.styles'
 
 const TEST_ID_PREFIX = 'array-details-table'
 
 /**
  * Renders a populated slot's value (formatted) wrapped in an inline editor for
- * in-place edits (ARSET). Empty slots render a muted "(empty)" marker and are
+ * in-place edits (ARSET). Empty slots render a muted "Empty" marker and are
  * not editable — filling a gap changes ARCOUNT/ARLEN and belongs to append /
  * set-at-index, not the value edit.
  */
@@ -52,9 +52,12 @@ export const ArrayValueCell = ({
   // slot arrived without a buffer payload.
   if (value == null) {
     return (
-      <Text color="subdued" data-testid={`${TEST_ID_PREFIX}-empty-${index}`}>
-        (empty)
-      </Text>
+      <S.EmptyValue
+        variant="italic"
+        data-testid={`${TEST_ID_PREFIX}-empty-${index}`}
+      >
+        Empty
+      </S.EmptyValue>
     )
   }
 


### PR DESCRIPTION
# What

Polish for the array View / Search / Aggregate tabs: empty
slots now render as an italic, muted **"Empty"** instead of **"(empty)"**.

Matches how vector sets display empty attribute values (`styled(Text)` with
`neutral500`, `variant="italic"`), so empty values look identical across key
types.

## Before

<img width="760" height="275" alt="Screenshot 2026-07-06 at 19 30 01" src="https://github.com/user-attachments/assets/38b5cc8a-fb76-42d8-a47d-d638b73d0e77" />

## After

<img width="760" height="275" alt="Screenshot 2026-07-06 at 19 29 51" src="https://github.com/user-attachments/assets/1abfb9c2-1f52-4191-b1d7-2dc3b46b942d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only copy and styling for null/undefined array values; no API or edit behavior changes.
> 
> **Overview**
> Empty array slots in the details table (View / Search / Aggregate) no longer show **(empty)** on subdued `Text`. They now render **Empty** via a new `EmptyValue` styled component (`neutral500`, `variant="italic"`), matching how vector sets show missing attribute values.
> 
> Unit tests in `ArrayDetailsTable.spec.tsx` were updated to assert the new label and copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335568e866e459ec5ca3130d41f9aea78d5faff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->