### PR TITLE
Fail E2E CI runs fast after 20 test failures

### DIFF
--- a/tests/e2e-playwright/playwright.config.ts
+++ b/tests/e2e-playwright/playwright.config.ts
@@ -13,6 +13,9 @@ const config: PlaywrightTestConfig<CustomTestOptions> = {
   forbidOnly: !!process.env.CI,
   // Retry failed tests to handle transient failures
   retries: process.env.CI ? 2 : 1,
+  // Bail on CI after enough failures to catch a systemic breakage without
+  // running the whole suite.
+  maxFailures: process.env.CI ? 20 : undefined,
   reporter: [['html'], ['list'], ['json', { outputFile: 'test-results/results.json' }]],
 
   use: {


### PR DESCRIPTION
# What

Adds `maxFailures: 20` to the Playwright config on CI. When a systemic
breakage (dead API, broken credential store, etc.) makes most of the suite
fail, the run now bails after 20 failures instead of grinding through all
~300 tests with retries.

Context: a recent [run](https://github.com/redis/RedisInsight/actions/runs/29996586331/job/89190178950) took ~52 min and nearly hit the 60-min job ceiling
because a broken API dependency made ~50 tests fail (mostly
`503 Keytar unavailable` and downstream 60s timeouts), yet the run kept going
to the end. With this change it would have aborted a few minutes in.

The threshold counts failed tests, not attempts, so a flaky test that passes
on retry doesn't count toward it. Local runs are unaffected (`maxFailures` is
only set when `CI` is true) so you still see every failure when debugging.

No global timeout is added on purpose - it would need bumping as the suite
grows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness-only change with no production code impact; local E2E behavior is unchanged.
> 
> **Overview**
> CI Playwright E2E runs now set **`maxFailures: 20`** in `playwright.config.ts` so a systemic outage (e.g. dead API, broken keytar) stops the job after twenty failed tests instead of running the full ~300-test suite with retries.
> 
> **Local runs are unchanged** — `maxFailures` is only applied when `CI` is set, so local debugging still surfaces every failure. The limit counts distinct failed tests, not retry attempts, so flakes that pass on retry do not push the run toward the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a66df21882a6471c3637b3e96391375086ed677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->