### PR TITLE
RI-8320 Add What's New content for 3.8.0 release

### DIFF
--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
@@ -22,10 +22,15 @@ jest.mock('uiSrc/telemetry', () => ({
 
 const latestVersion = whatsNewFeed[0].version
 
-const getOpenState = (flagsOn = false) => {
+// Card-level assertions pin to a shipped version so they don't churn when a
+// new release is added to the top of the feed. 3.6.0 has both a flag-gated
+// card (vector-sets) and an unflagged one (geodata-workbench).
+const CONTENT_VERSION = '3.6.0'
+
+const getOpenState = (flagsOn = false, version = latestVersion) => {
   let state = set(cloneDeep(initialStateDefault), 'app.whatsNew', {
     isOpen: true,
-    selectedVersion: latestVersion,
+    selectedVersion: version,
     lastVersionSeen: null,
   })
   if (flagsOn) {
@@ -70,7 +75,9 @@ describe('WhatsNewModal', () => {
   })
 
   it('should show where to find a feature', () => {
-    render(<WhatsNewModal />, { store: mockStore(getOpenState()) })
+    render(<WhatsNewModal />, {
+      store: mockStore(getOpenState(false, CONTENT_VERSION)),
+    })
 
     expect(
       screen.getByTestId('whats-new-card-location-geodata-workbench'),
@@ -78,7 +85,9 @@ describe('WhatsNewModal', () => {
   })
 
   it('should show flag-gated cards marked as coming soon when their flags are off', () => {
-    render(<WhatsNewModal />, { store: mockStore(getOpenState(false)) })
+    render(<WhatsNewModal />, {
+      store: mockStore(getOpenState(false, CONTENT_VERSION)),
+    })
 
     expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(
@@ -106,7 +115,9 @@ describe('WhatsNewModal', () => {
   })
 
   it('should not mark flag-gated cards when their flags are on', () => {
-    render(<WhatsNewModal />, { store: mockStore(getOpenState(true)) })
+    render(<WhatsNewModal />, {
+      store: mockStore(getOpenState(true, CONTENT_VERSION)),
+    })
 
     expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.tsx
@@ -92,7 +92,7 @@ const WhatsNewModal = () => {
 
   return (
     <Modal.Compose open={isOpen}>
-      <S.StyledContent persistent onCancel={onClose}>
+      <S.StyledContent onCancel={onClose}>
         <Modal.Content.Close icon={CancelIcon} onClick={onClose} />
         <Modal.Content.Header.Compose>
           <Modal.Content.Header.Title>

--- a/redisinsight/ui/src/constants/content/whats-new/index.ts
+++ b/redisinsight/ui/src/constants/content/whats-new/index.ts
@@ -1,10 +1,12 @@
 import { WhatsNewVersion } from './types'
+import { version380 } from './versions/v3.8.0'
 import { version360 } from './versions/v3.6.0'
 import { version341 } from './versions/v3.4.1'
 import { version320 } from './versions/v3.2.0'
 
 // One module per release — add the new version here in each release PR.
 export const WHATS_NEW_VERSIONS: WhatsNewVersion[] = [
+  version380,
   version360,
   version341,
   version320,

--- a/redisinsight/ui/src/constants/content/whats-new/versions/v3.8.0.ts
+++ b/redisinsight/ui/src/constants/content/whats-new/versions/v3.8.0.ts
@@ -1,0 +1,31 @@
+import { FeatureFlags } from 'uiSrc/constants/featureFlags'
+import { WhatsNewVersion, WhatsNewVersionType } from '../types'
+
+export const version380: WhatsNewVersion = {
+  version: '3.8.0',
+  releaseDate: '2026-07-21',
+  type: WhatsNewVersionType.Major,
+  cards: [
+    {
+      id: 'arrays',
+      title: 'Support for new Array data type',
+      body: "Arrays are a new indexed type in Redis 8.8 where each element's position is meaningful: sensor readings by time, calendar slots by interval, workflow steps by stage. Sparse data stays memory-cheap, and you can search and aggregate server-side instead of pulling everything client-side. In Redis Insight, create Arrays manually or from a sample, then browse, edit, search with AND/OR queries, and aggregate.",
+      location: 'Browser — add a key of type Array',
+      featureFlag: FeatureFlags.array,
+    },
+    {
+      id: 'ipv4-ipv6-selection',
+      tag: 'Improved',
+      title: 'IPv4 / IPv6 selection on connection',
+      body: 'Pick IPv4 or IPv6 explicitly when connecting to a database. Gives you a reliable connection in environments where one protocol does not resolve correctly.',
+      location: 'Database list — add or edit a database connection',
+    },
+    {
+      id: 'markdown-format',
+      tag: 'Improved',
+      title: 'Markdown value format',
+      body: 'View stored values rendered as formatted Markdown, for any key type. Makes documents, notes, and generated content readable without copying them out to another tool.',
+      location: 'Key details — switch the value format to Markdown',
+    },
+  ],
+}


### PR DESCRIPTION
# What

Adds the 3.8.0 entry to the in-app What's New feed and registers it as the latest release. The version highlights three cards: the new Array data type, IPv4/IPv6 selection on connection, and the Markdown value format.

Also drops the `persistent` prop from `WhatsNewModal`, and pins the modal spec's card-level assertions to a shipped version (3.6.0) so they no longer need updating each time a new release is added to the top of the feed.

<img width="840" height="776" alt="Screenshot 2026-07-16 at 9 59 27" src="https://github.com/user-attachments/assets/6f8041c1-f328-4402-bb3e-61b6d3847dfe" />

# Testing

- `WhatsNewModal.spec.tsx` passes (9/9).
- Manually: upgrade flow auto-opens the modal on 3.8.0 (major release); version selector browses prior versions; flag-gated Array card shows as "coming soon" when the flag is off.

---

Closes #RI-8320

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and test-harness updates only; the modal `persistent` removal is a small UX tweak with no auth or data-path changes.
> 
> **Overview**
> Registers **3.8.0** as the latest in-app What's New release with three cards: **Array** data type (flag-gated via `FeatureFlags.array`), **IPv4/IPv6** on database connections, and **Markdown** value format in key details.
> 
> `WhatsNewModal` no longer passes **`persistent`** on the modal content wrapper, so dismiss behavior follows the default modal pattern instead of forcing a persistent overlay.
> 
> `WhatsNewModal.spec.tsx` pins card-level assertions to **`3.6.0`** via `CONTENT_VERSION` and an optional `getOpenState` version argument, so those tests stay stable when a newer release is prepended to the feed; tests that intentionally target the latest version (e.g. release-notes link, telemetry) still use `latestVersion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5750849459e806cf1ff92dd3eb993d3171e865a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->