### PR TITLE
Create draft GitHub release if missing before uploading assets

### DIFF
--- a/.github/workflows/github-release-upload.yml
+++ b/.github/workflows/github-release-upload.yml
@@ -10,6 +10,7 @@ jobs:
   upload:
     name: Upload assets to GitHub draft release
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v7.0.0
 
@@ -27,21 +28,24 @@ jobs:
           APP_VERSION=$(jq -r '.version' redisinsight/package.json)
           echo "version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
 
-          RELEASE_TAG=$(gh release list --json tagName,isDraft \
-            --jq ".[] | select(.isDraft and .tagName == \"${APP_VERSION}\") | .tagName" \
-            | head -n 1)
+          RELEASE_TAG=$(gh release list --json tagName,name,isDraft \
+            --jq "[.[] | select(.isDraft and (.name | contains(\"${APP_VERSION}\")))][0].tagName")
 
-          if [ -z "$RELEASE_TAG" ]; then
-            echo "::warning::No draft release found for tag '${APP_VERSION}'. Skipping upload."
-            echo "found=false" >> "$GITHUB_OUTPUT"
+          if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+            echo "No draft release found for '${APP_VERSION}'. Creating one."
+            gh release create "${APP_VERSION}" \
+              --draft \
+              --target "${GITHUB_SHA}" \
+              --title "${APP_VERSION}" \
+              --notes "Release ${APP_VERSION}"
+            RELEASE_TAG="${APP_VERSION}"
           else
-            echo "Draft release found: ${RELEASE_TAG}"
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "Draft release found (tag: ${RELEASE_TAG})"
           fi
 
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Upload desktop installers to draft release
-        if: steps.find-release.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## What

Match the in-flight draft release by **name** and upload via its current tag (`--clobber`), since a draft keeps a placeholder tag until it's published. Creating a draft is now a fallback for when none exists (pinned to the built commit via `--target`), and the job is `continue-on-error` so it never blocks the release.

---

## Description

The `github-release-upload` job only attached desktop installers to a **pre-existing draft** GitHub release matching the app version. When no draft was found it logged a warning and `exit 0`'d — a green job that uploaded nothing.

That's what happened for **3.6.0**: the upload job ran ~6h before the release was created, found no draft, and skipped. The [3.6.0 release](https://github.com/redis/RedisInsight/releases/tag/3.6.0) ended up with zero assets.

## Changes

Create the draft release (`gh release create --draft`) when none exists, so the upload always has a target.

Release stays a **draft** — publishing remains a separate step.