### PR TITLE
RI-8300: Array Add Key show required asterisk in front of the label

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyArray/AddKeyArrayContiguous/AddKeyArrayContiguous.tsx
@@ -39,7 +39,10 @@ const AddKeyArrayContiguous = (props: AddKeyArrayContiguousProps) => {
 
   return (
     <>
-      <FormField label={config.startIndex.label}>
+      <FormField
+        label={config.startIndex.label}
+        required={config.startIndex.isRequire}
+      >
         <TextInput
           id={config.startIndex.name}
           placeholder={config.startIndex.placeholder}

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
@@ -135,19 +135,19 @@ export const AddArrayFormConfig: IAddArrayFormConfig = {
   startIndex: {
     name: 'startIndex',
     isRequire: true,
-    label: 'Start Index*',
+    label: 'Start Index',
     placeholder: 'Enter Start Index',
   },
   index: {
     name: 'index',
     isRequire: true,
-    label: 'Index*',
+    label: 'Index',
     placeholder: 'Enter Index',
   },
   value: {
     name: 'value',
     isRequire: true,
-    label: 'Value*',
+    label: 'Value',
     placeholder: 'Enter Value',
   },
 }


### PR DESCRIPTION
## Before

<img width="713" height="542" alt="Screenshot 2026-07-07 at 10 31 51" src="https://github.com/user-attachments/assets/bbef4f10-c718-4ce9-ae04-4f8fa2908a74" />

## After

<img width="713" height="542" alt="Screenshot 2026-07-07 at 10 31 31" src="https://github.com/user-attachments/assets/7bfcc9b3-76b9-42dc-b2b0-250e8afd974c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and label presentation only in the Add Key array UI; no validation or API behavior changes.
> 
> **Overview**
> **Array Add Key** required fields no longer bake `*` into label strings in `AddArrayFormConfig`; labels are plain text while `isRequire` stays `true` for Start Index, Index, and Value.
> 
> **Contiguous array** form passes `required={config.startIndex.isRequire}` into `FormField` for Start Index so the shared form component renders the required indicator in front of the label (matching the intended design in the PR screenshots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edb8e8cc2fbc0756abccf51f9b15d370938459f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->