### PR TITLE
chore: remove prodMode feature flag code references

### DIFF
--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -38,7 +38,6 @@ export enum KnownFeatures {
   DevBrowser = 'dev-browser',
   VectorSet = 'vectorSet',
   Array = 'array',
-  ProdMode = 'prodMode',
   DevLanguage = 'dev-language',
   WhatsNew = 'whatsNew',
   ValueDecoder = 'valueDecoder',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -91,10 +91,6 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.Array,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.ProdMode]: {
-    name: KnownFeatures.ProdMode,
-    storage: FeatureStorage.Database,
-  },
   [KnownFeatures.DevLanguage]: {
     name: KnownFeatures.DevLanguage,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -111,10 +111,6 @@ export class FeatureFlagProvider {
       ),
     );
     this.strategies.set(
-      KnownFeatures.ProdMode,
-      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
-    );
-    this.strategies.set(
       KnownFeatures.DevLanguage,
       new SwitchableFlagStrategy(
         this.featuresConfigService,

--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.spec.tsx
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.spec.tsx
@@ -1,32 +1,13 @@
-import { cloneDeep, set } from 'lodash'
 import React from 'react'
 
 import { Environment } from 'apiClient'
-import { FeatureFlags } from 'uiSrc/constants'
-import {
-  initialStateDefault,
-  mockStore,
-  render,
-  screen,
-} from 'uiSrc/utils/test-utils'
+import { render, screen } from 'uiSrc/utils/test-utils'
 
 import { EnvironmentBadge } from './EnvironmentBadge'
 
-const withProdModeFlag = (flag: boolean) => {
-  const state = set(
-    cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
-    { flag },
-  )
-  return { store: mockStore(state) }
-}
-
 describe('EnvironmentBadge', () => {
   it('renders the PROD badge for production environment', () => {
-    render(
-      <EnvironmentBadge environment={Environment.Production} />,
-      withProdModeFlag(true),
-    )
+    render(<EnvironmentBadge environment={Environment.Production} />)
 
     expect(
       screen.getByTestId(`environment-badge-${Environment.Production}`),
@@ -35,10 +16,7 @@ describe('EnvironmentBadge', () => {
   })
 
   it('renders the DEV label for development environment', () => {
-    render(
-      <EnvironmentBadge environment={Environment.Development} />,
-      withProdModeFlag(true),
-    )
+    render(<EnvironmentBadge environment={Environment.Development} />)
 
     expect(
       screen.getByTestId(`environment-badge-${Environment.Development}`),
@@ -49,26 +27,13 @@ describe('EnvironmentBadge', () => {
   it('renders nothing for unspecified environment', () => {
     const { container } = render(
       <EnvironmentBadge environment={Environment.Unspecified} />,
-      withProdModeFlag(true),
     )
 
     expect(container).toBeEmptyDOMElement()
   })
 
   it('renders nothing when environment is undefined', () => {
-    const { container } = render(
-      <EnvironmentBadge environment={undefined} />,
-      withProdModeFlag(true),
-    )
-
-    expect(container).toBeEmptyDOMElement()
-  })
-
-  it('renders nothing when the prodMode feature flag is off', () => {
-    const { container } = render(
-      <EnvironmentBadge environment={Environment.Production} />,
-      withProdModeFlag(false),
-    )
+    const { container } = render(<EnvironmentBadge environment={undefined} />)
 
     expect(container).toBeEmptyDOMElement()
   })
@@ -79,7 +44,6 @@ describe('EnvironmentBadge', () => {
         environment={Environment.Production}
         dataTestId="custom-badge"
       />,
-      withProdModeFlag(true),
     )
 
     expect(screen.getByTestId('custom-badge')).toBeInTheDocument()

--- a/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
+++ b/redisinsight/ui/src/components/environment-badge/EnvironmentBadge.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { useAppSelector } from 'uiSrc/slices/hooks'
 
-import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import { RiBadge } from 'uiSrc/components/base/display/badge/RiBadge'
 import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
 
@@ -12,9 +10,7 @@ export const EnvironmentBadge = ({
   environment,
   dataTestId,
 }: EnvironmentBadgeProps) => {
-  const flagEnabled = useAppSelector(appFeatureFlagProdModeSelector)
-
-  if (!flagEnabled || !environment) return null
+  if (!environment) return null
 
   const config = BADGE_CONFIG[environment]
   if (!config) return null

--- a/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.spec.ts
+++ b/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.spec.ts
@@ -1,5 +1,4 @@
 import { renderHook } from 'uiSrc/utils/test-utils'
-import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
   connectedInstanceDangerousCommandsSelector,
   connectedInstanceSelector,
@@ -7,11 +6,6 @@ import {
 import { Environment } from 'apiClient'
 
 import { useDatabaseEnvironment } from './useDatabaseEnvironment'
-
-jest.mock('uiSrc/slices/app/features', () => ({
-  ...jest.requireActual('uiSrc/slices/app/features'),
-  appFeatureFlagProdModeSelector: jest.fn().mockReturnValue(false),
-}))
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
@@ -21,17 +15,14 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   connectedInstanceDangerousCommandsSelector: jest.fn().mockReturnValue([]),
 }))
 
-const mockedFlag = appFeatureFlagProdModeSelector as jest.Mock
 const mockedInstance = connectedInstanceSelector as jest.Mock
 const mockedDangerousCommands =
   connectedInstanceDangerousCommandsSelector as jest.Mock
 
 const setMocks = (input: {
-  flag: boolean
   environment: Environment
   dangerousCommands?: string[]
 }) => {
-  mockedFlag.mockReturnValue(input.flag)
   mockedDangerousCommands.mockReturnValue(input.dangerousCommands ?? [])
   mockedInstance.mockReturnValue({
     id: 'db-1',
@@ -41,26 +32,20 @@ const setMocks = (input: {
 
 describe('useDatabaseEnvironment', () => {
   describe('truth table', () => {
-    it('falls back to unmarked when flag is off', () => {
-      setMocks({ flag: false, environment: Environment.Production })
-      const { result } = renderHook(useDatabaseEnvironment)
-      expect(result.current.environment).toBe(Environment.Unspecified)
-    })
-
-    it('returns production when flag on and connection is marked production', () => {
-      setMocks({ flag: true, environment: Environment.Production })
+    it('returns production when connection is marked production', () => {
+      setMocks({ environment: Environment.Production })
       const { result } = renderHook(useDatabaseEnvironment)
       expect(result.current.environment).toBe(Environment.Production)
     })
 
-    it('returns fast when flag on and connection is marked fast', () => {
-      setMocks({ flag: true, environment: Environment.Development })
+    it('returns fast when connection is marked fast', () => {
+      setMocks({ environment: Environment.Development })
       const { result } = renderHook(useDatabaseEnvironment)
       expect(result.current.environment).toBe(Environment.Development)
     })
 
-    it('returns unmarked when flag on and connection is unmarked', () => {
-      setMocks({ flag: true, environment: Environment.Unspecified })
+    it('returns unmarked when connection is unmarked', () => {
+      setMocks({ environment: Environment.Unspecified })
       const { result } = renderHook(useDatabaseEnvironment)
       expect(result.current.environment).toBe(Environment.Unspecified)
     })
@@ -69,7 +54,6 @@ describe('useDatabaseEnvironment', () => {
   describe('isDangerousCommand', () => {
     it('returns false outside production', () => {
       setMocks({
-        flag: true,
         environment: Environment.Unspecified,
         dangerousCommands: ['FLUSHDB', 'KEYS'],
       })
@@ -79,7 +63,6 @@ describe('useDatabaseEnvironment', () => {
 
     it('returns false in fast mode even for known dangerous commands', () => {
       setMocks({
-        flag: true,
         environment: Environment.Development,
         dangerousCommands: ['FLUSHDB'],
       })
@@ -89,7 +72,6 @@ describe('useDatabaseEnvironment', () => {
 
     it('matches case-insensitively inside production', () => {
       setMocks({
-        flag: true,
         environment: Environment.Production,
         dangerousCommands: ['FLUSHDB', 'KEYS'],
       })
@@ -101,7 +83,6 @@ describe('useDatabaseEnvironment', () => {
 
     it('returns false for unknown commands inside production', () => {
       setMocks({
-        flag: true,
         environment: Environment.Production,
         dangerousCommands: ['FLUSHDB'],
       })
@@ -111,7 +92,6 @@ describe('useDatabaseEnvironment', () => {
 
     it('handles empty / falsy command string', () => {
       setMocks({
-        flag: true,
         environment: Environment.Production,
         dangerousCommands: ['FLUSHDB'],
       })
@@ -121,7 +101,6 @@ describe('useDatabaseEnvironment', () => {
 
     it('handles a lowercase dangerousCommands list defensively', () => {
       setMocks({
-        flag: true,
         environment: Environment.Production,
         dangerousCommands: ['flushdb'],
       })

--- a/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
+++ b/redisinsight/ui/src/components/hooks/useDatabaseEnvironment.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { useAppSelector } from 'uiSrc/slices/hooks'
 import { Environment } from 'apiClient'
-import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
   connectedInstanceDangerousCommandsSelector,
   connectedInstanceSelector,
@@ -13,15 +12,12 @@ export interface UseDatabaseEnvironmentResult {
 }
 
 export const useDatabaseEnvironment = (): UseDatabaseEnvironmentResult => {
-  const flagEnabled = useAppSelector(appFeatureFlagProdModeSelector)
   const dangerousCommands = useAppSelector(
     connectedInstanceDangerousCommandsSelector,
   )
   const connectedInstance = useAppSelector(connectedInstanceSelector)
 
-  const environment: Environment = flagEnabled
-    ? connectedInstance.environment
-    : Environment.Unspecified
+  const environment: Environment = connectedInstance.environment
 
   const isDangerousCommand = useMemo(() => {
     const upper = new Set(dangerousCommands.map((c) => c.toUpperCase()))

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.spec.tsx
@@ -271,15 +271,7 @@ describe('InstanceHeader', () => {
         environment: env,
       })
 
-      const state = set(
-        cloneDeep(initialStateDefault),
-        `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
-        { flag: true },
-      )
-
-      return render(<InstanceHeader {...instance(mockedProps)} />, {
-        store: mockStore(state),
-      })
+      return render(<InstanceHeader {...instance(mockedProps)} />)
     }
 
     it('renders the PROD badge and marks the header as production', () => {
@@ -319,34 +311,6 @@ describe('InstanceHeader', () => {
       expect(
         screen.queryByTestId(`environment-badge-${Environment.Development}`),
       ).not.toBeInTheDocument()
-    })
-
-    it('does not render the badge when the prodMode flag is off', () => {
-      mockedConnectedInstanceSelector.mockReturnValue({
-        username: 'username',
-        id: 'instanceId',
-        loading: false,
-        environment: Environment.Production,
-      })
-
-      const state = set(
-        cloneDeep(initialStateDefault),
-        `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
-        { flag: false },
-      )
-
-      render(<InstanceHeader {...instance(mockedProps)} />, {
-        store: mockStore(state),
-      })
-
-      expect(
-        screen.queryByTestId(`environment-badge-${Environment.Production}`),
-      ).not.toBeInTheDocument()
-      // hook returns Unspecified when the flag is off, even if the stored env is Production
-      expect(screen.getByTestId('instance-header')).toHaveAttribute(
-        'data-environment',
-        Environment.Unspecified,
-      )
     })
   })
 

--- a/redisinsight/ui/src/components/instance-header/components/promote-production-prompt/PromoteProductionPrompt.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/promote-production-prompt/PromoteProductionPrompt.spec.tsx
@@ -24,7 +24,6 @@ import {
   connectedInstanceSelector,
   instancesSelector,
 } from 'uiSrc/slices/instances/instances'
-import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import { PromoteProductionPrompt } from './PromoteProductionPrompt'
 
 const mockHistoryPush = jest.fn()
@@ -47,11 +46,6 @@ jest.mock('uiSrc/services', () => ({
   },
 }))
 
-jest.mock('uiSrc/slices/app/features', () => ({
-  ...jest.requireActual('uiSrc/slices/app/features'),
-  appFeatureFlagProdModeSelector: jest.fn(),
-}))
-
 jest.mock('uiSrc/slices/instances/instances', () => ({
   ...jest.requireActual('uiSrc/slices/instances/instances'),
   connectedInstanceSelector: jest.fn(),
@@ -62,7 +56,6 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
 const mockSendEventTelemetry = jest.mocked(sendEventTelemetry)
 const mockLocalStorageGet = jest.mocked(localStorageService.get)
 const mockLocalStorageSet = jest.mocked(localStorageService.set)
-const mockProdModeSelector = jest.mocked(appFeatureFlagProdModeSelector)
 const mockConnectedInstanceSelector = jest.mocked(connectedInstanceSelector)
 const mockOverviewSelector = jest.mocked(connectedInstanceOverviewSelector)
 const mockInstancesSelector = jest.mocked(instancesSelector)
@@ -82,7 +75,6 @@ const buildProductionLikeInstance = () =>
 let store: typeof mockedStore
 
 interface MockOptions {
-  prodMode?: boolean
   connectedInstance?: Instance
   instances?: Instance[]
   totalKeys?: number
@@ -90,13 +82,11 @@ interface MockOptions {
 }
 
 const setMocks = ({
-  prodMode = true,
   connectedInstance = buildProductionLikeInstance(),
   instances,
   totalKeys = 50_000,
   actioned = false,
 }: MockOptions = {}) => {
-  mockProdModeSelector.mockReturnValue(prodMode)
   mockConnectedInstanceSelector.mockReturnValue(connectedInstance)
   mockOverviewSelector.mockReturnValue({ version: '', totalKeys })
   mockInstancesSelector.mockReturnValue({
@@ -137,15 +127,6 @@ describe('PromoteProductionPrompt', () => {
         }),
       }),
     )
-  })
-
-  it('does not render when the prodMode flag is disabled', () => {
-    setMocks({ prodMode: false })
-    renderComponent()
-
-    expect(
-      screen.queryByTestId('promote-production-prompt'),
-    ).not.toBeInTheDocument()
   })
 
   it('does not render when the prompt was already actioned', () => {

--- a/redisinsight/ui/src/components/instance-header/components/promote-production-prompt/hooks/usePromoteProductionPrompt.ts
+++ b/redisinsight/ui/src/components/instance-header/components/promote-production-prompt/hooks/usePromoteProductionPrompt.ts
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom'
 import { Environment } from 'apiClient'
 
 import { useAppSelector } from 'uiSrc/slices/hooks'
-import { appFeatureFlagProdModeSelector } from 'uiSrc/slices/app/features'
 import {
   connectedInstanceOverviewSelector,
   connectedInstanceSelector,
@@ -23,7 +22,6 @@ import { UsePromoteProductionPromptResult } from '../PromoteProductionPrompt.typ
  */
 export const usePromoteProductionPrompt =
   (): UsePromoteProductionPromptResult => {
-    const prodModeEnabled = useAppSelector(appFeatureFlagProdModeSelector)
     const { id, environment, host, tls, connectionType, username, password } =
       useAppSelector(connectedInstanceSelector)
     const { totalKeys } = useAppSelector(connectedInstanceOverviewSelector)
@@ -54,7 +52,6 @@ export const usePromoteProductionPrompt =
     })
 
     const shouldPromote =
-      prodModeEnabled &&
       instancesLoaded &&
       !featureDiscovered &&
       !alreadyActioned &&

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
@@ -39,11 +39,6 @@ const getOpenState = (flagsOn = false, version = latestVersion) => {
       `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
       { flag: true },
     )
-    state = set(
-      state,
-      `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
-      { flag: true },
-    )
   }
   return state
 }
@@ -122,9 +117,6 @@ describe('WhatsNewModal', () => {
     expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(
       screen.queryByTestId('whats-new-card-inactive-vector-sets'),
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('whats-new-card-inactive-dev-vs-prod-mode'),
     ).not.toBeInTheDocument()
   })
 

--- a/redisinsight/ui/src/constants/content/whats-new/versions/v3.6.0.ts
+++ b/redisinsight/ui/src/constants/content/whats-new/versions/v3.6.0.ts
@@ -18,7 +18,6 @@ export const version360: WhatsNewVersion = {
       title: 'Dev vs Production database mode',
       body: 'Tag connections as dev or production. Production shows a PROD badge and requires type-to-confirm before destructive actions. Makes it harder to run destructive actions against the wrong database.',
       location: "Database list — edit a database's connection settings",
-      featureFlag: FeatureFlags.prodMode,
     },
     {
       id: 'geodata-workbench',

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -16,7 +16,6 @@ export enum FeatureFlags {
   array = 'array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
-  prodMode = 'prodMode',
   devLanguage = 'dev-language',
   whatsNew = 'whatsNew',
   valueDecoder = 'valueDecoder',

--- a/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/databases-list/components/DatabasesListCellName/DatabasesListCellName.spec.tsx
@@ -1,32 +1,14 @@
-import { cloneDeep, set } from 'lodash'
 import React from 'react'
 
 import { Environment } from 'apiClient'
 import { Instance } from 'uiSrc/slices/interfaces'
-import { FeatureFlags } from 'uiSrc/constants'
-import {
-  initialStateDefault,
-  mockStore,
-  render,
-  screen,
-} from 'uiSrc/utils/test-utils'
+import { render, screen } from 'uiSrc/utils/test-utils'
 
 import DatabasesListCellName from './DatabasesListCellName'
 
-const renderCell = (
-  instance: Partial<Instance>,
-  { prodMode = true }: { prodMode?: boolean } = {},
-) => {
-  const state = set(
-    cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.prodMode}`,
-    { flag: prodMode },
-  )
-
+const renderCell = (instance: Partial<Instance>) => {
   const cellProps = { row: { original: instance as Instance } } as any
-  return render(<DatabasesListCellName {...cellProps} />, {
-    store: mockStore(state),
-  })
+  return render(<DatabasesListCellName {...cellProps} />)
 }
 
 describe('DatabasesListCellName', () => {
@@ -61,17 +43,6 @@ describe('DatabasesListCellName', () => {
       ).not.toBeInTheDocument()
       expect(screen.queryByText('PROD')).not.toBeInTheDocument()
       expect(screen.queryByText('DEV')).not.toBeInTheDocument()
-    })
-
-    it('does not render the badge when the prodMode flag is off', () => {
-      renderCell(
-        { ...baseInstance, environment: Environment.Production },
-        { prodMode: false },
-      )
-
-      expect(
-        screen.queryByTestId('environment-badge-db-1'),
-      ).not.toBeInTheDocument()
     })
   })
 

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionFrom.spec.tsx
@@ -13,8 +13,6 @@ import { appRedirectionSelector } from 'uiSrc/slices/app/url-handling'
 import { UrlHandlingActions } from 'uiSrc/slices/interfaces/urlHandling'
 import { ADD_NEW_CA_CERT, SshPassType } from 'uiSrc/pages/home/constants'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
-import { FeatureFlags } from 'uiSrc/constants/featureFlags'
-import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 
 import ManualConnectionForm, { Props } from './ManualConnectionForm'
 
@@ -1440,27 +1438,7 @@ describe('InstanceForm', () => {
   })
 
   describe('Database mode select', () => {
-    it('should not render the dropdown when the prodMode flag is off', () => {
-      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValueOnce({
-        [FeatureFlags.prodMode]: { flag: false },
-      })
-
-      render(
-        <ManualConnectionForm
-          {...instance(mockedProps)}
-          isEditMode={false}
-          formFields={formFields}
-        />,
-      )
-
-      expect(screen.queryByTestId('select-environment')).not.toBeInTheDocument()
-    })
-
-    it('should render the dropdown when the prodMode flag is on', () => {
-      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReturnValue({
-        [FeatureFlags.prodMode]: { flag: true },
-      })
-
+    it('should render the dropdown', () => {
       render(
         <ManualConnectionForm
           {...instance(mockedProps)}
@@ -1470,7 +1448,6 @@ describe('InstanceForm', () => {
       )
 
       expect(screen.getByTestId('select-environment')).toBeInTheDocument()
-      ;(appFeatureFlagsFeaturesSelector as jest.Mock).mockReset()
     })
   })
 })

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
@@ -12,8 +12,6 @@ import Divider from 'uiSrc/components/divider/Divider'
 import { BuildType } from 'uiSrc/constants/env'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
 import { Spacer } from 'uiSrc/components/base/layout'
-import FeatureFlagComponent from 'uiSrc/components/feature-flag-component'
-import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import DecompressionAndFormatters from './DecompressionAndFormatters'
 import { ManualFormTab } from '../constants'
 
@@ -60,14 +58,10 @@ const AddConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
-          <FeatureFlagComponent name={FeatureFlags.prodMode}>
-            <>
-              <Spacer size="m" />
-              <Divider />
-              <Spacer size="m" />
-              <EnvironmentSelect formik={formik} />
-            </>
-          </FeatureFlagComponent>
+          <Spacer size="m" />
+          <Divider />
+          <Spacer size="m" />
+          <EnvironmentSelect formik={formik} />
         </>
       )}
       {activeTab === ManualFormTab.Security && (

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -12,8 +12,6 @@ import { Spacer } from 'uiSrc/components/base/layout'
 import Divider from 'uiSrc/components/divider/Divider'
 import { BuildType } from 'uiSrc/constants/env'
 import { DbConnectionInfo } from 'uiSrc/pages/home/interfaces'
-import FeatureFlagComponent from 'uiSrc/components/feature-flag-component'
-import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import DecompressionAndFormatters from './DecompressionAndFormatters'
 
 import { AZURE_READONLY_FIELDS, ManualFormTab } from '../constants'
@@ -83,14 +81,10 @@ const EditConnection = (props: Props) => {
           <Divider />
           <Spacer size="m" />
           <ForceStandalone formik={formik} />
-          <FeatureFlagComponent name={FeatureFlags.prodMode}>
-            <>
-              <Spacer size="m" />
-              <Divider />
-              <Spacer size="m" />
-              <EnvironmentSelect formik={formik} />
-            </>
-          </FeatureFlagComponent>
+          <Spacer size="m" />
+          <Divider />
+          <Spacer size="m" />
+          <EnvironmentSelect formik={formik} />
           {isCloneMode && (
             <>
               <Spacer size="m" />

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -80,9 +80,6 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devBrowser]: {
         flag: false,
       },
-      [FeatureFlags.prodMode]: {
-        flag: false,
-      },
       [FeatureFlags.devLanguage]: {
         flag: false,
       },
@@ -222,8 +219,6 @@ export const appFeatureFlagsSelector = (state: RootState) =>
   state.app.features.featureFlags
 export const appFeatureFlagsFeaturesSelector = (state: RootState) =>
   state.app.features.featureFlags.features
-export const appFeatureFlagProdModeSelector = (state: RootState): boolean =>
-  state.app.features.featureFlags.features[FeatureFlags.prodMode]?.flag ?? false
 
 export const isValueDecoderEnabledSelector = (state: RootState): boolean =>
   state.app.features.featureFlags.features[FeatureFlags.valueDecoder]?.flag ??

--- a/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
+++ b/tests/e2e-playwright/pages/databases/components/AddDatabaseDialog.ts
@@ -165,7 +165,6 @@ export class AddDatabaseDialog {
 
   /**
    * Select an environment in the connection form's Environment dropdown.
-   * The dropdown is only rendered when the `prodMode` feature flag is enabled.
    *
    * Each `Environment` enum value (`unspecified` | `production` | `development`)
    * is rendered by the form as its capitalized counterpart in

--- a/tests/e2e-playwright/tests/parallel/browser/bulk-actions/environment-gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/bulk-actions/environment-gating.spec.ts
@@ -8,8 +8,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * type the database name in the type-to-confirm modal before the
  * destructive action runs against the real Redis backend.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('Browser > Bulk Actions — environment gating', () => {
   test.describe('Production DB', () => {
     let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/browser/key-details/environment-gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/key-details/environment-gating.spec.ts
@@ -12,8 +12,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * per-component wiring, and per-action confirmation strings are covered by
  * unit tests.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 const uniqueId = () => faker.string.alphanumeric(6);
 
 test.describe('Browser > Key Details — environment gating', () => {

--- a/tests/e2e-playwright/tests/parallel/databases/list/environment-badge.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/databases/list/environment-badge.spec.ts
@@ -7,8 +7,6 @@ import { Environment } from 'e2eSrc/types';
  * verified against the rendered badge in the databases list and the
  * instance header after connecting.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('Database List — environment badge', () => {
   const createdDatabaseNames: string[] = [];
 

--- a/tests/e2e-playwright/tests/parallel/insights/tutorials.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/insights/tutorials.spec.ts
@@ -8,8 +8,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * provider — this verifies the integration, not the per-button gating
  * logic (which has its own unit tests).
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('Workbench > Tutorials — environment gating', () => {
   test.describe('Production DB', () => {
     let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/parallel/workbench/profiler.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/workbench/profiler.spec.ts
@@ -7,8 +7,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * confirmation popover. Cancelling keeps the profiler stopped; confirming
  * actually starts the profiler against the real Redis backend.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('Workbench > Profiler (Bottom Panel) — environment gating', () => {
   test.describe('Production DB', () => {
     let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/serial/cli/dangerous-commands.spec.ts
+++ b/tests/e2e-playwright/tests/serial/cli/dangerous-commands.spec.ts
@@ -13,8 +13,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * because the confirm branch issues `FLUSHDB`, which would otherwise wipe
  * keys other tests rely on on the shared standalone Redis.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('CLI Panel — environment gating', () => {
   test.describe('Production DB', () => {
     let database: DatabaseInstance;

--- a/tests/e2e-playwright/tests/serial/workbench/dangerous-commands.spec.ts
+++ b/tests/e2e-playwright/tests/serial/workbench/dangerous-commands.spec.ts
@@ -13,8 +13,6 @@ import { DatabaseInstance, Environment } from 'e2eSrc/types';
  * because the confirm branch issues `FLUSHDB`, which would otherwise wipe
  * keys other tests rely on on the shared standalone Redis.
  */
-test.use({ featureFlags: { prodMode: true } });
-
 test.describe('Workbench > Command Execution — environment gating', () => {
   test.describe('Production DB', () => {
     let database: DatabaseInstance;


### PR DESCRIPTION
## Overview

The `prodMode` feature flag is fully rolled out in `features-config.json` (`flag: true`, `perc: [[0, 100]]`), so the production-mode UI is on for everyone. This PR removes **all code references** to the flag, leaving the feature always-on. The flag entry itself is intentionally kept in `api/config/features-config.json`.

## What changed

**Frontend**
- Removed `FeatureFlags.prodMode` enum entry, its default state, and the `appFeatureFlagProdModeSelector` selector
- Ungated the production-mode UI: `EnvironmentBadge`, `useDatabaseEnvironment`, `usePromoteProductionPrompt`, and the Environment select in Add/Edit connection forms
- Dropped `featureFlag: FeatureFlags.prodMode` from the 3.6.0 What's New card (now always active)

**Backend**
- Removed `KnownFeatures.ProdMode`, its `known-features` record entry, and its strategy registration

**Tests**
- Removed flag on/off unit-test cases and the `test.use({ featureFlags: { prodMode: true } })` E2E fixtures

## Not touched

- `api/config/features-config.json` — the `prodMode` entry stays, as requested
- The `prodModeCtaActioned` storage key and `PROD_MODE_*` telemetry events — these belong to the feature (which remains), not the flag

## Verification

- `type-check`: no new errors in changed files
- Affected UI unit tests (103) + backend feature-flag provider test: passing
- ESLint clean on all changed UI/API/E2E files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production safety UX (badges, type-to-confirm, dangerous commands) across the app; behavior should match the prior flag-on state but removes the ability to disable via flag in code.
> 
> **Overview**
> Removes the **`prodMode` feature flag** from application code now that dev vs production mode is fully rolled out. **Production-mode behavior is always on**; gating on the flag is gone.
> 
> **Backend:** Drops `KnownFeatures.ProdMode`, its known-features entry, and strategy registration in the feature-flag provider.
> 
> **Frontend:** Removes `FeatureFlags.prodMode`, default Redux state, and `appFeatureFlagProdModeSelector`. **Environment badges**, **`useDatabaseEnvironment`** (per-connection env and dangerous-command checks), the **promote-production prompt**, and the **Environment** field on add/edit connection forms no longer depend on the flag. The 3.6.0 What's New card for dev vs prod mode is no longer flag-gated.
> 
> **Tests:** Deletes flag on/off unit cases and `test.use({ featureFlags: { prodMode: true } })` from environment-gating E2E specs. The `prodMode` entry in `features-config.json` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83eca7c2b511dc288e78b56d54ec43c7f2209e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->