### PR TITLE
RI-8174 Promote dev-array feature flag to array

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 6.1,
+  "version": 7,
   "features": {
     "dev-language": {
       "flag": true,
@@ -148,9 +148,9 @@
       "flag": true,
       "perc": [[0, 100]]
     },
-    "dev-array": {
+    "array": {
       "flag": true,
-      "perc": [[0, 0]]
+      "perc": [[0, 100]]
     },
     "prodMode": {
       "flag": true,

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -37,7 +37,7 @@ export enum KnownFeatures {
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
   VectorSet = 'vectorSet',
-  DevArray = 'dev-array',
+  Array = 'array',
   ProdMode = 'prodMode',
   DevLanguage = 'dev-language',
   WhatsNew = 'whatsNew',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -87,8 +87,8 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.VectorSet,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.DevArray]: {
-    name: KnownFeatures.DevArray,
+  [KnownFeatures.Array]: {
+    name: KnownFeatures.Array,
     storage: FeatureStorage.Database,
   },
   [KnownFeatures.ProdMode]: {

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -104,7 +104,7 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
-      KnownFeatures.DevArray,
+      KnownFeatures.Array,
       new SwitchableFlagStrategy(
         this.featuresConfigService,
         this.settingsService,

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -13,7 +13,7 @@ export enum FeatureFlags {
   customTutorials = 'customTutorials',
   vectorSearchV2 = 'vectorSearchV2',
   vectorSet = 'vectorSet',
-  devArray = 'dev-array',
+  array = 'array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
   prodMode = 'prodMode',

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,7 +1,7 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 import {
-  isDevArrayEnabledSelector,
+  isArrayEnabledSelector,
   isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
@@ -22,7 +22,7 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     value: KeyTypes.Array,
     color: GROUP_TYPES_COLORS[KeyTypes.Array],
     minVersion: CommandsVersions.ARRAY.since,
-    isEnabledSelector: isDevArrayEnabledSelector,
+    isEnabledSelector: isArrayEnabledSelector,
   },
   {
     text: 'Set',

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -244,13 +244,13 @@ describe('FilterKeyType', () => {
     expect(queryByText('Vector Set')).not.toBeInTheDocument()
   })
 
-  it('should show Array when dev-array feature flag is enabled and redis version >= 8.8', async () => {
+  it('should show Array when array feature flag is enabled and redis version >= 8.8', async () => {
     connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
       version: '8.8.0',
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      `app.features.featureFlags.features.${FeatureFlags.array}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {
@@ -262,7 +262,7 @@ describe('FilterKeyType', () => {
     expect(queryByText('Array')).toBeInTheDocument()
   })
 
-  it('should hide Array when dev-array feature flag is disabled', () => {
+  it('should hide Array when array feature flag is disabled', () => {
     // Ensure the version gate is satisfied so the assertion truly
     // exercises the feature-flag path and not the version path.
     connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
@@ -281,7 +281,7 @@ describe('FilterKeyType', () => {
     }))
     const initialStoreState = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      `app.features.featureFlags.features.${FeatureFlags.array}`,
       { flag: true },
     )
     const { queryByText } = render(<FilterKeyType />, {

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -6,7 +6,7 @@ import {
 } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
 import {
-  isDevArrayEnabledSelector,
+  isArrayEnabledSelector,
   isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
@@ -28,7 +28,7 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     value: KeyTypes.Array,
     color: GROUP_TYPES_COLORS[KeyTypes.Array],
     minVersion: CommandsVersions.ARRAY.since,
-    isEnabledSelector: isDevArrayEnabledSelector,
+    isEnabledSelector: isArrayEnabledSelector,
   },
   {
     text: 'Set',

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/DecoderEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/DecoderEditor.tsx
@@ -9,10 +9,7 @@ import TextInput from 'uiSrc/components/base/inputs/TextInput'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { CopyButton } from 'uiSrc/components/copy-button/CopyButton'
 
-import {
-  DECODER_TYPE_OPTIONS,
-  VALUE_DECODER_TEST_ID,
-} from './constants'
+import { DECODER_TYPE_OPTIONS, VALUE_DECODER_TEST_ID } from './constants'
 import { serializeDecoderForClipboard } from './decoderClipboard'
 import {
   DECODER_TYPE_DESCRIPTIONS,
@@ -65,7 +62,10 @@ export const DecoderEditor = ({
   const isValid = isDecoderValid(decoder)
 
   return (
-    <S.DecoderSection $expanded={isExpanded} data-testid={`${VALUE_DECODER_TEST_ID}-decoder-${decoder.id}`}>
+    <S.DecoderSection
+      $expanded={isExpanded}
+      data-testid={`${VALUE_DECODER_TEST_ID}-decoder-${decoder.id}`}
+    >
       <S.DecoderHeader>
         <S.DecoderSummaryButton
           type="button"
@@ -101,7 +101,10 @@ export const DecoderEditor = ({
 
       {isExpanded && (
         <S.DecoderBody>
-          <FormField label="Name" additionalText="Optional label for this decoder.">
+          <FormField
+            label="Name"
+            additionalText="Optional label for this decoder."
+          >
             <TextInput
               value={decoder.name}
               onChange={(value) => handleFieldChange('name', value)}
@@ -120,7 +123,9 @@ export const DecoderEditor = ({
               patterns={
                 decoder.keyPatterns.length > 0 ? decoder.keyPatterns : ['']
               }
-              onChange={(keyPatterns) => handleFieldChange('keyPatterns', keyPatterns)}
+              onChange={(keyPatterns) =>
+                handleFieldChange('keyPatterns', keyPatterns)
+              }
             />
           </FormField>
 
@@ -141,7 +146,9 @@ export const DecoderEditor = ({
             <FieldsSchemaEditor
               sortListId={`decoder-${decoder.id}-schema`}
               nodes={decoder.schema}
-              onChange={(schema: SchemaNode[]) => handleFieldChange('schema', schema)}
+              onChange={(schema: SchemaNode[]) =>
+                handleFieldChange('schema', schema)
+              }
             />
           </Col>
         </S.DecoderBody>

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/DescriptionSelectValueRender.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/DescriptionSelectValueRender.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import { RiTooltip } from 'uiSrc/components'
 
 import {
@@ -10,7 +12,7 @@ import * as S from './ValueDecoderModal.styles'
 export const createDescriptionSelectValueRender = (
   descriptions: Record<string, string>,
 ): SelectValueRender => {
-  const render = ({ option, isOptionValue }: SelectValueRenderParams) => {
+  return ({ option, isOptionValue }: SelectValueRenderParams) => {
     const description = descriptions[String(option.value)] ?? ''
     const label = option.label ?? option.value
 
@@ -26,6 +28,4 @@ export const createDescriptionSelectValueRender = (
       </RiTooltip>
     )
   }
-
-  return render
 }

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/FieldsSchemaEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/FieldsSchemaEditor.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from 'react'
 
-import { ActionIconButton, SecondaryButton } from 'uiSrc/components/base/forms/buttons'
+import {
+  ActionIconButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
 import { DeleteIcon } from 'uiSrc/components/base/icons'
 import { Row } from 'uiSrc/components/base/layout/flex'
 import TextInput from 'uiSrc/components/base/inputs/TextInput'
@@ -129,7 +132,7 @@ const FieldRow = ({
             {sizeSource === 'field' ? (
               <RiSelect
                 options={sizeRefs}
-                value={field.sizeFieldRef || null}
+                value={field.sizeFieldRef || undefined}
                 onChange={(value) =>
                   onFieldChange(field.id, { sizeFieldRef: value ?? '' })
                 }
@@ -142,8 +145,7 @@ const FieldRow = ({
                   value={field.size === '' ? null : Number(field.size)}
                   onChange={(value) =>
                     onFieldChange(field.id, {
-                      size:
-                        value == null || Number.isNaN(value) ? '' : value,
+                      size: value == null || Number.isNaN(value) ? '' : value,
                     })
                   }
                   min={1}
@@ -222,7 +224,7 @@ const RepeatBlockEditor = ({
         <S.RepeatLabel>Repeat</S.RepeatLabel>
         <RiSelect
           options={toNumericOptions(repeatScopeNumeric)}
-          value={repeat.countFieldRef || null}
+          value={repeat.countFieldRef || undefined}
           onChange={(value) =>
             onRepeatChange(repeat.id, { countFieldRef: value ?? '' })
           }

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/KeyPatternsEditor.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/KeyPatternsEditor.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from 'react'
 
-import { ActionIconButton, SecondaryButton } from 'uiSrc/components/base/forms/buttons'
+import {
+  ActionIconButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
 import { DeleteIcon } from 'uiSrc/components/base/icons'
 import TextInput from 'uiSrc/components/base/inputs/TextInput'
 

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderHeaderLabel.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderHeaderLabel.tsx
@@ -38,7 +38,7 @@ export const ValueDecoderHeaderLabel = ({
   }
 
   return (
-    <Row gap="xs" align="center" inline>
+    <Row gap="xs" align="center">
       <Text size="m" variant="semiBold" component="span">
         {label}
       </Text>
@@ -51,9 +51,7 @@ export const ValueDecoderHeaderLabel = ({
         position="top"
       >
         <ToggleButton
-          aria-label={
-            isDecodeEnabled ? 'Show raw value' : 'Show decoded value'
-          }
+          aria-label={isDecodeEnabled ? 'Show raw value' : 'Show decoded value'}
           aria-pressed={isDecodeEnabled}
           $active={isDecodeEnabled}
           onClick={toggleDecodeEnabled}

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderModal.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderModal.styles.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import styled from 'styled-components'
 import { Modal } from 'uiSrc/components/base/display/modal'
 
@@ -39,7 +40,11 @@ export const FieldRowGrid = styled.div`
   min-width: 0;
 `
 
-export const DragHandle = styled.div`
+export const DragHandle = styled.div<{
+  children?: React.ReactNode
+  draggable?: boolean
+  onDragStart?: React.DragEventHandler<HTMLDivElement>
+}>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -54,13 +59,16 @@ export const DragHandle = styled.div`
   }
 `
 
-export const SortableRow = styled.div`
+export const SortableRow = styled.div<{
+  children?: React.ReactNode
+  onDragOver?: React.DragEventHandler<HTMLDivElement>
+  onDrop?: React.DragEventHandler<HTMLDivElement>
+}>`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.core.space.space050};
   padding: ${({ theme }) => theme.core.space.space100};
-  border-top: 1px solid
-    ${({ theme }) => theme.semantic.color.border.neutral400};
+  border-top: 1px solid ${({ theme }) => theme.semantic.color.border.neutral400};
 
   &:hover ${DragHandle} {
     opacity: 1;
@@ -91,7 +99,9 @@ export const KeyPatternRow = styled.div`
   min-width: 0;
 `
 
-export const KeyPatternLastRow = styled.div`
+export const KeyPatternLastRow = styled.div<{
+  children?: React.ReactNode
+}>`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.core.space.space100};
@@ -116,13 +126,16 @@ export const SizeSourceWrapper = styled.div`
   min-width: 180px;
 `
 
-export const SizeUnit = styled.span`
+export const SizeUnit = styled.span<{ children?: React.ReactNode }>`
   color: ${({ theme }) => theme.components.typography.colors.secondary};
   font-size: ${({ theme }) => theme.core.font.fontSize.s12};
   white-space: nowrap;
 `
 
-export const RepeatBlock = styled.div<{ $depth: number }>`
+export const RepeatBlock = styled.div<{
+  $depth: number
+  children?: React.ReactNode
+}>`
   margin-top: ${({ theme }) => theme.core.space.space100};
   margin-bottom: ${({ theme }) => theme.core.space.space100};
   padding: ${({ theme }) => theme.core.space.space100};
@@ -162,13 +175,19 @@ export const RepeatLabel = styled.span`
   white-space: nowrap;
 `
 
-export const SelectOptionAnchor = styled.span<{ $fullWidth?: boolean }>`
+export const SelectOptionAnchor = styled.span<{
+  $fullWidth?: boolean
+  children?: React.ReactNode
+}>`
   display: inline-flex;
   align-items: center;
   width: ${({ $fullWidth }) => ($fullWidth ? '100%' : 'auto')};
 `
 
-export const DecoderSection = styled.div<{ $expanded: boolean }>`
+export const DecoderSection = styled.div<{
+  $expanded: boolean
+  children?: React.ReactNode
+}>`
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral400};
   border-radius: ${({ theme }) => theme.core.space.space100};
   background: ${({ theme, $expanded }) =>
@@ -185,7 +204,11 @@ export const DecoderHeader = styled.div`
   padding: ${({ theme }) => theme.core.space.space100};
 `
 
-export const DecoderSummaryButton = styled.button`
+export const DecoderSummaryButton = styled.button<{
+  children?: React.ReactNode
+  type?: 'button' | 'submit' | 'reset'
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
+}>`
   display: inline-flex;
   align-items: center;
   gap: ${({ theme }) => theme.core.space.space100};
@@ -207,7 +230,10 @@ export const DecoderBody = styled.div`
     ${({ theme }) => theme.core.space.space100};
 `
 
-export const DecoderMatchBadge = styled.span<{ $warning?: boolean }>`
+export const DecoderMatchBadge = styled.span<{
+  $warning?: boolean
+  children?: React.ReactNode
+}>`
   color: ${({ theme, $warning }) =>
     $warning
       ? theme.components.typography.colors.attention

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderModal.tsx
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/ValueDecoderModal.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Modal } from 'uiSrc/components/base/display'
 import { Text } from 'uiSrc/components/base/text'
-import { PrimaryButton, SecondaryButton } from 'uiSrc/components/base/forms/buttons'
+import {
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
 import { CancelIcon } from 'uiSrc/components/base/icons'
 import { Row, Col } from 'uiSrc/components/base/layout/flex'
 import { CopyButton } from 'uiSrc/components/copy-button/CopyButton'
@@ -13,13 +16,13 @@ import {
   parseDecodersFromClipboard,
   serializeDecodersForClipboard,
 } from './decoderClipboard'
-import {
-  areDecodersValid,
-  getDecoderLabel,
-  normalizeRule,
-} from './schemaUtils'
+import { areDecodersValid, getDecoderLabel, normalizeRule } from './schemaUtils'
 import { ValueDecoderRule } from './types'
-import { findMatchingDecoderRule, getDefaultKeyPattern, matchKeyPattern } from './utils'
+import {
+  findMatchingDecoderRule,
+  getDefaultKeyPattern,
+  matchKeyPattern,
+} from './utils'
 import * as S from './ValueDecoderModal.styles'
 
 export interface ValueDecoderModalConfig {
@@ -200,77 +203,77 @@ export const ValueDecoderModal = ({
         <S.ModalBody
           content={
             <Col gap="l" data-testid={`${VALUE_DECODER_TEST_ID}-modal-form`}>
-                <Text color="secondary">
-                  Decoders are shared across all hash keys in this database. Add
-                  multiple decoders and key patterns; matching hash values can be
-                  decoded in the Value Preview. Copy decoders as JSON and paste
-                  them here or into another Redis Insight connection.
-                </Text>
+              <Text color="secondary">
+                Decoders are shared across all hash keys in this database. Add
+                multiple decoders and key patterns; matching hash values can be
+                decoded in the Value Preview. Copy decoders as JSON and paste
+                them here or into another Redis Insight connection.
+              </Text>
 
-                <Row justify="between" align="center" gap="m">
-                  <Text variant="semiBold">Decoders</Text>
-                  <Row gap="s" align="center">
-                    {pasteMessage && (
-                      <Text color="secondary" size="s">
-                        {pasteMessage}
-                      </Text>
-                    )}
-                    <CopyButton
-                      copy={serializeDecodersForClipboard(localDecoders)}
-                      aria-label="Copy all decoders"
-                      tooltipConfig={{ content: 'Copy all decoders' }}
-                      data-testid={`${VALUE_DECODER_TEST_ID}-copy-all`}
-                    />
-                    <SecondaryButton
-                      size="s"
-                      onClick={handlePasteFromClipboard}
-                      data-testid={`${VALUE_DECODER_TEST_ID}-paste-decoders`}
-                    >
-                      Paste
-                    </SecondaryButton>
-                    <SecondaryButton
-                      size="s"
-                      onClick={handleAddDecoder}
-                      data-testid={`${VALUE_DECODER_TEST_ID}-add-decoder`}
-                    >
-                      Add Decoder
-                    </SecondaryButton>
-                  </Row>
+              <Row justify="between" align="center" gap="m">
+                <Text variant="semiBold">Decoders</Text>
+                <Row gap="s" align="center">
+                  {pasteMessage && (
+                    <Text color="secondary" size="s">
+                      {pasteMessage}
+                    </Text>
+                  )}
+                  <CopyButton
+                    copy={serializeDecodersForClipboard(localDecoders)}
+                    aria-label="Copy all decoders"
+                    tooltipConfig={{ content: 'Copy all decoders' }}
+                    data-testid={`${VALUE_DECODER_TEST_ID}-copy-all`}
+                  />
+                  <SecondaryButton
+                    size="s"
+                    onClick={handlePasteFromClipboard}
+                    data-testid={`${VALUE_DECODER_TEST_ID}-paste-decoders`}
+                  >
+                    Paste
+                  </SecondaryButton>
+                  <SecondaryButton
+                    size="s"
+                    onClick={handleAddDecoder}
+                    data-testid={`${VALUE_DECODER_TEST_ID}-add-decoder`}
+                  >
+                    Add Decoder
+                  </SecondaryButton>
                 </Row>
+              </Row>
 
-                <Col gap="m">
-                  {localDecoders.map((decoder) => {
-                    const normalized = normalizeRule(decoder)
-                    const patternCount = normalized.keyPatterns.length
-                    const summary = `${getDecoderLabel(decoder)} · ${patternCount} pattern${patternCount === 1 ? '' : 's'}`
+              <Col gap="m">
+                {localDecoders.map((decoder) => {
+                  const normalized = normalizeRule(decoder)
+                  const patternCount = normalized.keyPatterns.length
+                  const summary = `${getDecoderLabel(decoder)} · ${patternCount} pattern${patternCount === 1 ? '' : 's'}`
 
-                    return (
-                      <DecoderEditor
-                        key={decoder.id}
-                        decoder={decoder}
-                        isExpanded={expandedId === decoder.id}
-                        onToggle={() =>
-                          setExpandedId((current) =>
-                            current === decoder.id ? null : decoder.id,
-                          )
-                        }
-                        onChange={(nextDecoder) =>
-                          handleUpdateDecoder(decoder.id, nextDecoder)
-                        }
-                        onRemove={() => handleRemoveDecoder(decoder.id)}
-                        canRemove
-                        summary={summary}
-                        matchesCurrentKey={Boolean(
-                          keyName &&
-                            normalized.keyPatterns.some((pattern) =>
-                              matchKeyPattern(pattern, keyName),
-                            ),
-                        )}
-                      />
-                    )
-                  })}
-                </Col>
+                  return (
+                    <DecoderEditor
+                      key={decoder.id}
+                      decoder={decoder}
+                      isExpanded={expandedId === decoder.id}
+                      onToggle={() =>
+                        setExpandedId((current) =>
+                          current === decoder.id ? null : decoder.id,
+                        )
+                      }
+                      onChange={(nextDecoder) =>
+                        handleUpdateDecoder(decoder.id, nextDecoder)
+                      }
+                      onRemove={() => handleRemoveDecoder(decoder.id)}
+                      canRemove
+                      summary={summary}
+                      matchesCurrentKey={Boolean(
+                        keyName &&
+                          normalized.keyPatterns.some((pattern) =>
+                            matchKeyPattern(pattern, keyName),
+                          ),
+                      )}
+                    />
+                  )
+                })}
               </Col>
+            </Col>
           }
         />
 

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/constants.ts
@@ -3,8 +3,8 @@ import {
   RepeatBlockDefinition,
   SchemaNode,
   ValueDecoderRule,
+  DecoderType,
 } from './types'
-import { DecoderType } from './types'
 
 export const VALUE_DECODER_TEST_ID = 'value-decoder'
 

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/decoderClipboard.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/decoderClipboard.ts
@@ -46,7 +46,7 @@ const remapSchemaIds = (
         id: idMap.get(node.id) ?? node.id,
         kind: 'field',
         sizeFieldRef: node.sizeFieldRef
-          ? idMap.get(node.sizeFieldRef) ?? node.sizeFieldRef
+          ? (idMap.get(node.sizeFieldRef) ?? node.sizeFieldRef)
           : undefined,
       }
     }
@@ -88,11 +88,15 @@ export const serializeDecodersForClipboard = (
   return JSON.stringify(payload, null, 2)
 }
 
-export const serializeDecoderForClipboard = (decoder: ValueDecoderRule): string =>
-  serializeDecodersForClipboard([decoder])
+export const serializeDecoderForClipboard = (
+  decoder: ValueDecoderRule,
+): string => serializeDecodersForClipboard([decoder])
+
+const isRecordLike = (value: unknown): value is Record<string, unknown> =>
+  isObjectLike(value)
 
 const isDecoderLike = (value: unknown): value is Record<string, unknown> => {
-  if (!isObjectLike(value)) {
+  if (!isRecordLike(value)) {
     return false
   }
 
@@ -109,7 +113,7 @@ const parseDecoderCandidates = (parsed: unknown): unknown[] => {
     return parsed
   }
 
-  if (!isObjectLike(parsed)) {
+  if (!isRecordLike(parsed)) {
     return []
   }
 
@@ -146,7 +150,9 @@ export const parseDecodersFromClipboard = (
 
     const decoders = candidates
       .filter(isDecoderLike)
-      .map((candidate) => cloneDecoderRule(candidate as ValueDecoderRule))
+      .map((candidate) =>
+        cloneDecoderRule(candidate as unknown as ValueDecoderRule),
+      )
 
     return decoders.length > 0 ? decoders : null
   } catch {

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/index.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/index.ts
@@ -1,10 +1,7 @@
 export { ConfigValueDecoderButton } from './ConfigValueDecoderButton'
 export { DecodedValueDisplay } from './DecodedValueDisplay'
 export { ValueDecoderHeaderLabel } from './ValueDecoderHeaderLabel'
-export {
-  ValueDecoderProvider,
-  useValueDecoder,
-} from './ValueDecoderProvider'
+export { ValueDecoderProvider, useValueDecoder } from './ValueDecoderProvider'
 export { ValueDecoderModal } from './ValueDecoderModal'
 export type {
   ValueDecoderRule,

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/schemaUtils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/schemaUtils.spec.ts
@@ -3,7 +3,12 @@ import {
   createEmptyField,
   createEmptyRepeatBlock,
 } from './constants'
-import { isDecoderValid, isSchemaValid, areDecodersValid, normalizeRule } from './schemaUtils'
+import {
+  isDecoderValid,
+  isSchemaValid,
+  areDecodersValid,
+  normalizeRule,
+} from './schemaUtils'
 import { BinaryFieldDefinition } from './types'
 
 describe('schemaUtils validation', () => {
@@ -34,9 +39,9 @@ describe('schemaUtils validation', () => {
         name: 'text',
         dataType: 'string',
         size: '',
-        sizeSource: 'field' as const,
+        sizeSource: 'field',
         sizeFieldRef: 'len',
-      }
+      } satisfies BinaryFieldDefinition
 
       const normalized = normalizeRule({
         ...createEmptyDecoder(),

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/schemaUtils.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/schemaUtils.ts
@@ -19,7 +19,9 @@ export interface NumericFieldRef {
 }
 
 export const isNumericCountType = (dataType: string): boolean =>
-  NUMERIC_COUNT_DATA_TYPES.includes(dataType as (typeof NUMERIC_COUNT_DATA_TYPES)[number])
+  NUMERIC_COUNT_DATA_TYPES.includes(
+    dataType as (typeof NUMERIC_COUNT_DATA_TYPES)[number],
+  )
 
 export const normalizeFieldNode = (
   field: Partial<BinaryFieldDefinition> & { id: string },
@@ -144,11 +146,7 @@ const normalizeSchemaRefs = (
   priorFields: NumericFieldRef[] = [],
 ): SchemaNode[] =>
   nodes.map((node, index) => {
-    const scopeNumeric = getPriorNumericFieldsInScope(
-      priorFields,
-      nodes,
-      index,
-    )
+    const scopeNumeric = getPriorNumericFieldsInScope(priorFields, nodes, index)
 
     if (isFieldNode(node)) {
       if (node.sizeSource !== 'field') {
@@ -178,7 +176,10 @@ export const normalizeRule = (rule: ValueDecoderRule): ValueDecoderRule => {
     (rule.schema?.length ?? 0) > 0
       ? rule.schema!.map(normalizeSchemaNode)
       : (rule.fields ?? []).map((field) =>
-          normalizeFieldNode({ ...field, id: field.id ?? `field-legacy-${field.name}` }),
+          normalizeFieldNode({
+            ...field,
+            id: field.id ?? `field-legacy-${field.name}`,
+          }),
         )
   const schema = normalizeSchemaRefs(schemaNodes)
 
@@ -274,9 +275,7 @@ export const isSchemaValid = (schema: SchemaNode[]): boolean =>
 
 export const isDecoderValid = (decoder: ValueDecoderRule): boolean => {
   const normalized = normalizeRule(decoder)
-  return (
-    normalized.keyPatterns.length > 0 && isSchemaValid(normalized.schema)
-  )
+  return normalized.keyPatterns.length > 0 && isSchemaValid(normalized.schema)
 }
 
 export const areDecodersValid = (decoders: ValueDecoderRule[]): boolean =>
@@ -335,4 +334,4 @@ export const isCustomSizeType = (dataType: string): boolean =>
 export const resolveSizeSource = (
   field: BinaryFieldDefinition,
 ): FieldSizeSource =>
-  isCustomSizeType(field.dataType) ? field.sizeSource ?? 'fixed' : 'fixed'
+  isCustomSizeType(field.dataType) ? (field.sizeSource ?? 'fixed') : 'fixed'

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/utils.spec.ts
@@ -11,7 +11,11 @@ import {
   parseBinaryBuffer,
   resolveRepeatCount,
 } from './utils'
-import { createEmptyField, createEmptyRepeatBlock, MAX_REPEAT_DECODE_ITERATIONS } from './constants'
+import {
+  createEmptyField,
+  createEmptyRepeatBlock,
+  MAX_REPEAT_DECODE_ITERATIONS,
+} from './constants'
 import { DecoderType, ParsedBinaryNode, ValueDecoderRule } from './types'
 
 const countGroupNodes = (nodes: ParsedBinaryNode[]): number =>
@@ -22,6 +26,11 @@ const countGroupNodes = (nodes: ParsedBinaryNode[]): number =>
 
     return count
   }, 0)
+
+const toUint16leBytes = (value: number) => [
+  value % 256,
+  Math.floor(value / 256),
+]
 
 describe('value-decoder utils', () => {
   describe('getFixedSize', () => {
@@ -36,9 +45,9 @@ describe('value-decoder utils', () => {
 
   describe('getDefaultKeyPattern', () => {
     it('returns the actual key name', () => {
-      expect(getDefaultKeyPattern('room:chunk-state:678729695330336:1:36')).toBe(
-        'room:chunk-state:678729695330336:1:36',
-      )
+      expect(
+        getDefaultKeyPattern('room:chunk-state:678729695330336:1:36'),
+      ).toBe('room:chunk-state:678729695330336:1:36')
     })
 
     it('escapes glob metacharacters for exact-key matching', () => {
@@ -102,7 +111,7 @@ describe('value-decoder utils', () => {
       expect(matchKeyPattern('user:\\[0-9\\]', 'user:3')).toBe(false)
       expect(matchKeyPattern('key:[A-Z\\-_]*', 'key:ABC')).toBe(true)
       expect(matchKeyPattern('key:[A-Z\\-_]*', 'key:A-B_')).toBe(true)
-      expect(matchKeyPattern('key:[A-Z\\-_]*', 'key:A0B')).toBe(false)
+      expect(matchKeyPattern('key:[A-Z\\-_]*', 'key:0AB')).toBe(false)
     })
   })
 
@@ -166,12 +175,12 @@ describe('value-decoder utils', () => {
         },
       ]
 
-      expect(findMatchingDecoderRule(overlappingRules, 'user:items:42')?.id).toBe(
-        'user-items',
-      )
-      expect(findMatchingDecoderRule(overlappingRules, 'user:profile:42')?.id).toBe(
-        'user-wide',
-      )
+      expect(
+        findMatchingDecoderRule(overlappingRules, 'user:items:42')?.id,
+      ).toBe('user-items')
+      expect(
+        findMatchingDecoderRule(overlappingRules, 'user:profile:42')?.id,
+      ).toBe('user-wide')
     })
 
     it('scores exact key patterns higher than wildcard patterns', () => {
@@ -199,9 +208,7 @@ describe('value-decoder utils', () => {
   describe('formatHexBytes', () => {
     it('formats bytes as uppercase hex pairs separated by spaces', () => {
       expect(
-        formatHexBytes([
-          0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe,
-        ]),
+        formatHexBytes([0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe]),
       ).toBe('DE AD BE EF CA FE BA BE')
     })
   })
@@ -233,11 +240,23 @@ describe('value-decoder utils', () => {
     })
 
     it('parses sequential binary fields', () => {
-      const buffer = new Uint8Array([1, 0, 2, 0, 3, 4])
+      const buffer = new Uint8Array([1, 2, 0, 3, 4])
       const parsed = parseBinaryBuffer(buffer, [
         { id: '1', kind: 'field', name: 'flag', dataType: 'uint8', size: 1 },
-        { id: '2', kind: 'field', name: 'count', dataType: 'uint16le', size: 2 },
-        { id: '3', kind: 'field', name: 'value', dataType: 'uint16be', size: 2 },
+        {
+          id: '2',
+          kind: 'field',
+          name: 'count',
+          dataType: 'uint16le',
+          size: 2,
+        },
+        {
+          id: '3',
+          kind: 'field',
+          name: 'value',
+          dataType: 'uint16be',
+          size: 2,
+        },
       ])
 
       expect(parsed).toEqual([
@@ -248,9 +267,7 @@ describe('value-decoder utils', () => {
     })
 
     it('uses a prior numeric field as string size', () => {
-      const buffer = new Uint8Array([
-        3, 0, 97, 98, 99,
-      ])
+      const buffer = new Uint8Array([3, 0, 97, 98, 99])
       const parsed = parseBinaryBuffer(buffer, [
         {
           id: '1',
@@ -277,7 +294,9 @@ describe('value-decoder utils', () => {
     })
 
     it('resolves dynamic size by field id when numeric names duplicate', () => {
-      const buffer = new Uint8Array([3, 0, 5, 97, 98, 99, 104, 101, 108, 108, 111])
+      const buffer = new Uint8Array([
+        3, 0, 5, 97, 98, 99, 104, 101, 108, 108, 111,
+      ])
       const parsed = parseBinaryBuffer(buffer, [
         {
           id: 'len-a',
@@ -357,13 +376,16 @@ describe('value-decoder utils', () => {
     })
 
     it('parses repeat blocks using a count field', () => {
-      const buffer = new Uint8Array([
-        2, 0, 1, 0, 2, 0, 3, 0, 4, 0,
-      ])
+      const buffer = new Uint8Array([2, 0, 1, 0, 2, 0, 3, 0, 4, 0])
       const repeatBlock = createEmptyRepeatBlock()
       repeatBlock.countFieldRef = '1'
       repeatBlock.fields = [
-        { ...createEmptyField(), name: 'anchor', dataType: 'uint16le', size: 2 },
+        {
+          ...createEmptyField(),
+          name: 'anchor',
+          dataType: 'uint16le',
+          size: 2,
+        },
         { ...createEmptyField(), name: 'focus', dataType: 'uint16le', size: 2 },
       ]
 
@@ -401,7 +423,11 @@ describe('value-decoder utils', () => {
 
     it('uses safe integer limits for bigint dynamic field sizes', () => {
       const buffer = new Uint8Array(10)
-      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+      const view = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        buffer.byteLength,
+      )
       view.setBigUint64(0, 9223372036854775807n, true)
 
       const parsed = parseBinaryBuffer(buffer, [
@@ -437,8 +463,7 @@ describe('value-decoder utils', () => {
     it('stops parsing sibling fields when repeat decoding is capped', () => {
       const repeatCount = MAX_REPEAT_DECODE_ITERATIONS + 1
       const bufferParts = [
-        repeatCount & 0xff,
-        (repeatCount >> 8) & 0xff,
+        ...toUint16leBytes(repeatCount),
         ...Array.from({ length: repeatCount }, () => 0xaa),
         0xbb,
       ]
@@ -474,15 +499,15 @@ describe('value-decoder utils', () => {
       ])
 
       expect(countGroupNodes(parsed)).toBe(MAX_REPEAT_DECODE_ITERATIONS)
-      expect(parsed.some((node) => node.kind === 'field' && node.name === 'tail')).toBe(
-        false,
-      )
+      expect(
+        parsed.some((node) => node.kind === 'field' && node.name === 'tail'),
+      ).toBe(false)
     })
 
     it('caps nested repeat decoding with a shared global budget', () => {
       const outerCount = 100
       const innerCount = 100
-      const bufferParts = [outerCount & 0xff, (outerCount >> 8) & 0xff]
+      const bufferParts = [...toUint16leBytes(outerCount)]
 
       for (let outer = 0; outer < outerCount; outer += 1) {
         bufferParts.push(innerCount)
@@ -538,7 +563,12 @@ describe('value-decoder utils', () => {
       const repeatBlock = createEmptyRepeatBlock()
       repeatBlock.countFieldRef = '1'
       repeatBlock.fields = [
-        { ...createEmptyField(), name: 'anchor', dataType: 'uint16le', size: 2 },
+        {
+          ...createEmptyField(),
+          name: 'anchor',
+          dataType: 'uint16le',
+          size: 2,
+        },
         { ...createEmptyField(), name: 'focus', dataType: 'uint16le', size: 2 },
       ]
 
@@ -602,7 +632,9 @@ describe('value-decoder utils', () => {
 
     it('formats flat parsed rows', () => {
       expect(
-        formatParsedFields([{ kind: 'field', name: 'id', size: 1, value: '7' }]),
+        formatParsedFields([
+          { kind: 'field', name: 'id', size: 1, value: '7' },
+        ]),
       ).toBe('[id] [1] [7]')
     })
 

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/utils.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/utils.ts
@@ -1,7 +1,11 @@
 import { bufferToUint8Array } from 'uiSrc/utils/formatters/bufferFormatters'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 
-import { BinaryDataType, isRepeatNode, MAX_REPEAT_DECODE_ITERATIONS } from './constants'
+import {
+  BinaryDataType,
+  isRepeatNode,
+  MAX_REPEAT_DECODE_ITERATIONS,
+} from './constants'
 import { isNumericCountType } from './schemaUtils'
 import {
   BinaryFieldDefinition,
@@ -15,9 +19,14 @@ export const getFixedSize = (type: string): number | 'custom' => {
   if (['uint8', 'int8', 'boolean'].includes(type)) return 1
   if (['uint16le', 'uint16be', 'int16le', 'int16be'].includes(type)) return 2
   if (
-    ['uint32le', 'uint32be', 'int32le', 'int32be', 'floatle', 'floatbe'].includes(
-      type,
-    )
+    [
+      'uint32le',
+      'uint32be',
+      'int32le',
+      'int32be',
+      'floatle',
+      'floatbe',
+    ].includes(type)
   ) {
     return 4
   }
@@ -41,7 +50,7 @@ export const formatHexBytes = (bytes: Uint8Array | Iterable<number>): string =>
     .map((byte) => byte.toString(16).padStart(2, '0').toUpperCase())
     .join(' ')
 
-const REGEX_SPECIAL_CHARS = /[.+^${}()|[\]\\]/g
+const REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/g
 
 const GLOB_ESCAPABLE_CHARS = new Set(['*', '?', '\\', '[', ']'])
 
@@ -590,5 +599,4 @@ export const parseBinaryBuffer = (
 export const parseBufferWithRule = (
   buffer: RedisResponseBuffer,
   schema: SchemaNode[],
-): ParsedBinaryNode[] =>
-  parseBinaryBuffer(bufferToUint8Array(buffer), schema)
+): ParsedBinaryNode[] => parseBinaryBuffer(bufferToUint8Array(buffer), schema)

--- a/redisinsight/ui/src/pages/browser/components/value-decoder/valueDecoderStorage.ts
+++ b/redisinsight/ui/src/pages/browser/components/value-decoder/valueDecoderStorage.ts
@@ -42,10 +42,7 @@ export const setValueDecoderRules = (
     return
   }
 
-  localStorageService?.set(
-    getValueDecoderRulesStorageKey(instanceId),
-    decoders,
-  )
+  localStorageService?.set(getValueDecoderRulesStorageKey(instanceId), decoders)
 }
 
 export const removeValueDecoderRules = (instanceId: string): void => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
@@ -44,9 +44,7 @@ import {
 } from 'uiSrc/pages/vector-search/hooks/useIsKeyIndexed'
 import { ViewIndexDataButton } from 'uiSrc/pages/browser/components/view-index-data-button'
 import { MakeSearchableButton } from 'uiSrc/pages/browser/components/make-searchable-button'
-import {
-  ConfigValueDecoderButton,
-} from 'uiSrc/pages/browser/components/value-decoder'
+import { ConfigValueDecoderButton } from 'uiSrc/pages/browser/components/value-decoder'
 import { KeyDetailsHeaderName } from './components/key-details-header-name'
 import { KeyDetailsHeaderTTL } from './components/key-details-header-ttl'
 import { KeyDetailsHeaderDelete } from './components/key-details-header-delete'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.spec.tsx
@@ -47,7 +47,7 @@ describe('DynamicTypeDetails', () => {
     expect(queryByTestId('too-long-key-name-details')).toBeInTheDocument()
   })
 
-  it('does not render array-details when dev-array flag is disabled', () => {
+  it('does not render array-details when array flag is disabled', () => {
     const { queryByTestId } = render(
       <DynamicTypeDetails
         {...instance(mockedProps)}
@@ -58,10 +58,10 @@ describe('DynamicTypeDetails', () => {
     expect(queryByTestId('unsupported-type-details')).toBeInTheDocument()
   })
 
-  it('renders array-details when dev-array flag is enabled', () => {
+  it('renders array-details when array flag is enabled', () => {
     const stateWithFlag = set(
       cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.devArray}`,
+      `app.features.featureFlags.features.${FeatureFlags.array}`,
       { flag: true },
     )
     const { queryByTestId } = render(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -8,7 +8,7 @@ import {
 import { KeyDetailsHeaderProps } from 'uiSrc/pages/browser/modules'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
-  isDevArrayEnabledSelector,
+  isArrayEnabledSelector,
   isValueDecoderEnabledSelector,
   isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
@@ -37,7 +37,7 @@ export interface Props extends KeyDetailsHeaderProps {
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
   const isVectorSet = useAppSelector(isVectorSetEnabledSelector)
-  const isArray = useAppSelector(isDevArrayEnabledSelector)
+  const isArray = useAppSelector(isArrayEnabledSelector)
   const isValueDecoderEnabled = useAppSelector(isValueDecoderEnabledSelector)
 
   const hashDetails = isValueDecoderEnabled ? (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
@@ -3,7 +3,7 @@ import React, { Ref, useCallback, useEffect, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { CellMeasurerCache } from 'react-virtualized'
 
-import { isNumber, toNumber } from 'lodash'
+import { isNumber, isString, toNumber } from 'lodash'
 import { Text } from 'uiSrc/components/base/text'
 import { getColumnWidth } from 'uiSrc/components/virtual-grid'
 import { StopPropagation } from 'uiSrc/components/virtual-table'
@@ -488,9 +488,7 @@ const HashDetailsTable = (props: Props) => {
             value={formattedValue}
             expanded={expanded}
             title={
-              isValid
-                ? 'Value'
-                : TEXT_FAILED_CONVENT_FORMATTER(viewFormatProp)
+              isValid ? 'Value' : TEXT_FAILED_CONVENT_FORMATTER(viewFormatProp)
             }
             tooltipContent={tooltipContent}
           />
@@ -524,7 +522,9 @@ const HashDetailsTable = (props: Props) => {
             testIdPrefix="hash"
           >
             <div className="innerCellAsCell">
-              {isValueDecoderEnabled && !isTruncatedFieldOrValue ? (
+              {isValueDecoderEnabled &&
+              !isTruncatedFieldOrValue &&
+              !isString(decompressedValueItem) ? (
                 <DecodedValueDisplay
                   buffer={decompressedValueItem}
                   expanded={expanded}

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -71,7 +71,7 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.vectorSet]: {
         flag: false,
       },
-      [FeatureFlags.devArray]: {
+      [FeatureFlags.array]: {
         flag: false,
       },
       [FeatureFlags.azureEntraId]: {
@@ -252,13 +252,13 @@ export const isVectorSetEnabledSelector = (state: RootState): boolean => {
   return features[FeatureFlags.vectorSet]?.flag ?? false
 }
 
-export const isDevArrayEnabledSelector = (state: RootState): boolean => {
+export const isArrayEnabledSelector = (state: RootState): boolean => {
   if (isDevelopment) {
     return true
   }
 
   const features = state.app.features.featureFlags.features
-  return features[FeatureFlags.devArray]?.flag ?? false
+  return features[FeatureFlags.array]?.flag ?? false
 }
 
 export const isDevLanguageEnabledSelector = (state: RootState): boolean => {

--- a/redisinsight/ui/src/slices/tests/app/features.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/features.spec.ts
@@ -15,7 +15,7 @@ import reducer, {
   getFeatureFlagsFailure,
   fetchFeatureFlags,
   isAzureEntraIdEnabledSelector,
-  isDevArrayEnabledSelector,
+  isArrayEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { FeatureFlags } from 'uiSrc/constants'
 import {
@@ -611,7 +611,7 @@ describe('slices', () => {
     })
   })
 
-  describe('isDevArrayEnabledSelector', () => {
+  describe('isArrayEnabledSelector', () => {
     const createRootState = (features: Record<string, { flag: boolean }>) => ({
       ...initialStateDefault,
       app: {
@@ -626,26 +626,26 @@ describe('slices', () => {
       },
     })
 
-    it('should return true when devArray flag is enabled', () => {
+    it('should return true when array flag is enabled', () => {
       const rootState = createRootState({
-        [FeatureFlags.devArray]: { flag: true },
+        [FeatureFlags.array]: { flag: true },
       })
 
-      expect(isDevArrayEnabledSelector(rootState)).toBe(true)
+      expect(isArrayEnabledSelector(rootState)).toBe(true)
     })
 
-    it('should return false when devArray flag is disabled', () => {
+    it('should return false when array flag is disabled', () => {
       const rootState = createRootState({
-        [FeatureFlags.devArray]: { flag: false },
+        [FeatureFlags.array]: { flag: false },
       })
 
-      expect(isDevArrayEnabledSelector(rootState)).toBe(false)
+      expect(isArrayEnabledSelector(rootState)).toBe(false)
     })
 
-    it('should return false when devArray flag is missing', () => {
+    it('should return false when array flag is missing', () => {
       const rootState = createRootState({})
 
-      expect(isDevArrayEnabledSelector(rootState)).toBe(false)
+      expect(isArrayEnabledSelector(rootState)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
# What

Promotes the `dev-array` feature flag to a regular `array` flag at full rollout (`perc: [[0, 100]]`), per the release-to-all decision. The flag keeps its switchable strategy, so it can still be overridden via local `config.json`. Config version bumped to 7.

# Testing

- Affected UI suites (features slice, FilterKeyType, DynamicTypeDetails) and the API feature module tests pass.
- Lint and type-check baselines are clean for the touched files.

---

References RI-8174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flag rename and full rollout change who sees Array in production; bundled decoder/glob and hash-display changes could affect edge-case hash value rendering.
> 
> **Overview**
> Promotes the Redis **Array** key type from the `dev-array` feature flag to **`array`**, with features config **version 7** and **`perc: [[0, 100]]`** so it is enabled for all users. API and UI constants, known-features wiring, and **`isArrayEnabledSelector`** replace the old dev naming; browser add-key, filter, and dynamic key details still gate Array on the flag and Redis **≥ 8.8**. The flag remains on **`SwitchableFlagStrategy`**, so local overrides still work.
> 
> The same PR bundles **value decoder** polish: styled-component prop typing for drag/drop rows, **`RiSelect`** empty values as `undefined`, and hash value cells skip decoded preview when the decompressed value is already a **string**. Decoder utils fix glob-to-regex escaping (including `*`) and adjust related unit tests; **`ValueDecoderModal`** markup indentation is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ad3e0f555003694780f2979bf58e770ce87d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->