### PR TITLE
RI-8298 Auto-open What's New after auto-update; show flag-gated cards as Coming soon

### DIFF
--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
@@ -11,6 +11,7 @@ import {
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { FeatureFlags } from 'uiSrc/constants'
 import { closeWhatsNew } from 'uiSrc/slices/app/whatsNew'
+import { setReleaseNotesViewed } from 'uiSrc/slices/app/info'
 import { whatsNewFeed } from 'uiSrc/utils'
 import WhatsNewModal from './WhatsNewModal'
 
@@ -127,5 +128,23 @@ describe('WhatsNewModal', () => {
       event: TelemetryEvent.WHATS_NEW_CLOSED,
       eventData: { version: latestVersion },
     })
+  })
+
+  it('should acknowledge a pending update for the running version on close', () => {
+    // set by ipcCheckUpdates only after the updated version is running
+    const state = set(
+      getOpenState(),
+      'app.info.electron.isReleaseNotesViewed',
+      false,
+    )
+    const store = mockStore(state)
+    render(<WhatsNewModal />, { store })
+
+    fireEvent.click(screen.getByTestId('whats-new-got-it-btn'))
+
+    expect(store.getActions()).toEqual([
+      setReleaseNotesViewed(true),
+      closeWhatsNew(),
+    ])
   })
 })

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
@@ -76,39 +76,44 @@ describe('WhatsNewModal', () => {
     ).toBeInTheDocument()
   })
 
-  it('should hide cards whose feature flag is off', () => {
+  it('should show flag-gated cards marked as coming soon when their flags are off', () => {
     render(<WhatsNewModal />, { store: mockStore(getOpenState(false)) })
 
+    expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(
-      screen.getByTestId('whats-new-card-geodata-workbench'),
+      screen.getByTestId('whats-new-card-inactive-vector-sets'),
     ).toBeInTheDocument()
+    // unflagged card carries no indicator
     expect(
-      screen.queryByTestId('whats-new-card-vector-sets'),
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('whats-new-card-dev-vs-prod-mode'),
+      screen.queryByTestId('whats-new-card-inactive-geodata-workbench'),
     ).not.toBeInTheDocument()
   })
 
-  it('should fall back to the first visible version when the selected one is hidden', () => {
-    // 3.2.0's only card is azure-gated, so the version is hidden by default
+  it('should show versions whose cards are all flag-gated off', () => {
+    // 3.2.0's only card is azure-gated and azure is off here
     const state = set(getOpenState(), 'app.whatsNew.selectedVersion', '3.2.0')
 
     render(<WhatsNewModal />, { store: mockStore(state) })
 
+    expect(
+      screen.getByTestId('whats-new-card-azure-managed-redis'),
+    ).toBeInTheDocument()
     expect(screen.getByTestId('whats-new-release-notes-link')).toHaveAttribute(
       'href',
-      expect.stringContaining(`/tag/${latestVersion}`),
+      expect.stringContaining('/tag/3.2.0'),
     )
   })
 
-  it('should show flag-gated cards when their flags are on', () => {
+  it('should not mark flag-gated cards when their flags are on', () => {
     render(<WhatsNewModal />, { store: mockStore(getOpenState(true)) })
 
     expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(
-      screen.getByTestId('whats-new-card-dev-vs-prod-mode'),
-    ).toBeInTheDocument()
+      screen.queryByTestId('whats-new-card-inactive-vector-sets'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('whats-new-card-inactive-dev-vs-prod-mode'),
+    ).not.toBeInTheDocument()
   })
 
   it('should dispatch close and send telemetry on "Got it"', () => {

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
@@ -7,6 +7,10 @@ import {
   setSelectedVersion,
   whatsNewSelector,
 } from 'uiSrc/slices/app/whatsNew'
+import {
+  appElectronInfoSelector,
+  setReleaseNotesViewed,
+} from 'uiSrc/slices/app/info'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { isWhatsNewCardActive, whatsNewFeed } from 'uiSrc/utils'
@@ -30,6 +34,7 @@ import * as S from './WhatsNewModal.styles'
 const WhatsNewModal = () => {
   const { isOpen, selectedVersion } = useAppSelector(whatsNewSelector)
   const features = useAppSelector(appFeatureFlagsFeaturesSelector)
+  const { isReleaseNotesViewed } = useAppSelector(appElectronInfoSelector)
   const dispatch = useAppDispatch()
   const { t, i18n } = useTranslation()
 
@@ -59,6 +64,13 @@ const WhatsNewModal = () => {
       event: TelemetryEvent.WHATS_NEW_CLOSED,
       eventData: { version: currentVersion },
     })
+    // Acknowledge a pending update like closing the legacy toast did, so the
+    // Release Notes indicator clears and the stored version is cleaned up.
+    // `false` is only set once the updated version is running — a pre-restart
+    // open must not acknowledge, or the post-restart flow would be skipped.
+    if (isReleaseNotesViewed === false) {
+      dispatch(setReleaseNotesViewed(true))
+    }
     dispatch(closeWhatsNew())
   }
 

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
@@ -9,7 +9,7 @@ import {
 } from 'uiSrc/slices/app/whatsNew'
 import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import { getVisibleWhatsNewVersions } from 'uiSrc/utils'
+import { isWhatsNewCardActive, whatsNewFeed } from 'uiSrc/utils'
 import { EXTERNAL_LINKS } from 'uiSrc/constants/links'
 
 import { Modal } from 'uiSrc/components/base/display'
@@ -35,16 +35,14 @@ const WhatsNewModal = () => {
 
   if (!isOpen) return null
 
-  const visibleVersions = getVisibleWhatsNewVersions(features)
   const versionEntry =
-    visibleVersions.find((v) => v.version === selectedVersion) ??
-    visibleVersions[0]
+    whatsNewFeed.find((v) => v.version === selectedVersion) ?? whatsNewFeed[0]
 
   if (!versionEntry) return null
 
   const currentVersion = versionEntry.version
 
-  const versionOptions: RiSelectOption[] = visibleVersions.map((v, index) => ({
+  const versionOptions: RiSelectOption[] = whatsNewFeed.map((v, index) => ({
     value: v.version,
     label:
       index === 0
@@ -119,6 +117,7 @@ const WhatsNewModal = () => {
               <FeatureCard
                 key={card.id}
                 card={card}
+                isActive={isWhatsNewCardActive(card, features)}
                 onLinkClick={onCardLinkClick}
               />
             ))}

--- a/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.spec.tsx
@@ -48,6 +48,37 @@ describe('FeatureCard', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('should mark an inactive card as coming soon and hide its location', () => {
+    const card = whatsNewCardFactory.build({
+      location: 'Browser — somewhere',
+    })
+
+    render(
+      <FeatureCard
+        card={card}
+        isActive={false}
+        onLinkClick={onLinkClickMock}
+      />,
+    )
+
+    expect(
+      screen.getByTestId(`whats-new-card-inactive-${card.id}`),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`whats-new-card-location-${card.id}`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not mark an active card', () => {
+    const card = whatsNewCardFactory.build()
+
+    render(<FeatureCard card={card} onLinkClick={onLinkClickMock} />)
+
+    expect(
+      screen.queryByTestId(`whats-new-card-inactive-${card.id}`),
+    ).not.toBeInTheDocument()
+  })
+
   it('should call onLinkClick with card id and href', () => {
     const link = { label: 'Learn more', href: 'https://redis.io/docs' }
     const card = whatsNewCardFactory.build({ links: [link] })

--- a/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.styles.ts
+++ b/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.styles.ts
@@ -2,12 +2,13 @@ import styled from 'styled-components'
 import { Col } from 'uiSrc/components/base/layout/flex'
 import { Text } from 'uiSrc/components/base/text'
 
-export const CardContainer = styled(Col)`
+export const CardContainer = styled(Col)<{ $inactive?: boolean }>`
   padding: ${({ theme }) => theme.core.space.space150};
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
   border-radius: ${({ theme }) => theme.core.space.space100};
   background-color: ${({ theme }) =>
     theme.semantic.color.background.neutral100};
+  opacity: ${({ $inactive }) => ($inactive ? 0.65 : 1)};
 `
 
 export const Location = styled(Text)`

--- a/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.tsx
+++ b/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.tsx
@@ -11,17 +11,23 @@ import { AllIconsType } from 'uiSrc/components/base/icons'
 import { Props } from './FeatureCard.types'
 import * as S from './FeatureCard.styles'
 
-const FeatureCard = ({ card, onLinkClick }: Props) => {
+const FeatureCard = ({ card, isActive = true, onLinkClick }: Props) => {
   const { id, title, body, tag, icon, location, links } = card
   const { t } = useTranslation()
 
   return (
-    <S.CardContainer data-testid={`whats-new-card-${id}`}>
+    <S.CardContainer $inactive={!isActive} data-testid={`whats-new-card-${id}`}>
       <Row align="center" gap="m">
         {icon && <RiIcon type={icon as AllIconsType} size="l" />}
         <Text size="m">{title}</Text>
         {tag && (
           <RiBadge label={tag} data-testid={`whats-new-card-tag-${id}`} />
+        )}
+        {!isActive && (
+          <RiBadge
+            label={t('whatsNew.card.comingSoon')}
+            data-testid={`whats-new-card-inactive-${id}`}
+          />
         )}
       </Row>
 
@@ -31,7 +37,7 @@ const FeatureCard = ({ card, onLinkClick }: Props) => {
         {body}
       </Text>
 
-      {location && (
+      {isActive && location && (
         <>
           <Spacer size="s" />
           <S.Location size="xs" data-testid={`whats-new-card-location-${id}`}>

--- a/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.types.ts
+++ b/redisinsight/ui/src/components/whats-new/components/feature-card/FeatureCard.types.ts
@@ -2,5 +2,7 @@ import { WhatsNewCard } from 'uiSrc/constants/content/whats-new'
 
 export interface Props {
   card: WhatsNewCard
+  /** The card's feature is usable in this build (flag on or not gated). */
+  isActive?: boolean
   onLinkClick: (cardId: string, href: string) => void
 }

--- a/redisinsight/ui/src/constants/telemetry.ts
+++ b/redisinsight/ui/src/constants/telemetry.ts
@@ -5,4 +5,5 @@ export enum ReleaseNotesSource {
 
 export enum WhatsNewSource {
   helpCenter = 'Help Center',
+  autoUpdate = 'Auto update',
 }

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -7,6 +7,7 @@ import {
   appServerInfoSelector,
   appElectronInfoSelector,
 } from 'uiSrc/slices/app/info'
+import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import {
   ipcAppRestart,
   ipcCheckUpdates,
@@ -21,6 +22,7 @@ const ConfigElectron = () => {
   let isCheckedUpdates = false
   const { isReleaseNotesViewed } = useAppSelector(appElectronInfoSelector)
   const serverInfo = useAppSelector(appServerInfoSelector)
+  const features = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const dispatch = useAppDispatch()
   const history = useHistory()
@@ -30,9 +32,12 @@ const ConfigElectron = () => {
     window.app?.updateAvailable?.(updateAvailableAction)
   }, [])
 
+  // Keyed on serverInfo only: must run once per load (consumes one-shot
+  // electron-store flags). Feature flags are already fetched — AppInit
+  // blocks rendering until they are.
   useEffect(() => {
     if (serverInfo) {
-      ipcCheckUpdates(serverInfo, dispatch)
+      ipcCheckUpdates(serverInfo, dispatch, features)
     }
   }, [serverInfo])
 

--- a/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
+++ b/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
@@ -5,11 +5,7 @@ import { ReleaseNotesSource, WhatsNewSource } from 'uiSrc/constants/telemetry'
 import { setElectronInfo, setReleaseNotesViewed } from 'uiSrc/slices/app/info'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { openWhatsNew } from 'uiSrc/slices/app/whatsNew'
-import {
-  FeatureFlagsMap,
-  getVisibleWhatsNewVersions,
-  isWhatsNewEligible,
-} from 'uiSrc/utils'
+import { FeatureFlagsMap, isWhatsNewEligible } from 'uiSrc/utils'
 import { localStorageService } from 'uiSrc/services'
 import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
 import successMessages from 'uiSrc/components/notifications/success-messages'
@@ -41,14 +37,12 @@ export const ipcCheckUpdates = async (
         null
 
       // The What's New modal replaces the update toast when the new version
-      // is eligible and has cards visible under this build's feature flags;
-      // otherwise fall back to the toast so the update is never silent.
+      // is eligible; otherwise fall back to the toast so the update is never
+      // silent. Flag-gated cards render as "coming soon", so no visibility
+      // check is needed.
       const shouldOpenWhatsNew =
         !!features?.[FeatureFlags.whatsNew]?.flag &&
-        isWhatsNewEligible(updateDownloadedVersion, lastVersionSeen) &&
-        getVisibleWhatsNewVersions(features).some(
-          (v) => v.version === updateDownloadedVersion,
-        )
+        isWhatsNewEligible(updateDownloadedVersion, lastVersionSeen)
 
       if (shouldOpenWhatsNew) {
         dispatch(openWhatsNew(updateDownloadedVersion))

--- a/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
+++ b/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
@@ -1,9 +1,17 @@
 import { Dispatch } from 'react'
 import { omit } from 'lodash'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import { ReleaseNotesSource } from 'uiSrc/constants/telemetry'
+import { ReleaseNotesSource, WhatsNewSource } from 'uiSrc/constants/telemetry'
 import { setElectronInfo, setReleaseNotesViewed } from 'uiSrc/slices/app/info'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
+import { openWhatsNew } from 'uiSrc/slices/app/whatsNew'
+import {
+  FeatureFlagsMap,
+  getVisibleWhatsNewVersions,
+  isWhatsNewEligible,
+} from 'uiSrc/utils'
+import { localStorageService } from 'uiSrc/services'
+import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { GetServerInfoResponse } from 'apiClient'
 import { ElectronStorageItem, IpcInvokeEvent } from '../constants'
@@ -11,6 +19,7 @@ import { ElectronStorageItem, IpcInvokeEvent } from '../constants'
 export const ipcCheckUpdates = async (
   serverInfo: GetServerInfoResponse,
   dispatch: Dispatch<any>,
+  features?: FeatureFlagsMap,
 ) => {
   const isUpdateDownloaded = await window.app.ipc.invoke(
     IpcInvokeEvent.getStoreValue,
@@ -27,19 +36,47 @@ export const ipcCheckUpdates = async (
 
   if (isUpdateDownloaded && !isUpdateAvailable) {
     if (serverInfo.appVersion === updateDownloadedVersion) {
-      dispatch(
-        addMessageNotification(
-          successMessages.INSTALLED_NEW_UPDATE(updateDownloadedVersion, () => {
-            dispatch(setReleaseNotesViewed(true))
-            sendEventTelemetry({
-              event: TelemetryEvent.RELEASE_NOTES_LINK_CLICKED,
-              eventData: {
-                source: ReleaseNotesSource.updateNotification,
+      const lastVersionSeen =
+        localStorageService?.get(BrowserStorageItem.whatsNewLastVersionSeen) ??
+        null
+
+      // The What's New modal replaces the update toast when the new version
+      // is eligible and has cards visible under this build's feature flags;
+      // otherwise fall back to the toast so the update is never silent.
+      const shouldOpenWhatsNew =
+        !!features?.[FeatureFlags.whatsNew]?.flag &&
+        isWhatsNewEligible(updateDownloadedVersion, lastVersionSeen) &&
+        getVisibleWhatsNewVersions(features).some(
+          (v) => v.version === updateDownloadedVersion,
+        )
+
+      if (shouldOpenWhatsNew) {
+        dispatch(openWhatsNew(updateDownloadedVersion))
+        sendEventTelemetry({
+          event: TelemetryEvent.WHATS_NEW_OPENED,
+          eventData: {
+            source: WhatsNewSource.autoUpdate,
+            version: updateDownloadedVersion,
+          },
+        })
+      } else {
+        dispatch(
+          addMessageNotification(
+            successMessages.INSTALLED_NEW_UPDATE(
+              updateDownloadedVersion,
+              () => {
+                dispatch(setReleaseNotesViewed(true))
+                sendEventTelemetry({
+                  event: TelemetryEvent.RELEASE_NOTES_LINK_CLICKED,
+                  eventData: {
+                    source: ReleaseNotesSource.updateNotification,
+                  },
+                })
               },
-            })
-          }),
-        ),
-      )
+            ),
+          ),
+        )
+      }
     }
 
     await window.app.ipc.invoke(

--- a/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
+++ b/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
@@ -12,6 +12,24 @@ import successMessages from 'uiSrc/components/notifications/success-messages'
 import { GetServerInfoResponse } from 'apiClient'
 import { ElectronStorageItem, IpcInvokeEvent } from '../constants'
 
+/**
+ * Whether the What's New modal should replace the update toast for the just
+ * installed version. Flag-gated cards render as "Coming soon", so no card
+ * visibility check is needed.
+ */
+const shouldOpenWhatsNew = (
+  version: string,
+  features?: FeatureFlagsMap,
+): boolean => {
+  const lastVersionSeen =
+    localStorageService?.get(BrowserStorageItem.whatsNewLastVersionSeen) ?? null
+
+  return (
+    !!features?.[FeatureFlags.whatsNew]?.flag &&
+    isWhatsNewEligible(version, lastVersionSeen)
+  )
+}
+
 export const ipcCheckUpdates = async (
   serverInfo: GetServerInfoResponse,
   dispatch: Dispatch<any>,
@@ -31,46 +49,32 @@ export const ipcCheckUpdates = async (
   )
 
   if (isUpdateDownloaded && !isUpdateAvailable) {
-    if (serverInfo.appVersion === updateDownloadedVersion) {
-      const lastVersionSeen =
-        localStorageService?.get(BrowserStorageItem.whatsNewLastVersionSeen) ??
-        null
-
-      // The What's New modal replaces the update toast when the new version
-      // is eligible; otherwise fall back to the toast so the update is never
-      // silent. Flag-gated cards render as "coming soon", so no visibility
-      // check is needed.
-      const shouldOpenWhatsNew =
-        !!features?.[FeatureFlags.whatsNew]?.flag &&
-        isWhatsNewEligible(updateDownloadedVersion, lastVersionSeen)
-
-      if (shouldOpenWhatsNew) {
-        dispatch(openWhatsNew(updateDownloadedVersion))
-        sendEventTelemetry({
-          event: TelemetryEvent.WHATS_NEW_OPENED,
-          eventData: {
-            source: WhatsNewSource.autoUpdate,
-            version: updateDownloadedVersion,
-          },
-        })
-      } else {
-        dispatch(
-          addMessageNotification(
-            successMessages.INSTALLED_NEW_UPDATE(
-              updateDownloadedVersion,
-              () => {
-                dispatch(setReleaseNotesViewed(true))
-                sendEventTelemetry({
-                  event: TelemetryEvent.RELEASE_NOTES_LINK_CLICKED,
-                  eventData: {
-                    source: ReleaseNotesSource.updateNotification,
-                  },
-                })
+    if (
+      serverInfo.appVersion === updateDownloadedVersion &&
+      shouldOpenWhatsNew(updateDownloadedVersion, features)
+    ) {
+      dispatch(openWhatsNew(updateDownloadedVersion))
+      sendEventTelemetry({
+        event: TelemetryEvent.WHATS_NEW_OPENED,
+        eventData: {
+          source: WhatsNewSource.autoUpdate,
+          version: updateDownloadedVersion,
+        },
+      })
+    } else if (serverInfo.appVersion === updateDownloadedVersion) {
+      dispatch(
+        addMessageNotification(
+          successMessages.INSTALLED_NEW_UPDATE(updateDownloadedVersion, () => {
+            dispatch(setReleaseNotesViewed(true))
+            sendEventTelemetry({
+              event: TelemetryEvent.RELEASE_NOTES_LINK_CLICKED,
+              eventData: {
+                source: ReleaseNotesSource.updateNotification,
               },
-            ),
-          ),
-        )
-      }
+            })
+          }),
+        ),
+      )
     }
 
     await window.app.ipc.invoke(

--- a/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
+++ b/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
@@ -87,8 +87,9 @@ describe('ipcCheckUpdates', () => {
     expect(actionTypes).toContain(addMessageNotification.type)
   })
 
-  it('should fall back to the toast when all cards of the version are flag-hidden', async () => {
-    // 3.2.0's only card is gated behind azureEntraId, which is off here
+  it('should open Whats New even when the version cards are flag-gated off', async () => {
+    // 3.2.0's only card is gated behind azureEntraId (off here) — it renders
+    // as "coming soon" instead of blocking the auto-open
     const version = '3.2.0'
     invokeMock
       .mockReturnValueOnce(true)
@@ -100,23 +101,6 @@ describe('ipcCheckUpdates', () => {
       store.dispatch,
       whatsNewOnFeatures,
     )
-
-    const actionTypes = store.getActions().map((action) => action.type)
-    expect(actionTypes).not.toContain(openWhatsNew.type)
-    expect(actionTypes).toContain(addMessageNotification.type)
-  })
-
-  it('should open Whats New for a version whose gated cards are enabled', async () => {
-    const version = '3.2.0'
-    invokeMock
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(version)
-
-    await ipcCheckUpdates(serverInfoMock(version), store.dispatch, {
-      ...whatsNewOnFeatures,
-      [FeatureFlags.azureEntraId]: { flag: true },
-    })
 
     expect(store.getActions()).toContainEqual(openWhatsNew(version))
   })

--- a/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
+++ b/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
@@ -1,7 +1,19 @@
 import { cloneDeep } from 'lodash'
 
+import { GetServerInfoResponse } from 'apiClient'
 import { cleanup, mockedStore } from 'uiSrc/utils/test-utils'
+import { FeatureFlagsMap, whatsNewFeed } from 'uiSrc/utils'
+import { openWhatsNew } from 'uiSrc/slices/app/whatsNew'
+import { addMessageNotification } from 'uiSrc/slices/app/notifications'
+import { FeatureFlags } from 'uiSrc/constants'
 import { ipcCheckUpdates, ipcSendEvents } from '../ipcCheckUpdates'
+
+const serverInfoMock = (appVersion: string): GetServerInfoResponse =>
+  ({ appVersion }) as unknown as GetServerInfoResponse
+
+const whatsNewOnFeatures: FeatureFlagsMap = {
+  [FeatureFlags.whatsNew]: { flag: true },
+}
 
 const invokeMock = jest.fn()
 let store: typeof mockedStore
@@ -25,6 +37,88 @@ describe('ipcCheckUpdates', () => {
     ipcCheckUpdates({ appVersion: appVersionMock }, () => {})
 
     expect(invokeMock).toBeCalled()
+  })
+
+  it('should open Whats New when enabled and the version is eligible', async () => {
+    const version = whatsNewFeed[0].version
+    invokeMock
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(version)
+
+    await ipcCheckUpdates(
+      serverInfoMock(version),
+      store.dispatch,
+      whatsNewOnFeatures,
+    )
+
+    expect(store.getActions()).toContainEqual(openWhatsNew(version))
+  })
+
+  it('should not open Whats New for an ineligible version even when enabled', async () => {
+    const version = '0.0.1'
+    invokeMock
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(version)
+
+    await ipcCheckUpdates(
+      serverInfoMock(version),
+      store.dispatch,
+      whatsNewOnFeatures,
+    )
+
+    const actionTypes = store.getActions().map((action) => action.type)
+    expect(actionTypes).not.toContain(openWhatsNew.type)
+    expect(actionTypes).toContain(addMessageNotification.type)
+  })
+
+  it('should fall back to the update toast when Whats New is disabled', async () => {
+    const version = whatsNewFeed[0].version
+    invokeMock
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(version)
+
+    await ipcCheckUpdates(serverInfoMock(version), store.dispatch, {})
+
+    const actionTypes = store.getActions().map((action) => action.type)
+    expect(actionTypes).not.toContain(openWhatsNew.type)
+    expect(actionTypes).toContain(addMessageNotification.type)
+  })
+
+  it('should fall back to the toast when all cards of the version are flag-hidden', async () => {
+    // 3.2.0's only card is gated behind azureEntraId, which is off here
+    const version = '3.2.0'
+    invokeMock
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(version)
+
+    await ipcCheckUpdates(
+      serverInfoMock(version),
+      store.dispatch,
+      whatsNewOnFeatures,
+    )
+
+    const actionTypes = store.getActions().map((action) => action.type)
+    expect(actionTypes).not.toContain(openWhatsNew.type)
+    expect(actionTypes).toContain(addMessageNotification.type)
+  })
+
+  it('should open Whats New for a version whose gated cards are enabled', async () => {
+    const version = '3.2.0'
+    invokeMock
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(version)
+
+    await ipcCheckUpdates(serverInfoMock(version), store.dispatch, {
+      ...whatsNewOnFeatures,
+      [FeatureFlags.azureEntraId]: { flag: true },
+    })
+
+    expect(store.getActions()).toContainEqual(openWhatsNew(version))
   })
 })
 describe('ipcSendEvents', () => {

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -216,6 +216,7 @@
   "settings.workbench.pipeline.summary": "Задава размера на пакета от команди за <pipelineLink>pipeline</pipelineLink> режима в Работна среда. 0 или 1 изпраща всяка команда поотделно.",
   "settings.workbench.pipeline.title": "Pipeline режим",
   "whatsNew.button.gotIt": "Разбрах",
+  "whatsNew.card.comingSoon": "Очаквайте скоро",
   "whatsNew.card.locationLabel": "Къде да го намерите:",
   "whatsNew.menuItem": "Какво ново?",
   "whatsNew.releaseDate": "Издадена на {{date}}",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -216,6 +216,7 @@
   "settings.workbench.pipeline.summary": "Sets the size of a command batch for the <pipelineLink>pipeline</pipelineLink> mode in Workbench. 0 or 1 pipelines every command.",
   "settings.workbench.pipeline.title": "Pipeline Mode",
   "whatsNew.button.gotIt": "Got it",
+  "whatsNew.card.comingSoon": "Coming soon",
   "whatsNew.card.locationLabel": "Where to find it:",
   "whatsNew.menuItem": "What's new?",
   "whatsNew.releaseDate": "Released {{date}}",

--- a/redisinsight/ui/src/utils/tests/whatsNew.spec.ts
+++ b/redisinsight/ui/src/utils/tests/whatsNew.spec.ts
@@ -1,9 +1,10 @@
 import { FeatureFlags } from 'uiSrc/constants'
 import {
-  getVisibleWhatsNewVersions,
+  isWhatsNewCardActive,
   isWhatsNewEligible,
   whatsNewFeed,
 } from 'uiSrc/utils'
+import { whatsNewCardFactory } from 'uiSrc/mocks/factories/whatsNew/WhatsNewCard.factory'
 
 const latestVersion = whatsNewFeed[0].version
 
@@ -21,22 +22,23 @@ describe('isWhatsNewEligible', () => {
   })
 })
 
-describe('getVisibleWhatsNewVersions', () => {
-  it('should drop flag-gated cards and omit versions left with none', () => {
-    const visible = getVisibleWhatsNewVersions({})
+describe('isWhatsNewCardActive', () => {
+  it('should be active for a card without a feature flag', () => {
+    const card = whatsNewCardFactory.build()
 
-    expect(visible.map((v) => v.version)).not.toContain('3.2.0')
-    visible.forEach((v) => {
-      expect(v.cards.length).toBeGreaterThan(0)
-      v.cards.forEach((card) => expect(card.featureFlag).toBeUndefined())
-    })
+    expect(isWhatsNewCardActive(card, {})).toEqual(true)
   })
 
-  it('should include gated cards when their flags are on', () => {
-    const visible = getVisibleWhatsNewVersions({
-      [FeatureFlags.azureEntraId]: { flag: true },
+  it('should follow the feature flag for gated cards', () => {
+    const card = whatsNewCardFactory.build({
+      featureFlag: FeatureFlags.azureEntraId,
     })
 
-    expect(visible.map((v) => v.version)).toContain('3.2.0')
+    expect(isWhatsNewCardActive(card, {})).toEqual(false)
+    expect(
+      isWhatsNewCardActive(card, {
+        [FeatureFlags.azureEntraId]: { flag: true },
+      }),
+    ).toEqual(true)
   })
 })

--- a/redisinsight/ui/src/utils/whatsNew.ts
+++ b/redisinsight/ui/src/utils/whatsNew.ts
@@ -8,7 +8,7 @@ import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import { FeatureFlagComponent } from 'uiSrc/slices/interfaces'
 import { isVersionHigher } from './comparisons'
 
-type FeatureFlagsMap = { [key in FeatureFlags]?: FeatureFlagComponent }
+export type FeatureFlagsMap = { [key in FeatureFlags]?: FeatureFlagComponent }
 
 /** Bundled release content, sorted latest-first. */
 export const whatsNewFeed: WhatsNewFeed = [...WHATS_NEW_VERSIONS].sort(

--- a/redisinsight/ui/src/utils/whatsNew.ts
+++ b/redisinsight/ui/src/utils/whatsNew.ts
@@ -1,5 +1,6 @@
 import {
   WHATS_NEW_VERSIONS,
+  WhatsNewCard,
   WhatsNewFeed,
   WhatsNewVersion,
   WhatsNewVersionType,
@@ -16,20 +17,13 @@ export const whatsNewFeed: WhatsNewFeed = [...WHATS_NEW_VERSIONS].sort(
 )
 
 /**
- * The feed with flag-gated cards resolved against the current feature flags:
- * hidden cards are dropped, versions left with no cards are omitted.
+ * Whether a card's feature is currently usable in this build: not flag-gated,
+ * or its flag is on. Cards are always shown; inactive ones are only marked.
  */
-export const getVisibleWhatsNewVersions = (
+export const isWhatsNewCardActive = (
+  card: WhatsNewCard,
   features?: FeatureFlagsMap,
-): WhatsNewFeed =>
-  whatsNewFeed
-    .map((version) => ({
-      ...version,
-      cards: version.cards.filter(
-        (card) => !card.featureFlag || features?.[card.featureFlag]?.flag,
-      ),
-    }))
-    .filter((version) => version.cards.length > 0)
+): boolean => !card.featureFlag || !!features?.[card.featureFlag]?.flag
 
 export const getLatestWhatsNewVersion = (): WhatsNewVersion | undefined =>
   whatsNewFeed[0]


### PR DESCRIPTION
# What

PR 2 of 2 for What's New ([#6174](https://github.com/redis/RedisInsight/pull/6174) shipped the modal + Help Center entry). Two behaviors:

**1. Auto-open after an electron auto-update.** On the first launch after an update, the What's New modal opens instead of the "Application updated" toast when the `whatsNew` flag is on and the version is eligible (in the bundled feed, not a `patch`, newer than the last version seen). Otherwise the toast still shows — an update is never silent. "Seen" is recorded only when the modal actually opens. Feature flags are guaranteed fetched before the check (`AppInit` blocks rendering until then).

**2. Flag-gated cards always render, marked "Coming soon".** Cards whose feature flag is off are dimmed, badged "Coming soon", and don't show their "Where to find it" hint; versions always appear in the selector. Users updating mid-rollout see the full release once per version instead of a rollout-bucket-dependent subset — nobody's "seen" state swallows features whose flags turn on days later.

> Design note: "Coming soon" wording is a first pass — for builds where a flag is permanently off (not a rollout), the label may over-promise. Open to alternatives (e.g. "Not enabled yet").

## Screenshots

<!-- modal with a Coming soon card -->
<img width="697" height="620" alt="Screenshot 2026-07-08 at 13 19 51" src="https://github.com/user-attachments/assets/4059062b-13bd-4c25-89bc-c9a7c6096c1b" />

# Testing

Unit: `ipcCheckUpdates` covers eligible → modal (including a version whose cards are all flag-gated off), ineligible version → toast, disabled flag → toast. Modal/FeatureCard specs cover the Coming soon indicator and hidden location hint.

Manual (desktop):
1. Quit the app. In the electron-store file (`config.json` under the app's userData directory), set:
   `"updateDownloaded": true`, `"updateDownloadedVersion": "<current app version>"`, `"isUpdateAvailable": false`
2. Clear `whatsNewLastVersionSeen` from the renderer's localStorage (or use a fresh profile).
3. Launch `yarn dev:desktop` → the modal auto-opens once; flag-off cards show dimmed with "Coming soon".
4. Relaunch → no modal, no toast (one-shot flag consumed, version marked seen).

> Rollout note: the **remote features config** needs `whatsNew` added with `version >= 6`, or its next sync will drop the flag delivered by the bundled config.

---

Closes RI-8298

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches one-shot electron update IPC and release-notes viewed state; mis-timing acknowledgment could skip post-restart UX, but behavior is guarded and covered by new unit tests.
> 
> **Overview**
> After a desktop auto-update, **What's New** can replace the legacy “Application updated” toast when the `whatsNew` feature flag is on and the installed version passes eligibility (`isWhatsNewEligible` + last-seen in localStorage). `ipcCheckUpdates` dispatches `openWhatsNew` with `WhatsNewSource.autoUpdate` telemetry; otherwise the toast path is unchanged so updates are never silent.
> 
> The modal no longer filters the feed via `getVisibleWhatsNewVersions`. All versions and cards stay in the selector; flag-gated cards use **`isWhatsNewCardActive`** and render dimmed with a **“Coming soon”** badge while hiding the “Where to find it” hint. Closing with **Got it** calls **`setReleaseNotesViewed(true)`** when `isReleaseNotesViewed === false`, matching the old toast acknowledgment for release-notes cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d20ce06a1a010c75307009aa70f56da1b653ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->