### PR TITLE
chore: remove whatsNew feature flag code references

### DIFF
--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -40,7 +40,6 @@ export enum KnownFeatures {
   Array = 'array',
   ProdMode = 'prodMode',
   DevLanguage = 'dev-language',
-  WhatsNew = 'whatsNew',
   ValueDecoder = 'valueDecoder',
 }
 

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -99,10 +99,6 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevLanguage,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.WhatsNew]: {
-    name: KnownFeatures.WhatsNew,
-    storage: FeatureStorage.Database,
-  },
   [KnownFeatures.ValueDecoder]: {
     name: KnownFeatures.ValueDecoder,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -122,10 +122,6 @@ export class FeatureFlagProvider {
       ),
     );
     this.strategies.set(
-      KnownFeatures.WhatsNew,
-      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
-    );
-    this.strategies.set(
       KnownFeatures.ValueDecoder,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );

--- a/redisinsight/ui/src/components/global-dialogs/GlobalDialogs.tsx
+++ b/redisinsight/ui/src/components/global-dialogs/GlobalDialogs.tsx
@@ -15,9 +15,7 @@ const GlobalDialogs = () => (
       <OAuthSelectPlan />
       <OAuthSsoDialog />
     </FeatureFlagComponent>
-    <FeatureFlagComponent name={FeatureFlags.whatsNew}>
-      <WhatsNewModal />
-    </FeatureFlagComponent>
+    <WhatsNewModal />
   </>
 )
 

--- a/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.spec.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.spec.tsx
@@ -110,19 +110,12 @@ describe('HelpMenu', () => {
   })
 
   it("should open What's new and send telemetry on click", () => {
-    const initialStoreState = set(
-      cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.whatsNew}`,
-      { flag: true },
-    )
-    const localStore = mockStore(initialStoreState)
-
-    render(sideBarWithHelpMenu, { store: localStore })
+    render(sideBarWithHelpMenu)
 
     fireEvent.click(screen.getByTestId('help-menu-button'))
     fireEvent.click(screen.getByTestId('whats-new-btn'))
 
-    expect(localStore.getActions()).toEqual([openWhatsNew()])
+    expect(store.getActions()).toEqual([openWhatsNew()])
     expect(sendEventTelemetry).toBeCalledWith({
       event: TelemetryEvent.WHATS_NEW_OPENED,
       eventData: {
@@ -130,21 +123,6 @@ describe('HelpMenu', () => {
         version: getLatestWhatsNewVersion()?.version,
       },
     })
-  })
-
-  it("should hide What's new item when its feature flag is off", () => {
-    const initialStoreState = set(
-      cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.whatsNew}`,
-      { flag: false },
-    )
-
-    render(sideBarWithHelpMenu, {
-      store: mockStore(initialStoreState),
-    })
-    fireEvent.click(screen.getByTestId('help-menu-button'))
-
-    expect(screen.queryByTestId('whats-new-btn')).not.toBeInTheDocument()
   })
 
   it('should show feature dependent items when feature flag is on', async () => {

--- a/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/help-menu/HelpMenu.tsx
@@ -178,19 +178,17 @@ const HelpMenu = () => {
               </Link>
             </Row>
 
-            <FeatureFlagComponent name={FeatureFlags.whatsNew}>
-              <Row className={styles.helpMenuItemLink} align="center" gap="xs">
-                <RiIcon type="StarsIcon" size="l" />
-                <Text
-                  size="xs"
-                  className={styles.helpMenuTextLink}
-                  onClick={onWhatsNewClick}
-                  data-testid="whats-new-btn"
-                >
-                  {t('whatsNew.menuItem')}
-                </Text>
-              </Row>
-            </FeatureFlagComponent>
+            <Row className={styles.helpMenuItemLink} align="center" gap="xs">
+              <RiIcon type="StarsIcon" size="l" />
+              <Text
+                size="xs"
+                className={styles.helpMenuTextLink}
+                onClick={onWhatsNewClick}
+                data-testid="whats-new-btn"
+              >
+                {t('whatsNew.menuItem')}
+              </Text>
+            </Row>
 
             <FeatureFlagComponent name={FeatureFlags.envDependent}>
               <Row className={styles.helpMenuItemLink} align="center" gap="xs">

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -18,6 +18,5 @@ export enum FeatureFlags {
   devBrowser = 'dev-browser',
   prodMode = 'prodMode',
   devLanguage = 'dev-language',
-  whatsNew = 'whatsNew',
   valueDecoder = 'valueDecoder',
 }

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -7,7 +7,6 @@ import {
   appServerInfoSelector,
   appElectronInfoSelector,
 } from 'uiSrc/slices/app/info'
-import { appFeatureFlagsFeaturesSelector } from 'uiSrc/slices/app/features'
 import {
   ipcAppRestart,
   ipcCheckUpdates,
@@ -22,7 +21,6 @@ const ConfigElectron = () => {
   let isCheckedUpdates = false
   const { isReleaseNotesViewed } = useAppSelector(appElectronInfoSelector)
   const serverInfo = useAppSelector(appServerInfoSelector)
-  const features = useAppSelector(appFeatureFlagsFeaturesSelector)
 
   const dispatch = useAppDispatch()
   const history = useHistory()
@@ -33,11 +31,10 @@ const ConfigElectron = () => {
   }, [])
 
   // Keyed on serverInfo only: must run once per load (consumes one-shot
-  // electron-store flags). Feature flags are already fetched — AppInit
-  // blocks rendering until they are.
+  // electron-store flags).
   useEffect(() => {
     if (serverInfo) {
-      ipcCheckUpdates(serverInfo, dispatch, features)
+      ipcCheckUpdates(serverInfo, dispatch)
     }
   }, [serverInfo])
 

--- a/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
+++ b/redisinsight/ui/src/electron/utils/ipcCheckUpdates.ts
@@ -5,9 +5,9 @@ import { ReleaseNotesSource, WhatsNewSource } from 'uiSrc/constants/telemetry'
 import { setElectronInfo, setReleaseNotesViewed } from 'uiSrc/slices/app/info'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
 import { openWhatsNew } from 'uiSrc/slices/app/whatsNew'
-import { FeatureFlagsMap, isWhatsNewEligible } from 'uiSrc/utils'
+import { isWhatsNewEligible } from 'uiSrc/utils'
 import { localStorageService } from 'uiSrc/services'
-import { BrowserStorageItem, FeatureFlags } from 'uiSrc/constants'
+import { BrowserStorageItem } from 'uiSrc/constants'
 import successMessages from 'uiSrc/components/notifications/success-messages'
 import { GetServerInfoResponse } from 'apiClient'
 import { ElectronStorageItem, IpcInvokeEvent } from '../constants'
@@ -17,23 +17,16 @@ import { ElectronStorageItem, IpcInvokeEvent } from '../constants'
  * installed version. Flag-gated cards render as "Coming soon", so no card
  * visibility check is needed.
  */
-const shouldOpenWhatsNew = (
-  version: string,
-  features?: FeatureFlagsMap,
-): boolean => {
+const shouldOpenWhatsNew = (version: string): boolean => {
   const lastVersionSeen =
     localStorageService?.get(BrowserStorageItem.whatsNewLastVersionSeen) ?? null
 
-  return (
-    !!features?.[FeatureFlags.whatsNew]?.flag &&
-    isWhatsNewEligible(version, lastVersionSeen)
-  )
+  return isWhatsNewEligible(version, lastVersionSeen)
 }
 
 export const ipcCheckUpdates = async (
   serverInfo: GetServerInfoResponse,
   dispatch: Dispatch<any>,
-  features?: FeatureFlagsMap,
 ) => {
   const isUpdateDownloaded = await window.app.ipc.invoke(
     IpcInvokeEvent.getStoreValue,
@@ -51,7 +44,7 @@ export const ipcCheckUpdates = async (
   if (isUpdateDownloaded && !isUpdateAvailable) {
     if (
       serverInfo.appVersion === updateDownloadedVersion &&
-      shouldOpenWhatsNew(updateDownloadedVersion, features)
+      shouldOpenWhatsNew(updateDownloadedVersion)
     ) {
       dispatch(openWhatsNew(updateDownloadedVersion))
       sendEventTelemetry({

--- a/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
+++ b/redisinsight/ui/src/electron/utils/tests/ipcCheckUpdates.spec.ts
@@ -2,18 +2,13 @@ import { cloneDeep } from 'lodash'
 
 import { GetServerInfoResponse } from 'apiClient'
 import { cleanup, mockedStore } from 'uiSrc/utils/test-utils'
-import { FeatureFlagsMap, whatsNewFeed } from 'uiSrc/utils'
+import { whatsNewFeed } from 'uiSrc/utils'
 import { openWhatsNew } from 'uiSrc/slices/app/whatsNew'
 import { addMessageNotification } from 'uiSrc/slices/app/notifications'
-import { FeatureFlags } from 'uiSrc/constants'
 import { ipcCheckUpdates, ipcSendEvents } from '../ipcCheckUpdates'
 
 const serverInfoMock = (appVersion: string): GetServerInfoResponse =>
   ({ appVersion }) as unknown as GetServerInfoResponse
-
-const whatsNewOnFeatures: FeatureFlagsMap = {
-  [FeatureFlags.whatsNew]: { flag: true },
-}
 
 const invokeMock = jest.fn()
 let store: typeof mockedStore
@@ -39,48 +34,26 @@ describe('ipcCheckUpdates', () => {
     expect(invokeMock).toBeCalled()
   })
 
-  it('should open Whats New when enabled and the version is eligible', async () => {
+  it('should open Whats New when the version is eligible', async () => {
     const version = whatsNewFeed[0].version
     invokeMock
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(version)
 
-    await ipcCheckUpdates(
-      serverInfoMock(version),
-      store.dispatch,
-      whatsNewOnFeatures,
-    )
+    await ipcCheckUpdates(serverInfoMock(version), store.dispatch)
 
     expect(store.getActions()).toContainEqual(openWhatsNew(version))
   })
 
-  it('should not open Whats New for an ineligible version even when enabled', async () => {
+  it('should fall back to the update toast for an ineligible version', async () => {
     const version = '0.0.1'
     invokeMock
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(version)
 
-    await ipcCheckUpdates(
-      serverInfoMock(version),
-      store.dispatch,
-      whatsNewOnFeatures,
-    )
-
-    const actionTypes = store.getActions().map((action) => action.type)
-    expect(actionTypes).not.toContain(openWhatsNew.type)
-    expect(actionTypes).toContain(addMessageNotification.type)
-  })
-
-  it('should fall back to the update toast when Whats New is disabled', async () => {
-    const version = whatsNewFeed[0].version
-    invokeMock
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(version)
-
-    await ipcCheckUpdates(serverInfoMock(version), store.dispatch, {})
+    await ipcCheckUpdates(serverInfoMock(version), store.dispatch)
 
     const actionTypes = store.getActions().map((action) => action.type)
     expect(actionTypes).not.toContain(openWhatsNew.type)
@@ -96,11 +69,7 @@ describe('ipcCheckUpdates', () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(version)
 
-    await ipcCheckUpdates(
-      serverInfoMock(version),
-      store.dispatch,
-      whatsNewOnFeatures,
-    )
+    await ipcCheckUpdates(serverInfoMock(version), store.dispatch)
 
     expect(store.getActions()).toContainEqual(openWhatsNew(version))
   })

--- a/redisinsight/ui/src/mocks/handlers/app/featureHandlers.ts
+++ b/redisinsight/ui/src/mocks/handlers/app/featureHandlers.ts
@@ -12,10 +12,6 @@ export const FEATURES_DATA_MOCK = {
       name: 'envDependent',
       flag: true,
     },
-    whatsNew: {
-      name: 'whatsNew',
-      flag: true,
-    },
     cloudSso: {
       name: 'cloudSso',
       flag: true,

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -62,9 +62,6 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.cloudAds]: {
         flag: riConfig.features.cloudAds.defaultFlag,
       },
-      [FeatureFlags.whatsNew]: {
-        flag: false,
-      },
       [FeatureFlags.vectorSearchV2]: {
         flag: false,
       },


### PR DESCRIPTION
## Overview

The `whatsNew` feature flag is fully rolled out in `features-config.json` (`flag: true`, `perc: [[0, 100]]`), so the What's New feature is on for everyone. This PR removes **all code references** to the flag, leaving the feature always-on. The flag entry itself is intentionally kept in `api/config/features-config.json`.

Follows up on #6247 (enable whatsNew for everyone).

## What changed

**Frontend**
- Removed `FeatureFlags.whatsNew` enum entry and its default state
- Ungated the `WhatsNewModal` in `GlobalDialogs` and the "What's New" item in `HelpMenu`
- Removed the flag check from `ipcCheckUpdates` and the now-unused `features` threading through it and `ConfigElectron`
- Removed the `whatsNew` entry from the feature mock (`featureHandlers`)

**Backend**
- Removed `KnownFeatures.WhatsNew`, its `known-features` record entry, and its strategy registration

**Tests**
- Removed flag on/off cases and the `features` argument

## Not touched

- `api/config/features-config.json` — the `whatsNew` entry stays, as requested
- The entire What's New feature: the `whatsNew` Redux slice, `constants/content/whats-new/*`, `WhatsNewModal`, `FeatureCard`, telemetry events, and the `whatsNewLastVersionSeen` storage — these are the feature, not the flag

## Verification

- `type-check`: no new errors in changed files
- Affected UI unit tests (57: HelpMenu, ipcCheckUpdates, ConfigElectron, init, WhatsNewModal, features) + backend feature-flag provider test: passing
- ESLint clean on all changed UI/API files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup after a full rollout: UI always shows What's New and backend no longer resolves the flag, with no auth or data-path changes.
> 
> **Overview**
> Removes all **code** references to the `whatsNew` feature flag now that the feature is fully rolled out, making What's New **always on** without changing the modal, Redux slice, or content. The `whatsNew` entry in `api/config/features-config.json` is intentionally left in place.
> 
> On the **API**, `KnownFeatures.WhatsNew`, its `known-features` mapping, and the `FeatureFlagProvider` strategy registration are deleted. On the **UI**, `FeatureFlags.whatsNew` and default Redux state are removed; `WhatsNewModal` and the Help menu item are no longer wrapped in `FeatureFlagComponent`; Electron `ipcCheckUpdates` / `ConfigElectron` no longer pass or check feature flags for auto-open (eligibility uses version logic only); mocks and tests drop flag on/off cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0ae804f2ffd41b1ac4275f6a4ff9cfbffa767b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->