### PR TITLE
fix(ui): prevent env badge clipping in database list name column

### DIFF
--- a/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.styles.ts
+++ b/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.styles.ts
@@ -3,7 +3,13 @@ import styled from 'styled-components'
 import { Row } from 'uiSrc/components/base/layout/flex'
 
 export const StyledCellNameWrapper = styled(Row)`
-  > span {
+  > * {
+    flex-shrink: 0;
+  }
+
+  > span:last-child {
+    flex-shrink: 1;
+    min-width: 0;
     overflow: hidden;
   }
 `


### PR DESCRIPTION
## Description

In the database list table, when the PROD/DEV environment badge is shown and the Name column isn't wide enough, the badge gets clipped (e.g. rendered as "PR" instead of "PROD").

| Before | After |
| - | - |
<img width="921" height="260" alt="Screenshot 2026-07-07 at 10 47 45" src="https://github.com/user-attachments/assets/fed90ead-453a-459e-b76a-81f4af8fa27d" />|<img width="921" height="260" alt="Screenshot 2026-07-07 at 10 45 30" src="https://github.com/user-attachments/assets/e372d3aa-ba86-40de-846b-fa442d85f966" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped flexbox styling in one styled component with no logic, API, or data changes.
> 
> **Overview**
> **Fixes PROD/DEV badge clipping** in the home database list when the Name column is narrow. Previously every flex child in `StyledCellNameWrapper` could shrink, so a long alias compressed the environment badge (e.g. "PR" instead of "PROD").
> 
> The styled row now sets **`flex-shrink: 0` on all direct children** so the status indicator and badge keep their natural width, and moves truncation to the name only via **`flex-shrink: 1` and `min-width: 0`** on the last `span`, with **`overflow: hidden`** preserved there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e968fb4a0e461d3d2b4b14172a0f49bfa34b1f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->