### PR TITLE
Add New Key: consistent required-field asterisks (in front of labels)

### DIFF
--- a/redisinsight/ui/src/components/base/forms/FormField.tsx
+++ b/redisinsight/ui/src/components/base/forms/FormField.tsx
@@ -23,6 +23,5 @@ export function FormField(props: RedisFormFieldProps) {
   return <RedisFormField {...props} />
 }
 
-// Standalone label (renders the required `*` in front of the text) for cases
-// like column headers that sit outside a `FormField`.
+// Standalone label for use outside a FormField (e.g. column headers).
 FormField.Label = RedisFormField.Label

--- a/redisinsight/ui/src/components/base/forms/FormField.tsx
+++ b/redisinsight/ui/src/components/base/forms/FormField.tsx
@@ -22,3 +22,7 @@ export function FormField(props: RedisFormFieldProps) {
   }
   return <RedisFormField {...props} />
 }
+
+// Standalone label (renders the required `*` in front of the text) for cases
+// like column headers that sit outside a `FormField`.
+FormField.Label = RedisFormField.Label

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -99,7 +99,6 @@ describe('AddKey', () => {
       />,
     )
 
-    // Label text is clean; the required asterisk renders in front of it.
     const keyType = screen.getByText('Key Type').closest('label')
     expect(keyType).toHaveTextContent('Key Type')
     expect(keyType?.textContent?.trimStart().startsWith('*')).toBe(true)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -99,7 +99,13 @@ describe('AddKey', () => {
       />,
     )
 
-    expect(screen.getByText(/Key Type\*/i)).toBeInTheDocument()
+    // Label text is clean; the required asterisk renders in front of it.
+    const keyType = screen.getByText('Key Type').closest('label')
+    expect(keyType).toHaveTextContent('Key Type')
+    expect(keyType?.textContent?.trimStart().startsWith('*')).toBe(true)
+
+    const keyName = screen.getByText('Key Name').closest('label')
+    expect(keyName?.textContent?.trimStart().startsWith('*')).toBe(true)
   })
 
   it('should have key type select with predefined first value from options', () => {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyCommonFields/AddKeyCommonFields.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyCommonFields/AddKeyCommonFields.tsx
@@ -58,7 +58,7 @@ const AddKeyCommonFields = (props: Props) => {
           <FormFieldset
             legend={{ children: 'Select key type', display: 'hidden' }}
           >
-            <FormField label="Key Type*">
+            <FormField label="Key Type" required>
               <RiSelect
                 options={options}
                 valueRender={({ option }): JSX.Element =>
@@ -91,7 +91,10 @@ const AddKeyCommonFields = (props: Props) => {
         </FlexItem>
       </Row>
       <Spacer size="m" />
-      <FormField label={config.keyName.label}>
+      <FormField
+        label={config.keyName.label}
+        required={config.keyName.isRequire}
+      >
         <TextInput
           name={config.keyName.name}
           id={config.keyName.name}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.spec.tsx
@@ -37,6 +37,14 @@ describe('AddKeyReJSON', () => {
     expect(render(<AddKeyReJSON {...instance(mockedProps)} />)).toBeTruthy()
   })
 
+  it('renders the Value label with the required asterisk in front', () => {
+    render(<AddKeyReJSON {...instance(mockedProps)} />)
+
+    const label = screen.getByText('Value').closest('label')
+    expect(label).toHaveTextContent('Value')
+    expect(label?.textContent?.trimStart().startsWith('*')).toBe(true)
+  })
+
   it('should set value properly', () => {
     render(<AddKeyReJSON {...instance(mockedProps)} />)
     const valueArea = screen.getByTestId('json-value')

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
@@ -73,7 +73,7 @@ const AddKeyReJSON = (props: Props) => {
 
   return (
     <form onSubmit={onFormSubmit}>
-      <FormField label={config.value.label}>
+      <FormField label={config.value.label} required={config.value.isRequire}>
         <>
           <MonacoJson
             value={ReJSONValue}

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.spec.tsx
@@ -13,6 +13,14 @@ describe('AddKeyZset', () => {
     expect(render(<AddKeyZset {...instance(mockedProps)} />)).toBeTruthy()
   })
 
+  it('shows a Score column header with the required asterisk in front', () => {
+    render(<AddKeyZset {...instance(mockedProps)} />)
+
+    const score = screen.getByText('Score').closest('label')
+    expect(score?.textContent?.trimStart().startsWith('*')).toBe(true)
+    expect(screen.getByText('Member')).toBeInTheDocument()
+  })
+
   it('should set member value properly', () => {
     render(<AddKeyZset {...instance(mockedProps)} />)
     const memberInput = screen.getByTestId(MEMBER_NAME)

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
@@ -178,6 +178,10 @@ const AddKeyZset = (props: Props) => {
         isClearDisabled={isClearDisabled}
         onClickRemove={onClickRemove}
         onClickAdd={addMember}
+        columnLabels={[
+          { label: config.member.label },
+          { label: config.score.label, required: config.score.isRequire },
+        ]}
       >
         {(item, index) => (
           <Row align="center" gap="m">

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/fields-config.ts
@@ -15,7 +15,7 @@ export const AddCommonFieldsFormConfig: IAddCommonFieldsFormConfig = {
   keyName: {
     name: 'keyName',
     isRequire: true,
-    label: 'Key Name*',
+    label: 'Key Name',
     placeholder: 'Enter Key Name',
   },
   keyTTL: {
@@ -55,8 +55,8 @@ export const AddZsetFormConfig: IAddZsetFormConfig = {
   score: {
     name: 'score',
     isRequire: true,
-    label: 'Score*',
-    placeholder: 'Enter Score*',
+    label: 'Score',
+    placeholder: 'Enter Score',
   },
   member: {
     name: 'member',
@@ -108,7 +108,7 @@ export const AddListFormConfig: IAddListFormConfig = {
     name: 'count',
     isRequire: true,
     label: 'Count',
-    placeholder: 'Enter Count*',
+    placeholder: 'Enter Count',
   },
 }
 
@@ -119,8 +119,8 @@ interface IAddJSONFormConfig {
 export const AddJSONFormConfig: IAddJSONFormConfig = {
   value: {
     name: 'value',
-    isRequire: false,
-    label: 'Value*',
+    isRequire: true,
+    label: 'Value',
     placeholder: 'Enter JSON',
   },
 }
@@ -163,7 +163,7 @@ export const AddStreamFormConfig: IAddStreamFormConfig = {
     id: 'entryId',
     name: 'Entry ID',
     isRequire: true,
-    label: 'Entry ID*',
+    label: 'Entry ID',
     placeholder: 'Enter Entry ID',
   },
   name: {

--- a/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.spec.tsx
@@ -37,7 +37,6 @@ describe('AddMultipleFields', () => {
     const score = screen.getByText('Score').closest('label')
     expect(score?.textContent?.trimStart().startsWith('*')).toBe(true)
 
-    // A non-required column shows no leading asterisk.
     const member = screen.getByText('Member').closest('label')
     expect(member?.textContent?.trimStart().startsWith('*')).toBe(false)
   })

--- a/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'uiSrc/utils/test-utils'
+import { render, screen } from 'uiSrc/utils/test-utils'
 
 import AddMultipleFields from './AddMultipleFields'
 
@@ -19,5 +19,26 @@ describe('AddMultipleFields', () => {
         </AddMultipleFields>,
       ),
     ).toBeTruthy()
+  })
+
+  it('renders column headers once, with the required asterisk in front', () => {
+    render(
+      <AddMultipleFields
+        items={testItems1}
+        isClearDisabled={() => true}
+        onClickAdd={jest.fn()}
+        onClickRemove={jest.fn()}
+        columnLabels={[{ label: 'Member' }, { label: 'Score', required: true }]}
+      >
+        {() => <div />}
+      </AddMultipleFields>,
+    )
+
+    const score = screen.getByText('Score').closest('label')
+    expect(score?.textContent?.trimStart().startsWith('*')).toBe(true)
+
+    // A non-required column shows no leading asterisk.
+    const member = screen.getByText('Member').closest('label')
+    expect(member?.textContent?.trimStart().startsWith('*')).toBe(false)
   })
 })

--- a/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.tsx
@@ -9,7 +9,13 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { HorizontalSpacer } from 'uiSrc/components/base/layout'
 import { RiTooltip } from 'uiSrc/components'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
 import { ItemsWrapper } from './AddMultipleFields.styles'
+
+export interface ColumnLabel {
+  label: string
+  required?: boolean
+}
 
 export interface Props<T> {
   items: T[]
@@ -17,10 +23,19 @@ export interface Props<T> {
   isClearDisabled: (item: T, index?: number) => boolean
   onClickRemove: (item: T, index?: number) => void
   onClickAdd: () => void
+  /** Optional one-time header row aligned to the item columns. */
+  columnLabels?: ColumnLabel[]
 }
 
 const AddMultipleFields = <T,>(props: Props<T>) => {
-  const { items, children, isClearDisabled, onClickRemove, onClickAdd } = props
+  const {
+    items,
+    children,
+    isClearDisabled,
+    onClickRemove,
+    onClickAdd,
+    columnLabels,
+  } = props
 
   const renderItem = (child: React.ReactNode, item: T, index?: number) => (
     <FlexItem key={index} grow>
@@ -43,6 +58,31 @@ const AddMultipleFields = <T,>(props: Props<T>) => {
 
   return (
     <Col gap="m">
+      {columnLabels && (
+        <Row align="center" gap="m" data-testid="multiple-fields-header">
+          <FlexItem grow>
+            <Row align="center" gap="m">
+              {columnLabels.map((col) => (
+                <FlexItem grow key={col.label}>
+                  <FormField.Label label={col.label} required={col.required} />
+                </FlexItem>
+              ))}
+            </Row>
+          </FlexItem>
+          {/* Hidden button matches the per-row remove column so the header
+              stays aligned with the inputs below. */}
+          <FlexItem>
+            <IconButton
+              icon={DeleteIcon}
+              aria-hidden
+              tabIndex={-1}
+              disabled
+              aria-label="spacer"
+              style={{ visibility: 'hidden' }}
+            />
+          </FlexItem>
+        </Row>
+      )}
       <ItemsWrapper gap="m">
         {items.map((item, index) =>
           renderItem(children(item, index), item, index),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mock } from 'ts-mockito'
-import { render } from 'uiSrc/utils/test-utils'
+import { render, screen } from 'uiSrc/utils/test-utils'
 
 import StreamEntryFields, { Props } from './StreamEntryFields'
 
@@ -11,5 +11,13 @@ describe('StreamEntryFields', () => {
     expect(
       render(<StreamEntryFields {...mockedProps} fields={[]} />),
     ).toBeTruthy()
+  })
+
+  it('renders the Entry ID label with the required asterisk in front', () => {
+    render(<StreamEntryFields {...mockedProps} fields={[]} />)
+
+    const label = screen.getByText('Entry ID').closest('label')
+    expect(label).toHaveTextContent('Entry ID')
+    expect(label?.textContent?.trimStart().startsWith('*')).toBe(true)
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
@@ -117,6 +117,7 @@ const StreamEntryFields = (props: Props) => {
       <EntryIdContainer>
         <FormField
           label={config.entryId.label}
+          required={config.entryId.isRequire}
           additionalText={
             <InlineRow align="center" gap="s">
               <RiTooltip


### PR DESCRIPTION
# What

Makes the required-field markers across the whole Add New Key form
consistent — every required field shows its asterisk **in front of** the
label (via redis-ui's `required`), replacing today's mix of
asterisk-after-label, asterisk-in-placeholder, and missing markers.

- **Key Name** and **Key Type** (common fields, shown for every type) → asterisk in front.
- **ReJSON `Value`** → asterisk in front, and fixed its config `isRequire` (was `false` though the field is required — empty JSON blocks submit).
- **Stream `Entry ID`** (shared `StreamEntryFields`, so the in-place add-entry form gets it too) → asterisk in front.
- **ZSet `Score`** (rendered in label-less repeated rows) → added a one-time **column header** row ("Member" / "Score *") via a new optional `columnLabels` prop on the shared `AddMultipleFields`, aligned to the row's remove-button column.
- Cleaned stray `*` from the `Enter Score` / `Enter Count` placeholders; exposed `FormField.Label` for standalone header labels.

# Preview

## Key name and key type (general)

| Before    | After |
| -------- | ------- |
| <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 51" src="https://github.com/user-attachments/assets/36396c6e-ce1c-4842-b143-df34ac9425f4" />  |  <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 35" src="https://github.com/user-attachments/assets/f702d4eb-cb57-4534-bd06-f2a46249b4c0" />    |

## JSON

| Before    | After |
| -------- | ------- |
|  <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 36 02" src="https://github.com/user-attachments/assets/aa509050-9491-467c-813f-c98757b9c4cd" />  |  <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 21" src="https://github.com/user-attachments/assets/96c95977-6e75-4064-9c5d-e4fff64affd9" />  |

## Stream

| Before    | After |
| -------- | ------- |
|  <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 36 09" src="https://github.com/user-attachments/assets/6b393e27-d001-4381-b14a-51f01ee1067a" /> | <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 26" src="https://github.com/user-attachments/assets/d3fd7983-78ec-451e-aa5c-4cf403a4c01f" /> |

## Sorted set score

| Before    | After |
| -------- | ------- |
|  <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 58" src="https://github.com/user-attachments/assets/9eb91490-2122-47cc-85a4-18ec9a6f9e35" /> | <img width="713" height="503" alt="Screenshot 2026-07-07 at 10 35 42" src="https://github.com/user-attachments/assets/5950755b-0430-4160-be1b-6e1748417520" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label and placeholder changes with no API or validation logic changes beyond aligning ReJSON config with existing submit rules.
> 
> **Overview**
> Standardizes **required-field markers** across the Add New Key flow by driving asterisks through redis-ui `FormField` **`required`** (leading asterisk) instead of `*` in label text or placeholders.
> 
> **Key Name**, **Key Type**, **ReJSON Value**, and **Stream Entry ID** now pass `required` from `fields-config` / hard-coded where needed; config strings drop trailing `*`, and **ReJSON `value.isRequire`** is corrected to `true` so it matches submit validation. **ZSet** adds a one-time **Member / Score** header via new optional **`columnLabels`** on **`AddMultipleFields`**, rendered with **`FormField.Label`** and a hidden remove button for column alignment.
> 
> Tests assert leading `*` on labels instead of matching combined strings like `Key Type*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c72d90eb044aba84f8139796c718b87c098a379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->