### PR TITLE
chore: drop AI-Made PR label instruction

### DIFF
--- a/.ai/skills/pull-requests/SKILL.md
+++ b/.ai/skills/pull-requests/SKILL.md
@@ -10,10 +10,6 @@ description: >-
 
 ## Creating a PR
 
-### Labels
-
-When creating PRs with AI assistance, always add the **"AI-Made"** label.
-
 ### PR Title
 
 Include issue number at the start:


### PR DESCRIPTION
# What

Removes the instruction in the `pull-requests` skill that told AI assistants to add the **"AI-Made"** label when creating PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 88111b08308a11092a7f8f739046962ff4a8dcfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->