### PR TITLE
RI-8329: Warn before editing values in a non-Unicode format

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.spec.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { render, screen, fireEvent } from 'uiSrc/utils/test-utils'
+import { cloneDeep } from 'lodash'
+import {
+  render,
+  screen,
+  fireEvent,
+  mockedStore,
+  mockStore,
+} from 'uiSrc/utils/test-utils'
 import { KeyValueFormat } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
 import { getConfig } from 'uiSrc/config'
@@ -139,6 +146,31 @@ describe('RowActionsCell — edit + expand', () => {
 
     fireEvent.click(screen.getByTestId('array-expand-btn-5'))
     expect(onOpenValueEditor).toHaveBeenCalledWith('5')
+  })
+
+  it('warns before inline edit when a non-Unicode format is selected', () => {
+    const onEditElement = jest.fn()
+    const state = cloneDeep(mockedStore.getState())
+    state.browser.keys.selectedKey.viewFormat = KeyValueFormat.JSON
+    const jsonStore = mockStore(state)
+
+    render(
+      <RowActionsCell
+        element={arrayElementWithValueFactory.build({ index: '5' })}
+        editConfig={buildEditConfig({
+          viewFormat: KeyValueFormat.JSON,
+          onEditElement,
+        })}
+      />,
+      { store: jsonStore },
+    )
+
+    fireEvent.click(screen.getByTestId('array-edit-btn-5'))
+
+    expect(onEditElement).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId('non-unicode-edit-to-unicode'),
+    ).toBeInTheDocument()
   })
 
   it('hides edit, expand and delete while this row is being edited', () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.tsx
@@ -6,6 +6,10 @@ import { RiTooltip } from 'uiSrc/components'
 import { EditIcon, ExtendIcon } from 'uiSrc/components/base/icons'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
+import {
+  NonUnicodeEditConfirmation,
+  useNonUnicodeEditGuard,
+} from 'uiSrc/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation'
 
 import { getArrayElementEditState } from '../../getArrayElementEditState'
 import { RowActionsCellProps } from './RowActionsCell.types'
@@ -24,6 +28,8 @@ export const RowActionsCell = ({
   deleteConfig,
 }: RowActionsCellProps) => {
   const { t } = useTranslation()
+  const editGuard = useNonUnicodeEditGuard()
+  const expandGuard = useNonUnicodeEditGuard()
 
   const { index, value } = element
 
@@ -71,32 +77,54 @@ export const RowActionsCell = ({
     >
       {showEditActions && (
         <>
-          <RiTooltip content={editState?.editDisabledReason ?? null}>
-            <IconButton
-              icon={EditIcon}
-              aria-label="Edit field"
-              disabled={isEditActionDisabled}
-              onClick={(e: React.MouseEvent) => {
-                // Search renders this table with expandRowOnClick — don't let
-                // the action click also toggle the neighbour band.
-                e.stopPropagation()
-                editConfig?.onEditElement(index, true)
-              }}
-              data-testid={`array-edit-btn-${index}`}
-            />
-          </RiTooltip>
-          <RiTooltip content={editState?.editDisabledReason ?? null}>
-            <IconButton
-              icon={ExtendIcon}
-              aria-label="Expand value editor"
-              disabled={isEditActionDisabled}
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation()
-                editConfig?.onOpenValueEditor(index)
-              }}
-              data-testid={`array-expand-btn-${index}`}
-            />
-          </RiTooltip>
+          <NonUnicodeEditConfirmation
+            isOpen={editGuard.isOpen}
+            format={editGuard.format}
+            onCancel={editGuard.cancel}
+            onChangeToUnicode={editGuard.changeToUnicode}
+            onEditAnyway={editGuard.editAnyway}
+            button={
+              <RiTooltip content={editState?.editDisabledReason ?? null}>
+                <IconButton
+                  icon={EditIcon}
+                  aria-label="Edit field"
+                  disabled={isEditActionDisabled}
+                  onClick={(e: React.MouseEvent) => {
+                    // Search renders this table with expandRowOnClick — don't
+                    // let the action click also toggle the neighbour band.
+                    e.stopPropagation()
+                    editGuard.requestEdit(() =>
+                      editConfig?.onEditElement(index, true),
+                    )
+                  }}
+                  data-testid={`array-edit-btn-${index}`}
+                />
+              </RiTooltip>
+            }
+          />
+          <NonUnicodeEditConfirmation
+            isOpen={expandGuard.isOpen}
+            format={expandGuard.format}
+            onCancel={expandGuard.cancel}
+            onChangeToUnicode={expandGuard.changeToUnicode}
+            onEditAnyway={expandGuard.editAnyway}
+            button={
+              <RiTooltip content={editState?.editDisabledReason ?? null}>
+                <IconButton
+                  icon={ExtendIcon}
+                  aria-label="Expand value editor"
+                  disabled={isEditActionDisabled}
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation()
+                    expandGuard.requestEdit(() =>
+                      editConfig?.onOpenValueEditor(index),
+                    )
+                  }}
+                  data-testid={`array-expand-btn-${index}`}
+                />
+              </RiTooltip>
+            }
+          />
         </>
       )}
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/array-details/array-details-table/components/RowActionsCell/RowActionsCell.tsx
@@ -29,7 +29,8 @@ export const RowActionsCell = ({
 }: RowActionsCellProps) => {
   const { t } = useTranslation()
   const editGuard = useNonUnicodeEditGuard()
-  const expandGuard = useNonUnicodeEditGuard()
+  // Drawer snapshots its seed on open, so a Unicode switch must not reopen it.
+  const expandGuard = useNonUnicodeEditGuard({ reenterAfterUnicode: false })
 
   const { index, value } = element
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.spec.tsx
@@ -4,6 +4,7 @@ import { cloneDeep } from 'lodash'
 import {
   cleanup,
   mockedStore,
+  mockStore,
   render,
   screen,
   fireEvent,
@@ -13,7 +14,10 @@ import {
 import { stringDataSelector, stringSelector } from 'uiSrc/slices/browser/string'
 import { setSelectedKeyRefreshDisabled } from 'uiSrc/slices/browser/keys'
 import { MOCK_TRUNCATED_BUFFER_VALUE } from 'uiSrc/mocks/data/bigString'
-import { TEXT_DISABLED_ACTION_WITH_TRUNCATED_DATA } from 'uiSrc/constants'
+import {
+  KeyValueFormat,
+  TEXT_DISABLED_ACTION_WITH_TRUNCATED_DATA,
+} from 'uiSrc/constants'
 import { handleCopy } from 'uiSrc/utils'
 import { Props, StringDetails } from './StringDetails'
 
@@ -114,6 +118,20 @@ describe('StringDetails', () => {
       <StringDetails {...instance(mockedProps)} />,
     )
     expect(queryByTestId('edit-key-value-btn')).toBeInTheDocument()
+  })
+
+  it('warns before editing when a non-Unicode format is selected', () => {
+    const state = cloneDeep(mockedStore.getState())
+    state.browser.keys.selectedKey.viewFormat = KeyValueFormat.JSON
+    const jsonStore = mockStore(state)
+
+    render(<StringDetails {...mockedProps} />, { store: jsonStore })
+
+    fireEvent.click(screen.getByTestId(EDIT_VALUE_BTN_TEST_ID))
+
+    expect(
+      screen.getByTestId('non-unicode-edit-to-unicode'),
+    ).toBeInTheDocument()
   })
 
   it('should disable refresh when editing', async () => {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
@@ -137,8 +137,7 @@ const StringDetails = (props: Props) => {
   // unsaved textarea the user is currently editing.
   const showCopyButton = !!keyValue && isFullyAvailable && !editItem
 
-  // Memoized so an unrelated re-render (e.g. a background refresh) doesn't
-  // recreate this component type and remount the open confirmation popover.
+  // Stable identity so a re-render doesn't remount (and close) the popover.
   const Actions = useCallback(
     () => (
       <Row align="center" gap="s" grow={false}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 
 import {
@@ -92,28 +92,33 @@ const StringDetails = (props: Props) => {
   const [editItem, setEditItem] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
-  const editGuard = useNonUnicodeEditGuard()
+  const {
+    isOpen: isEditConfirmOpen,
+    format: editConfirmFormat,
+    requestEdit,
+    cancel: cancelEditConfirm,
+    changeToUnicode: changeEditToUnicode,
+    editAnyway,
+  } = useNonUnicodeEditGuard()
 
-  const enterEdit = () => {
-    dispatch(setSelectedKeyRefreshDisabled(true))
-    setEditItem(true)
-  }
-
-  const handleHeaderEdit = () => {
+  const handleHeaderEdit = useCallback(() => {
     if (editItem) {
       dispatch(setSelectedKeyRefreshDisabled(false))
       setEditItem(false)
       return
     }
-    editGuard.requestEdit(enterEdit)
-  }
+    requestEdit(() => {
+      dispatch(setSelectedKeyRefreshDisabled(true))
+      setEditItem(true)
+    })
+  }, [editItem, requestEdit, dispatch])
 
-  const handleCopyValue = () => {
+  const handleCopyValue = useCallback(() => {
     sendEventTelemetry({
       event: TelemetryEvent.STRING_VALUE_COPIED,
       eventData: { databaseId: instanceId },
     })
-  }
+  }, [instanceId])
 
   const handleRefreshKey = (
     key: RedisResponseBuffer,
@@ -128,34 +133,54 @@ const StringDetails = (props: Props) => {
     onRemoveKey()
   }
 
-  const Actions = () => (
-    <Row align="center" gap="s" grow={false}>
-      {/* Hidden while editing: copyValue comes from the saved Redis value, not
-          the unsaved textarea the user is currently editing. */}
-      {keyValue && isFullyAvailable && !editItem && (
-        <CopyButton
-          copy={copyValue}
-          aria-label="Copy value"
-          onCopy={handleCopyValue}
-          data-testid="copy-string-value"
-        />
-      )}
-      <NonUnicodeEditConfirmation
-        isOpen={editGuard.isOpen}
-        format={editGuard.format}
-        onCancel={editGuard.cancel}
-        onChangeToUnicode={editGuard.changeToUnicode}
-        onEditAnyway={editGuard.editAnyway}
-        button={
-          <EditItemAction
-            title="Edit Value"
-            tooltipContent={editToolTip}
-            isEditable={isStringEditable && isEditable}
-            onEditItem={handleHeaderEdit}
+  // Hidden while editing: copyValue comes from the saved Redis value, not the
+  // unsaved textarea the user is currently editing.
+  const showCopyButton = !!keyValue && isFullyAvailable && !editItem
+
+  // Memoized so an unrelated re-render (e.g. a background refresh) doesn't
+  // recreate this component type and remount the open confirmation popover.
+  const Actions = useCallback(
+    () => (
+      <Row align="center" gap="s" grow={false}>
+        {showCopyButton && (
+          <CopyButton
+            copy={copyValue}
+            aria-label="Copy value"
+            onCopy={handleCopyValue}
+            data-testid="copy-string-value"
           />
-        }
-      />
-    </Row>
+        )}
+        <NonUnicodeEditConfirmation
+          isOpen={isEditConfirmOpen}
+          format={editConfirmFormat}
+          onCancel={cancelEditConfirm}
+          onChangeToUnicode={changeEditToUnicode}
+          onEditAnyway={editAnyway}
+          button={
+            <EditItemAction
+              title="Edit Value"
+              tooltipContent={editToolTip}
+              isEditable={isStringEditable && isEditable}
+              onEditItem={handleHeaderEdit}
+            />
+          }
+        />
+      </Row>
+    ),
+    [
+      showCopyButton,
+      copyValue,
+      handleCopyValue,
+      isEditConfirmOpen,
+      editConfirmFormat,
+      cancelEditConfirm,
+      changeEditToUnicode,
+      editAnyway,
+      editToolTip,
+      isStringEditable,
+      isEditable,
+      handleHeaderEdit,
+    ],
   )
 
   return (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/StringDetails.tsx
@@ -39,6 +39,10 @@ import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { CopyButton } from 'uiSrc/components/copy-button'
 import { Row } from 'uiSrc/components/base/layout/flex'
+import {
+  NonUnicodeEditConfirmation,
+  useNonUnicodeEditGuard,
+} from 'uiSrc/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation'
 import { StringDetailsValue } from './string-details-value'
 import { getStringCopyValue } from './StringDetails.utils'
 import { EditItemAction } from '../key-details-actions'
@@ -88,6 +92,21 @@ const StringDetails = (props: Props) => {
   const [editItem, setEditItem] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
+  const editGuard = useNonUnicodeEditGuard()
+
+  const enterEdit = () => {
+    dispatch(setSelectedKeyRefreshDisabled(true))
+    setEditItem(true)
+  }
+
+  const handleHeaderEdit = () => {
+    if (editItem) {
+      dispatch(setSelectedKeyRefreshDisabled(false))
+      setEditItem(false)
+      return
+    }
+    editGuard.requestEdit(enterEdit)
+  }
 
   const handleCopyValue = () => {
     sendEventTelemetry({
@@ -121,14 +140,20 @@ const StringDetails = (props: Props) => {
           data-testid="copy-string-value"
         />
       )}
-      <EditItemAction
-        title="Edit Value"
-        tooltipContent={editToolTip}
-        isEditable={isStringEditable && isEditable}
-        onEditItem={() => {
-          dispatch(setSelectedKeyRefreshDisabled(!editItem))
-          setEditItem(!editItem)
-        }}
+      <NonUnicodeEditConfirmation
+        isOpen={editGuard.isOpen}
+        format={editGuard.format}
+        onCancel={editGuard.cancel}
+        onChangeToUnicode={editGuard.changeToUnicode}
+        onEditAnyway={editGuard.editAnyway}
+        button={
+          <EditItemAction
+            title="Edit Value"
+            tooltipContent={editToolTip}
+            isEditable={isStringEditable && isEditable}
+            onEditItem={handleHeaderEdit}
+          />
+        }
       />
     </Row>
   )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -64,6 +64,10 @@ import {
   BrowserConfirmationCommandId,
   useProductionWriteConfirmation,
 } from 'uiSrc/components/production-write-confirmation'
+import {
+  NonUnicodeEditConfirmation,
+  useNonUnicodeEditGuard,
+} from 'uiSrc/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation'
 import styles from './styles.module.scss'
 
 const MIN_ROWS = 8
@@ -113,6 +117,7 @@ const StringDetailsValue = (props: Props) => {
 
   const dispatch = useAppDispatch()
   const { requestConfirmation } = useProductionWriteConfirmation()
+  const editGuard = useNonUnicodeEditGuard()
 
   useEffect(
     () => () => {
@@ -260,7 +265,9 @@ const StringDetailsValue = (props: Props) => {
         component="div"
         color="secondary"
         className={styles.stringValue}
-        onClick={() => isEditable && setIsEdit(true)}
+        onClick={() =>
+          isEditable && editGuard.requestEdit(() => setIsEdit(true))
+        }
         style={{ whiteSpace: 'break-spaces' }}
         data-testid="string-value"
       >
@@ -271,15 +278,24 @@ const StringDetailsValue = (props: Props) => {
     )
 
     return (
-      <RiTooltip
-        title={!isValid ? noEditableText : undefined}
-        anchorClassName={styles.tooltipAnchor}
-        className={styles.tooltip}
-        position="left"
-        data-testid="string-value-tooltip"
-      >
-        {textEl}
-      </RiTooltip>
+      <NonUnicodeEditConfirmation
+        isOpen={editGuard.isOpen}
+        format={editGuard.format}
+        onCancel={editGuard.cancel}
+        onChangeToUnicode={editGuard.changeToUnicode}
+        onEditAnyway={editGuard.editAnyway}
+        button={
+          <RiTooltip
+            title={!isValid ? noEditableText : undefined}
+            anchorClassName={styles.tooltipAnchor}
+            className={styles.tooltip}
+            position="left"
+            data-testid="string-value-tooltip"
+          >
+            {textEl}
+          </RiTooltip>
+        }
+      />
     )
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -13,6 +13,10 @@ import {
   BrowserConfirmationCommandId,
   useProductionWriteConfirmation,
 } from 'uiSrc/components/production-write-confirmation'
+import {
+  NonUnicodeEditConfirmation,
+  useNonUnicodeEditGuard,
+} from 'uiSrc/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -70,6 +74,7 @@ const EditableTextArea = (props: Props) => {
   const [isHovering, setIsHovering] = useState(false)
   const textAreaRef: Ref<HTMLTextAreaElement> = useRef(null)
   const { requestConfirmation } = useProductionWriteConfirmation()
+  const editGuard = useNonUnicodeEditGuard()
 
   useEffect(() => {
     setValue(initialValue)
@@ -113,25 +118,34 @@ const EditableTextArea = (props: Props) => {
         >
           {children}
         </Text>
-        {!hideEditButton && isHovering && (
-          <RiTooltip
-            content={editToolTipContent}
+        {!hideEditButton && (isHovering || editGuard.isOpen) && (
+          <NonUnicodeEditConfirmation
+            isOpen={editGuard.isOpen}
+            format={editGuard.format}
             anchorClassName={styles.editBtnAnchor}
-            data-testid={`${testIdPrefix}_edit-tooltip-${field}`}
-          >
-            <IconButton
-              icon={EditIcon}
-              aria-label="Edit field"
-              className={cx('editFieldBtn', styles.editBtn)}
-              disabled={isEditDisabled}
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation()
-                onEdit?.(true)
-                setIsHovering(false)
-              }}
-              data-testid={`${testIdPrefix}_edit-btn-${field}`}
-            />
-          </RiTooltip>
+            onCancel={editGuard.cancel}
+            onChangeToUnicode={editGuard.changeToUnicode}
+            onEditAnyway={editGuard.editAnyway}
+            button={
+              <RiTooltip
+                content={editToolTipContent}
+                data-testid={`${testIdPrefix}_edit-tooltip-${field}`}
+              >
+                <IconButton
+                  icon={EditIcon}
+                  aria-label="Edit field"
+                  className={cx('editFieldBtn', styles.editBtn)}
+                  disabled={isEditDisabled}
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation()
+                    editGuard.requestEdit(() => onEdit?.(true))
+                    setIsHovering(false)
+                  }}
+                  data-testid={`${testIdPrefix}_edit-btn-${field}`}
+                />
+              </RiTooltip>
+            }
+          />
         )}
       </div>
     )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/NonUnicodeEditConfirmation.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/NonUnicodeEditConfirmation.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+
+import ConfirmationPopover from 'uiSrc/components/confirmation-popover'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import {
+  EmptyButton,
+  PrimaryButton,
+  SecondaryButton,
+} from 'uiSrc/components/base/forms/buttons'
+import { KeyValueFormat } from 'uiSrc/constants'
+
+const getMessage = (format: KeyValueFormat) =>
+  `This value is shown using the ${format} format. Saving your changes may ` +
+  'store a reformatted value and alter the original data. Switch to Unicode ' +
+  'to edit the raw value safely.'
+
+export interface NonUnicodeEditConfirmationProps {
+  /** The edit trigger the popover anchors to. */
+  button: React.ReactNode
+  isOpen: boolean
+  format: KeyValueFormat
+  /** Class applied to the popover's anchor, to preserve the trigger's layout. */
+  anchorClassName?: string
+  onCancel: () => void
+  onChangeToUnicode: () => void
+  onEditAnyway: () => void
+}
+
+/**
+ * Warns before editing a value under a non-Unicode format, which can
+ * silently reformat the stored value on save.
+ */
+export const NonUnicodeEditConfirmation = ({
+  button,
+  isOpen,
+  format,
+  anchorClassName,
+  onCancel,
+  onChangeToUnicode,
+  onEditAnyway,
+}: NonUnicodeEditConfirmationProps) => (
+  <ConfirmationPopover
+    anchorPosition="leftCenter"
+    ownFocus
+    isOpen={isOpen}
+    closePopover={onCancel}
+    panelPaddingSize="m"
+    anchorClassName={anchorClassName}
+    button={button}
+    onClick={(e) => e.stopPropagation()}
+    title="Editing a non-Unicode value"
+    message={getMessage(format)}
+    confirmButton={
+      <Row gap="m" justify="end">
+        <EmptyButton
+          size="small"
+          onClick={onCancel}
+          data-testid="non-unicode-edit-cancel"
+        >
+          Cancel
+        </EmptyButton>
+        <SecondaryButton
+          size="small"
+          onClick={onEditAnyway}
+          data-testid="non-unicode-edit-anyway"
+        >
+          Edit anyway
+        </SecondaryButton>
+        <PrimaryButton
+          size="small"
+          onClick={onChangeToUnicode}
+          data-testid="non-unicode-edit-to-unicode"
+        >
+          Change to Unicode
+        </PrimaryButton>
+      </Row>
+    }
+  />
+)

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/index.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/index.ts
@@ -1,0 +1,3 @@
+export { NonUnicodeEditConfirmation } from './NonUnicodeEditConfirmation'
+export type { NonUnicodeEditConfirmationProps } from './NonUnicodeEditConfirmation'
+export { useNonUnicodeEditGuard } from './useNonUnicodeEditGuard'

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.spec.ts
@@ -102,6 +102,29 @@ describe('useNonUnicodeEditGuard', () => {
     jest.useRealTimers()
   })
 
+  it('switches to Unicode without re-entering when reenterAfterUnicode is false', () => {
+    jest.useFakeTimers()
+    const store = makeStore(KeyValueFormat.JSON)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(
+      () => useNonUnicodeEditGuard({ reenterAfterUnicode: false }),
+      { store },
+    )
+
+    act(() => result.current.requestEdit(proceed))
+    act(() => result.current.changeToUnicode())
+
+    expect(store.getActions()).toContainEqual(
+      setViewFormat(KeyValueFormat.Unicode),
+    )
+
+    act(() => jest.runAllTimers())
+
+    expect(proceed).not.toHaveBeenCalled()
+    jest.useRealTimers()
+  })
+
   it('discards the edit and closes on Cancel', () => {
     const store = makeStore(KeyValueFormat.JSON)
     const proceed = jest.fn()

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.spec.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.spec.ts
@@ -1,0 +1,117 @@
+import { cloneDeep } from 'lodash'
+import { act } from '@testing-library/react'
+
+import { renderHook, mockedStore, mockStore } from 'uiSrc/utils/test-utils'
+import { setViewFormat } from 'uiSrc/slices/browser/keys'
+import { KeyValueFormat } from 'uiSrc/constants'
+import { useNonUnicodeEditGuard } from './useNonUnicodeEditGuard'
+
+const makeStore = (viewFormat: KeyValueFormat) => {
+  const state = cloneDeep(mockedStore.getState())
+  state.browser.keys.selectedKey.viewFormat = viewFormat
+  return mockStore(state)
+}
+
+describe('useNonUnicodeEditGuard', () => {
+  it('runs the edit immediately when Unicode is selected', () => {
+    const store = makeStore(KeyValueFormat.Unicode)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('treats a missing format as Unicode and edits immediately', () => {
+    const state = cloneDeep(mockedStore.getState())
+    const selectedKey = state.browser.keys.selectedKey as {
+      viewFormat?: KeyValueFormat
+    }
+    delete selectedKey.viewFormat
+    const store = mockStore(state)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('runs the edit immediately for a non-editable format (e.g. HEX)', () => {
+    const store = makeStore(KeyValueFormat.HEX)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('defers the edit and opens the popover for a non-Unicode format', () => {
+    const store = makeStore(KeyValueFormat.JSON)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+
+    expect(proceed).not.toHaveBeenCalled()
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it('runs the deferred edit and closes on "Edit anyway"', () => {
+    const store = makeStore(KeyValueFormat.JSON)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+    act(() => result.current.editAnyway())
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('switches to Unicode and re-enters edit on "Change to Unicode"', () => {
+    jest.useFakeTimers()
+    const store = makeStore(KeyValueFormat.JSON)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+    act(() => result.current.changeToUnicode())
+
+    expect(result.current.isOpen).toBe(false)
+    expect(store.getActions()).toContainEqual(
+      setViewFormat(KeyValueFormat.Unicode),
+    )
+    // The edit is deferred until the table finishes its format reset.
+    expect(proceed).not.toHaveBeenCalled()
+
+    act(() => jest.runAllTimers())
+
+    expect(proceed).toHaveBeenCalledTimes(1)
+    jest.useRealTimers()
+  })
+
+  it('discards the edit and closes on Cancel', () => {
+    const store = makeStore(KeyValueFormat.JSON)
+    const proceed = jest.fn()
+
+    const { result } = renderHook(() => useNonUnicodeEditGuard(), { store })
+
+    act(() => result.current.requestEdit(proceed))
+    act(() => result.current.cancel())
+
+    expect(proceed).not.toHaveBeenCalled()
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+
+import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
+import {
+  defaultViewFormat,
+  selectedKeySelector,
+  setViewFormat,
+} from 'uiSrc/slices/browser/keys'
+import { isFormatEditable } from 'uiSrc/utils'
+import { KeyValueFormat } from 'uiSrc/constants'
+
+// Non-editable formats can't be edited at all, so only warn for an
+// editable non-Unicode format.
+const needsEditWarning = (format: KeyValueFormat) =>
+  format !== KeyValueFormat.Unicode && isFormatEditable(format)
+
+/**
+ * Guards entering edit mode: for a non-Unicode format it opens the
+ * confirmation and defers the edit; otherwise it proceeds immediately.
+ */
+export const useNonUnicodeEditGuard = () => {
+  const { viewFormat } = useAppSelector(selectedKeySelector)
+  const dispatch = useAppDispatch()
+
+  const format = viewFormat ?? defaultViewFormat
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [pendingEdit, setPendingEdit] = useState<(() => void) | null>(null)
+
+  const requestEdit = (proceed: () => void) => {
+    if (!needsEditWarning(format)) {
+      proceed()
+      return
+    }
+    // Store the callback (wrapped so setState does not invoke it).
+    setPendingEdit(() => proceed)
+    setIsOpen(true)
+  }
+
+  const cancel = () => {
+    setIsOpen(false)
+    setPendingEdit(null)
+  }
+
+  const editAnyway = () => {
+    setIsOpen(false)
+    pendingEdit?.()
+    setPendingEdit(null)
+  }
+
+  const changeToUnicode = () => {
+    const proceed = pendingEdit
+    dispatch(setViewFormat(KeyValueFormat.Unicode))
+    setIsOpen(false)
+    setPendingEdit(null)
+    // Defer past the table's format-change reset (which clears edit state)
+    // so the row reopens in place on its raw Unicode value.
+    if (proceed) {
+      setTimeout(proceed, 0)
+    }
+  }
+
+  return {
+    format,
+    isOpen,
+    requestEdit,
+    cancel,
+    editAnyway,
+    changeToUnicode,
+  }
+}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
@@ -14,11 +14,21 @@ import { KeyValueFormat } from 'uiSrc/constants'
 const needsEditWarning = (format: KeyValueFormat) =>
   format !== KeyValueFormat.Unicode && isFormatEditable(format)
 
+interface Options {
+  /**
+   * Re-run the pending edit after switching to Unicode. Disable where the
+   * editor snapshots its value under the opening format (e.g. the array drawer).
+   */
+  reenterAfterUnicode?: boolean
+}
+
 /**
  * Guards entering edit mode: for a non-Unicode format it opens the
  * confirmation and defers the edit; otherwise it proceeds immediately.
  */
-export const useNonUnicodeEditGuard = () => {
+export const useNonUnicodeEditGuard = ({
+  reenterAfterUnicode = true,
+}: Options = {}) => {
   const { viewFormat } = useAppSelector(selectedKeySelector)
   const dispatch = useAppDispatch()
 
@@ -59,10 +69,10 @@ export const useNonUnicodeEditGuard = () => {
     setPendingEdit(null)
     // Defer past the table's format-change reset (which clears edit state)
     // so the row reopens in place on its raw Unicode value.
-    if (proceed) {
+    if (reenterAfterUnicode && proceed) {
       setTimeout(proceed, 0)
     }
-  }, [pendingEdit, dispatch])
+  }, [pendingEdit, dispatch, reenterAfterUnicode])
 
   return {
     format,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import {
@@ -27,28 +27,33 @@ export const useNonUnicodeEditGuard = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [pendingEdit, setPendingEdit] = useState<(() => void) | null>(null)
 
-  const requestEdit = (proceed: () => void) => {
-    if (!needsEditWarning(format)) {
-      proceed()
-      return
-    }
-    // Store the callback (wrapped so setState does not invoke it).
-    setPendingEdit(() => proceed)
-    setIsOpen(true)
-  }
+  // Stable callbacks so consumers can memoize the surrounding UI without the
+  // popover remounting (and losing focus) on unrelated re-renders.
+  const requestEdit = useCallback(
+    (proceed: () => void) => {
+      if (!needsEditWarning(format)) {
+        proceed()
+        return
+      }
+      // Store the callback (wrapped so setState does not invoke it).
+      setPendingEdit(() => proceed)
+      setIsOpen(true)
+    },
+    [format],
+  )
 
-  const cancel = () => {
+  const cancel = useCallback(() => {
     setIsOpen(false)
     setPendingEdit(null)
-  }
+  }, [])
 
-  const editAnyway = () => {
+  const editAnyway = useCallback(() => {
     setIsOpen(false)
     pendingEdit?.()
     setPendingEdit(null)
-  }
+  }, [pendingEdit])
 
-  const changeToUnicode = () => {
+  const changeToUnicode = useCallback(() => {
     const proceed = pendingEdit
     dispatch(setViewFormat(KeyValueFormat.Unicode))
     setIsOpen(false)
@@ -58,7 +63,7 @@ export const useNonUnicodeEditGuard = () => {
     if (proceed) {
       setTimeout(proceed, 0)
     }
-  }
+  }, [pendingEdit, dispatch])
 
   return {
     format,

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/non-unicode-edit-confirmation/useNonUnicodeEditGuard.ts
@@ -27,8 +27,7 @@ export const useNonUnicodeEditGuard = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [pendingEdit, setPendingEdit] = useState<(() => void) | null>(null)
 
-  // Stable callbacks so consumers can memoize the surrounding UI without the
-  // popover remounting (and losing focus) on unrelated re-renders.
+  // Stable identities so consumers can memoize the UI around the popover.
   const requestEdit = useCallback(
     (proceed: () => void) => {
       if (!needsEditWarning(format)) {

--- a/redisinsight/ui/src/slices/browser/keys.ts
+++ b/redisinsight/ui/src/slices/browser/keys.ts
@@ -110,7 +110,7 @@ import {
 
 const riConfig = getConfig()
 
-const defaultViewFormat = KeyValueFormat.Unicode
+export const defaultViewFormat = KeyValueFormat.Unicode
 
 export const initialState: KeysStore = {
   loading: false,


### PR DESCRIPTION
# What

Editing a value while a non-Unicode value format (e.g. JSON) is selected
round-trips it through that format's serializer on save and can silently
rewrite the stored bytes — e.g. the string `00014` gets written back as `14`
(reported in GitHub #6269).

This adds an inline confirmation when the user starts editing a value under a
non-Unicode format, with three choices:
- **Cancel** — do nothing.
- **Edit anyway** — proceed under the current format.
- **Change to Unicode** — switch to the safe format and reopen the editor in
  place on the raw value, so large keyspaces don't have to be re-navigated.

The logic and popover live in one shared guard (`useNonUnicodeEditGuard` +
`NonUnicodeEditConfirmation`) wired into `EditableTextArea` (hash, list, array)
and `StringDetailsValue` (strings). The warning is format-only: it triggers for
editable non-Unicode formats (JSON, ASCII, Msgpack, PHP, DateTime, Markdown)
and never for Unicode or non-editable formats. ReJSON is out of scope — it has
no format selector and persists JSON directly, so the round-trip can't occur.

# Testing

1. `HSET demo:hash productInfoID "00014"` and open the key in the Browser.
2. Switch the value format to **JSON** — the value displays as `14`.
3. Click the edit pencil → the confirmation appears.
   - **Change to Unicode** → format switches and the editor reopens showing the
     raw `00014`.
   - **Edit anyway** → editor opens under JSON.
   - **Cancel** → nothing happens.
4. Repeat for a plain string (`SET demo:string "00014"`) and a list element —
   same warning. Confirm **Unicode** format shows no warning.

# Preview


https://github.com/user-attachments/assets/5ac9f0e8-d34e-4296-9279-9045c70b561a




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guard around existing edit flows; main behavioral change is deferring edit until user confirms or switches format.
> 
> **Overview**
> Adds a **confirmation step** when users start editing Redis values while an editable non-Unicode view format (e.g. JSON) is selected, so saves are less likely to silently rewrite stored bytes via format round-trips.
> 
> Introduces shared **`useNonUnicodeEditGuard`** and **`NonUnicodeEditConfirmation`** with **Cancel**, **Edit anyway**, and **Change to Unicode** (dispatches `setViewFormat`, optionally re-opens the editor after a deferred tick). The guard is wired into **string** header/value edit, **`EditableTextArea`** (hash/list/etc.), and **array** row inline edit and expand (expand uses `reenterAfterUnicode: false` so the drawer does not reopen on format switch). **`defaultViewFormat`** is exported from the keys slice for the hook. Component and hook tests cover the warning and actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b02df7241cee79bd71b23a44179ede5ac89f5dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->