### PR TITLE
RI-8312,RI-8314: Align array results table columns and expanded rows

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -11,6 +11,7 @@ import { ArrayTableConfig } from './ArrayDetailsTable.types'
 import {
   ACTIONS_COLUMN_SIZE,
   INDEX_COLUMN_SIZE,
+  SELECTION_COLUMN_WIDTH_REM,
   VALUE_COLUMN_SIZE,
 } from './constants'
 
@@ -104,6 +105,21 @@ export const arrayColumns: ColumnDef<ArrayDataElement>[] = [
   valueColumn,
 ]
 
-// Keep the index/value ratio intact until the panel is narrow enough to
-// trigger horizontal scroll, rather than letting the value column collapse.
-export const TABLE_MIN_WIDTH = `${INDEX_COLUMN_SIZE + VALUE_COLUMN_SIZE}px`
+// Width below which the table scrolls horizontally instead of squeezing the
+// index/value columns. Sums every column present — including the optional
+// selection (rem) and actions (px) columns, hence the calc.
+export const getTableMinWidth = ({
+  hasSelectionColumn,
+  hasActionsColumn,
+}: {
+  hasSelectionColumn: boolean
+  hasActionsColumn: boolean
+}): string => {
+  const pxColumns =
+    INDEX_COLUMN_SIZE +
+    VALUE_COLUMN_SIZE +
+    (hasActionsColumn ? ACTIONS_COLUMN_SIZE : 0)
+  return hasSelectionColumn
+    ? `calc(${pxColumns}px + ${SELECTION_COLUMN_WIDTH_REM}rem)`
+    : `${pxColumns}px`
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -8,11 +8,6 @@ import { ArrayValueCell } from './components/ArrayValueCell'
 import { RowActionsCell } from './components/RowActionsCell'
 import { BulkDeleteHeaderCell } from './components/BulkDeleteHeaderCell'
 import { ArrayTableConfig } from './ArrayDetailsTable.types'
-// Index values are usually small numbers, so the index column takes a modest
-// share and the value column (which can hold much larger content) gets the
-// majority — instead of an even split. Both stay resizable, and the index cell
-// truncates oversized indexes into a copyable tooltip, so large indexes are
-// still fully accessible rather than hard-clamped.
 import {
   ACTIONS_COLUMN_SIZE,
   INDEX_COLUMN_SIZE,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -8,10 +8,18 @@ import { ArrayValueCell } from './components/ArrayValueCell'
 import { RowActionsCell } from './components/RowActionsCell'
 import { BulkDeleteHeaderCell } from './components/BulkDeleteHeaderCell'
 import { ArrayTableConfig } from './ArrayDetailsTable.types'
+// Index values are usually small numbers, so the index column takes a modest
+// share and the value column (which can hold much larger content) gets the
+// majority — instead of an even split. Both stay resizable, and the index cell
+// truncates oversized indexes into a copyable tooltip, so large indexes are
+// still fully accessible rather than hard-clamped.
+import {
+  ACTIONS_COLUMN_SIZE,
+  INDEX_COLUMN_SIZE,
+  VALUE_COLUMN_SIZE,
+} from './constants'
 
 export const TEST_ID = 'array-details-table'
-
-const ACTIONS_COLUMN_SIZE = 48
 
 const indexColumn: ColumnDef<ArrayDataElement> = {
   id: 'index',
@@ -19,6 +27,8 @@ const indexColumn: ColumnDef<ArrayDataElement> = {
   header: 'Index',
   enableSorting: false,
   enableResizing: true,
+  size: INDEX_COLUMN_SIZE,
+  sizeUnit: 'px',
   cell: ({ row }: CellContext<ArrayDataElement, unknown>) => (
     <ArrayIndexCell
       index={row.original.index}
@@ -34,6 +44,8 @@ const valueColumn: ColumnDef<ArrayDataElement> = {
   header: 'Value',
   enableSorting: false,
   enableResizing: true,
+  size: VALUE_COLUMN_SIZE,
+  sizeUnit: 'px',
   cell: ({ row, table }: CellContext<ArrayDataElement, unknown>) => {
     const {
       compressor,
@@ -97,5 +109,6 @@ export const arrayColumns: ColumnDef<ArrayDataElement>[] = [
   valueColumn,
 ]
 
-const MIN_COLUMN_WIDTH = 160
-export const TABLE_MIN_WIDTH = `${arrayColumns.length * MIN_COLUMN_WIDTH}px`
+// Keep the index/value ratio intact until the panel is narrow enough to
+// trigger horizontal scroll, rather than letting the value column collapse.
+export const TABLE_MIN_WIDTH = `${INDEX_COLUMN_SIZE + VALUE_COLUMN_SIZE}px`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
@@ -3,6 +3,8 @@ import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { Table, TableProps } from 'uiSrc/components/base/layout/table'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 
+import { SELECTION_COLUMN_CELL_CLASS } from './constants'
+
 export const Container = styled(FlexItem)`
   display: flex;
   flex: 1;
@@ -30,5 +32,20 @@ export const StyledTable = styled(Table)`
   [data-role='table-body'] tr:focus-within .array-row-action,
   [data-role='table-body'] .array-row-action--open {
     opacity: 1;
+  }
+
+  /* Trim the row-selection column's default (wide) side padding so it hugs the
+     checkbox, and center the checkbox in the column (it renders in a full-width
+     flex wrapper that defaults to flex-start, and the column can stretch a touch
+     wider than its base). The element+class selector outranks the base cell
+     padding without needing !important. */
+  th.${SELECTION_COLUMN_CELL_CLASS}, td.${SELECTION_COLUMN_CELL_CLASS} {
+    padding-left: ${({ theme }) => theme.core.space.space050};
+    padding-right: ${({ theme }) => theme.core.space.space050};
+  }
+  th.${SELECTION_COLUMN_CELL_CLASS} > *,
+  td.${SELECTION_COLUMN_CELL_CLASS} > * {
+    width: 100%;
+    justify-content: center;
   }
 ` as unknown as (props: TableProps<ArrayDataElement>) => JSX.Element

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
@@ -34,11 +34,8 @@ export const StyledTable = styled(Table)`
     opacity: 1;
   }
 
-  /* Trim the row-selection column's default (wide) side padding so it hugs the
-     checkbox, and center the checkbox in the column (it renders in a full-width
-     flex wrapper that defaults to flex-start, and the column can stretch a touch
-     wider than its base). The element+class selector outranks the base cell
-     padding without needing !important. */
+  /* Trim the selection column's wide side padding and center the checkbox in it.
+     The element+class selector outranks the base cell padding (no !important). */
   th.${SELECTION_COLUMN_CELL_CLASS}, td.${SELECTION_COLUMN_CELL_CLASS} {
     padding-left: ${({ theme }) => theme.core.space.space050};
     padding-right: ${({ theme }) => theme.core.space.space050};

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -33,7 +33,7 @@ import {
 import {
   actionsColumn,
   arrayColumns,
-  TABLE_MIN_WIDTH,
+  getTableMinWidth,
   TEST_ID,
 } from './ArrayDetailsTable.config'
 import {
@@ -272,7 +272,7 @@ const ArrayDetailsTable = memo(
           data={elements}
           meta={meta}
           stripedRows
-          minWidth={TABLE_MIN_WIDTH}
+          minWidth={getTableMinWidth({ hasSelectionColumn, hasActionsColumn })}
           emptyState={emptyState}
           renderExpandedRow={renderExpandedRow}
           getIsRowExpandable={getIsRowExpandable}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.tsx
@@ -27,6 +27,8 @@ import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 import {
   ARRAY_TABLE_EMPTY_MESSAGE,
   ARRAY_TABLE_LOADING_MESSAGE,
+  SELECTION_COLUMN_CELL_CLASS,
+  SELECTION_COLUMN_WIDTH_REM,
 } from './constants'
 import {
   actionsColumn,
@@ -215,6 +217,14 @@ const ArrayDetailsTable = memo(
       () =>
         buildSelectionColumn<ArrayDataElement>({
           disableSelectAll: !hasSelectableRows,
+          // Override redis-ui's default 4.2rem so the column hugs the checkbox;
+          // the class trims the cell's side padding (see ArrayDetailsTable.styles).
+          size: SELECTION_COLUMN_WIDTH_REM,
+          sizeUnit: 'rem',
+          getCellProps: () => ({ className: SELECTION_COLUMN_CELL_CLASS }),
+          getHeaderCellProps: () => ({
+            className: SELECTION_COLUMN_CELL_CLASS,
+          }),
         }),
       [buildSelectionColumn, hasSelectableRows],
     )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -1,17 +1,14 @@
 export const ARRAY_TABLE_EMPTY_MESSAGE = 'No elements in range'
 export const ARRAY_TABLE_LOADING_MESSAGE = 'Loading…'
 
-// --- Array results table column sizing (see ArrayDetailsTable.config) ---
-// Base column widths. redis-ui's `Table` uses table-layout: fixed and hands out
-// slack proportionally to these, so their ratios hold at any table width. Shared
-// with NeighbourBand so the expanded row can mirror the same layout and line up
-// under the parent columns. The px sizes assume the app's 62.5% root (1rem =
-// 10px), the same scale the rem-based selection width resolves to.
+// Array results table column widths, shared with NeighbourBand so the expanded
+// row mirrors the same layout. The fixed table-layout shares slack in these
+// proportions, so their ratios hold at any width. px sizes assume the app's
+// 62.5% root (1rem = 10px) — the scale the rem selection width also resolves to.
 export const INDEX_COLUMN_SIZE = 140
 export const VALUE_COLUMN_SIZE = 420
 export const ACTIONS_COLUMN_SIZE = 48
-// The row-selection checkbox is 1.8rem; size its column snugly around it
-// (checkbox + `space050` side padding, applied via SELECTION_COLUMN_CELL_CLASS)
-// instead of redis-ui's default 4.2rem.
+// Snug around the 1.8rem checkbox (side padding via SELECTION_COLUMN_CELL_CLASS),
+// not redis-ui's default 4.2rem.
 export const SELECTION_COLUMN_WIDTH_REM = 2.6
 export const SELECTION_COLUMN_CELL_CLASS = 'array-selection-cell'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -1,2 +1,17 @@
 export const ARRAY_TABLE_EMPTY_MESSAGE = 'No elements in range'
 export const ARRAY_TABLE_LOADING_MESSAGE = 'Loading…'
+
+// --- Array results table column sizing (see ArrayDetailsTable.config) ---
+// Base column widths. redis-ui's `Table` uses table-layout: fixed and hands out
+// slack proportionally to these, so their ratios hold at any table width. Shared
+// with NeighbourBand so the expanded row can mirror the same layout and line up
+// under the parent columns. The px sizes assume the app's 62.5% root (1rem =
+// 10px), the same scale the rem-based selection width resolves to.
+export const INDEX_COLUMN_SIZE = 140
+export const VALUE_COLUMN_SIZE = 420
+export const ACTIONS_COLUMN_SIZE = 48
+// The row-selection checkbox is 1.8rem; size its column snugly around it
+// (checkbox + `space050` side padding, applied via SELECTION_COLUMN_CELL_CLASS)
+// instead of redis-ui's default 4.2rem.
+export const SELECTION_COLUMN_WIDTH_REM = 2.6
+export const SELECTION_COLUMN_CELL_CLASS = 'array-selection-cell'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -2,13 +2,10 @@ export const ARRAY_TABLE_EMPTY_MESSAGE = 'No elements in range'
 export const ARRAY_TABLE_LOADING_MESSAGE = 'Loading…'
 
 // Array results table column widths, shared with NeighbourBand so the expanded
-// row mirrors the same layout. The fixed table-layout shares slack in these
-// proportions, so their ratios hold at any width. px sizes assume the app's
-// 62.5% root (1rem = 10px) — the scale the rem selection width also resolves to.
+// row lines up with the same columns.
 export const INDEX_COLUMN_SIZE = 140
 export const VALUE_COLUMN_SIZE = 420
 export const ACTIONS_COLUMN_SIZE = 48
-// Snug around the 1.8rem checkbox (side padding via SELECTION_COLUMN_CELL_CLASS),
-// not redis-ui's default 4.2rem.
+// Snug around the 1.8rem checkbox, not redis-ui's default 4.2rem.
 export const SELECTION_COLUMN_WIDTH_REM = 2.6
 export const SELECTION_COLUMN_CELL_CLASS = 'array-selection-cell'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
@@ -5,8 +5,18 @@ import { Col } from 'uiSrc/components/base/layout/flex'
 const INDEX_COLUMN_MIN_WIDTH = '120px'
 const VALUE_COLUMN_MIN_WIDTH = '160px'
 
+// The expanded cell spans the full row (incl. the leading selection-checkbox
+// column) and starts flush at the table's left edge. Indenting by the checkbox
+// column width plus the index cell's own left padding lands the expanded
+// content under the parent row's expand arrow instead of shifting it left.
+// `4.2rem` mirrors redis-ui `useRowSelectionColumn` (its default column size).
+const SELECTION_COLUMN_WIDTH = '4.2rem'
+
 export const Band = styled(Col)`
   padding: ${({ theme }) => theme.core.space.space050};
+  padding-left: calc(
+    ${SELECTION_COLUMN_WIDTH} + ${({ theme }) => theme.core.space.space150}
+  );
 `
 
 export const BandRow = styled.div<
@@ -24,5 +34,8 @@ export const BandRow = styled.div<
 
 export const Message = styled(Col)`
   padding: ${({ theme }) => theme.core.space.space100};
+  padding-left: calc(
+    ${SELECTION_COLUMN_WIDTH} + ${({ theme }) => theme.core.space.space150}
+  );
   color: ${({ theme }) => theme.semantic.color.text.neutral600};
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
@@ -2,21 +2,26 @@ import React from 'react'
 import styled from 'styled-components'
 import { Col } from 'uiSrc/components/base/layout/flex'
 
-const INDEX_COLUMN_MIN_WIDTH = '120px'
-const VALUE_COLUMN_MIN_WIDTH = '160px'
+import {
+  ACTIONS_COLUMN_SIZE,
+  INDEX_COLUMN_SIZE,
+  SELECTION_COLUMN_WIDTH_REM,
+  VALUE_COLUMN_SIZE,
+} from '../../array-details-table/constants'
 
-// The expanded cell spans the full row (incl. the leading selection-checkbox
-// column) and starts flush at the table's left edge. Indenting by the checkbox
-// column width plus the index cell's own left padding lands the expanded
-// content under the parent row's expand arrow instead of shifting it left.
-// `4.2rem` mirrors redis-ui `useRowSelectionColumn` (its default column size).
-const SELECTION_COLUMN_WIDTH = '4.2rem'
+// The expanded cell spans the full row and starts flush at the table's left
+// edge, so mirror the parent table's column layout: a spacer for the leading
+// selection column, the index and value columns, and a spacer for the trailing
+// actions column. redis-ui's Table (table-layout: fixed) hands out slack
+// proportionally to each column, so a grid with the same proportions stays
+// aligned at any width. The selection width is rem; at the app's 62.5% root it
+// resolves to the same px scale as the other columns, so `* 10` puts all four
+// tracks on one proportional scale.
+const SELECTION_COLUMN_FR = SELECTION_COLUMN_WIDTH_REM * 10
 
 export const Band = styled(Col)`
-  padding: ${({ theme }) => theme.core.space.space050};
-  padding-left: calc(
-    ${SELECTION_COLUMN_WIDTH} + ${({ theme }) => theme.core.space.space150}
-  );
+  width: 100%;
+  padding: ${({ theme }) => theme.core.space.space050} 0;
 `
 
 export const BandRow = styled.div<
@@ -24,18 +29,31 @@ export const BandRow = styled.div<
 >`
   display: grid;
   grid-template-columns:
-    minmax(${INDEX_COLUMN_MIN_WIDTH}, 1fr)
-    minmax(${VALUE_COLUMN_MIN_WIDTH}, 2fr);
-  gap: ${({ theme }) => theme.core.space.space100};
-  padding: ${({ theme }) => theme.core.space.space050};
+    minmax(0, ${SELECTION_COLUMN_FR}fr)
+    minmax(0, ${INDEX_COLUMN_SIZE}fr)
+    minmax(0, ${VALUE_COLUMN_SIZE}fr)
+    minmax(0, ${ACTIONS_COLUMN_SIZE}fr);
+  /* Center cells vertically so a short index stays aligned with a value that
+     wraps to multiple lines. */
+  align-items: center;
   background: ${({ theme, $match }) =>
     $match ? theme.semantic.color.background.neutral200 : 'transparent'};
+`
+
+// Match the parent table body cell padding (0.4rem 1.2rem) and overflow so the
+// index/value content lines up under — and clips like — the parent columns.
+export const BandCell = styled.div`
+  min-width: 0;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.core.space.space050}
+    ${({ theme }) => theme.core.space.space150};
 `
 
 export const Message = styled(Col)`
   padding: ${({ theme }) => theme.core.space.space100};
   padding-left: calc(
-    ${SELECTION_COLUMN_WIDTH} + ${({ theme }) => theme.core.space.space150}
+    ${SELECTION_COLUMN_WIDTH_REM}rem +
+      ${({ theme }) => theme.core.space.space150}
   );
   color: ${({ theme }) => theme.semantic.color.text.neutral600};
 `

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.styles.ts
@@ -9,14 +9,9 @@ import {
   VALUE_COLUMN_SIZE,
 } from '../../array-details-table/constants'
 
-// The expanded cell spans the full row and starts flush at the table's left
-// edge, so mirror the parent table's column layout: a spacer for the leading
-// selection column, the index and value columns, and a spacer for the trailing
-// actions column. redis-ui's Table (table-layout: fixed) hands out slack
-// proportionally to each column, so a grid with the same proportions stays
-// aligned at any width. The selection width is rem; at the app's 62.5% root it
-// resolves to the same px scale as the other columns, so `* 10` puts all four
-// tracks on one proportional scale.
+// Mirror the parent table's columns (selection + index + value + actions
+// spacers) so expanded rows line up under them at any width. `* 10` scales the
+// rem selection width to the px columns' scale (app's 62.5% root).
 const SELECTION_COLUMN_FR = SELECTION_COLUMN_WIDTH_REM * 10
 
 export const Band = styled(Col)`
@@ -40,8 +35,8 @@ export const BandRow = styled.div<
     $match ? theme.semantic.color.background.neutral200 : 'transparent'};
 `
 
-// Match the parent table body cell padding (0.4rem 1.2rem) and overflow so the
-// index/value content lines up under — and clips like — the parent columns.
+// Match the parent body cell's padding and overflow so content lines up under —
+// and clips like — the parent columns.
 export const BandCell = styled.div`
   min-width: 0;
   overflow: hidden;

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
@@ -106,13 +106,21 @@ export const NeighbourBand = ({
                 : `${TEST_ID_PREFIX}-row-${el.index}`
             }
           >
-            <ArrayIndexCell index={el.index} />
-            <ArrayValueCell
-              index={el.index}
-              value={el.value}
-              compressor={compressor}
-              viewFormat={viewFormat}
-            />
+            {/* Spacer aligning with the parent's leading selection column. */}
+            <span />
+            <S.BandCell>
+              <ArrayIndexCell index={el.index} />
+            </S.BandCell>
+            <S.BandCell>
+              <ArrayValueCell
+                index={el.index}
+                value={el.value}
+                compressor={compressor}
+                viewFormat={viewFormat}
+              />
+            </S.BandCell>
+            {/* Spacer aligning with the parent's trailing actions column. */}
+            <span />
           </S.BandRow>
         )
       })}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/search-tab/NeighbourBand/NeighbourBand.tsx
@@ -106,7 +106,6 @@ export const NeighbourBand = ({
                 : `${TEST_ID_PREFIX}-row-${el.index}`
             }
           >
-            {/* Spacer aligning with the parent's leading selection column. */}
             <span />
             <S.BandCell>
               <ArrayIndexCell index={el.index} />
@@ -119,7 +118,6 @@ export const NeighbourBand = ({
                 viewFormat={viewFormat}
               />
             </S.BandCell>
-            {/* Spacer aligning with the parent's trailing actions column. */}
             <span />
           </S.BandRow>
         )


### PR DESCRIPTION
# Preview

## Before

<img width="1440" height="426" alt="Screenshot 2026-07-09 at 16 03 34" src="https://github.com/user-attachments/assets/2cc43c2f-c681-4e36-9c06-d8dea7b963d2" />

## After

<img width="1440" height="426" alt="Screenshot 2026-07-09 at 16 02 14" src="https://github.com/user-attachments/assets/875e82d3-2652-4b82-8b95-c355484a8175" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to array key details table and search neighbour band; no API, auth, or data logic.
> 
> **Overview**
> **Aligns array search expanded rows with the parent results table** by centralizing column widths and using the same four-column layout (selection, index, value, actions).
> 
> Shared constants in `constants.ts` define index/value/actions widths and a narrower selection column (2.6rem vs redis-ui’s 4.2rem). The table applies those sizes, trims selection-cell padding via `array-selection-cell`, and computes `minWidth` with `getTableMinWidth` so horizontal scroll accounts for optional selection and delete columns.
> 
> **NeighbourBand** mirrors that grid with spacer columns and `BandCell` padding/overflow so index and value content lines up under the parent table at different widths; loading/error messages indent to match the index column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d0a15d6d2f429556b3d29aa31c66c796c24000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->