### PR TITLE
feat(vector-search): drop the vectorSearchV2 feature flag

### DIFF
--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -32,7 +32,6 @@ export enum KnownFeatures {
   EnhancedCloudUI = 'enhancedCloudUI',
   DatabaseManagement = 'databaseManagement',
   CustomTutorials = 'customTutorials',
-  VectorSearchV2 = 'vectorSearchV2',
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -66,11 +66,6 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
       flag: SERVER_CONFIG.customTutorials,
     }),
   },
-  [KnownFeatures.VectorSearchV2]: {
-    name: KnownFeatures.VectorSearchV2,
-    storage: FeatureStorage.Database,
-  },
-
   [KnownFeatures.AzureEntraId]: {
     name: KnownFeatures.AzureEntraId,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -85,13 +85,6 @@ export class FeatureFlagProvider {
       ),
     );
     this.strategies.set(
-      KnownFeatures.VectorSearchV2,
-      new SwitchableFlagStrategy(
-        this.featuresConfigService,
-        this.settingsService,
-      ),
-    );
-    this.strategies.set(
       KnownFeatures.AzureEntraId,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );

--- a/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
+++ b/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
@@ -74,13 +74,11 @@ const INSTANCE_ROUTES: IRoute[] = [
     path: Pages.browser(':instanceId'),
     component: LAZY_LOAD ? LazyBrowserPage : BrowserPage,
   },
-  // Vector search route - behind feature flag
   {
     pageName: PageNames.vectorSearch,
     path: Pages.vectorSearch(':instanceId'),
     component: LAZY_LOAD ? LazyVectorSearchPageRouter : VectorSearchPageRouter,
     routes: VECTOR_SEARCH_ROUTES,
-    featureFlag: FeatureFlags.vectorSearchV2,
   },
   {
     pageName: PageNames.workbench,

--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react'
 import { Props as HighlightedFeatureProps } from 'uiSrc/components/hightlighted-feature/HighlightedFeature'
 import { ANALYTICS_ROUTES } from 'uiSrc/components/main-router/constants/sub-routes'
 import {
-  appFeatureFlagsFeaturesSelector,
   appFeaturePagesHighlightingSelector,
   removeFeatureFromHighlighting,
 } from 'uiSrc/slices/app/features'
@@ -48,9 +47,6 @@ export function useNavigation() {
     connectedRdiInstanceSelector,
   )
   const highlightedPages = useAppSelector(appFeaturePagesHighlightingSelector)
-  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useAppSelector(
-    appFeatureFlagsFeaturesSelector,
-  )
 
   const isRdiWorkspace = workspace === AppWorkspace.RDI
 
@@ -99,7 +95,7 @@ export function useNavigation() {
       iconType: BrowserIcon,
       onboard: ONBOARDING_FEATURES.BROWSER_PAGE,
     },
-    vectorSearchFeature?.flag && {
+    {
       tooltipText: 'Search',
       pageName: PageNames.vectorSearch,
       ariaLabel: 'Search',

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.spec.tsx
@@ -27,7 +27,7 @@ import {
   resetCliSettings,
 } from 'uiSrc/slices/cli/cli-settings'
 import { setMonitorInitialState, showMonitor } from 'uiSrc/slices/cli/monitor'
-import { FeatureFlags, Pages } from 'uiSrc/constants'
+import { Pages } from 'uiSrc/constants'
 import {
   dbAnalysisSelector,
   setDatabaseAnalysisViewTab,
@@ -602,37 +602,7 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should skip vector search step and navigate to workbench on next when vectorSearchV2 is off', () => {
-      const pushMock = jest.fn()
-      reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
-
-      render(
-        <OnboardingTour options={ONBOARDING_FEATURES.BROWSER_PROFILER}>
-          <span />
-        </OnboardingTour>,
-      )
-      fireEvent.click(screen.getByTestId('next-btn'))
-
-      expect(pushMock).toHaveBeenCalledWith(Pages.workbench(''))
-
-      const expectedActions = [
-        resetCliSettings(),
-        resetCliHelperSettings(),
-        setMonitorInitialState(),
-        setOnboardNextStep(),
-        setOnboardNextStep(),
-      ]
-      expect(clearStoreActions(store.getActions())).toEqual(
-        clearStoreActions(expectedActions),
-      )
-    })
-
-    it('should navigate to vector search on next when vectorSearchV2 is on', () => {
-      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
-        databaseChat: { flag: false },
-        [FeatureFlags.vectorSearchV2]: { flag: true },
-      })
-
+    it('should navigate to vector search on next', () => {
       const pushMock = jest.fn()
       reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
 
@@ -905,35 +875,7 @@ describe('ONBOARDING_FEATURES', () => {
       )
     })
 
-    it('should skip vector search step and navigate to browser on back when vectorSearchV2 is off', () => {
-      const pushMock = jest.fn()
-      reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
-
-      render(
-        <OnboardingTour options={ONBOARDING_FEATURES.WORKBENCH_PAGE}>
-          <span />
-        </OnboardingTour>,
-      )
-      fireEvent.click(screen.getByTestId('back-btn'))
-
-      expect(pushMock).toHaveBeenCalledWith(Pages.browser(''))
-
-      const expectedActions = [
-        setOnboardPrevStep(),
-        showMonitor(),
-        setOnboardPrevStep(),
-      ]
-      expect(clearStoreActions(store.getActions().slice(-3))).toEqual(
-        clearStoreActions(expectedActions),
-      )
-    })
-
-    it('should navigate to vector search on back when vectorSearchV2 is on', () => {
-      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
-        databaseChat: { flag: false },
-        [FeatureFlags.vectorSearchV2]: { flag: true },
-      })
-
+    it('should navigate to vector search on back', () => {
       const pushMock = jest.fn()
       reactRouterDom.useHistory = jest.fn().mockReturnValue({ push: pushMock })
 

--- a/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
+++ b/redisinsight/ui/src/components/onboarding-features/OnboardingFeatures.tsx
@@ -268,8 +268,6 @@ const ONBOARDING_FEATURES = {
       const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
-      const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } =
-        useAppSelector(appFeatureFlagsFeaturesSelector)
 
       const dispatch = useAppDispatch()
       const history = useHistory()
@@ -301,12 +299,7 @@ const ONBOARDING_FEATURES = {
           dispatch(resetCliHelperSettings())
           dispatch(setMonitorInitialState())
 
-          if (vectorSearchFeature?.flag) {
-            history.push(Pages.vectorSearch(connectedInstanceId))
-          } else {
-            dispatch(setOnboardNextStep())
-            history.push(Pages.workbench(connectedInstanceId))
-          }
+          history.push(Pages.vectorSearch(connectedInstanceId))
 
           sendNextTelemetryEvent(...telemetryArgs)
         },
@@ -359,8 +352,6 @@ const ONBOARDING_FEATURES = {
       const { id: connectedInstanceId = '' } = useAppSelector(
         connectedInstanceSelector,
       )
-      const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } =
-        useAppSelector(appFeatureFlagsFeaturesSelector)
       const [firstIndex, setFirstIndex] = useState<Nullable<string>>(null)
 
       const dispatch = useAppDispatch()
@@ -445,13 +436,7 @@ const ONBOARDING_FEATURES = {
         ),
         onSkip: () => sendClosedTelemetryEvent(...telemetryArgs),
         onBack: () => {
-          if (vectorSearchFeature?.flag) {
-            history.push(Pages.vectorSearch(connectedInstanceId))
-          } else {
-            history.push(Pages.browser(connectedInstanceId))
-            dispatch(setOnboardPrevStep())
-            dispatch(showMonitor())
-          }
+          history.push(Pages.vectorSearch(connectedInstanceId))
 
           sendBackTelemetryEvent(...telemetryArgs)
         },

--- a/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
+++ b/redisinsight/ui/src/components/onboarding-tour/OnboardingTour.tsx
@@ -1,15 +1,12 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import React, { useEffect, useState } from 'react'
+import { useAppDispatch } from 'uiSrc/slices/hooks'
 import cx from 'classnames'
 
 import {
-  appFeatureFlagsFeaturesSelector,
   skipOnboarding,
   setOnboardNextStep,
   setOnboardPrevStep,
 } from 'uiSrc/slices/app/features'
-import { FeatureFlags } from 'uiSrc/constants'
-import { OnboardingSteps } from 'uiSrc/constants/onboarding'
 import { CancelSlimIcon } from 'uiSrc/components/base/icons'
 import {
   EmptyButton,
@@ -53,23 +50,8 @@ const OnboardingTour = (props: Props) => {
     onSkip = () => {},
   } = Inner ? Inner() : {}
 
-  const { [FeatureFlags.vectorSearchV2]: vectorSearchFeature } = useAppSelector(
-    appFeatureFlagsFeaturesSelector,
-  )
-
   const [isOpen, setIsOpen] = useState(step === currentStep && isActive)
   const isLastStep = currentStep === totalSteps
-
-  const { displayStep, displayTotalSteps } = useMemo(() => {
-    const skippedSteps = vectorSearchFeature?.flag ? 0 : 1
-    return {
-      displayStep:
-        currentStep > OnboardingSteps.VectorSearchPage
-          ? currentStep - skippedSteps
-          : currentStep,
-      displayTotalSteps: totalSteps - skippedSteps,
-    }
-  }, [currentStep, totalSteps, vectorSearchFeature?.flag])
 
   const dispatch = useAppDispatch()
 
@@ -133,7 +115,7 @@ const OnboardingTour = (props: Props) => {
       <Spacer />
       <Row align="center" justify="between">
         <ColorText data-testid="step-progress">
-          {displayStep} of {displayTotalSteps}
+          {currentStep} of {totalSteps}
         </ColorText>
         <Row grow={false} gap="m">
           {currentStep > 1 && (

--- a/redisinsight/ui/src/constants/content/whats-new/versions/v3.4.1.ts
+++ b/redisinsight/ui/src/constants/content/whats-new/versions/v3.4.1.ts
@@ -11,7 +11,6 @@ export const version341: WhatsNewVersion = {
       title: 'Dedicated Search workspace',
       body: 'A new Search workspace with full index lifecycle support: create indexes from sample or existing data, query indexed data with an assisted editor, and save queries to a Query Library for reuse.',
       location: 'Search workspace in the main database navigation',
-      featureFlag: FeatureFlags.vectorSearchV2,
     },
     {
       id: 'azure-integration-enhancements',

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -11,7 +11,6 @@ export enum FeatureFlags {
   cloudAds = 'cloudAds',
   databaseManagement = 'databaseManagement',
   customTutorials = 'customTutorials',
-  vectorSearchV2 = 'vectorSearchV2',
   vectorSet = 'vectorSet',
   array = 'array',
   azureEntraId = 'azureEntraId',

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -92,8 +92,6 @@ const BrowserPage = () => {
   const overview = useAppSelector(connectedInstanceOverviewSelector)
   const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
   const isDevBrowser = featureFlags?.[FeatureFlags.devBrowser]?.flag ?? false
-  const isVectorSearch =
-    featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
   const panelMinSize = isDevBrowser ? 20 : 45
   const panelDefaultSize = 50
 
@@ -232,12 +230,11 @@ const BrowserPage = () => {
 
   const handleCreateIndexPanel = useCallback(
     (value: boolean) => {
-      if (value && isVectorSearch) {
+      if (value) {
         history.push(Pages.vectorSearch(instanceId))
-        return
       }
     },
-    [isVectorSearch, instanceId],
+    [instanceId],
   )
 
   const closeRightPanels = useCallback(() => {

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
@@ -29,7 +29,7 @@ import { localStorageService } from 'uiSrc/services'
 import { SearchMode } from 'uiSrc/slices/interfaces/keys'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
-import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
+import { BrowserStorageItem } from 'uiSrc/constants'
 import RediSearchIndexesList, { Props } from './RediSearchIndexesList'
 import { INSTANCE_ID_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 import { setStoreRef } from 'uiSrc/utils/test-store'
@@ -120,19 +120,6 @@ describe('RediSearchIndexesList', () => {
               connectedInstance: {
                 ...state.connections.instances.connectedInstance,
                 modules: [{ name: RedisDefaultModules.Search }],
-              },
-            },
-          },
-          app: {
-            ...state.app,
-            features: {
-              ...state.app.features,
-              featureFlags: {
-                ...state.app.features.featureFlags,
-                features: {
-                  ...state.app.features.featureFlags?.features,
-                  [FeatureFlags.vectorSearchV2]: { flag: true },
-                },
               },
             },
           },

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -29,8 +29,7 @@ import {
   SCAN_TREE_COUNT_DEFAULT,
 } from 'uiSrc/constants/api'
 import { localStorageService } from 'uiSrc/services'
-import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
-import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
+import { BrowserStorageItem } from 'uiSrc/constants'
 
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { PlusIcon, ResetIcon } from 'uiSrc/components/base/icons'
@@ -63,9 +62,6 @@ const RediSearchIndexesList = (props: Props) => {
   } = useAppSelector(connectedInstanceSelector)
 
   const selectedValue = selectedIndex ? bufferToString(selectedIndex) : ''
-  const featureFlags = useAppSelector(appFeatureFlagsFeaturesSelector)
-  const isVectorSearch =
-    featureFlags?.[FeatureFlags.vectorSearchV2]?.flag ?? false
 
   const dispatch = useAppDispatch()
   const location = useLocation()
@@ -157,25 +153,23 @@ const RediSearchIndexesList = (props: Props) => {
     }
   })
 
-  if (isVectorSearch) {
-    options.push({
-      value: CREATE,
-      inputDisplay: <span>CREATE</span>,
-      dropdownDisplay: (
-        <Row align="center" justify="start" gap="xs">
-          <PlusIcon size="M" />
-          <Text
-            size="M"
-            variant="semiBold"
-            color="primary"
-            data-testid="create-index-btn"
-          >
-            Create Index
-          </Text>
-        </Row>
-      ),
-    })
-  }
+  options.push({
+    value: CREATE,
+    inputDisplay: <span>CREATE</span>,
+    dropdownDisplay: (
+      <Row align="center" justify="start" gap="xs">
+        <PlusIcon size="M" />
+        <Text
+          size="M"
+          variant="semiBold"
+          color="primary"
+          data-testid="create-index-btn"
+        >
+          Create Index
+        </Text>
+      </Row>
+    ),
+  })
 
   const onChangeIndex = (value: string) => {
     if (value === CREATE) {

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/KeyDetailsHeader.tsx
@@ -169,24 +169,22 @@ const KeyDetailsHeader = ({
                 <FlexItem grow />
                 {isSearchableType &&
                   keyIndexedStatus === UseIsKeyIndexedStatus.Ready && (
-                    <FeatureFlagComponent name={FeatureFlags.vectorSearchV2}>
-                      <FlexItem>
-                        {indexes.length > 0 ? (
-                          <ViewIndexDataButton
-                            indexes={indexes}
-                            instanceId={instanceId}
+                    <FlexItem>
+                      {indexes.length > 0 ? (
+                        <ViewIndexDataButton
+                          indexes={indexes}
+                          instanceId={instanceId}
+                        />
+                      ) : (
+                        <S.MakeSearchableWrapper>
+                          <MakeSearchableButton
+                            keyName={keyBuffer!}
+                            keyNameString={keyName ?? ''}
+                            keyType={type as KeyTypes}
                           />
-                        ) : (
-                          <S.MakeSearchableWrapper>
-                            <MakeSearchableButton
-                              keyName={keyBuffer!}
-                              keyNameString={keyName ?? ''}
-                              keyType={type as KeyTypes}
-                            />
-                          </S.MakeSearchableWrapper>
-                        )}
-                      </FlexItem>
-                    </FeatureFlagComponent>
+                        </S.MakeSearchableWrapper>
+                      )}
+                    </FlexItem>
                   )}
                 {type === KeyTypes.Hash && (
                   <FeatureFlagComponent name={FeatureFlags.valueDecoder}>

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -62,9 +62,6 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.cloudAds]: {
         flag: riConfig.features.cloudAds.defaultFlag,
       },
-      [FeatureFlags.vectorSearchV2]: {
-        flag: false,
-      },
       [FeatureFlags.vectorSet]: {
         flag: false,
       },

--- a/tests/e2e-playwright/tests/serial/vector-search/browser-integration/browser-integration.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/browser-integration/browser-integration.spec.ts
@@ -10,8 +10,6 @@ const TEST_INDEX_PREFIX = `test-vs-browser-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-browser-${uniqueId}-idx`;
 const TEST_INDEX_NAME_2 = `test-vs-browser-${uniqueId}-idx2`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Browser Page Integration
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/create-index/existing-data.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/create-index/existing-data.spec.ts
@@ -17,8 +17,6 @@ const TEST_HASH_KEY = hashKey.keyName;
 const TEST_JSON_KEY = jsonKey.keyName;
 const seedIndex = IndexConfigFactory.build();
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Create Index - Existing Data
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/create-index/onboarding.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/create-index/onboarding.spec.ts
@@ -11,8 +11,6 @@ const TEST_SELECT_KEY = `${TEST_INDEX_PREFIX}:selkey`;
 const TEST_CREATE_KEY = `${TEST_INDEX_PREFIX}:crtkey`;
 const seedIndex = IndexConfigFactory.build();
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Select Key Onboarding
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/create-index/sample-data.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/create-index/sample-data.spec.ts
@@ -12,8 +12,6 @@ const SAMPLE_DATASETS = [
   { id: 'content-recommendations', label: 'Content Recommendations (Movies)', expectedQueryCount: 5 },
 ] as const;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Create Index - Sample Data
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/list-indexes/create-index.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/list-indexes/create-index.spec.ts
@@ -10,8 +10,6 @@ const seedIndex = IndexConfigFactory.build();
 const SAMPLE_INDEX_NAMES = ['idx:bikes_vss', 'idx:movies_vss'];
 const SAMPLE_KEY_PREFIXES = ['bikes:*', 'movie:*'];
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Create Index from List Page
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/list-indexes/list-indexes.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/list-indexes/list-indexes.spec.ts
@@ -8,8 +8,6 @@ const uniqueId = faker.string.alphanumeric(6);
 const TEST_INDEX_PREFIX = `test-vs-list-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-list-${uniqueId}-idx`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > List Indexes
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/navigation/navigation.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/navigation/navigation.spec.ts
@@ -12,8 +12,6 @@ const uniqueId = faker.string.alphanumeric(6);
 const TEST_INDEX_PREFIX = `test-vs-nav-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-nav-${uniqueId}-idx`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Navigation and RQE Availability
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/query/query-editor.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/query/query-editor.spec.ts
@@ -8,8 +8,6 @@ const uniqueId = faker.string.alphanumeric(6);
 const TEST_INDEX_PREFIX = `test-vs-query-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-query-${uniqueId}-idx`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Query Page
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/query/query-library.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/query/query-library.spec.ts
@@ -9,8 +9,6 @@ const TEST_INDEX_PREFIX = `test-vs-lib-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-lib-${uniqueId}-idx`;
 const TEST_QUERY = '* => [KNN 10 @vec $BLOB]';
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 test.describe('Vector Search > Query Library', () => {
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/serial/vector-search/query/query-onboarding.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/query/query-onboarding.spec.ts
@@ -8,8 +8,6 @@ const uniqueId = faker.string.alphanumeric(6);
 const TEST_INDEX_PREFIX = `test-vs-qonboard-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-qonboard-${uniqueId}-idx`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Query Page Onboarding
  *

--- a/tests/e2e-playwright/tests/serial/vector-search/query/save-query.spec.ts
+++ b/tests/e2e-playwright/tests/serial/vector-search/query/save-query.spec.ts
@@ -8,8 +8,6 @@ const uniqueId = faker.string.alphanumeric(6);
 const TEST_INDEX_PREFIX = `test-vs-save-${uniqueId}:`;
 const TEST_INDEX_NAME = `test-vs-save-${uniqueId}-idx`;
 
-test.use({ featureFlags: { vectorSearchV2: true } });
-
 /**
  * Vector Search > Save Query
  *


### PR DESCRIPTION
## Summary

Vector search is stable and fully rolled out, so this removes the `vectorSearchV2` feature-flag gating and makes the feature always on.

The flag is kept in `features-config.json` only, so older app versions still receive it as enabled. Everything else is removed:
- **UI**: all gating (route, nav, browser, onboarding, What's New) plus the FE enum + default state
- **Backend**: `KnownFeatures` entry, known-features record, and strategy registration
- **E2E**: the now no-op `featureFlags: { vectorSearchV2: true }` overrides

## Testing
- `yarn type-check` and `yarn lint` — clean
- Affected UI specs and `feature-flag.provider.spec.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-removal and UX un-gating only; no new auth or data paths. Slightly wider exposure of Search for builds that previously had the flag off in app code.
> 
> **Overview**
> Removes **`vectorSearchV2`** now that the Search workspace is always on. The dedicated Search route, nav item, browser “Create index” / make-searchable actions, and onboarding paths no longer check a flag.
> 
> **Backend:** `KnownFeatures.VectorSearchV2`, its known-features entry, and `SwitchableFlagStrategy` registration are deleted from the feature module.
> 
> **UI:** The flag is removed from `FeatureFlags`, Redux defaults, route `featureFlag`, What's New card gating, and conditional wrappers in browser/onboarding/tour components. Onboarding always routes through Search and shows full step counts.
> 
> **Tests:** E2E specs drop `test.use({ featureFlags: { vectorSearchV2: true } })`; unit tests are simplified for the unconditional flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e830c1dce43bc0a3849300d1a71a7ad16ec2c425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->