### PR TITLE
RI-8090 Fix full screen mode for query results

### DIFF
--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -306,6 +306,7 @@ const QueryCardHeader = (props: Props) => {
 
   return (
     <Row
+      grow={false}
       onClick={handleToggleOpen}
       tabIndex={0}
       onKeyDown={() => {}}


### PR DESCRIPTION
# What

Fixes full screen mode for query result cards, which was entirely broken in Workbench and Vector Search: the card header stretched to fill half the screen and the result content floated in the middle of the viewport.

The header `Row` inherits the layout component's default `flex-grow: 1`. In normal view the card container is a block element so this is inert, but in full screen the container becomes a flex column (`height: 100%`), so the header grew far past its 45px height and pushed the results out of place. Setting `grow={false}` keeps the header at its natural height; the results area below already has `flex: auto` and now fills the remaining space as before.

| Before | After | 
| - | - |
| <img width="1399" height="940" alt="image" src="https://github.com/user-attachments/assets/cd1cafc5-cbc3-445f-853d-6ce1a3555543" /> | <img width="1399" height="940" alt="image" src="https://github.com/user-attachments/assets/48c7f104-2ff5-4fc0-841a-3689b1fb2c47" /> |

# Testing

1. Connect to a database and open Workbench (or Vector Search)
2. Run any command and expand the result card
3. Click the full screen icon on the card
4. The card should cover the entire app window with the header bar at the top and the results filling the rest; Esc / the shrink icon exits full screen
5. Verified in browser: header stays 45px in full screen, normal (non-full-screen) card layout unchanged

---

Closes #RI-8090

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5980d0c7b2f228565a6cec323c4cb60f198d3678. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->