### PR TITLE
Fix Windows build: use cmd.exe-valid path for build:statics:win

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "i18n:extract": "i18next-cli extract",
     "i18n:check": "node ./scripts/check-i18n-locales.js",
     "build:statics": "npm run build:defaults && sh ./scripts/build-statics.sh",
-    "build:statics:win": "npm run build:defaults && ./scripts/build-statics.cmd",
+    "build:statics:win": "npm run build:defaults && .\\scripts\\build-statics.cmd",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir redisinsight",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --cache --cache-strategy content",
     "lint:ui": "eslint ./redisinsight/ui --ext .js,.jsx,.ts,.tsx --cache --cache-strategy content",


### PR DESCRIPTION
# What

The `build:statics:win` npm script invoked `./scripts/build-statics.cmd`, a
POSIX-style path. npm runs scripts through cmd.exe on Windows, where a leading
`./` is invalid — the Windows build failed at "Install plugins dependencies and
build plugins" with:

    '.' is not recognized as an internal or external command

yarn classic tolerated the `./` prefix, so this only surfaced after the
yarn → npm migration (#6216). Changed the invocation to `.\scripts\build-statics.cmd`,
matching the backslash convention the batch file already uses internally.

Swept the rest of the migration for the same class of bug: this was the only
occurrence. All other `./` paths in npm scripts are command *arguments*
(`node ./…`, `eslint ./…`, etc.), which cmd.exe passes through fine, or
non-script JSON fields.

# Testing

Check this pipeline: https://github.com/redis/RedisInsight/actions/runs/29825280976/job/88617142941

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single npm script path change for Windows builds only; no runtime, auth, or application logic affected.
> 
> **Overview**
> Fixes the Windows static assets build step by changing how `build:statics:win` invokes the batch file.
> 
> The script now runs `.\scripts\build-statics.cmd` instead of `./scripts/build-statics.cmd`. Under npm on Windows (cmd.exe), a leading `./` on a standalone command is treated as invalid and caused the plugins/statics step to fail with `'.' is not recognized as an internal or external command` after the yarn→npm migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe44ebe1ee5ace571c5bbc0cfdc9ab1e0197f23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->