### PR TITLE
Allow editing root-level scalar JSON values

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.spec.tsx
@@ -268,6 +268,31 @@ describe('RejsonDetails', () => {
     })
   })
 
+  describe('change editor type button for scalar root values', () => {
+    it.each([
+      ['null', mockedJSONNull],
+      ['string', mockedJSONString],
+      ['boolean', mockedJSONBoolean],
+      ['number', mockedJSONNumber],
+    ])(
+      'should render the change editor type button for a %s root',
+      (dataType, data) => {
+        render(
+          <RejsonDetails
+            {...instance(mockedProps)}
+            data={data}
+            dataType={dataType}
+            parentPath="$"
+            selectedKey={mockedSelectedKey}
+            isDownloaded
+          />,
+        )
+
+        expect(screen.getByTestId('change-editor-type')).toBeInTheDocument()
+      },
+    )
+  })
+
   it('should open inline editor to add JSON key value for object', () => {
     render(
       <RejsonDetails

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/rejson-details/RejsonDetails.tsx
@@ -13,7 +13,13 @@ import {
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
-import { getBrackets, isRealArray, isRealObject, wrapPath } from '../utils'
+import {
+  getBrackets,
+  isRealArray,
+  isRealObject,
+  isScalar,
+  wrapPath,
+} from '../utils'
 import { BaseProps, ObjectTypes } from '../interfaces'
 import RejsonDynamicTypes from '../rejson-dynamic-types'
 import { AddItem, JsonValueActions } from '../components'
@@ -88,6 +94,9 @@ const RejsonDetails = (props: BaseProps) => {
 
   const isObject = isRealObject(data, dataType)
   const isArray = isRealArray(data, dataType)
+  // Scalar roots (e.g. a bare null/string/number/boolean document) have no
+  // inline edit affordance, so expose the text editor as the way to edit them.
+  const isScalarRoot = !isObject && !isArray && isScalar(data)
 
   return (
     <div className={styles.jsonData} id="jsonData" data-testid="json-data">
@@ -101,7 +110,9 @@ const RejsonDetails = (props: BaseProps) => {
               )}
           </span>
           <TopRowActions align="center" justify="end" grow={false}>
-            {(isObject || isArray) && <ChangeEditorTypeButton />}
+            {(isObject || isArray || isScalarRoot) && (
+              <ChangeEditorTypeButton />
+            )}
             <JsonValueActions
               data={data}
               selectedKey={selectedKey}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/utils/utils.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/utils/utils.ts
@@ -1,6 +1,6 @@
 import { isArray, isNull, isString } from 'lodash'
 import JSONBigInt from 'json-bigint'
-import { JSONScalarValue, ObjectTypes } from '../interfaces'
+import { ObjectTypes } from '../interfaces'
 import styles from '../styles.module.scss'
 
 enum ClassNames {
@@ -11,7 +11,7 @@ enum ClassNames {
   others = 'jsonNonStringPrimitive',
 }
 
-export function isScalar(x: JSONScalarValue) {
+export function isScalar(x: unknown) {
   return (
     ['string', 'number', 'boolean', 'bigint'].indexOf(typeof x) !== -1 ||
     x === null


### PR DESCRIPTION
# What

RedisJSON documents whose root value is a scalar (`null`, string, number, boolean — e.g. `JSON.SET mykey $ null`) were rendered read-only in the default key detail view, with no inline edit and no way to reach the text editor. You could create such a key but never edit or delete it from the UI.

This exposes the **Change editor type** button for scalar roots (previously gated to objects/arrays only), so the Monaco text editor — which can edit the whole document — becomes reachable. Object/array-only affordances (brackets, add-field) are unchanged.

Also widens the `isScalar` type guard to accept `unknown`, since it's a runtime `typeof` check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change in RedisJSON key details plus a type-signature tweak; no auth, persistence, or API changes.
> 
> **Overview**
> Scalar-root RedisJSON keys (`null`, string, number, boolean) were stuck in the tree view with no path to the Monaco text editor. **`RejsonDetails`** now treats a scalar root as eligible for **`ChangeEditorTypeButton`** (same switch used for objects/arrays), so users can edit the whole document in the text editor. Object/array-only UI (brackets, add-field) is unchanged.
> 
> The **`isScalar`** helper now accepts **`unknown`** instead of a narrow JSON scalar type, matching its runtime `typeof` / null checks. Tests cover the change-editor button for each scalar root type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2617583a07895b383e365ed9a24e802c32e968f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->