### PR TITLE
fix(ui): show loading state on quick add-database button

### DIFF
--- a/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
@@ -154,6 +154,7 @@ const AddDatabaseScreen = (props: Props) => {
                   <PrimaryButton
                     type="submit"
                     disabled={!!isInvalid}
+                    loading={isLoading}
                     icon={isInvalid ? InfoIcon : undefined}
                     data-testid="btn-submit"
                   >


### PR DESCRIPTION
## Description

The submit button on the quick **Add database** (Connection URL) screen did not reflect the in-flight connection request. The sibling **Test connection** button already consumed `loadingChanging`, but the submit button was missing the `loading` prop — so when connecting to a database that is unreachable, the button stayed unchanged for the full connection timeout (up to 30s) with no spinner and no disabled state, giving the impression that nothing was happening.

## Fix

Wire `loading={isLoading}` into the submit `PrimaryButton` in `AddDatabaseScreen.tsx`, mirroring the existing **Test connection** button and the manual connection form. No new state — `loadingChanging` is already toggled by `createInstanceStandaloneAction`.

**Before:**

https://github.com/user-attachments/assets/c3a18008-20e2-45bb-b2ec-6f3b51fb1dc2
 
**After:**

https://github.com/user-attachments/assets/3c113399-d777-4d6d-b74d-c2ba71f38211


## Testing

Add Database → Connection URL `redis://default@10.255.255.1:6379` → **Add database**. A blackhole IP silently drops packets (unlike a closed port, which refuses instantly), so the request hangs the full connection timeout — long enough to observe the button state.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-prop UI change reusing existing Redux loading state; no new logic or backend impact.
> 
> **Overview**
> The quick **Add database** submit button on the Connection URL screen now uses the existing `loadingChanging` flag via `loading={isLoading}`, matching **Test connection** and the manual form.
> 
> During slow or hanging `createInstanceStandaloneAction` requests (e.g. unreachable hosts), the button shows a spinner and stays disabled until the request finishes instead of looking idle for the full timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91dbb642d7225a5ad9e3f7f706e69ca69a96168c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->