### PR TITLE
Fix e2e navigation helper hanging on an empty databases list

### DIFF
--- a/tests/e2e-playwright/pages/BasePage.ts
+++ b/tests/e2e-playwright/pages/BasePage.ts
@@ -89,16 +89,19 @@ export abstract class BasePage {
     // blocking here for the full test timeout.
     if (!(await this.waitForDatabaseList())) return;
 
-    // Always start from page 1 so we scan every page.
+    // Always start from page 1 so we scan every page. Bail if page 1 doesn't
+    // render so gotoDatabase() can reload and retry.
     if ((await firstPage.isVisible()) && (await firstPage.isEnabled())) {
       await firstPage.click();
-      await this.waitForDatabaseList();
+      if (!(await this.waitForDatabaseList())) return;
     }
 
     while (!(await row.isVisible())) {
       if (!(await nextPage.isVisible()) || !(await nextPage.isEnabled())) break;
       await nextPage.click();
-      await this.waitForDatabaseList();
+      // Stop paginating if the next page fails to render rows, rather than
+      // blindly advancing past a page that may hold the target row.
+      if (!(await this.waitForDatabaseList())) break;
     }
   }
 

--- a/tests/e2e-playwright/pages/BasePage.ts
+++ b/tests/e2e-playwright/pages/BasePage.ts
@@ -7,6 +7,11 @@ import { Page, Locator, expect } from '@playwright/test';
  * Navigation is UI-based for cross-platform compatibility (browser + Electron)
  */
 export abstract class BasePage {
+  // Bounded wait for the databases list to render at least one row. Kept short
+  // so an empty/stale list falls through to a reload instead of blocking for
+  // the full test timeout.
+  private static readonly DATABASE_LIST_TIMEOUT_MS = 10_000;
+
   readonly page: Page;
 
   // Common UI elements
@@ -79,27 +84,41 @@ export abstract class BasePage {
     const firstPage = this.page.getByRole('button', { name: 'first page' });
     const nextPage = this.page.getByRole('button', { name: 'next page' });
 
-    await this.page
-      .getByTestId(/^instance-name-/)
-      .first()
-      .waitFor({ state: 'visible' });
+    // Empty list (e.g. a DB was just created via API and the cached home list
+    // is stale) — bail out so gotoDatabase() can reload and retry instead of
+    // blocking here for the full test timeout.
+    if (!(await this.waitForDatabaseList())) return;
 
     // Always start from page 1 so we scan every page.
     if ((await firstPage.isVisible()) && (await firstPage.isEnabled())) {
       await firstPage.click();
-      await this.page
-        .getByTestId(/^instance-name-/)
-        .first()
-        .waitFor({ state: 'visible' });
+      await this.waitForDatabaseList();
     }
 
     while (!(await row.isVisible())) {
       if (!(await nextPage.isVisible()) || !(await nextPage.isEnabled())) break;
       await nextPage.click();
+      await this.waitForDatabaseList();
+    }
+  }
+
+  /**
+   * Wait (briefly) for the databases list to render at least one row.
+   * Returns false instead of throwing when the list is empty, so callers can
+   * reload a stale list rather than blocking for the whole test timeout.
+   */
+  private async waitForDatabaseList(): Promise<boolean> {
+    try {
       await this.page
         .getByTestId(/^instance-name-/)
         .first()
-        .waitFor({ state: 'visible' });
+        .waitFor({
+          state: 'visible',
+          timeout: BasePage.DATABASE_LIST_TIMEOUT_MS,
+        });
+      return true;
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
# What

`gotoDatabase()` has a reload-and-retry fallback for when the home databases
list is stale (a DB created via API isn't reflected yet). That fallback was
unreachable: `paginateToRow()` first waited for any `instance-name` row using
the default 60s test timeout, so an empty list blocked for the full timeout
before the reload could run.

This surfaced as the `Vector Search > Navigation` specs timing out — they
create a database via API and immediately navigate, hitting the empty/stale
list.

The list-load wait is now bounded (`DATABASE_LIST_TIMEOUT_MS`, 10s) and returns
`false` on an empty list, so `gotoDatabase()` reloads to fetch a fresh list and
retries instead of hanging. Fast path (list already populated) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Playwright page-object change; no production app behavior.
> 
> **Overview**
> Fixes Playwright navigation hanging when the home databases list is empty or stale after API-created DBs (e.g. Vector Search navigation specs).
> 
> **`paginateToRow`** no longer waits up to the full test timeout for an `instance-name` row. It uses a new **`waitForDatabaseList()`** helper with a **10s** cap (`DATABASE_LIST_TIMEOUT_MS`) that returns **`false`** when no rows appear instead of throwing.
> 
> Pagination now **bails early** when the list stays empty after going to page 1 or after clicking next page, so **`gotoDatabase()`**’s existing reload-and-retry path can run instead of blocking for ~60s first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b92195faf08cd69462950c37de4bda75b926cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->