### PR TITLE
Fix vector set element test ids breaking under rich value formats

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { KeyValueFormat } from 'uiSrc/constants'
+import { stringToBuffer } from 'uiSrc/utils'
+import { ElementNameCell } from './ElementNameCell'
+
+const element = { name: stringToBuffer('element-abc') }
+
+describe('ElementNameCell', () => {
+  it('builds the test id from the raw name', () => {
+    render(
+      <ElementNameCell
+        element={element}
+        compressor={null}
+        viewFormat={KeyValueFormat.Unicode}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('vector-set-element-value-element-abc'),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the raw-name test id when the format renders JSX', () => {
+    render(
+      <ElementNameCell
+        element={element}
+        compressor={null}
+        viewFormat={KeyValueFormat.Markdown}
+      />,
+    )
+
+    expect(
+      screen.getByTestId('vector-set-element-value-element-abc'),
+    ).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/vector-set-details/vector-set-element-list/components/ElementNameCell/ElementNameCell.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
-import { createTooltipContent, formattingBuffer } from 'uiSrc/utils'
+import {
+  bufferToString,
+  createTooltipContent,
+  formattingBuffer,
+} from 'uiSrc/utils'
 import { TEXT_FAILED_CONVENT_FORMATTER } from 'uiSrc/constants'
 import { decompressingBuffer } from 'uiSrc/utils/decompressors'
 import { FormattedValue } from 'uiSrc/pages/browser/modules/key-details/shared'
@@ -31,8 +35,11 @@ export const ElementNameCell = ({
     viewFormat,
   )
 
-  const testIdSuffix =
-    typeof value === 'string' ? value?.substring(0, 200) : value
+  // Test ids must not depend on the view format: rich formats (Markdown,
+  // JSON) return JSX from formattingBuffer, not a string.
+  const testIdSuffix = bufferToString(
+    decompressedItem as RedisResponseBuffer,
+  ).substring(0, 200)
 
   return (
     <Row data-testid={`vector-set-element-value-${testIdSuffix}`}>

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/value-markdown.spec.ts
@@ -74,6 +74,16 @@ test.describe('Browser > Key Details - Markdown value format', () => {
     await apiHelper.deleteKeysByPattern(database.id, `${TEST_KEY_PREFIX}*`);
   });
 
+  // The format choice persists (localStorage + in-memory store) and Electron
+  // runs the whole suite in one app instance, so reset it before it can leak
+  // into later specs. Registered after the hook above => runs before it,
+  // while the key details panel is still open.
+  test.afterEach(async ({ browserPage }) => {
+    if (await browserPage.keyDetails.formatDropdown.isVisible()) {
+      await browserPage.keyDetails.changeValueFormat('Unicode');
+    }
+  });
+
   test('should render a markdown String value through the sanitized pipeline', async ({ apiHelper, browserPage }) => {
     const keyData = StringKeyFactory.build({ value: RENDERED_MARKDOWN });
     await apiHelper.createStringKey(database.id, keyData.keyName, keyData.value);


### PR DESCRIPTION
# What

Every PR's **Electron** e2e run has been red since RI-8228 (#6175) merged: all four vector-set specs fail with "element not visible" while the elements render fine on screen. The chain:

- `ElementNameCell` derived its `data-testid` from `formattingBuffer(...)` output, which is a **JSX element** for rich formats (Markdown, JSON) — so the testid rendered as `vector-set-element-value-[object Object]` and every locator missed it.
- The new `value-markdown.spec` switches the value format to Markdown, the choice persists (localStorage + in-memory store), and the serial Electron suite runs in **one shared app instance** — so the format leaked into every later spec. Web runners get a fresh context per test, which is why only Electron failed.

Fixes:
- `ElementNameCell` builds the testid from the **raw element name** — testids no longer depend on the display format.
- `value-markdown.spec` resets the format to Unicode after each test so the leak can't hit anything else.

# Testing

- New unit spec covers the regression: under `KeyValueFormat.Markdown` the testid must stay the raw name — it fails against the previous code (`[object Object]`) and passes with the fix.
- Vector-set element list unit specs pass; lint/type-check clean.
- The definitive proof is this PR's own Electron e2e job: the four vector-set specs should go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-id and e2e isolation changes only; display formatting and tooltips are unchanged aside from how test ids are derived.
> 
> **Overview**
> Fixes Electron e2e failures where vector-set specs could not find element rows after Markdown value-format coverage landed.
> 
> **`ElementNameCell`** no longer builds `data-testid` from `formattingBuffer` output. Rich formats (Markdown, JSON) return JSX, which produced `vector-set-element-value-[object Object]` and broke locators that expect the raw element name. Test ids now come from **`bufferToString`** on the decompressed name (truncated to 200 chars), independent of display format.
> 
> **`value-markdown.spec`** adds an **`afterEach`** that resets the key-details value format to **Unicode** when the format dropdown is visible, so a persisted Markdown choice does not leak into later specs in the single shared Electron app instance.
> 
> New unit tests in **`ElementNameCell.spec.tsx`** lock in Unicode and Markdown cases for the stable test id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3050da364339226f40ff75cec5b414083ee624e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->