### PR TITLE
RI-8275 E2E: fix Vector Search run button locator

### DIFF
--- a/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
@@ -27,7 +27,7 @@ export class QueryEditor {
 
     this.container = page.getByTestId('vector-search-query-editor');
     this.actionsBar = page.getByTestId('vector-search-actions');
-    this.runButton = this.actionsBar.getByRole('button', { name: 'submit' });
+    this.runButton = this.actionsBar.getByTestId('btn-submit');
     this.explainButton = this.actionsBar.getByRole('button', { name: 'explain' });
     this.profileButton = this.actionsBar.getByRole('button', { name: 'profile' });
     this.saveButton = this.actionsBar.getByRole('button', { name: 'save' });

--- a/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/QueryEditor.ts
@@ -27,7 +27,7 @@ export class QueryEditor {
 
     this.container = page.getByTestId('vector-search-query-editor');
     this.actionsBar = page.getByTestId('vector-search-actions');
-    this.runButton = this.actionsBar.getByTestId('btn-submit');
+    this.runButton = this.actionsBar.getByRole('button', { name: 'Run' });
     this.explainButton = this.actionsBar.getByRole('button', { name: 'explain' });
     this.profileButton = this.actionsBar.getByRole('button', { name: 'profile' });
     this.saveButton = this.actionsBar.getByRole('button', { name: 'save' });

--- a/tests/e2e-playwright/pages/vector-search/components/QueryResults.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/QueryResults.ts
@@ -65,10 +65,9 @@ export class QueryResults {
 
   /**
    * Get the expand/collapse toggle on the first result card.
-   * exact: true prevents matching the outer div[role="button"] card header.
    */
   get firstCardToggleCollapseButton(): Locator {
-    return this.container.getByRole('button', { name: 'toggle collapse', exact: true }).first();
+    return this.container.getByTestId('toggle-collapse').first();
   }
 
   /**

--- a/tests/e2e-playwright/pages/vector-search/components/QueryResults.ts
+++ b/tests/e2e-playwright/pages/vector-search/components/QueryResults.ts
@@ -65,9 +65,10 @@ export class QueryResults {
 
   /**
    * Get the expand/collapse toggle on the first result card.
+   * exact: true prevents matching the outer div[role="button"] card header.
    */
   get firstCardToggleCollapseButton(): Locator {
-    return this.container.getByTestId('toggle-collapse').first();
+    return this.container.getByRole('button', { name: 'Toggle result', exact: true }).first();
   }
 
   /**


### PR DESCRIPTION
# What

The RI-8275 Workbench i18n migration (#6189) translated two aria-labels in the shared query components, which broke Vector Search page-object locators:

- **Run button**: `"submit"` → `"Run query"` — all 5 `query-editor.spec.ts` tests timed out in the nightly run ([run 29296209901](https://github.com/redis/RedisInsight/actions/runs/29296209901/job/86971784956))
- **Result-card collapse toggle**: `"toggle collapse"` → `"Toggle result"` — masked until the run button was fixed, surfaced in this PR's first CI run

Update both locators to the buttons' user-facing names: `{ name: 'Run' }` for the run button and `{ name: 'Toggle result', exact: true }` for the icon-only collapse toggle (exact to avoid matching the card header's composite accessible name).

# Testing

- `yarn --cwd tests/e2e-playwright test tests/serial/vector-search/query/query-editor.spec.ts` (chromium-serial)
- E2E workspace lint + type-check pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)