### PR TITLE
feat(feature-flags): roll out whatsNew to 50% of users

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "features": {
     "dev-language": {
       "flag": true,
@@ -158,7 +158,7 @@
     },
     "whatsNew": {
       "flag": true,
-      "perc": [[0, 100]]
+      "perc": [[0, 50]]
     },
     "valueDecoder": {
       "flag": false,


### PR DESCRIPTION
## Description

Reduces the `whatsNew` feature flag rollout from 100% to 50% of users.

- `redisinsight/api/config/features-config.json`: change `whatsNew.perc` from `[[0, 100]]` to `[[0, 50]]`
- Bump config `version` 7 → 8 so clients pick up the updated config

The flag remains enabled (`flag: true`); only the rollout percentage changes. No frontend or strategy changes are required.

## Testing

Config-only change — no code paths modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only percentage and version bump for a UI feature flag; no application code or security paths change.
> 
> **Overview**
> **Halves the `whatsNew` feature rollout** by changing `whatsNew.perc` from `[[0, 100]]` to `[[0, 50]]` in `features-config.json`. The feature stays enabled (`flag: true`); only the percentage-based exposure changes.
> 
> **Bumps config `version` from 7 to 8** so clients reload the updated feature configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838ebcd80d20606e9f8c2d1ef5baefe445a15630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->