### PR TITLE
RI-8228 Markdown value encoding (all key types)

### DIFF
--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
@@ -204,16 +204,44 @@ describe('MarkdownViewer', () => {
 
     it('should strip on* attributes', () => {
       setupPipeline({
-        html: '<p><img src="x" onerror="window.__pwned = true"></p>',
+        html: '<p onclick="window.__pwned = true">text</p>',
       })
       renderComponent()
 
-      const img = screen
-        .getByTestId('markdown-viewer')
-        .querySelector('img') as HTMLImageElement
-      expect(img).not.toBeNull()
-      expect(img.hasAttribute('onerror')).toBe(false)
+      const paragraph = screen.getByText('text')
+      expect(paragraph.hasAttribute('onclick')).toBe(false)
       expect(testWindow.__pwned).toBeUndefined()
+    })
+
+    it('should not render images that could load remote resources', () => {
+      setupPipeline({
+        html:
+          '<p>before</p>' +
+          '<img src="https://evil.example/pixel.png" alt="tracker">' +
+          '<p>after</p>',
+      })
+      renderComponent()
+
+      const container = screen.getByTestId('markdown-viewer')
+      expect(container.querySelector('img')).toBeNull()
+      expect(container.querySelector('p')).toHaveTextContent('before')
+    })
+
+    it('should not render media or embedding elements', () => {
+      setupPipeline({
+        html:
+          '<video src="https://evil.example/v.mp4"></video>' +
+          '<audio src="https://evil.example/a.mp3"></audio>' +
+          '<svg><image href="https://evil.example/x"></image></svg>' +
+          '<p>safe</p>',
+      })
+      renderComponent()
+
+      const container = screen.getByTestId('markdown-viewer')
+      expect(container.querySelector('video')).toBeNull()
+      expect(container.querySelector('audio')).toBeNull()
+      expect(container.querySelector('svg')).toBeNull()
+      expect(container.querySelector('p')).toHaveTextContent('safe')
     })
 
     it('should strip style attributes', () => {

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
@@ -1,0 +1,272 @@
+import React from 'react'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import { faker } from '@faker-js/faker'
+
+import { render, screen } from 'uiSrc/utils/test-utils'
+import {
+  rehypeWrapSymbols,
+  remarkSanitize,
+} from 'uiSrc/utils/formatters/markdown'
+
+import { MarkdownViewer } from './MarkdownViewer'
+import { MarkdownViewerProps } from './MarkdownViewer.types'
+
+// The unified pipeline is mocked via moduleNameMapper (shared jest.fn stubs), so
+// these tests control the serialized HTML the component would emit and cover how
+// that output is hardened and rendered: the real DOMPurify sanitize plus the real
+// JsxParser tag/attribute blacklists. Full markdown conversion is covered by e2e.
+interface PipelineOptions {
+  html?: string
+  shouldThrow?: boolean
+}
+
+const setupPipeline = ({
+  html = '',
+  shouldThrow = false,
+}: PipelineOptions = {}) => {
+  const use = jest.fn()
+  const processSync = jest.fn(() => {
+    if (shouldThrow) {
+      throw new Error('markdown parse failed')
+    }
+    return html
+  })
+  const chain = { use, processSync }
+  use.mockReturnValue(chain)
+  ;(unified as unknown as jest.Mock).mockReturnValue(chain)
+  return { use, processSync }
+}
+
+const testWindow = window as unknown as { __pwned?: boolean }
+
+describe('MarkdownViewer', () => {
+  const defaultProps: MarkdownViewerProps = {
+    value: faker.lorem.sentence(),
+  }
+
+  const renderComponent = (propsOverride?: Partial<MarkdownViewerProps>) => {
+    const props = { ...defaultProps, ...propsOverride }
+
+    return render(<MarkdownViewer {...props} />)
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete testWindow.__pwned
+  })
+
+  it('should render container with the default data-testid', () => {
+    setupPipeline({ html: '<p>hello</p>' })
+    renderComponent()
+
+    expect(screen.getByTestId('markdown-viewer')).toBeInTheDocument()
+  })
+
+  it('should render container with a custom data-testid', () => {
+    setupPipeline({ html: '<p>hello</p>' })
+    renderComponent({ 'data-testid': 'custom-markdown' })
+
+    expect(screen.getByTestId('custom-markdown')).toBeInTheDocument()
+  })
+
+  it('should run the pipeline with the required plugins in order and pass the value', () => {
+    const value = '# Title'
+    const { use, processSync } = setupPipeline({ html: '<h1>Title</h1>' })
+
+    renderComponent({ value })
+
+    // remark-rehype's jest mock has no default export, so its slot asserts
+    // undefined plus the options object. rehypeWrapSymbols is given the symbol
+    // set to wrap ({ and } only; > is left for DOMPurify to encode).
+    expect(use.mock.calls).toEqual([
+      [remarkParse],
+      [remarkSanitize],
+      [remarkGfm],
+      [remarkRehype, { allowDangerousHtml: true }],
+      [rehypeWrapSymbols, ['{', '}']],
+      [rehypeStringify, { allowDangerousHtml: true }],
+    ])
+    expect(processSync).toBeCalledWith(value)
+  })
+
+  it('should render representative GFM pipeline output', () => {
+    setupPipeline({
+      html:
+        '<h1>Title</h1>' +
+        '<p><strong>bold</strong></p>' +
+        '<ul><li>first item</li></ul>' +
+        '<table><thead><tr><th>name</th></tr></thead>' +
+        '<tbody><tr><td>redis</td></tr></tbody></table>' +
+        '<pre><code>const x = 1</code></pre>' +
+        '<p><a href="https://redis.io" target="_blank">Redis</a></p>',
+    })
+    renderComponent()
+
+    const container = screen.getByTestId('markdown-viewer')
+    expect(container.querySelector('h1')).toHaveTextContent('Title')
+    expect(container.querySelector('strong')).toHaveTextContent('bold')
+    expect(container.querySelector('ul li')).toHaveTextContent('first item')
+    expect(container.querySelector('table th')).toHaveTextContent('name')
+    expect(container.querySelector('table td')).toHaveTextContent('redis')
+    expect(container.querySelector('pre code')).toHaveTextContent('const x = 1')
+    expect(container.querySelector('a')).toHaveAttribute(
+      'href',
+      'https://redis.io',
+    )
+  })
+
+  it('should render plain text as a paragraph, unchanged', () => {
+    const value = 'just some plain text'
+    setupPipeline({ html: `<p>${value}</p>` })
+    renderComponent({ value })
+
+    const text = screen.getByText(value)
+    expect(text.tagName).toBe('P')
+  })
+
+  it('should render {, } and > characters literally', () => {
+    // The pipeline wraps only { and } as {"$&"}; > stays a literal text char
+    // that DOMPurify re-encodes to &gt; and JsxParser decodes back to >.
+    setupPipeline({ html: '<p>values {"{"}a: 1{"}"} > threshold</p>' })
+    renderComponent({ value: 'values {a: 1} > threshold' })
+
+    expect(screen.getByTestId('markdown-viewer')).toHaveTextContent(
+      'values {a: 1} > threshold',
+    )
+  })
+
+  it('should preserve target="_blank" on external links', () => {
+    setupPipeline({
+      html: '<p><a href="https://redis.io" target="_blank">site</a></p>',
+    })
+    renderComponent()
+
+    const link = screen.getByText('site')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('should add target="_blank" and rel to absolute links that lack it', () => {
+    // DOMPurify's afterSanitizeAttributes hook (registered by remarkSanitize)
+    // marks absolute links to open in a new tab and hardens them against
+    // reverse tabnabbing.
+    setupPipeline({ html: '<p><a href="https://redis.io">site</a></p>' })
+    renderComponent()
+
+    const link = screen.getByText('site')
+    expect(link).toHaveAttribute('href', 'https://redis.io')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('should strip javascript: hrefs from links', () => {
+    setupPipeline({
+      html: '<p><a href="javascript:window.__pwned = true">click</a></p>',
+    })
+    renderComponent()
+
+    const link = screen.getByText('click')
+    expect(link.hasAttribute('href')).toBe(false)
+    expect(testWindow.__pwned).toBeUndefined()
+  })
+
+  it('should strip relative hrefs from links', () => {
+    setupPipeline({ html: '<p><a href="/relative/path">local</a></p>' })
+    renderComponent()
+
+    const link = screen.getByText('local')
+    expect(link.hasAttribute('href')).toBe(false)
+  })
+
+  describe('hardening', () => {
+    it('should not render script elements or execute them', () => {
+      setupPipeline({
+        html: '<p>before</p><script>window.__pwned = true</script>',
+      })
+      renderComponent()
+
+      const container = screen.getByTestId('markdown-viewer')
+      expect(container.querySelector('script')).toBeNull()
+      expect(container.querySelector('p')).toHaveTextContent('before')
+      expect(testWindow.__pwned).toBeUndefined()
+    })
+
+    it('should strip on* attributes', () => {
+      setupPipeline({
+        html: '<p><img src="x" onerror="window.__pwned = true"></p>',
+      })
+      renderComponent()
+
+      const img = screen
+        .getByTestId('markdown-viewer')
+        .querySelector('img') as HTMLImageElement
+      expect(img).not.toBeNull()
+      expect(img.hasAttribute('onerror')).toBe(false)
+      expect(testWindow.__pwned).toBeUndefined()
+    })
+
+    it('should strip style attributes', () => {
+      setupPipeline({
+        html: '<p style="background: url(https://evil.example)">styled</p>',
+      })
+      renderComponent()
+
+      const paragraph = screen.getByText('styled')
+      expect(paragraph.hasAttribute('style')).toBe(false)
+    })
+
+    it('should not render iframe and link elements', () => {
+      setupPipeline({
+        html:
+          '<iframe src="https://evil.example"></iframe>' +
+          '<link rel="stylesheet" href="https://evil.example/x.css">' +
+          '<p>safe</p>',
+      })
+      renderComponent()
+
+      const container = screen.getByTestId('markdown-viewer')
+      expect(container.querySelector('iframe')).toBeNull()
+      expect(container.querySelector('link')).toBeNull()
+      expect(container.querySelector('p')).toHaveTextContent('safe')
+    })
+
+    it('should keep rendering surrounding content when a script is embedded', () => {
+      // DOMPurify normalizes the string, so a dangerous node does not poison
+      // the whole document into the empty-viewer JsxParser bail.
+      setupPipeline({
+        html:
+          '<h1>Title</h1>' +
+          '<script>window.__pwned = true</script>' +
+          '<p>after</p>',
+      })
+      renderComponent()
+
+      const container = screen.getByTestId('markdown-viewer')
+      expect(container.querySelector('script')).toBeNull()
+      expect(container.querySelector('h1')).toHaveTextContent('Title')
+      expect(container.querySelector('p')).toHaveTextContent('after')
+      expect(testWindow.__pwned).toBeUndefined()
+    })
+  })
+
+  it('should render an empty value without crashing', () => {
+    const { processSync } = setupPipeline({ html: '' })
+    renderComponent({ value: '' })
+
+    expect(screen.getByTestId('markdown-viewer')).toBeInTheDocument()
+    expect(processSync).toBeCalledWith('')
+  })
+
+  it('should fall back to the raw value as plain text when the pipeline throws', () => {
+    const value = '# Title *raw*'
+    setupPipeline({ shouldThrow: true })
+    renderComponent({ value })
+
+    const container = screen.getByTestId('markdown-viewer')
+    expect(container).toHaveTextContent(value)
+    expect(container.querySelector('h1')).toBeNull()
+  })
+})

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.spec.tsx
@@ -7,18 +7,15 @@ import rehypeStringify from 'rehype-stringify'
 import { faker } from '@faker-js/faker'
 
 import { render, screen } from 'uiSrc/utils/test-utils'
-import {
-  rehypeWrapSymbols,
-  remarkSanitize,
-} from 'uiSrc/utils/formatters/markdown'
+import { remarkSanitize } from 'uiSrc/utils/formatters/markdown'
 
 import { MarkdownViewer } from './MarkdownViewer'
 import { MarkdownViewerProps } from './MarkdownViewer.types'
 
 // The unified pipeline is mocked via moduleNameMapper (shared jest.fn stubs), so
 // these tests control the serialized HTML the component would emit and cover how
-// that output is hardened and rendered: the real DOMPurify sanitize plus the real
-// JsxParser tag/attribute blacklists. Full markdown conversion is covered by e2e.
+// the real DOMPurify sanitize hardens it before it is rendered. Full markdown
+// conversion is covered by e2e.
 interface PipelineOptions {
   html?: string
   shouldThrow?: boolean
@@ -80,14 +77,12 @@ describe('MarkdownViewer', () => {
     renderComponent({ value })
 
     // remark-rehype's jest mock has no default export, so its slot asserts
-    // undefined plus the options object. rehypeWrapSymbols is given the symbol
-    // set to wrap ({ and } only; > is left for DOMPurify to encode).
+    // undefined plus the options object.
     expect(use.mock.calls).toEqual([
       [remarkParse],
       [remarkSanitize],
       [remarkGfm],
       [remarkRehype, { allowDangerousHtml: true }],
-      [rehypeWrapSymbols, ['{', '}']],
       [rehypeStringify, { allowDangerousHtml: true }],
     ])
     expect(processSync).toBeCalledWith(value)
@@ -129,14 +124,27 @@ describe('MarkdownViewer', () => {
   })
 
   it('should render {, } and > characters literally', () => {
-    // The pipeline wraps only { and } as {"$&"}; > stays a literal text char
-    // that DOMPurify re-encodes to &gt; and JsxParser decodes back to >.
-    setupPipeline({ html: '<p>values {"{"}a: 1{"}"} > threshold</p>' })
+    // Rendered as HTML, not parsed as JSX, so braces are literal text.
+    setupPipeline({ html: '<p>values {a: 1} &#x3E; threshold</p>' })
     renderComponent({ value: 'values {a: 1} > threshold' })
 
     expect(screen.getByTestId('markdown-viewer')).toHaveTextContent(
       'values {a: 1} > threshold',
     )
+  })
+
+  it('should not evaluate JSX expressions embedded in raw HTML', () => {
+    // DOMPurify keeps `{...}` as inert text; a JSX parser would execute it.
+    setupPipeline({
+      html: '<div>{"".constructor.constructor("window.__pwned = true")()}</div>',
+    })
+    renderComponent({ value: 'irrelevant' })
+
+    const container = screen.getByTestId('markdown-viewer')
+    expect(container).toHaveTextContent(
+      '{"".constructor.constructor("window.__pwned = true")()}',
+    )
+    expect(testWindow.__pwned).toBeUndefined()
   })
 
   it('should preserve target="_blank" on external links', () => {
@@ -234,8 +242,7 @@ describe('MarkdownViewer', () => {
     })
 
     it('should keep rendering surrounding content when a script is embedded', () => {
-      // DOMPurify normalizes the string, so a dangerous node does not poison
-      // the whole document into the empty-viewer JsxParser bail.
+      // DOMPurify strips the script and keeps the surrounding nodes.
       setupPipeline({
         html:
           '<h1>Title</h1>' +

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
@@ -130,8 +130,4 @@ export const Container = styled.div<
     border-top: 1px solid
       ${({ theme }) => theme.semantic.color.border.neutral500};
   }
-
-  img {
-    max-width: 100%;
-  }
 `

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
@@ -1,0 +1,135 @@
+import { PropsWithChildren } from 'react'
+import styled from 'styled-components'
+
+import { CommonProps } from 'uiSrc/components/base/theme/types'
+
+export const Container = styled.div<PropsWithChildren<CommonProps>>`
+  font-size: ${({ theme }) => theme.core.font.fontSize.s14};
+  color: ${({ theme }) => theme.semantic.color.text.neutral800};
+  line-height: 1.5;
+  overflow-wrap: break-word;
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: ${({ theme }) => theme.core.space.space200} 0
+      ${({ theme }) => theme.core.space.space100};
+    font-weight: ${({ theme }) => theme.core.font.fontWeight.semiBold};
+  }
+
+  h1 {
+    font-size: ${({ theme }) => theme.core.font.fontSize.s20};
+  }
+
+  h2 {
+    font-size: ${({ theme }) => theme.core.font.fontSize.s18};
+  }
+
+  h3 {
+    font-size: ${({ theme }) => theme.core.font.fontSize.s16};
+  }
+
+  h4,
+  h5,
+  h6 {
+    font-size: ${({ theme }) => theme.core.font.fontSize.s14};
+  }
+
+  p {
+    margin: ${({ theme }) => theme.core.space.space100} 0;
+  }
+
+  ul,
+  ol {
+    margin: ${({ theme }) => theme.core.space.space100} 0;
+    padding-left: ${({ theme }) => theme.core.space.space300};
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  code {
+    padding: 0 ${({ theme }) => theme.core.space.space050};
+    font-family: ${({ theme }) =>
+      theme.core.font.fontFamily.sourceCodeProRegular};
+    font-size: ${({ theme }) => theme.core.font.fontSize.s13};
+    background-color: ${({ theme }) =>
+      theme.semantic.color.background.neutral300};
+    border-radius: ${({ theme }) => theme.core.space.space050};
+  }
+
+  pre {
+    margin: ${({ theme }) => theme.core.space.space100} 0;
+    padding: ${({ theme }) => theme.core.space.space150};
+    background-color: ${({ theme }) =>
+      theme.semantic.color.background.neutral300};
+    border-radius: ${({ theme }) => theme.core.space.space050};
+    overflow-x: auto;
+
+    code {
+      padding: 0;
+      background-color: transparent;
+    }
+  }
+
+  blockquote {
+    margin: ${({ theme }) => theme.core.space.space100} 0;
+    padding-left: ${({ theme }) => theme.core.space.space150};
+    border-left: 2px solid
+      ${({ theme }) => theme.semantic.color.border.neutral500};
+    color: ${({ theme }) => theme.semantic.color.text.neutral600};
+  }
+
+  table {
+    margin: ${({ theme }) => theme.core.space.space100} 0;
+    border-collapse: collapse;
+  }
+
+  th,
+  td {
+    padding: ${({ theme }) => theme.core.space.space050}
+      ${({ theme }) => theme.core.space.space150};
+    border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+  }
+
+  th {
+    font-weight: ${({ theme }) => theme.core.font.fontWeight.semiBold};
+    background-color: ${({ theme }) =>
+      theme.semantic.color.background.neutral300};
+  }
+
+  a {
+    color: ${({ theme }) => theme.semantic.color.text.informative400};
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  hr {
+    margin: ${({ theme }) => theme.core.space.space150} 0;
+    border: none;
+    border-top: 1px solid
+      ${({ theme }) => theme.semantic.color.border.neutral500};
+  }
+
+  img {
+    max-width: 100%;
+  }
+`

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.styles.ts
@@ -1,9 +1,11 @@
-import { PropsWithChildren } from 'react'
+import { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 import { CommonProps } from 'uiSrc/components/base/theme/types'
 
-export const Container = styled.div<PropsWithChildren<CommonProps>>`
+export const Container = styled.div<
+  CommonProps & HTMLAttributes<HTMLDivElement>
+>`
   font-size: ${({ theme }) => theme.core.font.fontSize.s14};
   color: ${({ theme }) => theme.semantic.color.text.neutral800};
   line-height: 1.5;

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
@@ -13,8 +13,30 @@ import { Nullable } from 'uiSrc/utils'
 import { MarkdownViewerProps } from './MarkdownViewer.types'
 import * as S from './MarkdownViewer.styles'
 
-// DOMPurify drops script/iframe/on* by default; style is the one it keeps.
-const SANITIZE_CONFIG = { FORBID_ATTR: ['style'] }
+// Untrusted values get no elements that load remote resources (img/media leak
+// the viewer's IP and enable tracking), embed/script content, or take input.
+// DOMPurify drops on* handlers by default; style is the attribute it keeps.
+const FORBIDDEN_TAGS = [
+  'img',
+  'video',
+  'audio',
+  'source',
+  'svg',
+  'math',
+  'iframe',
+  'object',
+  'embed',
+  'link',
+  'style',
+  'meta',
+  'base',
+  'form',
+  'input',
+  'textarea',
+  'select',
+  'button',
+]
+const SANITIZE_CONFIG = { FORBID_TAGS: FORBIDDEN_TAGS, FORBID_ATTR: ['style'] }
 
 // The custom plugin types its tree as DOM nodes, so it is cast to unist Plugin.
 const markdownToSafeHtml = (value: string): string => {

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
@@ -17,8 +17,6 @@ import { Nullable } from 'uiSrc/utils'
 import { MarkdownViewerProps } from './MarkdownViewer.types'
 import * as S from './MarkdownViewer.styles'
 
-// Tags that can execute code, load external resources, submit data, or hijack
-// layout; none are legitimate output of value markdown.
 const BLACKLISTED_TAGS = [
   'script',
   'iframe',
@@ -45,33 +43,26 @@ const BLACKLISTED_TAGS = [
 
 const BLACKLISTED_ATTRS = [/^on.*/i, /^style$/i]
 
-// Symbols wrapped as {"$&"} string expressions so JsxParser renders them
-// literally. Only "{" and "}" are wrapped: DOMPurify leaves them untouched but
-// re-encodes ">" to "&gt;", which JsxParser decodes back to ">". Wrapping ">"
-// too would make DOMPurify turn {">"} into {"&gt;"}, which JsxParser renders
-// verbatim instead of as ">".
+// ">" stays unwrapped: DOMPurify re-encodes it to "&gt;" and JsxParser decodes
+// it back, while a wrapped {">"} would render as the "&gt;" entity text.
 const JSX_WRAP_SYMBOLS = ['{', '}']
 
-// remarkSanitize and rehypeWrapSymbols type their trees as DOM nodes while
-// unified expects unist plugins, so they are cast at the use site.
+// The custom plugins type their trees as DOM nodes, so they are cast to unist Plugin.
 const markdownToHtml = (value: string): string => {
   const html = String(
     unified()
       .use(remarkParse)
       .use(remarkSanitize as unknown as Plugin)
-      .use(remarkGfm) // support GitHub Flavored Markdown
-      .use(remarkRehype, { allowDangerousHtml: true }) // Pass raw HTML strings through.
-      .use(rehypeWrapSymbols as unknown as Plugin<[string[]]>, JSX_WRAP_SYMBOLS) // Wrap curly braces for JSX parse
-      .use(rehypeStringify, { allowDangerousHtml: true }) // Serialize the raw HTML strings
+      .use(remarkGfm)
+      .use(remarkRehype, { allowDangerousHtml: true })
+      .use(rehypeWrapSymbols as unknown as Plugin<[string[]]>, JSX_WRAP_SYMBOLS)
+      .use(rehypeStringify, { allowDangerousHtml: true })
       .processSync(value),
   )
 
-  // Sanitize the final serialized string so markdown-native links (which
-  // remarkSanitize never inspects) and any raw HTML the mdast heuristics miss
-  // are neutralized before JsxParser. Href hardening (absolute-only links,
-  // target="_blank" and rel="noopener noreferrer") comes from the global
-  // DOMPurify hooks that remarkSanitize registers at module load, so
-  // remarkSanitize must stay in the pipeline imports for this call to apply it.
+  // Final-string sanitize covers what remarkSanitize never inspects (markdown-native
+  // links, raw HTML its mdast heuristics miss). Href hardening comes from the global
+  // DOMPurify hooks remarkSanitize registers at module load - it must stay imported.
   return DOMPurify.sanitize(html)
 }
 

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react'
+import JsxParser from 'react-jsx-parser'
+import { unified } from 'unified'
+import type { Plugin } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import DOMPurify from 'dompurify'
+
+import {
+  rehypeWrapSymbols,
+  remarkSanitize,
+} from 'uiSrc/utils/formatters/markdown'
+import { Nullable } from 'uiSrc/utils'
+
+import { MarkdownViewerProps } from './MarkdownViewer.types'
+import * as S from './MarkdownViewer.styles'
+
+// Tags that can execute code, load external resources, submit data, or hijack
+// layout; none are legitimate output of value markdown.
+const BLACKLISTED_TAGS = [
+  'script',
+  'iframe',
+  'link',
+  'object',
+  'embed',
+  'form',
+  'input',
+  'textarea',
+  'select',
+  'button',
+  'meta',
+  'base',
+  'style',
+  'svg',
+  'math',
+  'video',
+  'audio',
+  'source',
+  'applet',
+  'frame',
+  'frameset',
+]
+
+const BLACKLISTED_ATTRS = [/^on.*/i, /^style$/i]
+
+// Symbols wrapped as {"$&"} string expressions so JsxParser renders them
+// literally. Only "{" and "}" are wrapped: DOMPurify leaves them untouched but
+// re-encodes ">" to "&gt;", which JsxParser decodes back to ">". Wrapping ">"
+// too would make DOMPurify turn {">"} into {"&gt;"}, which JsxParser renders
+// verbatim instead of as ">".
+const JSX_WRAP_SYMBOLS = ['{', '}']
+
+// remarkSanitize and rehypeWrapSymbols type their trees as DOM nodes while
+// unified expects unist plugins, so they are cast at the use site.
+const markdownToHtml = (value: string): string => {
+  const html = String(
+    unified()
+      .use(remarkParse)
+      .use(remarkSanitize as unknown as Plugin)
+      .use(remarkGfm) // support GitHub Flavored Markdown
+      .use(remarkRehype, { allowDangerousHtml: true }) // Pass raw HTML strings through.
+      .use(rehypeWrapSymbols as unknown as Plugin<[string[]]>, JSX_WRAP_SYMBOLS) // Wrap curly braces for JSX parse
+      .use(rehypeStringify, { allowDangerousHtml: true }) // Serialize the raw HTML strings
+      .processSync(value),
+  )
+
+  // Sanitize the final serialized string so markdown-native links (which
+  // remarkSanitize never inspects) and any raw HTML the mdast heuristics miss
+  // are neutralized before JsxParser. Href hardening (absolute-only links,
+  // target="_blank" and rel="noopener noreferrer") comes from the global
+  // DOMPurify hooks that remarkSanitize registers at module load, so
+  // remarkSanitize must stay in the pipeline imports for this call to apply it.
+  return DOMPurify.sanitize(html)
+}
+
+export const MarkdownViewer = ({
+  value,
+  'data-testid': dataTestId = 'markdown-viewer',
+}: MarkdownViewerProps) => {
+  const html: Nullable<string> = useMemo(() => {
+    try {
+      return markdownToHtml(value)
+    } catch {
+      return null
+    }
+  }, [value])
+
+  return (
+    <S.Container data-testid={dataTestId}>
+      {html === null ? (
+        value
+      ) : (
+        <JsxParser
+          components={{}}
+          blacklistedTags={BLACKLISTED_TAGS}
+          blacklistedAttrs={BLACKLISTED_ATTRS}
+          autoCloseVoidElements
+          jsx={html}
+        />
+      )}
+    </S.Container>
+  )
+}

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react'
-import JsxParser from 'react-jsx-parser'
 import { unified } from 'unified'
 import type { Plugin } from 'unified'
 import remarkParse from 'remark-parse'
@@ -8,62 +7,30 @@ import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
 import DOMPurify from 'dompurify'
 
-import {
-  rehypeWrapSymbols,
-  remarkSanitize,
-} from 'uiSrc/utils/formatters/markdown'
+import { remarkSanitize } from 'uiSrc/utils/formatters/markdown'
 import { Nullable } from 'uiSrc/utils'
 
 import { MarkdownViewerProps } from './MarkdownViewer.types'
 import * as S from './MarkdownViewer.styles'
 
-const BLACKLISTED_TAGS = [
-  'script',
-  'iframe',
-  'link',
-  'object',
-  'embed',
-  'form',
-  'input',
-  'textarea',
-  'select',
-  'button',
-  'meta',
-  'base',
-  'style',
-  'svg',
-  'math',
-  'video',
-  'audio',
-  'source',
-  'applet',
-  'frame',
-  'frameset',
-]
+// DOMPurify drops script/iframe/on* by default; style is the one it keeps.
+const SANITIZE_CONFIG = { FORBID_ATTR: ['style'] }
 
-const BLACKLISTED_ATTRS = [/^on.*/i, /^style$/i]
-
-// ">" stays unwrapped: DOMPurify re-encodes it to "&gt;" and JsxParser decodes
-// it back, while a wrapped {">"} would render as the "&gt;" entity text.
-const JSX_WRAP_SYMBOLS = ['{', '}']
-
-// The custom plugins type their trees as DOM nodes, so they are cast to unist Plugin.
-const markdownToHtml = (value: string): string => {
+// The custom plugin types its tree as DOM nodes, so it is cast to unist Plugin.
+const markdownToSafeHtml = (value: string): string => {
   const html = String(
     unified()
       .use(remarkParse)
       .use(remarkSanitize as unknown as Plugin)
       .use(remarkGfm)
       .use(remarkRehype, { allowDangerousHtml: true })
-      .use(rehypeWrapSymbols as unknown as Plugin<[string[]]>, JSX_WRAP_SYMBOLS)
       .use(rehypeStringify, { allowDangerousHtml: true })
       .processSync(value),
   )
 
-  // Final-string sanitize covers what remarkSanitize never inspects (markdown-native
-  // links, raw HTML its mdast heuristics miss). Href hardening comes from the global
-  // DOMPurify hooks remarkSanitize registers at module load - it must stay imported.
-  return DOMPurify.sanitize(html)
+  // Absolute-only links, target=_blank and rel=noopener come from the global
+  // DOMPurify hooks remarkSanitize registers at import; it must stay imported.
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG)
 }
 
 export const MarkdownViewer = ({
@@ -72,25 +39,24 @@ export const MarkdownViewer = ({
 }: MarkdownViewerProps) => {
   const html: Nullable<string> = useMemo(() => {
     try {
-      return markdownToHtml(value)
+      return markdownToSafeHtml(value)
     } catch {
       return null
     }
   }, [value])
 
+  if (html === null) {
+    return <S.Container data-testid={dataTestId}>{value}</S.Container>
+  }
+
+  // The value is untrusted, so it is rendered as DOMPurify-sanitized HTML rather
+  // than parsed as JSX: a JSX parser would evaluate `{...}` expressions embedded
+  // in raw HTML, which sanitization does not neutralize.
   return (
-    <S.Container data-testid={dataTestId}>
-      {html === null ? (
-        value
-      ) : (
-        <JsxParser
-          components={{}}
-          blacklistedTags={BLACKLISTED_TAGS}
-          blacklistedAttrs={BLACKLISTED_ATTRS}
-          autoCloseVoidElements
-          jsx={html}
-        />
-      )}
-    </S.Container>
+    <S.Container
+      data-testid={dataTestId}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   )
 }

--- a/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.types.ts
+++ b/redisinsight/ui/src/components/markdown-viewer/MarkdownViewer.types.ts
@@ -1,0 +1,4 @@
+export interface MarkdownViewerProps {
+  value: string
+  'data-testid'?: string
+}

--- a/redisinsight/ui/src/components/markdown-viewer/index.ts
+++ b/redisinsight/ui/src/components/markdown-viewer/index.ts
@@ -1,0 +1,2 @@
+export { MarkdownViewer } from './MarkdownViewer'
+export type { MarkdownViewerProps } from './MarkdownViewer.types'

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -158,6 +158,7 @@ export enum KeyValueFormat {
   Vector32Bit = 'Vector 32-bit',
   Vector64Bit = 'Vector 64-bit',
   DateTime = 'DateTime',
+  Markdown = 'Markdown',
 }
 
 export const DATETIME_FORMATTER_DEFAULT = 'HH:mm:ss d MMM yyyy'

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.spec.tsx
@@ -25,6 +25,7 @@ describe('KeyValueFormatter', () => {
       'Binary',
       'HEX',
       'JSON',
+      'Markdown',
       'Msgpack',
       'Pickle',
       'Protobuf',

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
@@ -45,7 +45,6 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
   const { value: keyValue } = useAppSelector(stringDataSelector)
 
   const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false)
-  const [typeSelected, setTypeSelected] = useState<KeyValueFormat>(viewFormat)
   const [options, setOptions] = useState<any[]>([])
 
   const dispatch = useAppDispatch()
@@ -66,7 +65,7 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
             content={
               !isStringFormattingEnabled
                 ? TEXT_DISABLED_STRING_FORMATTING
-                : typeSelected
+                : viewFormat
             }
             position="top"
             anchorClassName="flex-row"
@@ -114,7 +113,6 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
       },
     })
 
-    setTypeSelected(value)
     setIsSelectOpen(false)
     dispatch(setViewFormat(value))
   }
@@ -137,7 +135,7 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
             }
             return option.inputDisplay as JSX.Element
           }}
-          value={typeSelected}
+          value={viewFormat}
           onChange={(value: any) => onChangeType(value)}
           data-testid="select-format-key-value"
         />

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/constants.ts
@@ -22,6 +22,10 @@ export const KEY_VALUE_FORMATTER_OPTIONS = [
     value: KeyValueFormat.JSON,
   },
   {
+    text: 'Markdown',
+    value: KeyValueFormat.Markdown,
+  },
+  {
     text: 'Msgpack',
     value: KeyValueFormat.Msgpack,
   },

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.spec.tsx
@@ -17,13 +17,16 @@ import keysReducer, {
   setSelectedKeyRefreshDisabled,
 } from 'uiSrc/slices/browser/keys'
 import { stringToBuffer } from 'uiSrc/utils'
+import { KeyValueFormat } from 'uiSrc/constants'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
   arrayElementFactory,
   arrayElementWithValueFactory,
 } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
 
 import { ArrayDetailsTable } from './ArrayDetailsTable'
+import { ArrayExpandedValue } from './components'
 
 // Store whose selected key is set but whose array `data.keyName` is still
 // empty — the Search-tab / pre-View-load condition the edit key must survive.
@@ -494,6 +497,49 @@ describe('ArrayDetailsTable', () => {
     await user.click(screen.getByTestId('array-details-table-index-7'))
 
     expect(await screen.findByTestId('expanded-7')).toBeInTheDocument()
+  })
+
+  it('renders the expanded value surface in a Markdown-format sub-row', async () => {
+    const user = userEvent.setup()
+    const state = cloneDeep(initialStateDefault)
+    state.browser.keys.selectedKey.viewFormat = KeyValueFormat.Markdown
+    render(
+      <ArrayDetailsTable
+        elements={[
+          arrayElementWithValueFactory.build({
+            index: '7',
+            value: stringToBuffer('# markdown heading'),
+          }),
+        ]}
+        loading={false}
+        isActive
+        expandRowOnClick
+        getIsRowExpandable={(element) => element.value != null}
+        renderExpandedRow={(row) => (
+          <ArrayExpandedValue
+            index={row.original.index}
+            value={row.original.value as RedisResponseBuffer}
+          />
+        )}
+      />,
+      { store: mockStore(state) },
+    )
+
+    // Collapsed: the Markdown cell renders the rich viewer inline; the
+    // expanded sub-row surface is not mounted yet.
+    expect(screen.getAllByTestId('markdown-viewer')).toHaveLength(1)
+    expect(
+      screen.queryByTestId('array-expanded-value-7'),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    // Expanded: the sub-row mounts its own full-value surface alongside the
+    // inline cell viewer.
+    expect(
+      await screen.findByTestId('array-expanded-value-7'),
+    ).toBeInTheDocument()
+    expect(screen.getAllByTestId('markdown-viewer')).toHaveLength(2)
   })
 
   it('renders no expand affordance when expansion props are omitted', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { cloneDeep } from 'lodash'
+import {
+  initialStateDefault,
+  mockStore,
+  render,
+  screen,
+} from 'uiSrc/utils/test-utils'
+import { KeyValueFormat } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+import { ArrayExpandedValue } from './ArrayExpandedValue'
+
+const renderExpanded = (
+  value: RedisResponseBuffer,
+  viewFormat: KeyValueFormat,
+) => {
+  const state = cloneDeep(initialStateDefault)
+  state.browser.keys.selectedKey.viewFormat = viewFormat
+  return render(<ArrayExpandedValue index="7" value={value} />, {
+    store: mockStore(state),
+  })
+}
+
+describe('ArrayExpandedValue', () => {
+  it('routes a Markdown-format value through the markdown viewer', () => {
+    renderExpanded(stringToBuffer('# Heading'), KeyValueFormat.Markdown)
+
+    // The expanded value is handed to MarkdownViewer (its container), not the
+    // plain-text branch. The unified pipeline is stubbed in jsdom, so the rich
+    // HTML render itself is covered by the e2e / live verification.
+    expect(screen.getByTestId('array-expanded-value-7')).toBeInTheDocument()
+    expect(screen.getByTestId('markdown-viewer')).toBeInTheDocument()
+  })
+
+  it('renders the full text for a Unicode-format value', () => {
+    renderExpanded(
+      stringToBuffer('first line\nsecond line'),
+      KeyValueFormat.Unicode,
+    )
+
+    const container = screen.getByTestId('array-expanded-value-7')
+    expect(container).toHaveTextContent('first line')
+    expect(container).toHaveTextContent('second line')
+    // Plain text must not go through the markdown/JSON rich viewers.
+    expect(screen.queryByTestId('markdown-viewer')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('value-as-json')).not.toBeInTheDocument()
+  })
+
+  it('renders the JSON tree for a JSON-format value', () => {
+    renderExpanded(stringToBuffer('{"name":"redis"}'), KeyValueFormat.JSON)
+
+    expect(screen.getByTestId('array-expanded-value-7')).toBeInTheDocument()
+    expect(screen.getByTestId('value-as-json')).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+import { Col } from 'uiSrc/components/base/layout/flex'
+
+export const Container = styled(Col)`
+  padding: ${({ theme }) =>
+    `${theme.core.space.space100} ${theme.core.space.space150}`};
+  min-width: 0;
+  overflow-wrap: anywhere;
+`
+
+// Text formats (Unicode/ASCII/…) come back as a raw string; preserve their
+// newlines and wrap long lines instead of overflowing the row horizontally.
+// Kept off the container so the rich viewers (markdown/JSON), which set their
+// own layout, don't inherit whitespace preservation.
+export const PlainText = styled.div`
+  white-space: break-spaces;
+  overflow-wrap: anywhere;
+  font-size: ${({ theme }) => theme.core.font.fontSize.s14};
+  color: ${({ theme }) => theme.semantic.color.text.neutral800};
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.tsx
@@ -13,13 +13,8 @@ import * as S from './ArrayExpandedValue.styles'
 
 const TEST_ID_PREFIX = 'array-expanded-value'
 
-/**
- * Full formatted value for an expanded View-tab row. The collapsed cell shows a
- * truncated, compact value; this renders the format's rich, expanded surface —
- * MarkdownViewer for Markdown, an expanded JSON tree for JSON-like formats, and
- * the full wrapped text for the plain formats. Reads `compressor`/`viewFormat`
- * from the same selectors the table cells use, so it stays in sync with them.
- */
+// Reads compressor/viewFormat from the same selectors the table cells use,
+// so the expanded surface always matches the cells' format.
 export const ArrayExpandedValue = ({
   index,
   value,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
+import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { KeyValueCompressor } from 'uiSrc/constants'
+import { formattingBuffer, Nullable } from 'uiSrc/utils'
+import { decompressingBuffer } from 'uiSrc/utils/decompressors'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+import { ArrayExpandedValueProps } from './ArrayExpandedValue.types'
+import * as S from './ArrayExpandedValue.styles'
+
+const TEST_ID_PREFIX = 'array-expanded-value'
+
+/**
+ * Full formatted value for an expanded View-tab row. The collapsed cell shows a
+ * truncated, compact value; this renders the format's rich, expanded surface —
+ * MarkdownViewer for Markdown, an expanded JSON tree for JSON-like formats, and
+ * the full wrapped text for the plain formats. Reads `compressor`/`viewFormat`
+ * from the same selectors the table cells use, so it stays in sync with them.
+ */
+export const ArrayExpandedValue = ({
+  index,
+  value,
+}: ArrayExpandedValueProps) => {
+  const { compressor = null } = useAppSelector(
+    connectedInstanceSelector,
+  ) as unknown as { compressor: Nullable<KeyValueCompressor> }
+  const { viewFormat } = useAppSelector(selectedKeySelector)
+
+  const { value: decompressed } = decompressingBuffer(value, compressor)
+  const { value: formatted } = formattingBuffer(
+    decompressed as RedisResponseBuffer,
+    viewFormat,
+    { expanded: true },
+  )
+
+  return (
+    <S.Container data-testid={`${TEST_ID_PREFIX}-${index}`}>
+      {typeof formatted === 'string' ? (
+        <S.PlainText>{formatted}</S.PlainText>
+      ) : (
+        formatted
+      )}
+    </S.Container>
+  )
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.types.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayExpandedValue.types.ts
@@ -1,0 +1,9 @@
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+
+export interface ArrayExpandedValueProps {
+  /** Slot index — used only to build a stable, unique test id per row. */
+  index: string
+  /** Populated slot's raw value buffer. The View tab only expands populated
+   *  rows (`getIsRowExpandable` rejects empty slots), so this is never null. */
+  value: RedisResponseBuffer
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.spec.tsx
@@ -38,3 +38,26 @@ describe('ArrayValueCell — open editor Save lock', () => {
     expect(screen.getByTestId('apply-btn')).toBeDisabled()
   })
 })
+
+describe('ArrayValueCell — inline value rendering', () => {
+  it('renders Markdown values as rich markdown directly in the cell', () => {
+    renderCell({
+      isEditing: false,
+      viewFormat: KeyValueFormat.Markdown,
+      value: stringToBuffer('# Title'),
+    })
+    expect(screen.getByTestId('markdown-viewer')).toBeInTheDocument()
+  })
+
+  it('keeps non-Markdown formats compact without a markdown viewer', () => {
+    renderCell({
+      isEditing: false,
+      viewFormat: KeyValueFormat.JSON,
+      value: stringToBuffer('{"a":1}'),
+    })
+    expect(screen.queryByTestId('markdown-viewer')).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('array-details-table-value-1'),
+    ).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {
+  KeyValueFormat,
   TEXT_DISABLED_COMPRESSED_VALUE,
   TEXT_DISABLED_FORMATTER_EDITING,
   TEXT_FAILED_CONVENT_FORMATTER,
@@ -69,10 +70,14 @@ export const ArrayValueCell = ({
     compressor,
   )
   const decompressedBuffer = decompressed as RedisResponseBuffer
+  // Markdown renders its rich viewer inline in the cell so line-per-element
+  // documents read as formatted text without expanding each row. Other formats
+  // stay compact (truncated string) - their full value lives in the sub-row.
+  const isMarkdownFormat = viewFormat === KeyValueFormat.Markdown
   const { value: formatted, isValid } = formattingBuffer(
     decompressedBuffer,
     viewFormat,
-    { expanded: false },
+    { expanded: isMarkdownFormat },
   )
   const tooltipContent = createTooltipContent(
     formatted,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -70,9 +70,8 @@ export const ArrayValueCell = ({
     compressor,
   )
   const decompressedBuffer = decompressed as RedisResponseBuffer
-  // Markdown renders its rich viewer inline in the cell so line-per-element
-  // documents read as formatted text without expanding each row. Other formats
-  // stay compact (truncated string) - their full value lives in the sub-row.
+  // Only Markdown renders rich inline; other formats stay compact, with the
+  // full value in the expanded sub-row.
   const isMarkdownFormat = viewFormat === KeyValueFormat.Markdown
   const { value: formatted, isValid } = formattingBuffer(
     decompressedBuffer,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/ArrayValueCell.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import {
-  KeyValueFormat,
   TEXT_DISABLED_COMPRESSED_VALUE,
   TEXT_DISABLED_FORMATTER_EDITING,
   TEXT_FAILED_CONVENT_FORMATTER,
@@ -70,13 +69,10 @@ export const ArrayValueCell = ({
     compressor,
   )
   const decompressedBuffer = decompressed as RedisResponseBuffer
-  // Only Markdown renders rich inline; other formats stay compact, with the
-  // full value in the expanded sub-row.
-  const isMarkdownFormat = viewFormat === KeyValueFormat.Markdown
   const { value: formatted, isValid } = formattingBuffer(
     decompressedBuffer,
     viewFormat,
-    { expanded: isMarkdownFormat },
+    { expanded: false },
   )
   const tooltipContent = createTooltipContent(
     formatted,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/index.ts
@@ -1,2 +1,3 @@
 export { ArrayIndexCell } from './ArrayIndexCell'
 export { ArrayValueCell } from './ArrayValueCell'
+export { ArrayExpandedValue } from './ArrayExpandedValue'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.spec.tsx
@@ -55,6 +55,12 @@ describe('SearchTab', () => {
     expect(screen.getByTestId('array-search-form')).toBeInTheDocument()
   })
 
+  it('renders the value-format selector', () => {
+    renderTab()
+
+    expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+  })
+
   it('disables the search form while the key is locked for editing', () => {
     // isRefreshDisabled is set by the active table while a value editor is open
     // or an ARSET is in flight; the query form must not reload the table then.

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/SearchTab.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useRef, useState } from 'react'
 
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
+import { KeyTypes } from 'uiSrc/constants'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { bufferToString, isEqualBuffers } from 'uiSrc/utils'
 
 import { ArrayDetailsTable } from '../array-details-table'
 import { ArraySearchForm } from '../array-search-form'
 import { ContextOption } from '../array-search-form/ArraySearchForm.types'
+import { KeyDetailsSubheader } from '../../key-details-subheader/KeyDetailsSubheader'
 import { useArraySearchQuery, useArrayElementActions } from '../hooks'
 import { DEFAULT_CONTEXT } from '../constants'
 import * as S from '../tabs.styles'
@@ -90,6 +92,7 @@ const SearchTab = ({ keyProp, isActive }: SearchTabProps) => {
         onReset={handleReset}
         disabled={!isArrayKeyReady || isRefreshDisabled}
       />
+      {isArrayKeyReady && <KeyDetailsSubheader keyType={KeyTypes.Array} />}
       <S.TabBody>
         {/* Keep the tab blank until the user runs a search, then let
             ArrayDetailsTable own the loading / error / empty states. Gate on

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { cloneDeep } from 'lodash'
+import userEvent from '@testing-library/user-event'
 import {
   fireEvent,
   initialStateDefault,
@@ -8,12 +9,15 @@ import {
   screen,
   waitFor,
 } from 'uiSrc/utils/test-utils'
-import { KeyTypes } from 'uiSrc/constants'
+import { KeyTypes, KeyValueFormat } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
 import { apiService } from 'uiSrc/services'
 import { initialState as initialStateArray } from 'uiSrc/slices/browser/array'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
-import { arrayElementWithValueFactory } from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
+import {
+  arrayElementFactory,
+  arrayElementWithValueFactory,
+} from 'uiSrc/mocks/factories/browser/array/arrayElement.factory'
 import ViewTab from './ViewTab'
 
 jest.mock('uiSrc/services', () => ({
@@ -59,6 +63,54 @@ const renderView = (
 }
 
 describe('ViewTab', () => {
+  it('renders the value-format selector alongside Add Elements', () => {
+    renderView(keyBuffer, {}, [
+      arrayElementWithValueFactory.build({ index: '7' }),
+    ])
+
+    expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+    expect(screen.getByTestId(ADD_BTN)).toBeInTheDocument()
+  })
+
+  it('expands a populated row into the full formatted value', async () => {
+    const user = userEvent.setup()
+    const state = buildState([
+      arrayElementWithValueFactory.build({
+        index: '7',
+        value: stringToBuffer('# Heading'),
+      }),
+    ])
+    state.browser.keys.selectedKey.viewFormat = KeyValueFormat.Markdown
+    const store = mockStore(state)
+    store.clearActions()
+    render(<ViewTab keyProp={keyBuffer} isActive />, { store })
+
+    // Collapsed rows already render the Markdown viewer inline; the expanded
+    // sub-row surface is not mounted yet.
+    expect(screen.getAllByTestId('markdown-viewer')).toHaveLength(1)
+    expect(
+      screen.queryByTestId('array-expanded-value-7'),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('array-details-table-index-7'))
+
+    expect(
+      await screen.findByTestId('array-expanded-value-7'),
+    ).toBeInTheDocument()
+    expect(screen.getAllByTestId('markdown-viewer')).toHaveLength(2)
+  })
+
+  it('does not expand an empty slot', async () => {
+    const user = userEvent.setup()
+    renderView(keyBuffer, {}, [arrayElementFactory.build({ index: '3' })])
+
+    await user.click(screen.getByTestId('array-details-table-index-3'))
+
+    expect(
+      screen.queryByTestId('array-expanded-value-3'),
+    ).not.toBeInTheDocument()
+  })
+
   it('renders a per-row delete affordance for a populated element', () => {
     renderView(keyBuffer, {}, [
       arrayElementWithValueFactory.build({ index: '7' }),

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.styles.ts
@@ -1,9 +1,0 @@
-import styled from 'styled-components'
-import { FlexItem } from 'uiSrc/components/base/layout/flex'
-
-/** Subheader strip hosting the right-aligned "Add Elements" action, mirroring
- *  VectorSetKeySubheader so the array view matches the other key types. */
-export const SubheaderContainer = styled(FlexItem)`
-  padding: ${({ theme }) =>
-    `${theme.core?.space.space150} ${theme.core?.space.space200} 0`};
-`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/view-tab/ViewTab.tsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useRef, useState } from 'react'
-import AutoSizer from 'react-virtualized-auto-sizer'
 
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { deleteArrayRange } from 'uiSrc/slices/browser/array'
+import { KeyTypes } from 'uiSrc/constants'
+import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { bufferToString, isEqualBuffers } from 'uiSrc/utils'
-import { Row } from 'uiSrc/components/base/layout/flex'
 import { AddItemsAction } from 'uiSrc/pages/browser/modules/key-details/components/key-details-actions'
 
 import { ArrayDetailsTable } from '../array-details-table'
+import { ArrayExpandedValue } from '../array-details-table/components'
 import { ArrayRangeForm } from '../array-range-form'
 import { ArrayAddForm } from '../array-add-form'
+import { KeyDetailsSubheader } from '../../key-details-subheader/KeyDetailsSubheader'
 import { AddKeysContainer } from '../../common/AddKeysContainer.styled'
 import { useArrayRangeQuery, useArrayElementActions } from '../hooks'
 import * as S from '../tabs.styles'
-import * as LS from './ViewTab.styles'
 import { ViewTabProps } from './ViewTab.types'
 
 const ADD_ELEMENTS_TITLE = 'Add Elements'
@@ -102,6 +103,14 @@ const ViewTab = ({
     }
   }
 
+  const Actions = ({ width }: { width: number }) => (
+    <AddItemsAction
+      title={ADD_ELEMENTS_TITLE}
+      width={width}
+      openAddItemPanel={openAddPanel}
+    />
+  )
+
   return (
     <>
       <ArrayRangeForm
@@ -119,19 +128,7 @@ const ViewTab = ({
         disabled={!isArrayKeyReady || isRefreshDisabled}
       />
       {isArrayKeyReady && (
-        <LS.SubheaderContainer grow={false}>
-          <AutoSizer disableHeight>
-            {({ width = 0 }) => (
-              <Row style={{ width }} justify="end" align="center">
-                <AddItemsAction
-                  title={ADD_ELEMENTS_TITLE}
-                  width={width}
-                  openAddItemPanel={openAddPanel}
-                />
-              </Row>
-            )}
-          </AutoSizer>
-        </LS.SubheaderContainer>
+        <KeyDetailsSubheader keyType={KeyTypes.Array} Actions={Actions} />
       )}
       <S.TabBody>
         {!loading && (
@@ -144,6 +141,15 @@ const ViewTab = ({
               deleteConfig={deleteConfig}
               selectionConfig={selectionConfig}
               bulkDeleteConfig={bulkDeleteConfig}
+              expandRowOnClick
+              getIsRowExpandable={(element) => element.value != null}
+              renderExpandedRow={(row) => (
+                <ArrayExpandedValue
+                  index={row.original.index}
+                  // Non-null by getIsRowExpandable; values arrive as buffers.
+                  value={row.original.value as RedisResponseBuffer}
+                />
+              )}
             />
           </S.TabTableWrapper>
         )}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-subheader/KeyDetailsSubheader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-subheader/KeyDetailsSubheader.spec.tsx
@@ -1,14 +1,37 @@
 import React from 'react'
 import { instance, mock } from 'ts-mockito'
-import { render } from 'uiSrc/utils/test-utils'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { KeyTypes } from 'uiSrc/constants'
 import { KeyDetailsSubheader, Props } from './KeyDetailsSubheader'
 
 const mockedProps = mock<Props>()
+
+const MockActions = () => <div data-testid="mock-actions" />
 
 describe('KeyDetailsSubheader', () => {
   it('should render', () => {
     expect(
       render(<KeyDetailsSubheader {...instance(mockedProps)} />),
     ).toBeTruthy()
+  })
+
+  it('renders the value formatter for a supported key type', () => {
+    render(<KeyDetailsSubheader keyType={KeyTypes.Hash} />)
+    expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+  })
+
+  it('omits the trailing divider when no Actions are provided', () => {
+    render(<KeyDetailsSubheader keyType={KeyTypes.Hash} />)
+    expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+
+  it('renders the divider between the formatter and the Actions', () => {
+    render(
+      <KeyDetailsSubheader keyType={KeyTypes.Hash} Actions={MockActions} />,
+    )
+    expect(screen.getByTestId('select-format-key-value')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-actions')).toBeInTheDocument()
+    expect(screen.getByRole('separator')).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-subheader/KeyDetailsSubheader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-subheader/KeyDetailsSubheader.tsx
@@ -24,7 +24,9 @@ export const KeyDetailsSubheader = ({ keyType, Actions }: Props) => (
                 <FlexItem className={styles.keyFormatterItem}>
                   <KeyDetailsHeaderFormatter width={width} />
                 </FlexItem>
-                <Divider className={styles.divider} orientation="vertical" />
+                {!isUndefined(Actions) && (
+                  <Divider className={styles.divider} orientation="vertical" />
+                )}
               </>
             )}
             {!isUndefined(Actions) && <Actions width={width} />}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.spec.tsx
@@ -218,6 +218,24 @@ describe('StringDetailsValue', () => {
     )
   })
 
+  it('Should render the markdown viewer when viewFormat is Markdown', () => {
+    const stringDataSelectorMock = jest.fn().mockReturnValue({
+      value: fullValue,
+    })
+    const selectedKeySelectorMock = jest.fn().mockReturnValue({
+      viewFormat: KeyValueFormat.Markdown,
+    })
+    ;(selectedKeySelector as jest.Mock).mockImplementation(
+      selectedKeySelectorMock,
+    )
+    ;(stringDataSelector as jest.Mock).mockImplementation(
+      stringDataSelectorMock,
+    )
+
+    render(<StringDetailsValue {...instance(mockedProps)} />)
+    expect(screen.getByTestId('markdown-viewer')).toBeInTheDocument()
+  })
+
   it('Should not add "..." in the end of the full value', async () => {
     const stringDataSelectorMock = jest.fn().mockReturnValue({
       value: fullValue,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -257,6 +257,7 @@ const StringDetailsValue = (props: Props) => {
   const renderValue = (value: string) => {
     const textEl = (
       <Text
+        component="div"
         color="secondary"
         className={styles.stringValue}
         onClick={() => isEditable && setIsEdit(true)}

--- a/redisinsight/ui/src/services/formatter/MarkdownToJsxString.ts
+++ b/redisinsight/ui/src/services/formatter/MarkdownToJsxString.ts
@@ -3,12 +3,12 @@ import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import remarkGfm from 'remark-gfm'
 import rehypeStringify from 'rehype-stringify'
-import { visit } from 'unist-util-visit'
 
 import {
   remarkRedisUpload,
   remarkLink,
   rehypeLinks,
+  rehypeWrapSymbols,
   remarkImage,
   remarkCode,
   remarkSanitize,
@@ -29,7 +29,7 @@ class MarkdownToJsxString implements IFormatter {
         .use(remarkLink) // Customise links
         .use(remarkRehype, { allowDangerousHtml: true }) // Pass raw HTML strings through.
         .use(rehypeLinks, config ? { history: config.history } : undefined) // Customise links
-        .use(MarkdownToJsxString.rehypeWrapSymbols) // Wrap special symbols inside curly braces for JSX parse
+        .use(rehypeWrapSymbols) // Wrap special symbols inside curly braces for JSX parse
         .use(rehypeStringify, { allowDangerousHtml: true }) // Serialize the raw HTML strings
         .process(data)
         .then((file) => {
@@ -37,22 +37,6 @@ class MarkdownToJsxString implements IFormatter {
         })
         .catch((error) => reject(error))
     })
-  }
-
-  private static rehypeWrapSymbols(
-    symbols: string[] = ['{', '}', '>'],
-  ): (tree: Node) => void {
-    return (tree: any) => {
-      visit(tree, 'text', (node) => {
-        const { value } = node
-        if (value) {
-          node.value = value.replace(
-            new RegExp(`[${symbols.join()}]`, 'g'),
-            '{"$&"}',
-          )
-        }
-      })
-    }
   }
 }
 

--- a/redisinsight/ui/src/utils/formatters/markdown/index.ts
+++ b/redisinsight/ui/src/utils/formatters/markdown/index.ts
@@ -1,4 +1,5 @@
 import { rehypeLinks } from './rehypeLinks'
+import { rehypeWrapSymbols } from './rehypeWrapSymbols'
 import { remarkImage } from './remarkImage'
 import { remarkLink } from './remarkLink'
 import { remarkCode } from './remarkCode'
@@ -8,6 +9,7 @@ import { escapeJsxAttribute } from './escapeJsxAttribute'
 
 export {
   rehypeLinks,
+  rehypeWrapSymbols,
   remarkImage,
   remarkLink,
   remarkCode,

--- a/redisinsight/ui/src/utils/formatters/markdown/rehypeWrapSymbols.ts
+++ b/redisinsight/ui/src/utils/formatters/markdown/rehypeWrapSymbols.ts
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit'
+
+// Wraps characters that JSX treats as syntax in text nodes as {"$&"} string
+// expressions, so the serialized HTML string survives JsxParser and the
+// characters render literally.
+export const rehypeWrapSymbols =
+  (symbols: string[] = ['{', '}', '>']): ((tree: Node) => void) =>
+  (tree: any) => {
+    visit(tree, 'text', (node) => {
+      const { value } = node
+      if (value) {
+        node.value = value.replace(
+          new RegExp(`[${symbols.join()}]`, 'g'),
+          '{"$&"}',
+        )
+      }
+    })
+  }

--- a/redisinsight/ui/src/utils/formatters/markdown/remarkSanitize.ts
+++ b/redisinsight/ui/src/utils/formatters/markdown/remarkSanitize.ts
@@ -16,6 +16,7 @@ DOMPurify.addHook('afterSanitizeAttributes', (node: Element) => {
     }
 
     node.setAttribute('target', '_blank')
+    node.setAttribute('rel', 'noopener noreferrer')
   }
 })
 

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { encode } from 'msgpackr'
 // eslint-disable-next-line import/order
 import { Buffer } from 'buffer'
@@ -9,6 +10,7 @@ import JSONBigInt from 'json-bigint'
 import { store } from 'uiSrc/slices/store'
 
 import JSONViewer from 'uiSrc/components/json-viewer/JSONViewer'
+import { MarkdownViewer } from 'uiSrc/components/markdown-viewer'
 import {
   DATETIME_FORMATTER_DEFAULT,
   KeyValueFormat,
@@ -237,6 +239,13 @@ const formattingBuffer = (
         // if error return default
       }
       return { value, isValid: false }
+    }
+    case KeyValueFormat.Markdown: {
+      const value = bufferToUTF8(reply)
+      if (props?.expanded && !props?.tooltip) {
+        return { value: <MarkdownViewer value={value} />, isValid: true }
+      }
+      return { value, isValid: true }
     }
     default:
       return { value: bufferToUnicode(reply), isValid: true }

--- a/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
+++ b/redisinsight/ui/src/utils/formatters/valueFormatters.tsx
@@ -242,10 +242,12 @@ const formattingBuffer = (
     }
     case KeyValueFormat.Markdown: {
       const value = bufferToUTF8(reply)
-      if (props?.expanded && !props?.tooltip) {
-        return { value: <MarkdownViewer value={value} />, isValid: true }
+      // Selecting Markdown renders it wherever a value is shown, so it does not
+      // depend on a row being expanded. Tooltips still get the raw source.
+      if (props?.tooltip) {
+        return { value, isValid: true }
       }
-      return { value, isValid: true }
+      return { value: <MarkdownViewer value={value} />, isValid: true }
     }
     default:
       return { value: bufferToUnicode(reply), isValid: true }

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/rehypeWrapSymbols.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/rehypeWrapSymbols.spec.ts
@@ -1,0 +1,61 @@
+import { visit } from 'unist-util-visit'
+import { rehypeWrapSymbols } from 'uiSrc/utils/formatters/markdown'
+
+// unist-util-visit is already stubbed via moduleNameMapper; jest.mock() here
+// would shadow that shared instance with a per-spec automock the production
+// import never sees.
+
+const mockVisitWith = (node: { value?: string }) => {
+  ;(visit as jest.Mock).mockImplementation(
+    (_tree: any, _name: string, callback: (node: any) => void) => {
+      callback(node)
+    },
+  )
+}
+
+describe('rehypeWrapSymbols', () => {
+  it('should visit text nodes', () => {
+    mockVisitWith({ value: '' })
+
+    const tree = {} as Node
+    rehypeWrapSymbols()(tree)
+
+    expect(visit).toBeCalledWith(tree, 'text', expect.any(Function))
+  })
+
+  it('should wrap {, } and > as JSX string expressions', () => {
+    const node = { value: 'values {a: 1} > threshold' }
+    mockVisitWith(node)
+
+    rehypeWrapSymbols()({} as Node)
+
+    expect(node.value).toBe('values {"{"}a: 1{"}"} {">"} threshold')
+  })
+
+  it('should leave text without special symbols unchanged', () => {
+    const node = { value: 'plain text without specials' }
+    mockVisitWith(node)
+
+    rehypeWrapSymbols()({} as Node)
+
+    expect(node.value).toBe('plain text without specials')
+  })
+
+  it('should leave empty values untouched', () => {
+    const node = { value: '' }
+    mockVisitWith(node)
+
+    rehypeWrapSymbols()({} as Node)
+
+    expect(node.value).toBe('')
+  })
+
+  it('should wrap only the given symbols when a custom list is passed', () => {
+    const node = { value: 'a > b < c' }
+    mockVisitWith(node)
+
+    rehypeWrapSymbols(['<'])({} as Node)
+
+    expect(node.value).toBe('a > b {"<"} c')
+  })
+})

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/remarkImage.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/remarkImage.spec.ts
@@ -2,7 +2,6 @@ import { visit } from 'unist-util-visit'
 import { RESOURCES_BASE_URL } from 'uiSrc/services/resourcesService'
 import { remarkImage } from 'uiSrc/utils/formatters/markdown'
 
-jest.mock('unist-util-visit')
 const TUTORIAL_PATH = 'static/custom-tutorials/tutorial-id'
 const testCases = [
   {

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/remarkLink.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/remarkLink.spec.ts
@@ -1,8 +1,6 @@
 import { visit } from 'unist-util-visit'
 import { remarkLink } from 'uiSrc/utils/formatters/markdown'
 
-jest.mock('unist-util-visit')
-
 describe('remarkLink', () => {
   it('should not modify codeNode if title is not Redis Cloud', () => {
     const codeNode = {

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/remarkRedisCode.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/remarkRedisCode.spec.ts
@@ -1,8 +1,6 @@
 import { visit } from 'unist-util-visit'
 import { remarkCode } from 'uiSrc/utils/formatters/markdown'
 
-jest.mock('unist-util-visit')
-
 const visitMock = visit as jest.Mock
 
 const setupVisitMock = (node: Record<string, unknown>) => {

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/remarkRedisUpload.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/remarkRedisUpload.spec.ts
@@ -1,8 +1,6 @@
 import { visit } from 'unist-util-visit'
 import { remarkRedisUpload } from 'uiSrc/utils/formatters/markdown'
 
-jest.mock('unist-util-visit')
-
 const getValue = (label: string, path: string) =>
   `<RedisUploadButton label="${label}" path="${path}" />`
 

--- a/redisinsight/ui/src/utils/tests/formatters/markdown/remarkSanitize.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/markdown/remarkSanitize.spec.ts
@@ -1,13 +1,12 @@
 import { visit } from 'unist-util-visit'
 import { remarkSanitize } from 'uiSrc/utils/formatters/markdown'
 
-jest.mock('unist-util-visit')
-
 const testCases = [
   { input: '', output: '' },
   {
     input: '<a href="https://localhost">',
-    output: '<a href="https://localhost" target="_blank">',
+    output:
+      '<a href="https://localhost" target="_blank" rel="noopener noreferrer">',
   },
   { input: '<a href="/settings">', output: '<a>' },
   { input: '<a href="javascript:alert(1)">', output: '<a>' },

--- a/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
@@ -1,7 +1,9 @@
+import React from 'react'
 import { format } from 'date-fns'
 import { encode } from 'msgpackr'
 import { serialize } from 'php-serialize'
 import { DATETIME_FORMATTER_DEFAULT, KeyValueFormat } from 'uiSrc/constants'
+import { MarkdownViewer } from 'uiSrc/components/markdown-viewer'
 import {
   anyToBuffer,
   bufferToSerializedFormat,
@@ -410,6 +412,39 @@ describe('formattingBuffer', () => {
           expected,
         )
       })
+    })
+  })
+
+  describe(KeyValueFormat.Markdown, () => {
+    const source = '# Title'
+    const input = stringToBuffer(source)
+
+    it('should render a MarkdownViewer element when expanded', () => {
+      const { value, isValid } = formattingBuffer(
+        input,
+        KeyValueFormat.Markdown,
+        { expanded: true },
+      )
+
+      expect(isValid).toEqual(true)
+      expect(React.isValidElement(value)).toEqual(true)
+      expect(React.isValidElement(value) && value.type).toEqual(MarkdownViewer)
+    })
+
+    it('should return the raw markdown source when not expanded', () => {
+      expect(formattingBuffer(input, KeyValueFormat.Markdown)).toEqual({
+        value: source,
+        isValid: true,
+      })
+    })
+
+    it('should return the raw markdown source when expanded inside a tooltip', () => {
+      expect(
+        formattingBuffer(input, KeyValueFormat.Markdown, {
+          expanded: true,
+          tooltip: true,
+        }),
+      ).toEqual({ value: source, isValid: true })
     })
   })
 })

--- a/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
+++ b/redisinsight/ui/src/utils/tests/formatters/valueFormatters.spec.ts
@@ -431,19 +431,19 @@ describe('formattingBuffer', () => {
       expect(React.isValidElement(value) && value.type).toEqual(MarkdownViewer)
     })
 
-    it('should return the raw markdown source when not expanded', () => {
-      expect(formattingBuffer(input, KeyValueFormat.Markdown)).toEqual({
-        value: source,
-        isValid: true,
-      })
+    it('should render a MarkdownViewer element even when not expanded', () => {
+      const { value, isValid } = formattingBuffer(
+        input,
+        KeyValueFormat.Markdown,
+      )
+
+      expect(isValid).toEqual(true)
+      expect(React.isValidElement(value) && value.type).toEqual(MarkdownViewer)
     })
 
-    it('should return the raw markdown source when expanded inside a tooltip', () => {
+    it('should return the raw markdown source inside a tooltip', () => {
       expect(
-        formattingBuffer(input, KeyValueFormat.Markdown, {
-          expanded: true,
-          tooltip: true,
-        }),
+        formattingBuffer(input, KeyValueFormat.Markdown, { tooltip: true }),
       ).toEqual({ value: source, isValid: true })
     })
   })

--- a/tests/e2e-playwright/pages/browser/components/KeyDetails.ts
+++ b/tests/e2e-playwright/pages/browser/components/KeyDetails.ts
@@ -67,6 +67,9 @@ export class KeyDetails {
   readonly addJsonFieldButton: Locator;
   readonly changeEditorTypeButton: Locator;
 
+  // Markdown-specific
+  readonly markdownViewer: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
@@ -135,6 +138,9 @@ export class KeyDetails {
     this.jsonContent = page.getByTestId('json-details');
     this.addJsonFieldButton = page.getByRole('button', { name: 'Add field' });
     this.changeEditorTypeButton = page.getByRole('button', { name: 'Change editor type' });
+
+    // Markdown-specific - the rendered (sanitized) markdown output
+    this.markdownViewer = page.getByTestId('markdown-viewer');
   }
 
   async isVisible(): Promise<boolean> {
@@ -882,5 +888,10 @@ export class KeyDetails {
     const scalarValues = this.page.getByTestId('json-scalar-value');
     const targetValue = scalarValues.nth(fieldIndex);
     return await targetValue.innerText();
+  }
+
+  // Markdown methods
+  async waitForMarkdownViewer(): Promise<void> {
+    await this.markdownViewer.waitFor({ state: 'visible' });
   }
 }

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
@@ -29,26 +29,25 @@ const RENDERED_MARKDOWN = [
 const LITERAL_SYMBOLS_TEXT = 'Config {a: 1} applies when value > 5.';
 
 // Untrusted value from Redis mixing safe markdown with the dangerous parts the
-// sanitizer must defuse: a script tag, an event-handler attribute and a
-// javascript: link. Blocks are contiguous (no blank lines) on purpose: this
-// payload would otherwise make the JSX parser drop the whole document into an
-// empty viewer. Sanitizing the final HTML normalizes it, so the safe heading
-// still renders while none of the dangerous parts survive or execute.
+// sanitizer must defuse: a script tag, an event-handler attribute, a javascript:
+// link, and a raw-HTML element carrying a JSX expression (inert as HTML text,
+// but a JSX parser would execute it). The safe heading must still render.
 const XSS_MARKDOWN = [
   '# Safe Heading',
   '<script>window.__xssPwned = true</script>',
   '<img src=x onerror="window.__xssPwned=true">',
   '[raw js link](javascript:alert(1))',
+  '<div>{"".constructor.constructor("window.__xssPwned = true")()}</div>',
 ].join('\n');
 
 /**
  * Browser > Key Details - String Markdown format
  *
  * The Markdown value format renders a String value through the real sanitized
- * markdown pipeline (unified + remark/rehype + DOMPurify) and a JSX parser with
- * tag/attribute blacklists. Jest globally mocks that pipeline, so this e2e is
- * the only coverage that runs it end to end - including the XSS sanitization,
- * which matters because Redis values are untrusted input.
+ * markdown pipeline (unified + remark/rehype + DOMPurify). Jest globally mocks
+ * that pipeline, so this e2e is the only coverage that runs it end to end -
+ * including the XSS sanitization, which matters because Redis values are
+ * untrusted input.
  */
 test.describe('Browser > Key Details - String Markdown format', () => {
   let database: DatabaseInstance;
@@ -129,8 +128,7 @@ test.describe('Browser > Key Details - String Markdown format', () => {
     await browserPage.keyDetails.waitForMarkdownViewer();
     const viewer = browserPage.keyDetails.markdownViewer;
 
-    // The safe heading still renders - sanitizing the final HTML normalizes the
-    // contiguous payload instead of dropping the whole document.
+    // The safe heading still renders alongside the defused payload.
     await expect(viewer.getByRole('heading', { level: 1, name: 'Safe Heading' })).toBeVisible();
 
     // No injected script executed.

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from 'e2eSrc/fixtures/base';
+import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
+import { StringKeyFactory, TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
+import { DatabaseInstance } from 'e2eSrc/types';
+
+const MARKDOWN_FORMAT = 'Markdown';
+
+// A markdown document exercising the pieces the viewer must render: heading,
+// bold, a GFM table, a fenced code block and an external link. The link is a
+// markdown-native [text](url) link: sanitizing the final serialized HTML runs
+// the DOMPurify href hook on every anchor, so native links get target="_blank"
+// and rel="noopener noreferrer" too (not just raw-HTML ones). The last line
+// carries {, } and > to prove the DOMPurify round-trip renders those literally.
+const RENDERED_MARKDOWN = [
+  '# Heading Markdown Test',
+  '',
+  'This has **bold text** and a [Redis link](https://redis.io).',
+  '',
+  '| Feature | Status |',
+  '| ------- | ------ |',
+  '| Markdown | ready |',
+  '',
+  '```js',
+  'const answer = 42',
+  '```',
+  '',
+  'Config {a: 1} applies when value > 5.',
+].join('\n');
+const LITERAL_SYMBOLS_TEXT = 'Config {a: 1} applies when value > 5.';
+
+// Untrusted value from Redis mixing safe markdown with the dangerous parts the
+// sanitizer must defuse: a script tag, an event-handler attribute and a
+// javascript: link. Blocks are contiguous (no blank lines) on purpose: this
+// payload would otherwise make the JSX parser drop the whole document into an
+// empty viewer. Sanitizing the final HTML normalizes it, so the safe heading
+// still renders while none of the dangerous parts survive or execute.
+const XSS_MARKDOWN = [
+  '# Safe Heading',
+  '<script>window.__xssPwned = true</script>',
+  '<img src=x onerror="window.__xssPwned=true">',
+  '[raw js link](javascript:alert(1))',
+].join('\n');
+
+/**
+ * Browser > Key Details - String Markdown format
+ *
+ * The Markdown value format renders a String value through the real sanitized
+ * markdown pipeline (unified + remark/rehype + DOMPurify) and a JSX parser with
+ * tag/attribute blacklists. Jest globally mocks that pipeline, so this e2e is
+ * the only coverage that runs it end to end - including the XSS sanitization,
+ * which matters because Redis values are untrusted input.
+ */
+test.describe('Browser > Key Details - String Markdown format', () => {
+  let database: DatabaseInstance;
+
+  test.beforeAll(async ({ apiHelper }) => {
+    const config = StandaloneConfigFactory.build({ name: 'test-key-details-markdown-db' });
+    database = await apiHelper.createDatabase(config);
+  });
+
+  test.afterAll(async ({ apiHelper }) => {
+    if (database?.id) {
+      await apiHelper.deleteDatabase(database.id);
+    }
+  });
+
+  test.beforeEach(async ({ browserPage }) => {
+    await browserPage.goto(database.id);
+  });
+
+  test.afterEach(async ({ apiHelper }) => {
+    await apiHelper.deleteKeysByPattern(database.id, `${TEST_KEY_PREFIX}*`);
+  });
+
+  test('should render a markdown String value through the sanitized pipeline', async ({ apiHelper, browserPage }) => {
+    const keyData = StringKeyFactory.build({ value: RENDERED_MARKDOWN });
+    await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);
+
+    // Open the key in the details panel.
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+
+    // Switch the value format to Markdown and wait for the rendered viewer.
+    await browserPage.keyDetails.changeValueFormat(MARKDOWN_FORMAT);
+    await browserPage.keyDetails.waitForMarkdownViewer();
+    const viewer = browserPage.keyDetails.markdownViewer;
+
+    // Heading renders as a real <h1>, not raw "# " markdown text.
+    await expect(viewer.getByRole('heading', { level: 1, name: 'Heading Markdown Test' })).toBeVisible();
+
+    // Inline formatting renders as elements.
+    await expect(viewer.locator('strong', { hasText: 'bold text' })).toBeVisible();
+
+    // Markdown-native external link renders, is forced to open in a new tab and
+    // is hardened against reverse tabnabbing.
+    const link = viewer.getByRole('link', { name: 'Redis link' });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', /noopener/);
+    await expect(link).toHaveAttribute('href', 'https://redis.io');
+
+    // GFM table renders with header and body cells.
+    await expect(viewer.locator('table')).toBeVisible();
+    await expect(viewer.locator('th', { hasText: 'Feature' })).toBeVisible();
+    await expect(viewer.locator('td', { hasText: 'ready' })).toBeVisible();
+
+    // Fenced code block renders inside <pre><code>.
+    await expect(viewer.locator('pre code')).toContainText('const answer = 42');
+
+    // { } and > survive the DOMPurify round-trip and render literally.
+    await expect(viewer).toContainText(LITERAL_SYMBOLS_TEXT);
+    await expect(viewer).not.toContainText('&gt;');
+
+    // Raw markdown syntax is not shown verbatim.
+    await expect(viewer).not.toContainText('# Heading');
+    await expect(viewer).not.toContainText('**bold text**');
+  });
+
+  test('should render markdown but keep an XSS payload inert', async ({ apiHelper, browserPage, page }) => {
+    const keyData = StringKeyFactory.build({ value: XSS_MARKDOWN });
+    await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);
+
+    // Open the key and switch to Markdown.
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+    await browserPage.keyDetails.changeValueFormat(MARKDOWN_FORMAT);
+    await browserPage.keyDetails.waitForMarkdownViewer();
+    const viewer = browserPage.keyDetails.markdownViewer;
+
+    // The safe heading still renders - sanitizing the final HTML normalizes the
+    // contiguous payload instead of dropping the whole document.
+    await expect(viewer.getByRole('heading', { level: 1, name: 'Safe Heading' })).toBeVisible();
+
+    // No injected script executed.
+    const xssPwned = await page.evaluate(() => (window as Window & { __xssPwned?: boolean }).__xssPwned);
+    expect(xssPwned).toBeUndefined();
+
+    // No dangerous nodes/attributes survived sanitization.
+    await expect(viewer.locator('script')).toHaveCount(0);
+    await expect(viewer.locator('[onerror]')).toHaveCount(0);
+    await expect(viewer.locator('a[href^="javascript:"]')).toHaveCount(0);
+  });
+});

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/string-markdown.spec.ts
@@ -30,12 +30,14 @@ const LITERAL_SYMBOLS_TEXT = 'Config {a: 1} applies when value > 5.';
 
 // Untrusted value from Redis mixing safe markdown with the dangerous parts the
 // sanitizer must defuse: a script tag, an event-handler attribute, a javascript:
-// link, and a raw-HTML element carrying a JSX expression (inert as HTML text,
-// but a JSX parser would execute it). The safe heading must still render.
+// link, a remote image (tracking pixel / IP leak), and a raw-HTML element
+// carrying a JSX expression (inert as HTML text, but a JSX parser would execute
+// it). The safe heading must still render.
 const XSS_MARKDOWN = [
   '# Safe Heading',
   '<script>window.__xssPwned = true</script>',
   '<img src=x onerror="window.__xssPwned=true">',
+  '![tracker](https://evil.example/pixel.png)',
   '[raw js link](javascript:alert(1))',
   '<div>{"".constructor.constructor("window.__xssPwned = true")()}</div>',
 ].join('\n');
@@ -139,5 +141,6 @@ test.describe('Browser > Key Details - String Markdown format', () => {
     await expect(viewer.locator('script')).toHaveCount(0);
     await expect(viewer.locator('[onerror]')).toHaveCount(0);
     await expect(viewer.locator('a[href^="javascript:"]')).toHaveCount(0);
+    await expect(viewer.locator('img')).toHaveCount(0);
   });
 });

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'e2eSrc/fixtures/base';
 import { StandaloneConfigFactory } from 'e2eSrc/test-data/databases';
-import { StringKeyFactory, TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
+import { StringKeyFactory, ListKeyFactory, HashKeyFactory, TEST_KEY_PREFIX } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 
 const MARKDOWN_FORMAT = 'Markdown';
@@ -43,15 +43,16 @@ const XSS_MARKDOWN = [
 ].join('\n');
 
 /**
- * Browser > Key Details - String Markdown format
+ * Browser > Key Details - Markdown value format
  *
- * The Markdown value format renders a String value through the real sanitized
- * markdown pipeline (unified + remark/rehype + DOMPurify). Jest globally mocks
- * that pipeline, so this e2e is the only coverage that runs it end to end -
- * including the XSS sanitization, which matters because Redis values are
- * untrusted input.
+ * The Markdown value format renders a value through the real sanitized markdown
+ * pipeline (unified + remark/rehype + DOMPurify). Jest globally mocks that
+ * pipeline, so this e2e is the only coverage that runs it end to end - including
+ * the XSS sanitization, which matters because Redis values are untrusted input.
+ * Selecting Markdown renders inline for every key type (String, List, Hash, ...)
+ * without expanding a row.
  */
-test.describe('Browser > Key Details - String Markdown format', () => {
+test.describe('Browser > Key Details - Markdown value format', () => {
   let database: DatabaseInstance;
 
   test.beforeAll(async ({ apiHelper }) => {
@@ -116,6 +117,41 @@ test.describe('Browser > Key Details - String Markdown format', () => {
     // Raw markdown syntax is not shown verbatim.
     await expect(viewer).not.toContainText('# Heading');
     await expect(viewer).not.toContainText('**bold text**');
+  });
+
+  test('should render markdown inline in List element cells on selection', async ({ apiHelper, browserPage, page }) => {
+    const keyData = ListKeyFactory.build({
+      elements: [RENDERED_MARKDOWN, '## Second **element**'],
+    });
+    await apiHelper.createListKey(database.id, keyData.keyName, keyData.elements);
+
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+    await browserPage.keyDetails.changeValueFormat(MARKDOWN_FORMAT);
+
+    // Each element cell renders its value as markdown inline, with no row
+    // expansion (the heading appears only when the value is rendered, not raw).
+    await expect(browserPage.keyDetails.markdownViewer.first()).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Heading Markdown Test' })).toBeVisible();
+    await expect(page.locator('strong', { hasText: 'bold text' })).toBeVisible();
+  });
+
+  test('should render markdown inline in Hash value cells on selection', async ({ apiHelper, browserPage, page }) => {
+    const keyData = HashKeyFactory.build({
+      fields: [{ field: 'readme', value: RENDERED_MARKDOWN }],
+    });
+    await apiHelper.createHashKey(database.id, keyData.keyName, keyData.fields);
+
+    await browserPage.keyList.searchKeys(keyData.keyName);
+    await browserPage.keyList.clickKey(keyData.keyName);
+    await browserPage.keyDetails.waitForKeyDetails();
+    await browserPage.keyDetails.changeValueFormat(MARKDOWN_FORMAT);
+
+    // The value cell renders as markdown inline, with no row expansion.
+    await expect(browserPage.keyDetails.markdownViewer.first()).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Heading Markdown Test' })).toBeVisible();
+    await expect(page.locator('strong', { hasText: 'bold text' })).toBeVisible();
   });
 
   test('should render markdown but keep an XSS payload inert', async ({ apiHelper, browserPage, page }) => {


### PR DESCRIPTION
# What

Adds **Markdown** as a value-encoding format in the formatter chain, available for all key types. Values render as sanitized GitHub-Flavored Markdown via a new synchronous `MarkdownViewer` (unified pipeline + DOMPurify over the final HTML + hardened JsxParser); editing keeps the raw markdown source. Link sanitization now also sets `rel="noopener noreferrer"` next to `target="_blank"`.

The Array view gets the format selector next to **Add Elements** (View and Search tabs), inline markdown rendering in value cells, and expandable rows showing the full formatted value for any encoding.

Also fixes a latent test-infra landmine: spec-level `jest.mock()` on modules already stubbed via `moduleNameMapper` (`unified`, `unist-util-visit`) splits the mock instance from what production imports receive - failing on fresh macOS installs while passing in CI. The redundant mocks are removed from all markdown plugin specs.

# Testing

- Unit: new specs for `MarkdownViewer` (incl. XSS-hardening against real DOMPurify/JsxParser), `rehypeWrapSymbols`, `ArrayExpandedValue`, formatter/selector/array-tab wiring; full suite green (852 suites).
- E2E (Playwright): `string-markdown.spec.ts` - real-browser markdown rendering and XSS payload inertness (`<script>`, `onerror`, `javascript:` links) on a String key.
- Manual: verified live against Redis 8.8 with an array holding a markdown document line-per-element - inline rendering, expanded rows, selector placement, Search context band.

<img width="2482" height="1201" alt="image" src="https://github.com/user-attachments/assets/f6300f8d-0a06-4fe7-a567-922472319cc5" />
<img width="1243" height="876" alt="image" src="https://github.com/user-attachments/assets/c29c648c-388f-4ce7-8c93-12e424191b3c" />
<img width="1251" height="456" alt="image" src="https://github.com/user-attachments/assets/9a546f8b-f587-4e4c-bb6c-2c4c2eb92527" />
<img width="683" height="571" alt="image" src="https://github.com/user-attachments/assets/f7d14a00-2e4a-47be-b078-1b466c243fb4" />


---

Closes #RI-8228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renders untrusted Redis values as HTML via dangerouslySetInnerHTML, but the change is centered on sanitization, forbidden tags, and broad unit/e2e XSS coverage; array UI wiring is mostly additive.
> 
> **Overview**
> Adds **Markdown** as a key value format so Redis values can be viewed as sanitized GitHub-Flavored Markdown across key types (strings, lists, hashes, array cells, etc.).
> 
> A new **`MarkdownViewer`** runs markdown through unified (`remark-parse` → `remarkSanitize` → GFM → rehype) and then **DOMPurify** on the final HTML, rendered via `dangerouslySetInnerHTML` (not a JSX parser) so `{...}` in raw HTML stays inert. It forbids remote-loading tags (images, media, iframes), strips risky links, and falls back to plain text if parsing fails. **`formattingBuffer`** returns a `MarkdownViewer` for `KeyValueFormat.Markdown` (raw source in tooltips). Link hardening in **`remarkSanitize`** now also sets `rel="noopener noreferrer"` on absolute links.
> 
> **Array keys** gain the value-format selector on View and Search tabs via shared **`KeyDetailsSubheader`** (with **Add Elements** on View), **click-to-expand** populated rows showing **`ArrayExpandedValue`** (full formatted value), and inline markdown in value cells. **`KeyDetailsHeaderFormatter`** drives the select from Redux **`viewFormat`** instead of duplicate local state; the subheader divider only shows when **Actions** are present.
> 
> **`rehypeWrapSymbols`** is extracted for the tutorial **`MarkdownToJsxString`** path. Redundant per-spec **`jest.mock('unist-util-visit')`** calls are removed where **`moduleNameMapper`** already stubs those modules. Playwright e2e covers real pipeline rendering and XSS inertness on string/list/hash keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4780bc9568594101da788f4c807d88523537a4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->