### PR TITLE
RI-8322: plugin command sandbox bypass via startsWith()

### DIFF
--- a/redisinsight/api/.tscheck.rec.json
+++ b/redisinsight/api/.tscheck.rec.json
@@ -1329,10 +1329,6 @@
   "src/modules/tag/tag.service.spec.ts": {
     "TS2345": 2
   },
-  "src/modules/workbench/plugins.service.spec.ts": {
-    "TS7005": 11,
-    "TS7034": 3
-  },
   "src/modules/workbench/providers/plugin-commands-whitelist.provider.spec.ts": {
     "TS7005": 10,
     "TS7034": 2

--- a/redisinsight/api/src/modules/workbench/plugins.service.spec.ts
+++ b/redisinsight/api/src/modules/workbench/plugins.service.spec.ts
@@ -14,6 +14,7 @@ import { WorkbenchCommandsExecutor } from 'src/modules/workbench/providers/workb
 import { BadRequestException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { PluginsService } from 'src/modules/workbench/plugins.service';
+import { CommandExecutionStatus } from 'src/modules/cli/dto/cli.dto';
 import { PluginCommandsWhitelistProvider } from 'src/modules/workbench/providers/plugin-commands-whitelist.provider';
 import { PluginStateRepository } from 'src/modules/workbench/repositories/plugin-state.repository';
 import { PluginState } from 'src/modules/workbench/models/plugin-state';
@@ -52,9 +53,13 @@ const mockPluginStateProvider = () => ({
 
 describe('PluginsService', () => {
   let service: PluginsService;
-  let workbenchCommandsExecutor;
-  let pluginsCommandsWhitelistProvider;
-  let pluginStateProvider;
+  let workbenchCommandsExecutor: ReturnType<
+    typeof mockWorkbenchCommandsExecutor
+  >;
+  let pluginsCommandsWhitelistProvider: ReturnType<
+    typeof mockPluginCommandsWhitelistProvider
+  >;
+  let pluginStateProvider: ReturnType<typeof mockPluginStateProvider>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -80,14 +85,15 @@ describe('PluginsService', () => {
     }).compile();
 
     service = module.get<PluginsService>(PluginsService);
-    workbenchCommandsExecutor = module.get<WorkbenchCommandsExecutor>(
+    workbenchCommandsExecutor = module.get(
       WorkbenchCommandsExecutor,
-    );
-    pluginsCommandsWhitelistProvider =
-      module.get<PluginCommandsWhitelistProvider>(
-        PluginCommandsWhitelistProvider,
-      );
-    pluginStateProvider = module.get(PluginStateRepository);
+    ) as unknown as typeof workbenchCommandsExecutor;
+    pluginsCommandsWhitelistProvider = module.get(
+      PluginCommandsWhitelistProvider,
+    ) as unknown as typeof pluginsCommandsWhitelistProvider;
+    pluginStateProvider = module.get(
+      PluginStateRepository,
+    ) as unknown as typeof pluginStateProvider;
   });
 
   describe('sendCommand', () => {
@@ -127,6 +133,39 @@ describe('PluginsService', () => {
         type: CommandExecutionType.Workbench,
       });
       expect(workbenchCommandsExecutor.sendCommand).not.toHaveBeenCalled();
+    });
+    it.each(['getdel foo', 'getex foo', 'getset foo bar'])(
+      'should reject non-whitelisted command "%s" that shares a prefix with a whitelisted command',
+      async (command) => {
+        pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
+          mockWhitelistCommandsResponse,
+        );
+
+        const dto = { command, mode: RunQueryMode.ASCII };
+
+        const result = await service.sendCommand(
+          mockWorkbenchClientMetadata,
+          dto,
+        );
+
+        expect(result.result?.[0]?.status).toEqual(CommandExecutionStatus.Fail);
+        expect(workbenchCommandsExecutor.sendCommand).not.toHaveBeenCalled();
+      },
+    );
+    it('should allow a whitelisted command regardless of casing', async () => {
+      pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
+        mockWhitelistCommandsResponse,
+      );
+
+      const result = await service.sendCommand(mockWorkbenchClientMetadata, {
+        command: 'GET foo',
+        mode: RunQueryMode.ASCII,
+      });
+
+      expect(result.result?.[0]?.status).not.toEqual(
+        CommandExecutionStatus.Fail,
+      );
+      expect(workbenchCommandsExecutor.sendCommand).toHaveBeenCalled();
     });
     it('should throw an error when command execution failed', async () => {
       pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(

--- a/redisinsight/api/src/modules/workbench/plugins.service.spec.ts
+++ b/redisinsight/api/src/modules/workbench/plugins.service.spec.ts
@@ -134,7 +134,7 @@ describe('PluginsService', () => {
       });
       expect(workbenchCommandsExecutor.sendCommand).not.toHaveBeenCalled();
     });
-    it.each(['getdel foo', 'getex foo', 'getset foo bar'])(
+    it.each(['getdel foo', 'getex foo', 'getset foo bar', 'getdel\tfoo'])(
       'should reject non-whitelisted command "%s" that shares a prefix with a whitelisted command',
       async (command) => {
         pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
@@ -152,21 +152,24 @@ describe('PluginsService', () => {
         expect(workbenchCommandsExecutor.sendCommand).not.toHaveBeenCalled();
       },
     );
-    it('should allow a whitelisted command regardless of casing', async () => {
-      pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
-        mockWhitelistCommandsResponse,
-      );
+    it.each(['GET foo', 'get\tfoo'])(
+      'should allow whitelisted command "%s" regardless of casing or delimiter',
+      async (command) => {
+        pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
+          mockWhitelistCommandsResponse,
+        );
 
-      const result = await service.sendCommand(mockWorkbenchClientMetadata, {
-        command: 'GET foo',
-        mode: RunQueryMode.ASCII,
-      });
+        const result = await service.sendCommand(mockWorkbenchClientMetadata, {
+          command,
+          mode: RunQueryMode.ASCII,
+        });
 
-      expect(result.result?.[0]?.status).not.toEqual(
-        CommandExecutionStatus.Fail,
-      );
-      expect(workbenchCommandsExecutor.sendCommand).toHaveBeenCalled();
-    });
+        expect(result.result?.[0]?.status).not.toEqual(
+          CommandExecutionStatus.Fail,
+        );
+        expect(workbenchCommandsExecutor.sendCommand).toHaveBeenCalled();
+      },
+    );
     it('should throw an error when command execution failed', async () => {
       pluginsCommandsWhitelistProvider.getWhitelistCommands.mockResolvedValueOnce(
         mockWhitelistCommandsResponse,

--- a/redisinsight/api/src/modules/workbench/plugins.service.ts
+++ b/redisinsight/api/src/modules/workbench/plugins.service.ts
@@ -133,14 +133,14 @@ export class PluginsService {
     clientMetadata: ClientMetadata,
     commandLine: string,
   ) {
-    const targetCommand = commandLine.toLowerCase();
+    const targetCommand = commandLine.toLowerCase().split(' ')[0];
 
     const whitelist = await this.getWhitelistCommands(clientMetadata);
 
-    if (!whitelist.find((command) => targetCommand.startsWith(command))) {
+    if (!whitelist.includes(targetCommand)) {
       throw new CommandNotSupportedError(
         ERROR_MESSAGES.PLUGIN_COMMAND_NOT_SUPPORTED(
-          targetCommand.split(' ')[0].toUpperCase(),
+          targetCommand.toUpperCase(),
         ),
       );
     }

--- a/redisinsight/api/src/modules/workbench/plugins.service.ts
+++ b/redisinsight/api/src/modules/workbench/plugins.service.ts
@@ -13,6 +13,7 @@ import config from 'src/utils/config';
 import { ClientMetadata } from 'src/common/models';
 import { PluginStateRepository } from 'src/modules/workbench/repositories/plugin-state.repository';
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
+import { splitCliCommandLine } from 'src/utils/cli-helper';
 
 const PLUGINS_CONFIG = config.get('plugins');
 
@@ -133,11 +134,19 @@ export class PluginsService {
     clientMetadata: ClientMetadata,
     commandLine: string,
   ) {
-    const targetCommand = commandLine.toLowerCase().split(' ')[0];
+    let targetCommand = '';
+    try {
+      // Tokenize exactly as the executor does so validation and execution
+      // agree on the command word; unparseable input stays rejected.
+      targetCommand =
+        `${splitCliCommandLine(commandLine)[0] ?? ''}`.toLowerCase();
+    } catch (e) {
+      // ignore parsing errors and fall through to the not-supported error
+    }
 
     const whitelist = await this.getWhitelistCommands(clientMetadata);
 
-    if (!whitelist.includes(targetCommand)) {
+    if (!targetCommand || !whitelist.includes(targetCommand)) {
       throw new CommandNotSupportedError(
         ERROR_MESSAGES.PLUGIN_COMMAND_NOT_SUPPORTED(
           targetCommand.toUpperCase(),


### PR DESCRIPTION
## What

The Workbench plugin command sandbox validates commands against a whitelist of
read-only commands, but enforcement used `targetCommand.startsWith(command)`.
Because `get` is whitelisted, prefix matches like `GETDEL` (reads + deletes),
`GETEX` (modifies TTL), and `GETSET` (reads + overwrites) passed the check
despite not being whitelisted — letting a read-only plugin execute destructive
operations and breaking the sandbox trust boundary.

## Changes

- Replace the prefix `startsWith` matcher with an exact command-word match:
  compare `commandLine.toLowerCase().split(' ')[0]` against the whitelist using
  `.includes(...)`. `get foo` still passes; `getdel foo` no longer does.
- Casing is handled (both sides lowercased) and multi-word command lines resolve
  to their first token.
- Add tests asserting `GETDEL`/`GETEX`/`GETSET` are rejected while `GET` (any
  casing) is allowed.
- Typed the spec's mock provider/executor holders, which cleared 14 pre-existing
  implicit-`any` type errors; refreshed the API `.tscheck.rec.json` baseline
  accordingly (net decrease).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security fix on plugin command authorization; incorrect matching could still allow destructive Redis commands from plugins or break legitimate read-only plugin behavior.
> 
> **Overview**
> Fixes a **plugin command sandbox bypass** where whitelist checks used `startsWith`, so commands like `GETDEL`, `GETEX`, and `GETSET` could pass when `get` was allowed.
> 
> **`checkWhitelistedCommands`** now takes the first token via `splitCliCommandLine` (same as the workbench executor), lowercases it, and requires an **exact** `whitelist.includes` match instead of a prefix match. Legitimate `GET` (any casing, tab/space delimiters) still runs; prefix lookalikes are rejected before `sendCommand`.
> 
> Adds parameterized unit tests for those cases and tightens `plugins.service.spec.ts` mock typing; drops the corresponding entries from `.tscheck.rec.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6587ced032591e721cda5b11934cd8f83ddb834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->