### PR TITLE
fix(ui): make search index list scrollable

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
@@ -7,7 +7,12 @@ export const ContentArea = styled(Row)`
 `
 
 export const TableWrapper = styled(Col)`
+  /* Inset so the table card chrome (rounded corners / shadow) is not
+     clipped by the scrollport below */
   padding: 2px;
   min-width: 0;
+  /* Bound the height to the resizable panel so the list scrolls
+     instead of overflowing, matching the database list scroll fix */
+  height: 100%;
   overflow: auto;
 `

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
@@ -7,12 +7,12 @@ export const ContentArea = styled(Row)`
 `
 
 export const TableWrapper = styled(Col)`
-  /* Inset so the table card chrome (rounded corners / shadow) is not
-     clipped by the scrollport below */
   padding: 2px;
   min-width: 0;
-  /* Bound the height to the resizable panel so the list scrolls
-     instead of overflowing, matching the database list scroll fix */
-  height: 100%;
   overflow: auto;
+`
+
+export const ScrollableWrapper = styled.div`
+  height: 100%;
+  overflow-y: auto;
 `

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.styles.ts
@@ -9,10 +9,9 @@ export const ContentArea = styled(Row)`
 export const TableWrapper = styled(Col)`
   padding: 2px;
   min-width: 0;
-  overflow: auto;
 `
 
 export const ScrollableWrapper = styled.div`
   height: 100%;
-  overflow-y: auto;
+  overflow: auto;
 `

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
@@ -35,15 +35,17 @@ export const ListContent = () => {
           minSize={30}
           defaultSize={viewingIndexName !== null ? 70 : 100}
         >
-          <S.TableWrapper>
-            <IndexList
-              data={data}
-              loading={loading}
-              onQueryClick={onQueryClick}
-              actions={actions}
-              dataTestId="vector-search--list--table"
-            />
-          </S.TableWrapper>
+          <S.ScrollableWrapper>
+            <S.TableWrapper>
+              <IndexList
+                data={data}
+                loading={loading}
+                onQueryClick={onQueryClick}
+                actions={actions}
+                dataTestId="vector-search--list--table"
+              />
+            </S.TableWrapper>
+          </S.ScrollableWrapper>
         </ResizablePanel>
 
         {viewingIndexName !== null && (


### PR DESCRIPTION
# What

The vector-search index list did not scroll when there were many indexes — the table overflowed its resizable panel. This wraps the list in a dedicated `ScrollableWrapper` so the whole list scrolls within its container, matching the recent database list scroll fix.

Before:

https://github.com/user-attachments/assets/3a7c463d-0085-47d5-9c80-28c84870bf99

After:

https://github.com/user-attachments/assets/edc446ac-fc7e-4946-896d-d2a53db87874

# Testing

1. Connect to a database with a RediSearch module.
2. Open the **Search** page so the index list is shown.
3. Create/have enough indexes to exceed the panel height.
4. Verify the list scrolls vertically within its container (the header/layout stays put), instead of overflowing or being clipped.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout/CSS change on the Search index list with no auth, data, or API impact.
> 
> **Overview**
> Fixes the vector-search **index list** overflowing its horizontal **resizable panel** when many indexes are present.
> 
> A new **`ScrollableWrapper`** (`height: 100%`, `overflow: auto`) wraps **`IndexList`** inside the panel; **`TableWrapper`** no longer owns scrolling (padding/min-width only). The list scrolls inside the panel while the surrounding layout and side panel stay fixed—aligned with the recent database list scroll fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b78751818038708a8f1c20b56d677308f4996c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->