### PR TITLE
Add scheduled dependency vulnerability audit + dead-dependencies skill

### DIFF
--- a/.ai/skills/dead-dependencies/SKILL.md
+++ b/.ai/skills/dead-dependencies/SKILL.md
@@ -41,7 +41,7 @@ removed (worked example at the bottom).
 ```bash
 PKG=jsonpath   # the dependency to check
 grep -rn "$PKG" \
-  redisinsight configs scripts .storybook \
+  redisinsight configs scripts tests .storybook \
   --include=*.ts --include=*.tsx --include=*.js --include=*.jsx \
   --include=*.mjs --include=*.cjs --include=*.json \
   2>/dev/null | grep -v node_modules
@@ -113,7 +113,7 @@ grep each for an import, then apply steps 2–5 to the ones with zero hits:
 node -e "const p=require('./package.json');console.log([...Object.keys(p.dependencies||{}),...Object.keys(p.devDependencies||{})].join('\n'))" \
 | while read PKG; do
     hits=$(grep -rl --include=*.ts --include=*.tsx --include=*.js --include=*.jsx --include=*.mjs \
-      -e "from ['\"]$PKG" -e "require(['\"]$PKG" redisinsight configs scripts 2>/dev/null | grep -vc node_modules)
+      -e "from ['\"]$PKG" -e "require(['\"]$PKG" redisinsight configs scripts tests 2>/dev/null | grep -vc node_modules)
     [ "$hits" = "0" ] && echo "candidate: $PKG"
   done
 ```

--- a/.ai/skills/dead-dependencies/SKILL.md
+++ b/.ai/skills/dead-dependencies/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: dead-dependencies
+description: >-
+  Find and safely remove unused ("dead") npm dependencies in RedisInsight
+  using a grep + leaf-check + build-gate recipe. Use when cleaning up
+  dependencies, investigating whether a package is still used, removing a
+  suspected leftover, or when the user mentions dead deps, unused
+  dependencies, dependency cleanup, leftover packages, or "is this safe to
+  remove". Complements the weekly vulnerability audit
+  (`scripts/dependency-audit-report.mjs`), which only reports vulnerabilities.
+---
+
+# Dead Dependencies
+
+Identify and safely remove unused npm dependencies. This is a **local,
+interactive** workflow — a scheduled report can only ever guess; confirming a
+dependency is dead requires grepping real usage and running the build.
+
+## Why manual (not knip/depcheck)
+
+Static tools over-report badly in this repo and must not be trusted blindly:
+
+- The root `package.json` is a **mega-manifest** (UI + desktop + build + test
+  + storybook + electron), so a tool scanning one area flags everything used
+  elsewhere as "unused".
+- Lots of dependencies are referenced **without an `import`**: webpack loaders
+  and eslint/jest/babel plugins by string in config, tools invoked from
+  `package.json` `scripts`, runtime `-r` preloads, dynamic `require`, and
+  ambient `@types/*`.
+- The webpack→Vite migration left **genuinely dead** build tooling behind,
+  mixed in with false positives.
+
+The reliable signal is: **grep for usage → confirm it's a leaf → remove it and
+run the build gate.** That is exactly how `jsonpath` was confirmed dead and
+removed (worked example at the bottom).
+
+## The recipe (per candidate)
+
+### 1. Grep the whole repo for real usage
+
+```bash
+PKG=jsonpath   # the dependency to check
+grep -rn "$PKG" \
+  redisinsight configs scripts .storybook \
+  --include=*.ts --include=*.tsx --include=*.js --include=*.jsx \
+  --include=*.mjs --include=*.cjs --include=*.json \
+  2>/dev/null | grep -v node_modules
+```
+
+Look for `import ... from '$PKG'`, `require('$PKG')`, `import('$PKG')`, and
+bare references. Ignore unrelated substring hits (e.g. `nestjs-form-data` when
+checking `form-data`, or a package name appearing only in tutorial/`manifest`
+text). **Zero real references → candidate for the next steps.**
+
+### 2. Rule out no-import usage
+
+A clean grep is **necessary but not sufficient**. Check the ways a package is
+used without an `import`:
+
+- **Config string references** — search the build/test config for the bare
+  name: `.eslintrc.js`, `configs/webpack.config.*.ts`,
+  `redisinsight/ui/vite.config.mjs`, `jest.config.cjs`, `babel.config.cjs`,
+  `electron-builder.json`, `.mocharc*`. eslint plugins, webpack loaders, and
+  jest/mocha reporters live here.
+- **`package.json` scripts** — a tool like `concurrently`, `lint-staged`, or a
+  reporter is "used" if a `scripts` entry (any workspace) invokes it.
+- **Runtime preloads / dynamic** — `node -r <pkg>`, `require(variable)`, or a
+  wasm/worker loader with a computed path.
+
+### 3. Leaf check
+
+```bash
+npm ls "$PKG"        # in the workspace that declares it
+```
+
+Confirm nothing else in the tree depends on it, and note any transitive deps it
+uniquely pulls (removing `jsonpath` also dropped `underscore`).
+
+### 4. Classify before acting
+
+| Situation | Action |
+| --- | --- |
+| Plain runtime/dev dep, zero references anywhere | **Delete** (after the gate below) |
+| `@types/x` where base `x` bundles its own types (`node_modules/x/package.json` has `types`/`typings`) | **Delete** — the DefinitelyTyped package is obsolete |
+| `@types/x` that's ambient/global-only (e.g. `@types/webpack-env`) | **Keep** — never imported by design |
+| Declared in more than one workspace (`package.json`), used in only one | **Relocate/dedupe** — remove the *unused* declaration, never the used copy |
+| Shadows a Node builtin (`buffer`, `assert`, …) | **Keep** — usually a false positive |
+| Referenced only in a config/`scripts` (step 2 hit) | **Keep** |
+
+### 5. The gate — the only real proof
+
+Remove it, reinstall (per the repo's dependency rules — never hand-edit
+`package.json`/lockfile, never `--ignore-scripts`), and verify the affected
+area builds:
+
+```bash
+npm uninstall "$PKG"          # in the declaring workspace; updates the lockfile
+npm run type-check            # or the affected workspace's type-check
+npm run test                  # / test:api, as relevant
+npm run build                 # if it's a build-time dep
+```
+
+Green across the relevant checks = safe. Commit the `package.json` +
+`package-lock.json` change (see the git-safety / dependency rules in
+`CLAUDE.md`). If anything goes red, it wasn't dead — restore it.
+
+## Optional: enumerate candidates to sweep
+
+To triage the whole surface rather than one package, list declared deps and
+grep each for an import, then apply steps 2–5 to the ones with zero hits:
+
+```bash
+node -e "const p=require('./package.json');console.log([...Object.keys(p.dependencies||{}),...Object.keys(p.devDependencies||{})].join('\n'))" \
+| while read PKG; do
+    hits=$(grep -rl --include=*.ts --include=*.tsx --include=*.js --include=*.jsx --include=*.mjs \
+      -e "from ['\"]$PKG" -e "require(['\"]$PKG" redisinsight configs scripts 2>/dev/null | grep -vc node_modules)
+    [ "$hits" = "0" ] && echo "candidate: $PKG"
+  done
+```
+
+This is a **first filter only** — every candidate still goes through steps 2–5.
+Expect false positives (config/string/dynamic/ambient use). Never delete straight
+from this list.
+
+## Worked example — `jsonpath`
+
+1. Grep across the repo → the only hits were unrelated tutorial text in a
+   `manifest.json`; **no `import`/`require`**.
+2. Not referenced in any config or script.
+3. `npm ls jsonpath` → a leaf; it was also the sole reason `underscore` was
+   installed.
+4. Plain runtime dep, zero references → likely deletable.
+5. Removed `jsonpath` + `@types/jsonpath`, `npm install`, `npm run type-check`
+   → green. Confirmed dead; committed. (`underscore` dropped with it.)

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -98,10 +98,11 @@ jobs:
                 title: "${{ github.workflow }} — see step summary for the affected trees"
                 title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      # Covers a step failing before the report runs (e.g. the core tests),
-      # which would otherwise stop the job with no alert.
+      # Covers a step failing at or before the report (e.g. the core tests),
+      # which would otherwise stop the job with no alert. Gated on the report
+      # not succeeding so a failing post-report Slack step doesn't trip it.
       - name: Alert Slack when the audit workflow failed
-        if: failure()
+        if: failure() && steps.report.outcome != 'success'
         uses: slackapi/slack-github-action@v3.0.5
         with:
           method: chat.postMessage

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -26,6 +26,20 @@ jobs:
         with:
           ref: ${{ inputs.branch || github.ref }}
 
+      # Label Slack with the tree actually audited. A manual run can check out a
+      # different ref via inputs.branch, so github.ref_name/github.sha (the
+      # trigger ref) would misname it.
+      - name: Resolve audited ref
+        id: audited
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          TRIGGER_REF: ${{ github.ref_name }}
+        run: |
+          {
+            echo "ref=${INPUT_BRANCH:-$TRIGGER_REF}"
+            echo "sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
       # `npm audit` reads the committed lockfiles and the core tests are plain
       # `node --test` — neither needs `node_modules`, so we only set up Node.
       - name: Setup Node
@@ -49,7 +63,7 @@ jobs:
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |
             channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
-            text: "<!here> *Dependency audit — ${{ steps.report.outputs.total_hc }} high/critical* — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            text: "<!here> *Dependency audit — ${{ steps.report.outputs.total_hc }} high/critical* — `${{ github.repository }}` on `${{ steps.audited.outputs.ref }}` @ `${{ steps.audited.outputs.sha }}`"
             attachments:
               - color: "${{ steps.report.outputs.color }}"
                 title: "${{ github.workflow }}"
@@ -78,7 +92,7 @@ jobs:
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |
             channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
-            text: "<!here> *Dependency audit could not run* — one or more lockfiles failed to audit; the vulnerability report is incomplete — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            text: "<!here> *Dependency audit could not run* — one or more lockfiles failed to audit; the vulnerability report is incomplete — `${{ github.repository }}` on `${{ steps.audited.outputs.ref }}` @ `${{ steps.audited.outputs.sha }}`"
             attachments:
               - color: "#cc0000"
                 title: "${{ github.workflow }} — see step summary for the affected trees"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -97,3 +97,20 @@ jobs:
               - color: "#cc0000"
                 title: "${{ github.workflow }} — see step summary for the affected trees"
                 title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      # The report step always exits 0, so the steps above cover a broken audit.
+      # This covers the other case: a step failing before the report runs (e.g.
+      # the core tests), which would otherwise stop the job with no alert.
+      - name: Alert Slack when the audit workflow failed
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
+          payload: |
+            channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
+            text: "<!here> *Dependency audit workflow failed* — a step errored before the report completed — `${{ github.repository }}` on `${{ steps.audited.outputs.ref || github.ref_name }}`"
+            attachments:
+              - color: "#cc0000"
+                title: "${{ github.workflow }} — check the failed step"
+                title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,69 @@
+name: Dependency Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch/ref to audit (blank = current ref)'
+        type: string
+        default: ''
+  schedule:
+    - cron: '0 7 * * 1' # weekly, Monday 07:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      # `npm audit` reads the committed lockfiles and the core tests are plain
+      # `node --test` — neither needs `node_modules`, so we only set up Node.
+      - name: Setup Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Run dependency-audit core tests
+        run: npm run test:scripts
+
+      - name: Run dependency audit report
+        id: report
+        run: node scripts/dependency-audit-report.mjs --github
+
+      # Inline payload mirrors the E2E nightly Slack step.
+      - name: Post to Slack
+        if: steps.report.outputs.post == 'true'
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
+          payload: |
+            channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
+            text: "<!here> *Dependency audit — ${{ steps.report.outputs.total_hc }} high/critical* — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            attachments:
+              - color: "${{ steps.report.outputs.color }}"
+                title: "${{ github.workflow }}"
+                title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                fields:
+                  - title: "Prod Critical"
+                    value: "${{ steps.report.outputs.prod_critical }}"
+                    short: true
+                  - title: "Prod High"
+                    value: "${{ steps.report.outputs.prod_high }}"
+                    short: true
+                  - title: "Dev Critical"
+                    value: "${{ steps.report.outputs.dev_critical }}"
+                    short: true
+                  - title: "Dev High"
+                    value: "${{ steps.report.outputs.dev_high }}"
+                    short: true

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -59,6 +59,9 @@ jobs:
         if: steps.report.outputs.post == 'true'
         uses: slackapi/slack-github-action@v4.0.0
         with:
+          # Fail the step on a Slack API error; v4 stays green otherwise,
+          # hiding an alert that never got delivered.
+          errors: true
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |
@@ -88,6 +91,9 @@ jobs:
         if: steps.report.outputs.failed == 'true'
         uses: slackapi/slack-github-action@v4.0.0
         with:
+          # Fail the step on a Slack API error; v4 stays green otherwise,
+          # hiding an alert that never got delivered.
+          errors: true
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |
@@ -105,6 +111,9 @@ jobs:
         if: failure() && steps.report.outcome != 'success'
         uses: slackapi/slack-github-action@v4.0.0
         with:
+          # Fail the step on a Slack API error; v4 stays green otherwise,
+          # hiding an alert that never got delivered.
+          errors: true
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
           payload: |

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -98,9 +98,9 @@ jobs:
                 title: "${{ github.workflow }} — see step summary for the affected trees"
                 title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      # Covers a step failing at or before the report (e.g. the core tests),
-      # which would otherwise stop the job with no alert. Gated on the report
-      # not succeeding so a failing post-report Slack step doesn't trip it.
+      # A failure at or before the report (e.g. the core tests) would otherwise
+      # stop the job with no alert. The report-outcome gate skips post-report
+      # Slack failures.
       - name: Alert Slack when the audit workflow failed
         if: failure() && steps.report.outcome != 'success'
         uses: slackapi/slack-github-action@v3.0.5

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -22,7 +22,7 @@ jobs:
     name: Audit dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -43,7 +43,7 @@ jobs:
       # `npm audit` reads the committed lockfiles and the core tests are plain
       # `node --test` — neither needs `node_modules`, so we only set up Node.
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version-file: '.nvmrc'
 
@@ -57,7 +57,7 @@ jobs:
       # Inline payload mirrors the E2E nightly Slack step.
       - name: Post to Slack
         if: steps.report.outputs.post == 'true'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
@@ -86,7 +86,7 @@ jobs:
       # quietly render as clean.
       - name: Alert Slack when the audit could not run
         if: steps.report.outputs.failed == 'true'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
@@ -103,7 +103,7 @@ jobs:
       # Slack failures.
       - name: Alert Slack when the audit workflow failed
         if: failure() && steps.report.outcome != 'success'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TEST_REPORT_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -98,9 +98,8 @@ jobs:
                 title: "${{ github.workflow }} — see step summary for the affected trees"
                 title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      # The report step always exits 0, so the steps above cover a broken audit.
-      # This covers the other case: a step failing before the report runs (e.g.
-      # the core tests), which would otherwise stop the job with no alert.
+      # Covers a step failing before the report runs (e.g. the core tests),
+      # which would otherwise stop the job with no alert.
       - name: Alert Slack when the audit workflow failed
         if: failure()
         uses: slackapi/slack-github-action@v3.0.5

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -68,9 +68,8 @@ jobs:
                     value: "${{ steps.report.outputs.dev_high }}"
                     short: true
 
-      # Separate alert: a lockfile could not be audited, so the report above is
-      # incomplete. Kept distinct from the vulnerability report so a broken
-      # audit can't quietly render as clean.
+      # Kept separate from the vulnerability report so a broken audit can't
+      # quietly render as clean.
       - name: Alert Slack when the audit could not run
         if: steps.report.outputs.failed == 'true'
         uses: slackapi/slack-github-action@v3.0.5

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -85,10 +85,10 @@ jobs:
                     value: "${{ steps.report.outputs.dev_high }}"
                     short: true
 
-      # Kept separate from the vulnerability report so a broken audit can't
-      # quietly render as clean.
+      # Separate from the vulnerability report so a broken audit can't read as
+      # clean, and still fires if the post above errored out.
       - name: Alert Slack when the audit could not run
-        if: steps.report.outputs.failed == 'true'
+        if: ${{ !cancelled() && steps.report.outputs.failed == 'true' }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
           # Fail the step on a Slack API error; v4 stays green otherwise,

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -67,3 +67,20 @@ jobs:
                   - title: "Dev High"
                     value: "${{ steps.report.outputs.dev_high }}"
                     short: true
+
+      # Separate alert: a lockfile could not be audited, so the report above is
+      # incomplete. Kept distinct from the vulnerability report so a broken
+      # audit can't quietly render as clean.
+      - name: Alert Slack when the audit could not run
+        if: steps.report.outputs.failed == 'true'
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TEST_REPORT_KEY }}
+          payload: |
+            channel: "${{ secrets.SLACK_TEST_REPORT_CHANNEL }}"
+            text: "<!here> *Dependency audit could not run* — one or more lockfiles failed to audit; the vulnerability report is incomplete — `${{ github.repository }}` on `${{ github.ref_name }}` @ `${{ github.sha }}`"
+            attachments:
+              - color: "#cc0000"
+                title: "${{ github.workflow }} — see step summary for the affected trees"
+                title_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "tscheck": "npm run tscheck --prefix redisinsight/ui && npm run tscheck --prefix redisinsight/api && npm run tscheck --prefix redisinsight/desktop",
     "tscheck:force": "npm run tscheck:force --prefix redisinsight/ui && npm run tscheck:force --prefix redisinsight/api && npm run tscheck:force --prefix redisinsight/desktop",
     "sb": "storybook dev -p 6006",
-    "build-sb": "storybook build"
+    "build-sb": "storybook build",
+    "deps:audit": "node scripts/dependency-audit-report.mjs",
+    "test:scripts": "node --test scripts/lib/*.test.mjs"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/dependency-audit-report.mjs
+++ b/scripts/dependency-audit-report.mjs
@@ -44,12 +44,19 @@ function runJson(cmd, args, cwd) {
 function auditTree(dir, warnings) {
   const cwd = join(ROOT, dir);
   if (!existsSync(join(cwd, 'package-lock.json'))) {
-    console.error(`WARN: no lockfile in ${dir}, skipping`);
+    const msg = `no lockfile in ${dir}; tree not audited`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
     return null;
   }
   const fullAudit = runJson('npm', ['audit', '--json'], cwd);
   const prodAudit = runJson('npm', ['audit', '--omit=dev', '--json'], cwd);
-  if (!fullAudit) return null;
+  if (!fullAudit) {
+    const msg = `audit failed for ${dir}; tree not audited`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
+    return null;
+  }
   if (!prodAudit) {
     const msg = `prod audit failed for ${dir}; prod/dev split may under-report`;
     console.error(`WARN: ${msg}`);
@@ -78,6 +85,10 @@ try {
   const trees = AUDIT_DIRS.map((dir) => auditTree(dir, warnings)).filter(
     Boolean,
   );
+  // A dropped tree (missing lockfile or failed `npm audit`) means the audit
+  // itself is broken — distinct from "the audit ran and found nothing". This
+  // gates a separate Slack alert so a broken audit can't masquerade as clean.
+  const failed = trees.length < AUDIT_DIRS.length;
   const report = buildReport({ trees, warnings });
   const summary = buildStepSummary(report);
 
@@ -95,6 +106,7 @@ try {
       `post=${shouldPostSlack(report)}`,
       `color=${slackColor(report)}`,
       `total_hc=${prod.critical + prod.high + dev.critical + dev.high}`,
+      `failed=${failed}`,
       `prod_critical=${prod.critical}`,
       `prod_high=${prod.high}`,
       `dev_critical=${dev.critical}`,

--- a/scripts/dependency-audit-report.mjs
+++ b/scripts/dependency-audit-report.mjs
@@ -85,9 +85,8 @@ try {
   const trees = AUDIT_DIRS.map((dir) => auditTree(dir, warnings)).filter(
     Boolean,
   );
-  // A dropped tree (missing lockfile or failed `npm audit`) means the audit
-  // itself is broken — distinct from "the audit ran and found nothing". This
-  // gates a separate Slack alert so a broken audit can't masquerade as clean.
+  // A dropped tree means a lockfile couldn't be audited — a broken audit, not
+  // a clean one. Alert on it separately so it can't read as clean.
   const failed = trees.length < AUDIT_DIRS.length;
   const report = buildReport({ trees, warnings });
   const summary = buildStepSummary(report);

--- a/scripts/dependency-audit-report.mjs
+++ b/scripts/dependency-audit-report.mjs
@@ -17,28 +17,37 @@ import {
 const ROOT = process.cwd();
 
 function runJson(cmd, args, cwd) {
+  const label = `${cmd} ${args.join(' ')} in ${cwd}`;
+  let raw;
   try {
-    const out = execFileSync(cmd, args, {
+    raw = execFileSync(cmd, args, {
       cwd,
       encoding: 'utf8',
       maxBuffer: 1 << 28,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    return JSON.parse(out);
   } catch (err) {
     // npm audit exits non-zero when vulnerabilities exist but still prints JSON.
-    if (err.stdout) {
-      try {
-        return JSON.parse(err.stdout);
-      } catch {
-        /* fall through */
-      }
+    raw = err.stdout;
+    if (!raw) {
+      console.error(`WARN: ${label} failed: ${err.message}`);
+      return null;
     }
-    console.error(
-      `WARN: ${cmd} ${args.join(' ')} in ${cwd} failed: ${err.message}`,
-    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.error(`WARN: ${label} produced unparsable output`);
     return null;
   }
+  // npm serializes hard failures (bad lockfile, registry down) as {"error":…}
+  // even under --json. Treat that as a failed audit, not an empty clean one.
+  if (parsed && parsed.error) {
+    console.error(`WARN: ${label} reported: ${parsed.error.code || 'error'}`);
+    return null;
+  }
+  return parsed;
 }
 
 function auditTree(dir, warnings) {
@@ -57,16 +66,21 @@ function auditTree(dir, warnings) {
     warnings.push(msg);
     return null;
   }
-  if (!prodAudit) {
-    const msg = `prod audit failed for ${dir}; prod/dev split may under-report`;
-    console.error(`WARN: ${msg}`);
-    warnings.push(msg);
-  }
-  return analyzeTree({
+  const result = analyzeTree({
     tree: dir === '.' ? 'root' : dir,
     fullAudit,
-    prodAudit: prodAudit || { vulnerabilities: {} },
+    prodAudit,
   });
+  if (!prodAudit) {
+    // No prod/dev split available. analyzeTree counts every finding as prod so
+    // production exposure is never under-stated; flag the tree so the
+    // broken-audit alert fires and a human confirms the split.
+    const msg = `prod audit failed for ${dir}; findings counted as prod`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
+    result.incomplete = true;
+  }
+  return result;
 }
 
 function parseArgs(argv) {
@@ -85,9 +99,11 @@ try {
   const trees = AUDIT_DIRS.map((dir) => auditTree(dir, warnings)).filter(
     Boolean,
   );
-  // A dropped tree means a lockfile couldn't be audited — a broken audit, not
-  // a clean one. Alert on it separately so it can't read as clean.
-  const failed = trees.length < AUDIT_DIRS.length;
+  // The audit is broken if any tree was dropped (lockfile missing or `npm
+  // audit` failed) or came back incomplete (no prod/dev split). Alert on it
+  // separately so a broken audit can't read as clean.
+  const failed =
+    trees.length < AUDIT_DIRS.length || trees.some((t) => t.incomplete);
   const report = buildReport({ trees, warnings });
   const summary = buildStepSummary(report);
 
@@ -117,6 +133,11 @@ try {
   console.error(
     `ERROR: dependency-audit-report failed unexpectedly: ${err.stack || err.message}`,
   );
+  // A crash mid-report is itself a broken audit — signal it so the alert fires
+  // rather than the run looking like a quiet success.
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, 'post=false\nfailed=true\n');
+  }
 }
 
 process.exit(0);

--- a/scripts/dependency-audit-report.mjs
+++ b/scripts/dependency-audit-report.mjs
@@ -72,9 +72,8 @@ function auditTree(dir, warnings) {
     prodAudit,
   });
   if (!prodAudit) {
-    // No prod/dev split available. analyzeTree counts every finding as prod so
-    // production exposure is never under-stated; flag the tree so the
-    // broken-audit alert fires and a human confirms the split.
+    // Split unavailable — flag the tree so the broken-audit alert fires and a
+    // human confirms the counts.
     const msg = `prod audit failed for ${dir}; findings counted as prod`;
     console.error(`WARN: ${msg}`);
     warnings.push(msg);
@@ -99,8 +98,7 @@ try {
   const trees = AUDIT_DIRS.map((dir) => auditTree(dir, warnings)).filter(
     Boolean,
   );
-  // The audit is broken if any tree was dropped (lockfile missing or `npm
-  // audit` failed) or came back incomplete (no prod/dev split). Alert on it
+  // A dropped or incomplete tree means the audit didn't fully run — alert on it
   // separately so a broken audit can't read as clean.
   const failed =
     trees.length < AUDIT_DIRS.length || trees.some((t) => t.incomplete);

--- a/scripts/dependency-audit-report.mjs
+++ b/scripts/dependency-audit-report.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Runs `npm audit` across every lockfile and renders the vulnerability report.
+// Report-only: always exits 0. (Dead-dependency detection lives in the
+// `.ai/skills/dead-dependencies` skill — it is a local, interactive workflow.)
+import { execFileSync } from 'node:child_process';
+import { existsSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  AUDIT_DIRS,
+  analyzeTree,
+  buildReport,
+  buildStepSummary,
+  shouldPostSlack,
+  slackColor,
+} from './lib/dependency-audit-core.mjs';
+
+const ROOT = process.cwd();
+
+function runJson(cmd, args, cwd) {
+  try {
+    const out = execFileSync(cmd, args, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 1 << 28,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return JSON.parse(out);
+  } catch (err) {
+    // npm audit exits non-zero when vulnerabilities exist but still prints JSON.
+    if (err.stdout) {
+      try {
+        return JSON.parse(err.stdout);
+      } catch {
+        /* fall through */
+      }
+    }
+    console.error(
+      `WARN: ${cmd} ${args.join(' ')} in ${cwd} failed: ${err.message}`,
+    );
+    return null;
+  }
+}
+
+function auditTree(dir, warnings) {
+  const cwd = join(ROOT, dir);
+  if (!existsSync(join(cwd, 'package-lock.json'))) {
+    console.error(`WARN: no lockfile in ${dir}, skipping`);
+    return null;
+  }
+  const fullAudit = runJson('npm', ['audit', '--json'], cwd);
+  const prodAudit = runJson('npm', ['audit', '--omit=dev', '--json'], cwd);
+  if (!fullAudit) return null;
+  if (!prodAudit) {
+    const msg = `prod audit failed for ${dir}; prod/dev split may under-report`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
+  }
+  return analyzeTree({
+    tree: dir === '.' ? 'root' : dir,
+    fullAudit,
+    prodAudit: prodAudit || { vulnerabilities: {} },
+  });
+}
+
+function parseArgs(argv) {
+  const args = { github: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--github') args.github = true;
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+// Report-only: always exit 0 so this never fails a CI job on its own.
+try {
+  const warnings = [];
+  const trees = AUDIT_DIRS.map((dir) => auditTree(dir, warnings)).filter(
+    Boolean,
+  );
+  const report = buildReport({ trees, warnings });
+  const summary = buildStepSummary(report);
+
+  if (args.github && process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary + '\n');
+  } else {
+    process.stdout.write(summary + '\n');
+  }
+
+  // The Slack message is built inline in the workflow; emit only the counts
+  // and colour it templates in.
+  if (process.env.GITHUB_OUTPUT) {
+    const { prod, dev } = report.counts;
+    const outputs = [
+      `post=${shouldPostSlack(report)}`,
+      `color=${slackColor(report)}`,
+      `total_hc=${prod.critical + prod.high + dev.critical + dev.high}`,
+      `prod_critical=${prod.critical}`,
+      `prod_high=${prod.high}`,
+      `dev_critical=${dev.critical}`,
+      `dev_high=${dev.high}`,
+    ];
+    appendFileSync(process.env.GITHUB_OUTPUT, outputs.join('\n') + '\n');
+  }
+} catch (err) {
+  console.error(
+    `ERROR: dependency-audit-report failed unexpectedly: ${err.stack || err.message}`,
+  );
+}
+
+process.exit(0);

--- a/scripts/lib/dependency-audit-core.mjs
+++ b/scripts/lib/dependency-audit-core.mjs
@@ -1,0 +1,138 @@
+// Pure helpers for the dependency-audit report. No I/O, no shelling out.
+
+// The 12 independent lockfile directories (relative to repo root).
+export const AUDIT_DIRS = [
+  '.',
+  'redisinsight',
+  'redisinsight/api',
+  'tests/e2e-playwright',
+  'redisinsight/ui/src/packages',
+  'redisinsight/ui/src/packages/clients-list',
+  'redisinsight/ui/src/packages/geodata',
+  'redisinsight/ui/src/packages/redisearch',
+  'redisinsight/ui/src/packages/redisgraph',
+  'redisinsight/ui/src/packages/redisinsight-plugin-sdk',
+  'redisinsight/ui/src/packages/redistimeseries-app',
+  'redisinsight/ui/src/packages/ri-explain',
+];
+
+const HIGH_CRITICAL = new Set(['high', 'critical']);
+
+function firstAdvisory(vuln) {
+  const via = (vuln.via || []).find((v) => typeof v === 'object');
+  return via || { title: '(transitive)', url: '' };
+}
+
+export function analyzeTree({ tree, fullAudit, prodAudit }) {
+  const meta = (fullAudit.metadata && fullAudit.metadata.vulnerabilities) || {};
+  const totals = {
+    critical: meta.critical || 0,
+    high: meta.high || 0,
+    moderate: meta.moderate || 0,
+    low: meta.low || 0,
+  };
+  const prodVulns = (prodAudit && prodAudit.vulnerabilities) || {};
+  const findings = [];
+  for (const [name, vuln] of Object.entries(fullAudit.vulnerabilities || {})) {
+    if (!HIGH_CRITICAL.has(vuln.severity)) continue;
+    const adv = firstAdvisory(vuln);
+    findings.push({
+      name,
+      severity: vuln.severity,
+      tree,
+      scope: prodVulns[name] ? 'prod' : 'dev',
+      title: adv.title,
+      url: adv.url,
+    });
+  }
+  return { tree, totals, findings };
+}
+
+const SEVERITY_RANK = { critical: 0, high: 1 };
+
+export function buildReport({ trees, warnings }) {
+  const counts = {
+    prod: { critical: 0, high: 0 },
+    dev: { critical: 0, high: 0 },
+  };
+  const findings = [];
+  const byTree = [];
+  for (const t of trees) {
+    byTree.push({ tree: t.tree, totals: t.totals });
+    for (const f of t.findings) {
+      counts[f.scope][f.severity] += 1;
+      findings.push(f);
+    }
+  }
+  findings.sort(
+    (a, b) =>
+      SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
+      a.name.localeCompare(b.name),
+  );
+  return {
+    counts,
+    findings,
+    byTree,
+    warnings: warnings || [],
+  };
+}
+
+export function shouldPostSlack(report) {
+  const { prod, dev } = report.counts;
+  return prod.critical + prod.high + dev.critical + dev.high > 0;
+}
+
+export function buildStepSummary(report) {
+  const { counts, findings, byTree, warnings } = report;
+  const lines = [];
+  lines.push('# Dependency Audit');
+  lines.push('');
+  lines.push(
+    `**Prod:** ${counts.prod.critical} critical, ${counts.prod.high} high · ` +
+      `**Dev/all:** ${counts.dev.critical} critical, ${counts.dev.high} high`,
+  );
+  lines.push('');
+
+  if (warnings?.length) {
+    lines.push('## ⚠️ Warnings');
+    for (const w of warnings) lines.push(`- ${w}`);
+    lines.push('');
+  }
+
+  lines.push('## Per-tree totals');
+  lines.push('| Tree | Critical | High | Moderate | Low |');
+  lines.push('| --- | --- | --- | --- | --- |');
+  for (const { tree, totals } of byTree) {
+    lines.push(
+      `| ${tree} | ${totals.critical} | ${totals.high} | ${totals.moderate} | ${totals.low} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## High & critical advisories');
+  if (findings.length === 0) {
+    lines.push('_No high or critical advisories._');
+  } else {
+    lines.push('| Severity | Scope | Package | Tree | Advisory |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const f of findings) {
+      const link = f.url ? `[${f.title}](${f.url})` : f.title;
+      lines.push(
+        `| ${f.severity} | ${f.scope} | ${f.name} | ${f.tree} | ${link} |`,
+      );
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+export const SLACK_COLOR_CRITICAL = '#cc0000';
+export const SLACK_COLOR_HIGH = '#d29922';
+
+// The Slack message is built inline in the workflow; expose only its colour.
+export function slackColor(report) {
+  const { prod, dev } = report.counts;
+  return prod.critical + dev.critical > 0
+    ? SLACK_COLOR_CRITICAL
+    : SLACK_COLOR_HIGH;
+}

--- a/scripts/lib/dependency-audit-core.mjs
+++ b/scripts/lib/dependency-audit-core.mjs
@@ -31,6 +31,9 @@ export function analyzeTree({ tree, fullAudit, prodAudit }) {
     moderate: meta.moderate || 0,
     low: meta.low || 0,
   };
+  // Without a prod-only audit we can't tell prod from dev; count every finding
+  // as prod so production exposure is never under-stated.
+  const prodUnknown = !prodAudit;
   const prodVulns = (prodAudit && prodAudit.vulnerabilities) || {};
   const findings = [];
   for (const [name, vuln] of Object.entries(fullAudit.vulnerabilities || {})) {
@@ -40,7 +43,7 @@ export function analyzeTree({ tree, fullAudit, prodAudit }) {
       name,
       severity: vuln.severity,
       tree,
-      scope: prodVulns[name] ? 'prod' : 'dev',
+      scope: prodUnknown || prodVulns[name] ? 'prod' : 'dev',
       title: adv.title,
       url: adv.url,
     });

--- a/scripts/lib/dependency-audit-core.test.mjs
+++ b/scripts/lib/dependency-audit-core.test.mjs
@@ -1,0 +1,261 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  analyzeTree,
+  buildReport,
+  shouldPostSlack,
+  buildStepSummary,
+  slackColor,
+  SLACK_COLOR_CRITICAL,
+  SLACK_COLOR_HIGH,
+} from './dependency-audit-core.mjs';
+
+const FULL = {
+  vulnerabilities: {
+    protobufjs: {
+      name: 'protobufjs',
+      severity: 'critical',
+      via: [
+        {
+          title: 'Arbitrary code execution in protobufjs',
+          url: 'https://ghsa/xq3m',
+          severity: 'critical',
+          range: '<7.5.5',
+        },
+      ],
+      range: '<=7.6.2',
+      fixAvailable: true,
+    },
+    'shell-quote': {
+      name: 'shell-quote',
+      severity: 'critical',
+      via: [
+        {
+          title: 'shell-quote newline injection',
+          url: 'https://ghsa/g4rg',
+          severity: 'critical',
+          range: '<=1.8.3',
+        },
+      ],
+      range: '1.1.0 - 1.8.3',
+      fixAvailable: true,
+    },
+    lodash: {
+      name: 'lodash',
+      severity: 'moderate',
+      via: [
+        {
+          title: 'prototype pollution',
+          url: 'https://ghsa/lodash',
+          severity: 'moderate',
+          range: '*',
+        },
+      ],
+      range: '*',
+      fixAvailable: true,
+    },
+  },
+  metadata: {
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: 1,
+      high: 0,
+      critical: 2,
+      total: 3,
+    },
+  },
+};
+// Only protobufjs is a production dependency.
+const PROD = {
+  vulnerabilities: {
+    protobufjs: FULL.vulnerabilities.protobufjs,
+  },
+  metadata: {
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: 0,
+      high: 0,
+      critical: 1,
+      total: 1,
+    },
+  },
+};
+
+test('analyzeTree returns per-tree totals from metadata', () => {
+  const r = analyzeTree({ tree: 'root', fullAudit: FULL, prodAudit: PROD });
+  assert.deepEqual(r.totals, { critical: 2, high: 0, moderate: 1, low: 0 });
+  assert.equal(r.tree, 'root');
+});
+
+test('analyzeTree emits only high/critical findings', () => {
+  const r = analyzeTree({ tree: 'root', fullAudit: FULL, prodAudit: PROD });
+  assert.equal(r.findings.length, 2); // lodash (moderate) excluded
+  assert.ok(
+    r.findings.every((f) => f.severity === 'critical' || f.severity === 'high'),
+  );
+});
+
+test('analyzeTree tags prod vs dev via the prod audit', () => {
+  const r = analyzeTree({ tree: 'root', fullAudit: FULL, prodAudit: PROD });
+  const byName = Object.fromEntries(r.findings.map((f) => [f.name, f]));
+  assert.equal(byName.protobufjs.scope, 'prod');
+  assert.equal(byName['shell-quote'].scope, 'dev');
+  assert.equal(
+    byName.protobufjs.title,
+    'Arbitrary code execution in protobufjs',
+  );
+  assert.equal(byName.protobufjs.url, 'https://ghsa/xq3m');
+});
+
+test('analyzeTree tolerates empty audit', () => {
+  const empty = {
+    vulnerabilities: {},
+    metadata: {
+      vulnerabilities: {
+        info: 0,
+        low: 0,
+        moderate: 0,
+        high: 0,
+        critical: 0,
+        total: 0,
+      },
+    },
+  };
+  const r = analyzeTree({ tree: 'x', fullAudit: empty, prodAudit: empty });
+  assert.deepEqual(r.findings, []);
+  assert.deepEqual(r.totals, { critical: 0, high: 0, moderate: 0, low: 0 });
+});
+
+test('buildReport aggregates prod/dev counts and sorts findings', () => {
+  const trees = [
+    {
+      tree: 'root',
+      totals: { critical: 1, high: 1, moderate: 0, low: 0 },
+      findings: [
+        {
+          name: 'protobufjs',
+          severity: 'critical',
+          tree: 'root',
+          scope: 'prod',
+          title: 't',
+          url: 'u',
+        },
+        {
+          name: 'form-data',
+          severity: 'high',
+          tree: 'root',
+          scope: 'prod',
+          title: 't',
+          url: 'u',
+        },
+      ],
+    },
+    {
+      tree: 'redisinsight/api',
+      totals: { critical: 1, high: 0, moderate: 0, low: 0 },
+      findings: [
+        {
+          name: 'shell-quote',
+          severity: 'critical',
+          tree: 'redisinsight/api',
+          scope: 'dev',
+          title: 't',
+          url: 'u',
+        },
+      ],
+    },
+  ];
+  const report = buildReport({ trees });
+  assert.deepEqual(report.counts.prod, { critical: 1, high: 1 });
+  assert.deepEqual(report.counts.dev, { critical: 1, high: 0 });
+  assert.equal(report.findings[0].severity, 'critical'); // critical sorted first
+  assert.equal(report.byTree.length, 2);
+});
+
+test('buildReport defaults warnings to [] when omitted', () => {
+  const report = buildReport({ trees: [] });
+  assert.deepEqual(report.warnings, []);
+});
+
+test('shouldPostSlack is true only with high/critical', () => {
+  const none = {
+    counts: { prod: { critical: 0, high: 0 }, dev: { critical: 0, high: 0 } },
+  };
+  const some = {
+    counts: { prod: { critical: 0, high: 0 }, dev: { critical: 0, high: 1 } },
+  };
+  assert.equal(shouldPostSlack(none), false);
+  assert.equal(shouldPostSlack(some), true);
+});
+
+test('buildStepSummary includes counts, findings, and per-tree table', () => {
+  const report = {
+    counts: { prod: { critical: 1, high: 0 }, dev: { critical: 1, high: 0 } },
+    findings: [
+      {
+        name: 'protobufjs',
+        severity: 'critical',
+        tree: 'root',
+        scope: 'prod',
+        title: 'ACE',
+        url: 'https://ghsa/x',
+      },
+      {
+        name: 'shell-quote',
+        severity: 'critical',
+        tree: 'redisinsight/api',
+        scope: 'dev',
+        title: 'newline',
+        url: 'https://ghsa/y',
+      },
+    ],
+    byTree: [
+      { tree: 'root', totals: { critical: 1, high: 0, moderate: 2, low: 0 } },
+    ],
+  };
+  const md = buildStepSummary(report);
+  assert.match(md, /Dependency Audit/);
+  assert.match(md, /protobufjs/);
+  assert.match(md, /shell-quote/);
+  assert.match(md, /\| root \|/); // per-tree table row
+  assert.match(md, /https:\/\/ghsa\/x/); // advisory link
+});
+
+test('buildStepSummary handles a clean report', () => {
+  const md = buildStepSummary({
+    counts: { prod: { critical: 0, high: 0 }, dev: { critical: 0, high: 0 } },
+    findings: [],
+    byTree: [],
+  });
+  assert.match(md, /No high or critical/);
+});
+
+test('buildStepSummary renders a Warnings section when present', () => {
+  const md = buildStepSummary({
+    counts: { prod: { critical: 0, high: 0 }, dev: { critical: 0, high: 0 } },
+    findings: [],
+    byTree: [],
+    warnings: [
+      'prod audit failed for redisinsight; prod/dev split may under-report',
+    ],
+  });
+  assert.match(md, /## ⚠️ Warnings/);
+  assert.match(md, /prod audit failed for redisinsight/);
+});
+
+test('slackColor is red when any critical present, orange when only high', () => {
+  assert.equal(
+    slackColor({
+      counts: { prod: { critical: 1, high: 0 }, dev: { critical: 0, high: 0 } },
+    }),
+    SLACK_COLOR_CRITICAL,
+  );
+  assert.equal(
+    slackColor({
+      counts: { prod: { critical: 0, high: 2 }, dev: { critical: 0, high: 1 } },
+    }),
+    SLACK_COLOR_HIGH,
+  );
+});

--- a/scripts/lib/dependency-audit-core.test.mjs
+++ b/scripts/lib/dependency-audit-core.test.mjs
@@ -109,6 +109,13 @@ test('analyzeTree tags prod vs dev via the prod audit', () => {
   assert.equal(byName.protobufjs.url, 'https://ghsa/xq3m');
 });
 
+test('analyzeTree counts findings as prod when the prod audit is absent', () => {
+  // A failed prod-only audit must not downgrade real prod vulns to dev.
+  const r = analyzeTree({ tree: 'root', fullAudit: FULL, prodAudit: null });
+  assert.equal(r.findings.length, 2);
+  assert.ok(r.findings.every((f) => f.scope === 'prod'));
+});
+
 test('analyzeTree tolerates empty audit', () => {
   const empty = {
     vulnerabilities: {},


### PR DESCRIPTION
# What

Adds automated visibility into dependency health after the npm migration, in
two parts:

**1. Scheduled vulnerability audit** (`ci(deps)`)
A weekly (Mon 07:00 UTC) + manual GitHub Actions workflow that runs `npm audit`
across all 12 lockfiles and reports the result:
- Full report in the Actions run step-summary (per-tree severity table +
  high/critical advisory list, prod vs dev labelled).
- Slack alert **only** on high/critical findings — same channel/secrets and
  inline-payload style as the E2E nightly flow.
- Report-only (never fails the job); no dependency install needed (audit reads
  lockfiles). Logic lives in a pure, unit-tested core module.

**2. `dead-dependencies` skill** (`docs(deps)`)
A repo skill capturing the reliable local workflow for finding/removing unused
deps — grep for real usage → `npm ls` leaf-check → classify → build/type-check
/test gate. Static tools (knip/depcheck) over-report badly in this repo, so
this stays a guided local task rather than a noisy scheduled report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation-only changes; audit is read-only on lockfiles and does not modify dependencies or application runtime code.
> 
> **Overview**
> Adds **scheduled dependency vulnerability visibility** and **documented guidance** for safely removing unused packages after the npm migration.
> 
> A new **Dependency Audit** GitHub Actions workflow runs weekly (Mon 07:00 UTC) and on manual dispatch. It runs `npm audit` across **12 lockfile trees** without installing `node_modules`, writes a markdown report to the job step summary (per-tree severities, high/critical advisories with **prod vs dev** scope), and posts to Slack **only** when high/critical findings exist. Separate Slack paths cover incomplete audits and workflow failures so a broken run cannot look clean. Reporting is **report-only** (script always exits 0).
> 
> New **`scripts/dependency-audit-report.mjs`** shells out to `npm audit` (full + `--omit=dev` per tree) and delegates aggregation to a **unit-tested** `scripts/lib/dependency-audit-core.mjs`. Root **`deps:audit`** and **`test:scripts`** npm scripts run the report locally and the core tests in CI.
> 
> A new **`.ai/skills/dead-dependencies`** skill documents a local grep → config/scripts check → `npm ls` leaf check → classify → type-check/test/build gate workflow for removing dead deps (explicitly not knip/depcheck), complementing the audit which only surfaces vulnerabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a709ae36d6f97494b229f1a622bba0ecd7e70125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->