### PR TITLE
RI-8321: Enforce x-window-id auth on WebSocket connections

### DIFF
--- a/redisinsight/api/src/main.ts
+++ b/redisinsight/api/src/main.ts
@@ -95,12 +95,13 @@ export default async function bootstrap(apiPort?: number): Promise<IApp> {
         },
       },
     );
+
+    app.useWebSocketAdapter(new SessionMetadataAdapter(app));
   } else {
     app.setGlobalPrefix(serverConfig.globalPrefix);
+    // Must be the only web socket adapter here or the window-id auth gate is lost.
     app.useWebSocketAdapter(new WindowsAuthAdapter(app));
   }
-
-  app.useWebSocketAdapter(new SessionMetadataAdapter(app));
 
   const logFileProvider = app.get(LogFileProvider);
 

--- a/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.spec.ts
+++ b/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { Socket } from 'socket.io';
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { WindowsAuthAdapter } from 'src/modules/auth/window-auth/adapters/window-auth.adapter';
+import { WindowAuthService } from 'src/modules/auth/window-auth/window-auth.service';
+import { mockDefaultSessionMetadata } from 'src/__mocks__';
+
+const AUTHORIZED_WINDOW_ID = 'window-1';
+
+const createBaseBindMessageHandlersMock = () => {
+  const mockBaseBindMessageHandlers = jest.fn();
+
+  jest
+    .spyOn(IoAdapter.prototype, 'bindMessageHandlers')
+    .mockImplementation(() => {
+      mockBaseBindMessageHandlers();
+    });
+
+  return mockBaseBindMessageHandlers;
+};
+
+const createMockSocket = (windowId?: string) =>
+  ({
+    request: {},
+    disconnect: jest.fn(),
+    data: {},
+    join: jest.fn(),
+    handshake: { headers: windowId ? { 'x-window-id': windowId } : {} },
+  }) as unknown as Socket;
+
+describe('WindowsAuthAdapter', () => {
+  let app: INestApplication;
+  let adapter: WindowsAuthAdapter;
+  let windowAuthService: WindowAuthService;
+  let mockBaseBindMessageHandlers: ReturnType<
+    typeof createBaseBindMessageHandlersMock
+  >;
+
+  const mockWindowAuthService = {
+    isAuthorized: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockBaseBindMessageHandlers = createBaseBindMessageHandlersMock();
+  });
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: WindowAuthService, useValue: mockWindowAuthService },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    adapter = new WindowsAuthAdapter(app);
+    app.useWebSocketAdapter(adapter);
+    await app.init();
+    windowAuthService = app.get(WindowAuthService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should attach session metadata, join the user room and bind handlers when the window id is authorized', async () => {
+    (windowAuthService.isAuthorized as jest.Mock).mockResolvedValue(true);
+    const socket = createMockSocket(AUTHORIZED_WINDOW_ID);
+
+    await adapter.bindMessageHandlers(socket, [], jest.fn());
+
+    expect(windowAuthService.isAuthorized).toHaveBeenCalledWith(
+      AUTHORIZED_WINDOW_ID,
+    );
+    expect(mockBaseBindMessageHandlers).toHaveBeenCalledTimes(1);
+    expect(socket.data).toEqual({
+      sessionMetadata: mockDefaultSessionMetadata,
+    });
+    expect(socket.join).toHaveBeenCalledTimes(1);
+    expect(socket.join).toHaveBeenCalledWith('user:1');
+  });
+
+  it('should not bind handlers or attach session metadata when the window id is not authorized', async () => {
+    (windowAuthService.isAuthorized as jest.Mock).mockResolvedValue(false);
+    const socket = createMockSocket();
+
+    await adapter.bindMessageHandlers(socket, [], jest.fn());
+
+    expect(mockBaseBindMessageHandlers).not.toHaveBeenCalled();
+    expect(socket.data).toEqual({});
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+});

--- a/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.spec.ts
+++ b/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.spec.ts
@@ -81,12 +81,13 @@ describe('WindowsAuthAdapter', () => {
     expect(socket.join).toHaveBeenCalledWith('user:1');
   });
 
-  it('should not bind handlers or attach session metadata when the window id is not authorized', async () => {
+  it('should disconnect the socket and bind nothing when the window id is not authorized', async () => {
     (windowAuthService.isAuthorized as jest.Mock).mockResolvedValue(false);
     const socket = createMockSocket();
 
     await adapter.bindMessageHandlers(socket, [], jest.fn());
 
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
     expect(mockBaseBindMessageHandlers).not.toHaveBeenCalled();
     expect(socket.data).toEqual({});
     expect(socket.join).not.toHaveBeenCalled();

--- a/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.ts
+++ b/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.ts
@@ -30,6 +30,8 @@ export class WindowsAuthAdapter extends SessionMetadataAdapter {
 
     if (!isAuthorized) {
       this.logger.error(ERROR_MESSAGES.UNDEFINED_WINDOW_ID);
+      // Drop the connection so it can no longer receive namespace broadcasts.
+      socket.disconnect(true);
       return;
     }
 

--- a/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.ts
+++ b/redisinsight/api/src/modules/auth/window-auth/adapters/window-auth.adapter.ts
@@ -1,21 +1,21 @@
 import { INestApplication, Logger } from '@nestjs/common';
-import { IoAdapter } from '@nestjs/platform-socket.io';
 import { MessageMappingProperties } from '@nestjs/websockets';
 import { get } from 'lodash';
 import { Observable } from 'rxjs';
 import { Socket } from 'socket.io';
 import { API_HEADER_WINDOW_ID } from 'src/common/constants';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { SessionMetadataAdapter } from 'src/modules/auth/session-metadata/adapters/session-metadata.adapter';
 import { WindowAuthService } from '../window-auth.service';
 
-export class WindowsAuthAdapter extends IoAdapter {
+export class WindowsAuthAdapter extends SessionMetadataAdapter {
   private windowAuthService: WindowAuthService;
 
   private logger = new Logger('WindowsAuthAdapter');
 
-  constructor(private app: INestApplication) {
+  constructor(app: INestApplication) {
     super(app);
-    this.windowAuthService = this.app.get(WindowAuthService);
+    this.windowAuthService = app.get(WindowAuthService);
   }
 
   async bindMessageHandlers(


### PR DESCRIPTION
# What

The local WebSocket layer did not enforce the `x-window-id` authorization
that the HTTP API requires. `SessionMetadataAdapter` was registered as the
WebSocket adapter unconditionally after `WindowsAuthAdapter`, and NestJS keeps
only the last adapter set — so the auth gate never ran and every socket was
granted the default session. Unauthenticated cross-origin clients could reach
the `monitor`, `pub-sub`, and `bulk-actions` namespaces, observe live commands,
and trigger destructive bulk actions against saved databases.

`WindowsAuthAdapter` now extends `SessionMetadataAdapter`, so an authorized
socket gets both the window-id check and its session metadata, and it is the
only adapter wired for the desktop build. Web/dev builds keep the
metadata-only adapter, matching the Electron-only scope of the HTTP
`WindowAuthMiddleware`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes WebSocket authentication and connection teardown for the desktop build, closing a path where unauthenticated clients could use monitor/pub-sub/bulk-actions namespaces.
> 
> **Overview**
> **Fixes a WebSocket auth bypass** where registering `SessionMetadataAdapter` after `WindowsAuthAdapter` in bootstrap meant only the metadata adapter ran, so every socket got default session without an `x-window-id` check.
> 
> For **Electron** builds, bootstrap now registers **only** `WindowsAuthAdapter` (with an inline comment). **Web/dev** builds use `SessionMetadataAdapter` alone, matching HTTP window-auth scope.
> 
> `WindowsAuthAdapter` **extends** `SessionMetadataAdapter` and calls `super.bindMessageHandlers` after a successful window-id check, so authorized sockets still get session metadata and user-room join. **Unauthorized** sockets are **`disconnect(true)`** so they cannot keep receiving namespace broadcasts.
> 
> Adds **unit tests** for authorized vs unauthorized `bindMessageHandlers` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87342f388d67333c760470ac9857ba3581f025b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->