### PR TITLE
RI-8318 Refresh key indexes on key details refresh

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.spec.tsx
@@ -10,7 +10,16 @@ import {
 } from 'uiSrc/utils/test-utils'
 import { KeyTypes } from 'uiSrc/constants'
 import { deleteSelectedKey } from 'uiSrc/slices/browser/keys'
+import {
+  useIsKeyIndexed,
+  UseIsKeyIndexedStatus,
+} from 'uiSrc/pages/vector-search/hooks/useIsKeyIndexed'
 import { KeyDetailsHeaderProps, KeyDetailsHeader } from './KeyDetailsHeader'
+
+jest.mock('uiSrc/pages/vector-search/hooks/useIsKeyIndexed', () => ({
+  ...jest.requireActual('uiSrc/pages/vector-search/hooks/useIsKeyIndexed'),
+  useIsKeyIndexed: jest.fn(),
+}))
 
 const mockedProps = mock<KeyDetailsHeaderProps>()
 
@@ -25,6 +34,13 @@ beforeEach(() => {
   cleanup()
   store = cloneDeep(mockedStore)
   store.clearActions()
+
+  jest.mocked(useIsKeyIndexed).mockReturnValue({
+    isIndexed: false,
+    indexes: [],
+    status: UseIsKeyIndexedStatus.Idle,
+    refresh: jest.fn(),
+  })
 })
 
 jest.mock('uiSrc/slices/browser/string', () => ({
@@ -104,6 +120,22 @@ describe('KeyDetailsHeader', () => {
         expect(component).toBeTruthy()
       },
     )
+  })
+
+  it('should refresh the key indexes on key refresh', () => {
+    const refresh = jest.fn()
+    jest.mocked(useIsKeyIndexed).mockReturnValue({
+      isIndexed: false,
+      indexes: [],
+      status: UseIsKeyIndexedStatus.Idle,
+      refresh,
+    })
+
+    render(<KeyDetailsHeader {...mockedProps} />)
+
+    fireEvent.click(screen.getByTestId('key-refresh-btn'))
+
+    expect(refresh).toHaveBeenCalled()
   })
 
   describe('should call onDelete', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
@@ -88,14 +88,17 @@ const KeyDetailsHeader = ({
   const { viewType } = useAppSelector(keysSelector)
 
   const isSearchableType = SEARCHABLE_KEY_TYPES.includes(type as KeyTypes)
-  const { indexes, status: keyIndexedStatus } = useIsKeyIndexed(
-    isSearchableType ? keyName || '' : '',
-  )
+  const {
+    indexes,
+    status: keyIndexedStatus,
+    refresh: refreshKeyIndexes,
+  } = useIsKeyIndexed(isSearchableType ? keyName || '' : '')
 
   const dispatch = useAppDispatch()
 
   const handleRefreshKey = () => {
     dispatch(refreshKey(keyBuffer!, type, undefined, length))
+    refreshKeyIndexes()
   }
 
   const handleEditTTL = (key: RedisResponseBuffer, ttl: number) => {


### PR DESCRIPTION
# What

The "View index" / "Make searchable" button in the key details header is driven by a key-indexes lookup that is cached per key, so refreshing the key details kept showing a stale state after an index was created or dropped elsewhere. The key refresh action now also forces a key-indexes re-fetch (via the force path `useIsKeyIndexed` already exposes), so the button reflects the current indexes.

Before:

https://github.com/user-attachments/assets/dec3c7b6-6984-46db-a2c7-a59ffa17f6ac

After:

https://github.com/user-attachments/assets/901a9a5f-cd4b-4eb0-af0f-b79f9f808c7c

# Testing

- Unit: new case in `KeyDetailsHeader.spec.tsx` — clicking the key refresh button calls the key-indexes refresh; existing header and `useIsKeyIndexed` suites pass.
- Manual: select a Hash/JSON key showing "Make searchable", create a covering index from the Search page, hit the refresh button on the key details — the button switches to "View index" without reselecting the key (and vice versa after `FT.DROPINDEX`).

---

Closes #RI-8318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI wiring change in the browser key header with a unit test; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes stale **View index** / **Make searchable** state in the key details header when RediSearch indexes change outside that view.
> 
> `handleRefreshKey` in `KeyDetailsHeader` now calls `refreshKeyIndexes()` from `useIsKeyIndexed` (force re-fetch) in addition to the existing `refreshKey` dispatch, so the header buttons match the current indexes after the refresh control is used.
> 
> Tests mock `useIsKeyIndexed` and assert the refresh button invokes the hook’s `refresh` callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a3da306c08fbc71d51650a914f8a97f4ed2c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->