### PR TITLE
Polish the array actions column

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.config.tsx
@@ -9,6 +9,7 @@ import { RowActionsCell } from './components/RowActionsCell'
 import { BulkDeleteHeaderCell } from './components/BulkDeleteHeaderCell'
 import { ArrayTableConfig } from './ArrayDetailsTable.types'
 import {
+  ACTIONS_COLUMN_CELL_CLASS,
   ACTIONS_COLUMN_SIZE,
   INDEX_COLUMN_SIZE,
   SELECTION_COLUMN_WIDTH_REM,
@@ -98,6 +99,8 @@ export const actionsColumn: ColumnDef<ArrayDataElement> = {
   enableResizing: false,
   size: ACTIONS_COLUMN_SIZE,
   sizeUnit: 'px',
+  // Center the bulk trigger in the header cell (see ArrayDetailsTable.styles).
+  getHeaderCellProps: () => ({ className: ACTIONS_COLUMN_CELL_CLASS }),
   cell: ({ row, table }: CellContext<ArrayDataElement, unknown>) => {
     const {
       compressor,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/ArrayDetailsTable.styles.ts
@@ -3,7 +3,10 @@ import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { Table, TableProps } from 'uiSrc/components/base/layout/table'
 import { ArrayDataElement } from 'uiSrc/slices/interfaces/array'
 
-import { SELECTION_COLUMN_CELL_CLASS } from './constants'
+import {
+  ACTIONS_COLUMN_CELL_CLASS,
+  SELECTION_COLUMN_CELL_CLASS,
+} from './constants'
 
 export const Container = styled(FlexItem)`
   display: flex;
@@ -42,6 +45,17 @@ export const StyledTable = styled(Table)`
   }
   th.${SELECTION_COLUMN_CELL_CLASS} > *,
   td.${SELECTION_COLUMN_CELL_CLASS} > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* Actions column header: trim the side padding so the bulk trigger centers
+     in the column instead of hugging the padding. */
+  th.${ACTIONS_COLUMN_CELL_CLASS} {
+    padding-left: ${({ theme }) => theme.core.space.space050};
+    padding-right: ${({ theme }) => theme.core.space.space050};
+  }
+  th.${ACTIONS_COLUMN_CELL_CLASS} > * {
     width: 100%;
     justify-content: center;
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -5,8 +5,8 @@ export const ARRAY_TABLE_LOADING_MESSAGE = 'Loading…'
 // row lines up with the same columns.
 export const INDEX_COLUMN_SIZE = 140
 export const VALUE_COLUMN_SIZE = 420
-// Room for up to three hover actions (edit · expand · delete).
-export const ACTIONS_COLUMN_SIZE = 120
+// Snug fit for the row hover actions (edit · expand · delete).
+export const ACTIONS_COLUMN_SIZE = 60
 // Snug around the 1.8rem checkbox, not redis-ui's default 4.2rem.
 export const SELECTION_COLUMN_WIDTH_REM = 2.6
 export const SELECTION_COLUMN_CELL_CLASS = 'array-selection-cell'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/constants.ts
@@ -10,3 +10,4 @@ export const ACTIONS_COLUMN_SIZE = 120
 // Snug around the 1.8rem checkbox, not redis-ui's default 4.2rem.
 export const SELECTION_COLUMN_WIDTH_REM = 2.6
 export const SELECTION_COLUMN_CELL_CLASS = 'array-selection-cell'
+export const ACTIONS_COLUMN_CELL_CLASS = 'array-actions-cell'


### PR DESCRIPTION
# What

Polish the array details table's actions column:

- Center the bulk-delete trigger in the column header. It was sitting after
  the header cell's wide default side padding, so it read as off-center.
  Applies the same cell-class treatment the selection column already uses.
- Narrow the column from 120px to 60px for a tighter layout.

Header/column only — the per-row actions (edit · expand · delete) are left
untouched.

# Preview

## Before

<img width="1448" height="888" alt="Screenshot 2026-07-10 at 14 14 59" src="https://github.com/user-attachments/assets/8f187d8f-3f80-440d-acb9-619e5428dabe" />

<img width="1448" height="592" alt="Screenshot 2026-07-10 at 14 19 31" src="https://github.com/user-attachments/assets/febd1d03-0aa4-44f8-9cdf-0baaf3181576" />


## After

<img width="1448" height="888" alt="Screenshot 2026-07-10 at 14 14 40" src="https://github.com/user-attachments/assets/447d3417-d165-4318-90fa-7383f90ffaf0" />

<img width="1448" height="592" alt="Screenshot 2026-07-10 at 14 19 22" src="https://github.com/user-attachments/assets/fdf6c69c-e3f2-4e88-922d-58135a9abf62" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header/column styling and width only; no data or behavior changes beyond layout.
> 
> **Overview**
> Tightens the array details table **actions** column layout: width drops from **120px** to **60px**, and the bulk-delete header control is centered using the same cell-class pattern as the selection column.
> 
> The actions column definition now sets `getHeaderCellProps` with `ACTIONS_COLUMN_CELL_CLASS` (`array-actions-cell`), and `ArrayDetailsTable.styles` trims header side padding and centers the header content. **Per-row** hover actions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0833d7ad364f52dcd5597e22c83b935bd0751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->