### PR TITLE
fix(instance): connect on deep-link to refresh modules

### DIFF
--- a/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
+++ b/redisinsight/ui/src/mocks/handlers/instances/instancesHandlers.ts
@@ -77,6 +77,10 @@ export const getDatabasesApiSpy = jest
     HttpResponse.json(INSTANCES_MOCK, { status: 200 }),
   )
 
+export const connectDatabaseApiSpy = jest
+  .fn()
+  .mockImplementation(async () => HttpResponse.text('', { status: 200 }))
+
 const handlers: HttpHandler[] = [
   // fetchInstancesAction
   http.get(getMswURL(ApiEndpoints.DATABASES), getDatabasesApiSpy),
@@ -93,9 +97,10 @@ const handlers: HttpHandler[] = [
       return HttpResponse.json(MOCK_INFO_API_RESPONSE, { status: 200 })
     },
   ),
-  http.get(getMswURL(`${ApiEndpoints.DATABASES}/:id/connect`), async () => {
-    return HttpResponse.text('', { status: 200 })
-  }),
+  http.get(
+    getMswURL(`${ApiEndpoints.DATABASES}/:id/connect`),
+    connectDatabaseApiSpy,
+  ),
   http.post<
     any,
     {

--- a/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
@@ -39,10 +39,8 @@ import {
   setInitialRecommendationsState,
 } from 'uiSrc/slices/recommendations/recommendations'
 import {
-  getDatabaseConfigInfo,
   loadInstances,
-  setConnectedInfoInstance,
-  setConnectedInstance,
+  resetConnectedInstance,
   setDefaultInstance,
 } from 'uiSrc/slices/instances/instances'
 import * as rdiInstanceSlice from 'uiSrc/slices/rdi/instances'
@@ -157,10 +155,7 @@ describe('InstancePage', () => {
       loadRdiInstances(),
       getAllPlugins(),
       setDefaultInstance(),
-      setConnectedInstance(),
-      getDatabaseConfigInfo(),
-      setConnectedInfoInstance(),
-      getRecommendations(),
+      resetConnectedInstance(),
       ...resetContextActions,
       clearExpertChatHistory(),
       setConnectivityError(null),

--- a/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
@@ -121,15 +121,27 @@ describe('InstancePage', () => {
       contextInstanceId: 'prevId',
     })
 
+    // Seed a different already-connected DB so InstancePage resets on switch
+    // (Redis Stack keeps the same id and must not reset).
+    const initialState = set(
+      cloneDeep(initialStateDefault),
+      'connections.instances.connectedInstance.id',
+      'prevId',
+    )
+    const testStore = mockStore(initialState)
+
     // Flush pending async thunks leaked from previous test renders
     await act(async () => {})
-    store.clearActions()
+    testStore.clearActions()
 
     await act(() => {
       render(
         <BrowserRouter>
           <InstancePage {...instance(mockedProps)} />
         </BrowserRouter>,
+        {
+          store: testStore,
+        },
       )
     })
 
@@ -163,9 +175,39 @@ describe('InstancePage', () => {
       setDbConfig(undefined),
     ]
 
-    expect(store.getActions().slice(0, expectedActions.length)).toEqual(
+    expect(testStore.getActions().slice(0, expectedActions.length)).toEqual(
       expectedActions,
     )
+  })
+
+  it('should not reset connected instance when already connected to same id', async () => {
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextInstanceId: '',
+    })
+
+    const initialState = set(
+      cloneDeep(initialStateDefault),
+      'connections.instances.connectedInstance.id',
+      INSTANCE_ID_MOCK,
+    )
+    const testStore = mockStore(initialState)
+
+    await act(async () => {})
+    testStore.clearActions()
+
+    await act(() => {
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+        {
+          store: testStore,
+        },
+      )
+    })
+
+    expect(testStore.getActions()).not.toContainEqual(resetConnectedInstance())
+    expect(testStore.getActions()).toContainEqual(setDefaultInstance())
   })
 
   it('should call databases list api', async () => {

--- a/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
@@ -34,10 +34,7 @@ import {
 import { setClusterDetailsInitialState } from 'uiSrc/slices/analytics/clusterDetails'
 import { setDatabaseAnalysisInitialState } from 'uiSrc/slices/analytics/dbAnalysis'
 import { setInitialAnalyticsSettings } from 'uiSrc/slices/analytics/settings'
-import {
-  getRecommendations,
-  setInitialRecommendationsState,
-} from 'uiSrc/slices/recommendations/recommendations'
+import { setInitialRecommendationsState } from 'uiSrc/slices/recommendations/recommendations'
 import {
   loadInstances,
   resetConnectedInstance,

--- a/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
@@ -2,6 +2,8 @@ import { cloneDeep, set } from 'lodash'
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { instance, mock } from 'ts-mockito'
+import { faker } from '@faker-js/faker'
+import { http, HttpResponse } from 'msw'
 
 import { waitFor, within } from '@testing-library/react'
 import {
@@ -11,7 +13,9 @@ import {
   act,
   mockStore,
   initialStateDefault,
+  getMswURL,
 } from 'uiSrc/utils/test-utils'
+import { mswServer } from 'uiSrc/mocks/server'
 import { resetKeys, resetPatternKeysData } from 'uiSrc/slices/browser/keys'
 import { setMonitorInitialState } from 'uiSrc/slices/cli/monitor'
 import { setInitialPubSubState } from 'uiSrc/slices/pubsub/pubsub'
@@ -34,11 +38,19 @@ import {
 import { setClusterDetailsInitialState } from 'uiSrc/slices/analytics/clusterDetails'
 import { setDatabaseAnalysisInitialState } from 'uiSrc/slices/analytics/dbAnalysis'
 import { setInitialAnalyticsSettings } from 'uiSrc/slices/analytics/settings'
-import { setInitialRecommendationsState } from 'uiSrc/slices/recommendations/recommendations'
 import {
+  getRecommendations,
+  setInitialRecommendationsState,
+} from 'uiSrc/slices/recommendations/recommendations'
+import {
+  getDatabaseConfigInfo,
   loadInstances,
   resetConnectedInstance,
+  setConnectedInfoInstance,
+  setConnectedInstance,
   setDefaultInstance,
+  setDefaultInstanceFailure,
+  setDefaultInstanceSuccess,
 } from 'uiSrc/slices/instances/instances'
 import * as rdiInstanceSlice from 'uiSrc/slices/rdi/instances'
 import { loadInstances as loadRdiInstances } from 'uiSrc/slices/rdi/instances'
@@ -46,13 +58,23 @@ import { loadInstances as loadRdiInstances } from 'uiSrc/slices/rdi/instances'
 import { clearExpertChatHistory } from 'uiSrc/slices/panels/aiAssistant'
 import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import { getAllPlugins } from 'uiSrc/slices/app/plugins'
-import { DEFAULT_RDI_SHOWN_COLUMNS, FeatureFlags } from 'uiSrc/constants'
-import { getDatabasesApiSpy } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
+import { ApiEndpoints, DEFAULT_RDI_SHOWN_COLUMNS, FeatureFlags } from 'uiSrc/constants'
+import {
+  connectDatabaseApiSpy,
+  getDatabasesApiSpy,
+} from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 import { RdiInstance } from 'uiSrc/slices/interfaces'
 import InstancePage, { Props } from './InstancePage'
 
 const INSTANCE_ID_MOCK = 'instanceId'
 const mockedProps = mock<Props>()
+
+const instanceDataActions = [
+  setConnectedInstance(),
+  getDatabaseConfigInfo(),
+  setConnectedInfoInstance(),
+  getRecommendations(),
+]
 
 jest.mock('uiSrc/services', () => ({
   localStorageService: {
@@ -85,6 +107,10 @@ beforeEach(() => {
   store = cloneDeep(mockedStore)
   store.clearActions()
   getDatabasesApiSpy.mockClear()
+  connectDatabaseApiSpy.mockClear()
+  connectDatabaseApiSpy.mockImplementation(async () =>
+    HttpResponse.text('', { status: 200 }),
+  )
 })
 
 /**
@@ -114,8 +140,9 @@ describe('InstancePage', () => {
   })
 
   it('should call proper actions with resetting context', async () => {
+    const prevInstanceId = faker.string.uuid()
     ;(appContextSelector as jest.Mock).mockReturnValue({
-      contextInstanceId: 'prevId',
+      contextInstanceId: prevInstanceId,
     })
 
     // Seed a different already-connected DB so InstancePage resets on switch
@@ -123,7 +150,7 @@ describe('InstancePage', () => {
     const initialState = set(
       cloneDeep(initialStateDefault),
       'connections.instances.connectedInstance.id',
-      'prevId',
+      prevInstanceId,
     )
     const testStore = mockStore(initialState)
 
@@ -177,7 +204,7 @@ describe('InstancePage', () => {
     )
   })
 
-  it('should not reset connected instance when already connected to same id', async () => {
+  it('should load instance data without connect when already connected to same id', async () => {
     ;(appContextSelector as jest.Mock).mockReturnValue({
       contextInstanceId: '',
     })
@@ -203,8 +230,119 @@ describe('InstancePage', () => {
       )
     })
 
+    expect(connectDatabaseApiSpy).not.toHaveBeenCalled()
     expect(testStore.getActions()).not.toContainEqual(resetConnectedInstance())
-    expect(testStore.getActions()).toContainEqual(setDefaultInstance())
+
+    await waitFor(() =>
+      expect(testStore.getActions()).toEqual(
+        expect.arrayContaining(instanceDataActions),
+      ),
+    )
+  })
+
+  it('should load instance data after successful connect', async () => {
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextInstanceId: '',
+    })
+
+    const testStore = mockStore(cloneDeep(initialStateDefault))
+
+    await act(async () => {})
+    testStore.clearActions()
+
+    await act(() => {
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+        {
+          store: testStore,
+        },
+      )
+    })
+
+    await waitFor(() => {
+      expect(connectDatabaseApiSpy).toHaveBeenCalled()
+      expect(testStore.getActions()).toEqual(
+        expect.arrayContaining([
+          setDefaultInstanceSuccess(),
+          ...instanceDataActions,
+        ]),
+      )
+    })
+  })
+
+  it('should load instance data after failed connect', async () => {
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextInstanceId: '',
+    })
+
+    mswServer.use(
+      http.get(
+        getMswURL(`${ApiEndpoints.DATABASES}/:id/connect`),
+        async () =>
+          HttpResponse.json(
+            { message: 'Service Unavailable' },
+            { status: 503 },
+          ),
+      ),
+    )
+
+    const testStore = mockStore(cloneDeep(initialStateDefault))
+
+    await act(async () => {})
+    testStore.clearActions()
+
+    await act(() => {
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+        {
+          store: testStore,
+        },
+      )
+    })
+
+    await waitFor(() => {
+      expect(testStore.getActions()).toEqual(
+        expect.arrayContaining([
+          setDefaultInstanceFailure('Service Unavailable'),
+          ...instanceDataActions,
+        ]),
+      )
+    })
+  })
+
+  it('should connect once on fresh deep link without resetting', async () => {
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextInstanceId: '',
+    })
+
+    const initialState = set(
+      cloneDeep(initialStateDefault),
+      'connections.instances.connectedInstance.id',
+      '',
+    )
+    const testStore = mockStore(initialState)
+
+    await act(async () => {})
+    testStore.clearActions()
+    connectDatabaseApiSpy.mockClear()
+
+    await act(() => {
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+        {
+          store: testStore,
+        },
+      )
+    })
+
+    await waitFor(() => expect(connectDatabaseApiSpy).toHaveBeenCalledTimes(1))
+    expect(testStore.getActions()).not.toContainEqual(resetConnectedInstance())
   })
 
   it('should call databases list api', async () => {

--- a/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.spec.tsx
@@ -58,7 +58,11 @@ import { loadInstances as loadRdiInstances } from 'uiSrc/slices/rdi/instances'
 import { clearExpertChatHistory } from 'uiSrc/slices/panels/aiAssistant'
 import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import { getAllPlugins } from 'uiSrc/slices/app/plugins'
-import { ApiEndpoints, DEFAULT_RDI_SHOWN_COLUMNS, FeatureFlags } from 'uiSrc/constants'
+import {
+  ApiEndpoints,
+  DEFAULT_RDI_SHOWN_COLUMNS,
+  FeatureFlags,
+} from 'uiSrc/constants'
 import {
   connectDatabaseApiSpy,
   getDatabasesApiSpy,
@@ -278,13 +282,8 @@ describe('InstancePage', () => {
     })
 
     mswServer.use(
-      http.get(
-        getMswURL(`${ApiEndpoints.DATABASES}/:id/connect`),
-        async () =>
-          HttpResponse.json(
-            { message: 'Service Unavailable' },
-            { status: 503 },
-          ),
+      http.get(getMswURL(`${ApiEndpoints.DATABASES}/:id/connect`), async () =>
+        HttpResponse.json({ message: 'Service Unavailable' }, { status: 503 }),
       ),
     )
 

--- a/redisinsight/ui/src/pages/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
+  checkConnectToInstanceAction,
   fetchConnectedInstanceAction,
   fetchConnectedInstanceInfoAction,
   fetchInstancesAction,
@@ -75,12 +76,21 @@ const InstancePage = ({ routes = [] }: Props) => {
   }, [])
 
   useEffect(() => {
-    dispatch(fetchConnectedInstanceAction(connectionInstanceId))
-    dispatch(getDatabaseConfigInfoAction(connectionInstanceId))
-    dispatch(fetchConnectedInstanceInfoAction(connectionInstanceId))
-    dispatch(fetchRecommendationsAction(connectionInstanceId))
-    let intervalId: ReturnType<typeof setInterval>
+    dispatch(
+      checkConnectToInstanceAction(
+        connectionInstanceId,
+        () => {
+          dispatch(fetchConnectedInstanceAction(connectionInstanceId))
+          dispatch(getDatabaseConfigInfoAction(connectionInstanceId))
+          dispatch(fetchConnectedInstanceInfoAction(connectionInstanceId))
+          dispatch(fetchRecommendationsAction(connectionInstanceId))
+        },
+        undefined,
+        contextInstanceId !== connectionInstanceId,
+      ),
+    )
 
+    let intervalId: ReturnType<typeof setInterval>
     if (shouldGetRecommendations) {
       intervalId = setInterval(() => {
         dispatch(fetchRecommendationsAction(connectionInstanceId))

--- a/redisinsight/ui/src/pages/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import {
   checkConnectToInstanceAction,
+  connectedInstanceSelector,
   fetchConnectedInstanceAction,
   fetchConnectedInstanceInfoAction,
   fetchInstancesAction,
@@ -50,6 +51,7 @@ const InstancePage = ({ routes = [] }: Props) => {
 
   const { data: rdiInstances } = useAppSelector(rdiInstancesSelector)
   const { data: dbInstances } = useAppSelector(dbInstancesSelector)
+  const { id: connectedInstanceId } = useAppSelector(connectedInstanceSelector)
 
   const { instanceId: connectionInstanceId } = useParams<{
     instanceId: string
@@ -76,6 +78,9 @@ const InstancePage = ({ routes = [] }: Props) => {
   }, [])
 
   useEffect(() => {
+    // Only reset when switching away from a different connected DB.
+    // Redis Stack already set connectedInstance.id before routing here;
+    // resetting would clear it and ProtectedRoute would bounce to home.
     dispatch(
       checkConnectToInstanceAction(
         connectionInstanceId,
@@ -86,7 +91,8 @@ const InstancePage = ({ routes = [] }: Props) => {
           dispatch(fetchRecommendationsAction(connectionInstanceId))
         },
         undefined,
-        contextInstanceId !== connectionInstanceId,
+        Boolean(connectedInstanceId) &&
+          connectedInstanceId !== connectionInstanceId,
       ),
     )
 

--- a/redisinsight/ui/src/pages/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.tsx
@@ -78,19 +78,23 @@ const InstancePage = ({ routes = [] }: Props) => {
   }, [])
 
   useEffect(() => {
+    const loadInstanceData = () => {
+      dispatch(fetchConnectedInstanceAction(connectionInstanceId))
+      dispatch(getDatabaseConfigInfoAction(connectionInstanceId))
+      dispatch(fetchConnectedInstanceInfoAction(connectionInstanceId))
+      dispatch(fetchRecommendationsAction(connectionInstanceId))
+    }
+
     // Only reset when switching away from a different connected DB.
     // Redis Stack already set connectedInstance.id before routing here;
     // resetting would clear it and ProtectedRoute would bounce to home.
+    // Always load instance data after connect attempt (success or fail) so
+    // connectedInstance.loading settles and Vector Search does not spin forever.
     dispatch(
       checkConnectToInstanceAction(
         connectionInstanceId,
-        () => {
-          dispatch(fetchConnectedInstanceAction(connectionInstanceId))
-          dispatch(getDatabaseConfigInfoAction(connectionInstanceId))
-          dispatch(fetchConnectedInstanceInfoAction(connectionInstanceId))
-          dispatch(fetchRecommendationsAction(connectionInstanceId))
-        },
-        undefined,
+        loadInstanceData,
+        loadInstanceData,
         Boolean(connectedInstanceId) &&
           connectedInstanceId !== connectionInstanceId,
       ),

--- a/redisinsight/ui/src/pages/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/instance/InstancePage.tsx
@@ -85,20 +85,25 @@ const InstancePage = ({ routes = [] }: Props) => {
       dispatch(fetchRecommendationsAction(connectionInstanceId))
     }
 
-    // Only reset when switching away from a different connected DB.
-    // Redis Stack already set connectedInstance.id before routing here;
-    // resetting would clear it and ProtectedRoute would bounce to home.
-    // Always load instance data after connect attempt (success or fail) so
-    // connectedInstance.loading settles and Vector Search does not spin forever.
-    dispatch(
-      checkConnectToInstanceAction(
-        connectionInstanceId,
-        loadInstanceData,
-        loadInstanceData,
-        Boolean(connectedInstanceId) &&
-          connectedInstanceId !== connectionInstanceId,
-      ),
-    )
+    // Picker / Redis Stack / nav already connect before routing here and set
+    // connectedInstance.id. Skip the redundant /connect (heavy: module probe,
+    // INFO, CLIENT LIST, recommendations, analytics) when we're already on
+    // the same id. Always load instance data after connect attempt (success or
+    // fail) so connectedInstance.loading settles and Vector Search does not
+    // spin forever. Only reset when switching away from a different DB —
+    // Redis Stack sets the id before mount; resetting would bounce ProtectedRoute.
+    if (connectedInstanceId === connectionInstanceId) {
+      loadInstanceData()
+    } else {
+      dispatch(
+        checkConnectToInstanceAction(
+          connectionInstanceId,
+          loadInstanceData,
+          loadInstanceData,
+          Boolean(connectedInstanceId),
+        ),
+      )
+    }
 
     let intervalId: ReturnType<typeof setInterval>
     if (shouldGetRecommendations) {

--- a/redisinsight/ui/src/slices/instances/instances.ts
+++ b/redisinsight/ui/src/slices/instances/instances.ts
@@ -759,6 +759,7 @@ export function fetchConnectedInstanceAction(
     } catch (_err) {
       const error = _err as AxiosError
       const errorMessage = getApiErrorMessage(error)
+      dispatch(setConnectedInstanceFailure())
       dispatch(setDefaultInstanceFailure(errorMessage))
       dispatch(addErrorNotification(error))
       onFail?.()

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -1596,9 +1596,7 @@ describe('instances slice', () => {
         }
         apiService.get = jest.fn().mockRejectedValue(responsePayload)
 
-        await store.dispatch<any>(
-          fetchConnectedInstanceAction(instances[0].id),
-        )
+        await store.dispatch<any>(fetchConnectedInstanceAction(instances[0].id))
 
         expect(store.getActions()).toEqual(
           expect.arrayContaining([

--- a/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
+++ b/redisinsight/ui/src/slices/tests/instances/instances.spec.ts
@@ -1585,6 +1585,31 @@ describe('instances slice', () => {
           ]),
         )
       })
+
+      it('dispatches setConnectedInstanceFailure when fetch fails', async () => {
+        const errorMessage = 'Not Found!'
+        const responsePayload = {
+          response: {
+            status: 404,
+            data: { message: errorMessage },
+          },
+        }
+        apiService.get = jest.fn().mockRejectedValue(responsePayload)
+
+        await store.dispatch<any>(
+          fetchConnectedInstanceAction(instances[0].id),
+        )
+
+        expect(store.getActions()).toEqual(
+          expect.arrayContaining([
+            setDefaultInstance(),
+            setConnectedInstance(),
+            setConnectedInstanceFailure(),
+            setDefaultInstanceFailure(errorMessage),
+            addErrorNotification(responsePayload as AxiosError),
+          ]),
+        )
+      })
     })
 
     describe('changeInstanceAliasAction', () => {


### PR DESCRIPTION
## Summary
- Call `checkConnectToInstanceAction` when mounting `InstancePage`, matching the DB picker / Redis Stack entry path.
- Refresh modules via `GET /databases/:id/connect` before fetching instance data used by Vector Search guards.
- Fixes Docker preconfigured databases (`modules: []`) opened via `/0/vector-search` incorrectly showing Redis Search as unavailable.

Fixes #6080

## Test plan
- [x] `InstancePage.spec.tsx` — 9/9 passed
- [x] Fresh preconfigured DB with `modules: []`; deep-link `/0/vector-search` triggers connect and populates `search` module
- [x] UI: deep-link Search shows indexes (e.g. `idx:trie`), not the RQE unavailable empty state
- [x] `/0/browser` still loads after deep-link / picker entry
- [x] Regression: open DB from picker, then Search — still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core instance mount/connect flow and when Redux state is reset; mistakes could cause double connects, missed module refresh, or routing bounce on DB switch, though behavior is heavily covered by new tests.
> 
> **Overview**
> **Fixes deep-linked Vector Search** when preconfigured DBs have empty `modules` by aligning `InstancePage` with the DB picker path: it calls `checkConnectToInstanceAction` ( `GET /databases/:id/connect` ) before loading instance data, unless Redux already has the same `connectedInstance.id`.
> 
> When the route id matches the connected id, it **skips connect** and only runs the instance fetch/config/info/recommendations bundle. On connect success or failure it still runs that bundle so `connectedInstance.loading` clears and Vector Search does not spin forever. **Reset** (`resetConnectedInstance` + context wipe) runs only when switching from a different connected DB, not on fresh deep links or Redis Stack pre-set id.
> 
> `fetchConnectedInstanceAction` now dispatches **`setConnectedInstanceFailure`** on API errors. MSW exposes **`connectDatabaseApiSpy`**; `InstancePage.spec.tsx` adds coverage for same-id skip, connect success/fail, DB switch reset, and single connect on deep link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89397ce3338fc5f6dcc7b717cf15c3d987d66a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->