### PR TITLE
E2E: stabilize databases-list row actions and edit-dialog locator

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { KeyValueFormat } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { ElementNameCell } from './ElementNameCell'
+
+const element = { name: stringToBuffer('element-abc') }
+
+describe('ElementNameCell', () => {
+  it('builds the test id from the raw name', () => {
+    render(
+      <ElementNameCell
+        element={element}
+        compressor={null}
+        viewFormat={KeyValueFormat.Unicode}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('vector-set-element-value-element-abc'),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the raw-name test id when the format renders JSX', () => {
+    render(
+      <ElementNameCell
+        element={element}
+        compressor={null}
+        viewFormat={KeyValueFormat.Markdown}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('vector-set-element-value-element-abc'),
+    ).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { createTooltipContent, formattingBuffer } from 'uiSrc/utils'
+import {
+  bufferToString,
+  createTooltipContent,
+  formattingBuffer,
+} from 'uiSrc/utils'
 import { TEXT_FAILED_CONVENT_FORMATTER } from 'uiSrc/constants'
 import { decompressingBuffer } from 'uiSrc/utils/decompressors'
 import { FormattedValue } from 'uiSrc/pages/browser/modules/key-details/shared'
@@ -31,8 +35,11 @@ export const ElementNameCell = ({
     viewFormat,
   )
 
-  const testIdSuffix =
-    typeof value === 'string' ? value?.substring(0, 200) : value
+  // Test ids must not depend on the view format: rich formats (Markdown,
+  // JSON) return JSX from formattingBuffer, not a string.
+  const testIdSuffix = bufferToString(
+    decompressedItem as RedisResponseBuffer,
+  ).substring(0, 200)
 
   return (
     <Row data-testid={`vector-set-element-value-${testIdSuffix}`}>

--- a/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
+++ b/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
@@ -75,7 +75,7 @@ export class AddDatabaseDialog {
     this.page = page;
 
     // Dialog controls
-    this.dialog = page.getByRole('dialog', { name: /add database|connection settings/i });
+    this.dialog = page.getByRole('dialog', { name: /add database|edit database|connection settings/i });
     this.connectionUrlInput = page.getByPlaceholder(/redis:\/\//i);
     this.connectionSettingsButton = page.getByTestId('btn-connection-settings');
     this.addDatabaseButton = page.getByRole('button', {

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
@@ -74,6 +74,16 @@ test.describe('Browser > Key Details - Markdown value format', () => {
     await apiHelper.deleteKeysByPattern(database.id, `${TEST_KEY_PREFIX}*`);
   });
 
+  // The format choice persists (localStorage + in-memory store) and Electron
+  // runs the whole suite in one app instance, so reset it before it can leak
+  // into later specs. Registered after the hook above => runs before it,
+  // while the key details panel is still open.
+  test.afterEach(async ({ browserPage }) => {
+    if (await browserPage.keyDetails.formatDropdown.isVisible()) {
+      await browserPage.keyDetails.changeValueFormat('Unicode');
+    }
+  });
+
   test('should render a markdown String value through the sanitized pipeline', async ({ apiHelper, browserPage }) => {
     const keyData = StringKeyFactory.build({ value: RENDERED_MARKDOWN });
     await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);

--- a/tests/e2e-playwright/tests/parallel/databases/list/database-list.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/databases/list/database-list.spec.ts
@@ -229,6 +229,8 @@ test.describe('Database List', () => {
     test('should edit database connection', async ({ databasesPage }) => {
       const { databaseList } = databasesPage;
 
+      // Parallel suites can page the row out of the unfiltered list
+      await databaseList.expectDatabaseVisible(standaloneDb1.name, { searchFirst: true });
       await databaseList.edit(standaloneDb1.name);
 
       const editDialog = databasesPage.page.getByRole('dialog', { name: /edit database/i });


### PR DESCRIPTION
# What

Fixes the tests that currently fail on every PR's E2E run:

- **`databases/list/database-list.spec.ts` › "should edit database connection"** — parallel suites can hold enough databases to page the target row out of the unfiltered list (e.g. `pagination.spec` seeds 20), so `edit()`'s hover waits on a non-rendered row until the test times out. The test now ensures the row is visible first via the existing `expectDatabaseVisible(name, { searchFirst: true })` pattern (same as `host.spec`). Row-action page objects stay side-effect free.
- **`databases/edit/host.spec.ts`** — `AddDatabaseDialog.dialog` only matched the add-flow titles (`/add database|connection settings/i`), while the row-edit dialog is titled **"Edit Database"**, so the spec timed out waiting for a dialog that was already open. The locator now accepts all three titles.
- **All four vector-set specs on Electron (red since RI-8228/#6175)** — `ElementNameCell` derived its `data-testid` from `formattingBuffer(...)` output, which is a JSX element for rich formats, so the testid rendered as `vector-set-element-value-[object Object]`. The new `value-markdown.spec` switches the persisted view format to Markdown, and the serial Electron suite shares one app instance, so the leaked format broke every later vector-set spec (web runners get a fresh context per test, which is why only Electron failed). The testid is now built from the raw element name, and `value-markdown.spec` resets the format after each test.

# Testing

- Reproduced the pagination state locally (18-database flood, target row paged out of the DOM): the searchFirst + edit flow opens the "Edit Database" dialog via the widened locator.
- `database-list.spec.ts` and `clone-database.spec.ts` pass locally (28 tests).
- New `ElementNameCell` unit spec covers the testid regression: it fails against the previous code (`[object Object]`) and passes with the fix; element-list unit specs pass.
- This PR's own Electron e2e job is the end-to-end proof for the vector-set fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)