### PR TITLE
Remove vectorSet feature flag

### DIFF
--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -35,7 +35,6 @@ export enum KnownFeatures {
   AzureEntraId = 'azureEntraId',
   DevAzureEntraId = 'dev-azureEntraId',
   DevBrowser = 'dev-browser',
-  VectorSet = 'vectorSet',
   Array = 'array',
   DevLanguage = 'dev-language',
   ValueDecoder = 'valueDecoder',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -78,10 +78,6 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevBrowser,
     storage: FeatureStorage.Database,
   },
-  [KnownFeatures.VectorSet]: {
-    name: KnownFeatures.VectorSet,
-    storage: FeatureStorage.Database,
-  },
   [KnownFeatures.Array]: {
     name: KnownFeatures.Array,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -93,10 +93,6 @@ export class FeatureFlagProvider {
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );
     this.strategies.set(
-      KnownFeatures.VectorSet,
-      new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
-    );
-    this.strategies.set(
       KnownFeatures.Array,
       new SwitchableFlagStrategy(
         this.featuresConfigService,

--- a/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
+++ b/redisinsight/ui/src/components/whats-new/WhatsNewModal.spec.tsx
@@ -23,9 +23,11 @@ jest.mock('uiSrc/telemetry', () => ({
 const latestVersion = whatsNewFeed[0].version
 
 // Card-level assertions pin to a shipped version so they don't churn when a
-// new release is added to the top of the feed. 3.6.0 has both a flag-gated
-// card (vector-sets) and an unflagged one (geodata-workbench).
+// new release is added to the top of the feed. 3.6.0 carries unflagged cards
+// (e.g. geodata-workbench); 3.2.0's azure-managed-redis card is flag-gated
+// (azureEntraId) and is used to exercise the coming-soon / active states.
 const CONTENT_VERSION = '3.6.0'
+const FLAG_GATED_VERSION = '3.2.0'
 
 const getOpenState = (flagsOn = false, version = latestVersion) => {
   let state = set(cloneDeep(initialStateDefault), 'app.whatsNew', {
@@ -36,7 +38,7 @@ const getOpenState = (flagsOn = false, version = latestVersion) => {
   if (flagsOn) {
     state = set(
       state,
-      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
+      `app.features.featureFlags.features.${FeatureFlags.azureEntraId}`,
       { flag: true },
     )
   }
@@ -77,21 +79,23 @@ describe('WhatsNewModal', () => {
     expect(
       screen.getByTestId('whats-new-card-location-geodata-workbench'),
     ).toBeInTheDocument()
-  })
-
-  it('should show flag-gated cards marked as coming soon when their flags are off', () => {
-    render(<WhatsNewModal />, {
-      store: mockStore(getOpenState(false, CONTENT_VERSION)),
-    })
-
-    expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
-    expect(
-      screen.getByTestId('whats-new-card-inactive-vector-sets'),
-    ).toBeInTheDocument()
     // unflagged card carries no indicator
     expect(
       screen.queryByTestId('whats-new-card-inactive-geodata-workbench'),
     ).not.toBeInTheDocument()
+  })
+
+  it('should show flag-gated cards marked as coming soon when their flags are off', () => {
+    render(<WhatsNewModal />, {
+      store: mockStore(getOpenState(false, FLAG_GATED_VERSION)),
+    })
+
+    expect(
+      screen.getByTestId('whats-new-card-azure-managed-redis'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('whats-new-card-inactive-azure-managed-redis'),
+    ).toBeInTheDocument()
   })
 
   it('should show versions whose cards are all flag-gated off', () => {
@@ -111,12 +115,14 @@ describe('WhatsNewModal', () => {
 
   it('should not mark flag-gated cards when their flags are on', () => {
     render(<WhatsNewModal />, {
-      store: mockStore(getOpenState(true, CONTENT_VERSION)),
+      store: mockStore(getOpenState(true, FLAG_GATED_VERSION)),
     })
 
-    expect(screen.getByTestId('whats-new-card-vector-sets')).toBeInTheDocument()
     expect(
-      screen.queryByTestId('whats-new-card-inactive-vector-sets'),
+      screen.getByTestId('whats-new-card-azure-managed-redis'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('whats-new-card-inactive-azure-managed-redis'),
     ).not.toBeInTheDocument()
   })
 

--- a/redisinsight/ui/src/constants/content/whats-new/versions/v3.6.0.ts
+++ b/redisinsight/ui/src/constants/content/whats-new/versions/v3.6.0.ts
@@ -1,4 +1,3 @@
-import { FeatureFlags } from 'uiSrc/constants/featureFlags'
 import { WhatsNewVersion, WhatsNewVersionType } from '../types'
 
 export const version360: WhatsNewVersion = {
@@ -11,7 +10,6 @@ export const version360: WhatsNewVersion = {
       title: 'Vector Sets support',
       body: 'Create Vector Sets (Redis 8) manually or from the bundled vec2word sample, add elements with attributes, and run similarity search in the GUI. Handy for prototyping semantic search.',
       location: 'Browser — add a key of type Vector Set',
-      featureFlag: FeatureFlags.vectorSet,
     },
     {
       id: 'dev-vs-prod-mode',

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -11,7 +11,6 @@ export enum FeatureFlags {
   cloudAds = 'cloudAds',
   databaseManagement = 'databaseManagement',
   customTutorials = 'customTutorials',
-  vectorSet = 'vectorSet',
   array = 'array',
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { cloneDeep, set } from 'lodash'
+import { cloneDeep } from 'lodash'
 
 import {
   cleanup,
-  initialStateDefault,
   mockedStore,
-  mockStore,
   render,
   screen,
   userEvent,
@@ -23,7 +21,6 @@ import {
 import * as appFeaturesSlice from 'uiSrc/slices/app/features'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { setSocialDialogState } from 'uiSrc/slices/oauth/cloud'
-import { FeatureFlags } from 'uiSrc/constants'
 import AddKey from './AddKey'
 
 const handleAddKeyPanelMock = () => {}
@@ -40,27 +37,13 @@ jest.mock('uiSrc/slices/instances/instances', () => ({
   }),
 }))
 
-/**
- * Build a fresh store with the `vectorSet` feature flag pre-seeded so the
- * Vector Set option's `isEnabledSelector` (which reads the flag from the
- * features slice) resolves correctly. We seed the store rather than spying
- * on the selector because the option config holds an import-time reference
- * to the selector, which jest spies on the module export cannot intercept.
- */
-const renderWithVectorSetFlag = (enabled: boolean) => {
-  const storeState = set(
-    cloneDeep(initialStateDefault),
-    `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
-    { flag: enabled },
-  )
-  return render(
+const renderAddKey = () =>
+  render(
     <AddKey
       onAddKeyPanel={handleAddKeyPanelMock}
       onClosePanel={handleCloseKeyMock}
     />,
-    { store: mockStore(storeState) },
   )
-}
 
 const mockRedisVersion = (version: string) =>
   (connectedInstanceOverviewSelector as jest.Mock).mockReturnValue({ version })
@@ -169,9 +152,9 @@ describe('AddKey', () => {
     ])
   })
 
-  it('should show Vector Set option when redis version >= 8.0 and vector set flag is enabled', async () => {
+  it('should show Vector Set option when redis version >= 8.0', async () => {
     mockRedisVersion('8.0.0')
-    renderWithVectorSetFlag(true)
+    renderAddKey()
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(await screen.findByText('Vector Set')).toBeInTheDocument()
@@ -179,15 +162,7 @@ describe('AddKey', () => {
 
   it('should hide Vector Set option when redis version < 8.0', async () => {
     mockRedisVersion('7.4.0')
-    renderWithVectorSetFlag(true)
-
-    await userEvent.click(screen.getByTestId('select-key-type'))
-    expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()
-  })
-
-  it('should hide Vector Set option when vector set flag is disabled', async () => {
-    mockRedisVersion('8.0.0')
-    renderWithVectorSetFlag(false)
+    renderAddKey()
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()

--- a/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/constants/key-type-options.ts
@@ -1,9 +1,6 @@
 import { GROUP_TYPES_COLORS, KeyTypes } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import {
-  isArrayEnabledSelector,
-  isVectorSetEnabledSelector,
-} from 'uiSrc/slices/app/features'
+import { isArrayEnabledSelector } from 'uiSrc/slices/app/features'
 import { AddKeyTypeOption } from '../AddKey.types'
 
 export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
@@ -54,6 +51,5 @@ export const ADD_KEY_TYPE_OPTIONS: AddKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isVectorSetEnabledSelector,
   },
 ]

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/FilterKeyType.spec.tsx
@@ -195,49 +195,22 @@ describe('FilterKeyType', () => {
     expect(graphElement).not.toBeInTheDocument()
   })
 
-  it('should show Vector Set when vector set feature flag is enabled and redis version >= 8.0', async () => {
+  it('should show Vector Set when redis version >= 8.0', async () => {
     connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
       version: '8.0.0',
     }))
-    const initialStoreState = set(
-      cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
-      { flag: true },
-    )
-    const { queryByText } = render(<FilterKeyType />, {
-      store: mockStore(initialStoreState),
-    })
+    const { queryByText } = render(<FilterKeyType />)
 
     await userEvent.click(screen.getByTestId(filterSelectId))
 
     expect(queryByText('Vector Set')).toBeInTheDocument()
   })
 
-  it('should hide Vector Set when vector set feature flag is disabled', () => {
-    // Ensure the version gate is satisfied so the assertion truly
-    // exercises the feature-flag path and not the version path.
-    connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
-      version: '8.0.0',
-    }))
-    const { queryByText } = render(<FilterKeyType />)
-
-    fireEvent.click(screen.getByTestId(filterSelectId))
-
-    expect(queryByText('Vector Set')).not.toBeInTheDocument()
-  })
-
-  it('should hide Vector Set when redis version < 8.0 even if feature flag is enabled', async () => {
+  it('should hide Vector Set when redis version < 8.0', async () => {
     connectedInstanceOverviewSelectorMock.mockImplementationOnce(() => ({
       version: '7.4.0',
     }))
-    const initialStoreState = set(
-      cloneDeep(initialStateDefault),
-      `app.features.featureFlags.features.${FeatureFlags.vectorSet}`,
-      { flag: true },
-    )
-    const { queryByText } = render(<FilterKeyType />, {
-      store: mockStore(initialStoreState),
-    })
+    const { queryByText } = render(<FilterKeyType />)
 
     await userEvent.click(screen.getByTestId(filterSelectId))
 

--- a/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
+++ b/redisinsight/ui/src/pages/browser/components/filter-key-type/constants.ts
@@ -5,10 +5,7 @@ import {
   FeatureFlags,
 } from 'uiSrc/constants'
 import { CommandsVersions } from 'uiSrc/constants/commandsVersions'
-import {
-  isArrayEnabledSelector,
-  isVectorSetEnabledSelector,
-} from 'uiSrc/slices/app/features'
+import { isArrayEnabledSelector } from 'uiSrc/slices/app/features'
 import { RedisDefaultModules } from 'uiSrc/slices/interfaces'
 import { FilterKeyTypeOption } from './FilterKeyType.types'
 
@@ -60,7 +57,6 @@ export const FILTER_KEY_TYPE_OPTIONS: FilterKeyTypeOption[] = [
     value: KeyTypes.VectorSet,
     color: GROUP_TYPES_COLORS[KeyTypes.VectorSet],
     minVersion: CommandsVersions.VECTOR_SET.since,
-    isEnabledSelector: isVectorSetEnabledSelector,
   },
   {
     text: 'Graph',

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/dynamic-type-details/DynamicTypeDetails.tsx
@@ -10,7 +10,6 @@ import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import {
   isArrayEnabledSelector,
   isValueDecoderEnabledSelector,
-  isVectorSetEnabledSelector,
 } from 'uiSrc/slices/app/features'
 import { isTruncatedString } from 'uiSrc/utils'
 import { ValueDecoderProvider } from 'uiSrc/pages/browser/components/value-decoder'
@@ -36,7 +35,6 @@ export interface Props extends KeyDetailsHeaderProps {
 
 const DynamicTypeDetails = (props: Props) => {
   const { keyType: selectedKeyType, keyProp } = props
-  const isVectorSet = useAppSelector(isVectorSetEnabledSelector)
   const isArray = useAppSelector(isArrayEnabledSelector)
   const isValueDecoderEnabled = useAppSelector(isValueDecoderEnabledSelector)
 
@@ -56,9 +54,7 @@ const DynamicTypeDetails = (props: Props) => {
     [KeyTypes.List]: <ListDetails {...props} />,
     [KeyTypes.ReJSON]: <RejsonDetailsWrapper {...props} />,
     [KeyTypes.Stream]: <StreamDetails {...props} />,
-    ...(isVectorSet && {
-      [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
-    }),
+    [KeyTypes.VectorSet]: <VectorSetDetails {...props} />,
     ...(isArray && {
       [KeyTypes.Array]: <ArrayDetails {...props} />,
     }),

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -62,9 +62,6 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.cloudAds]: {
         flag: riConfig.features.cloudAds.defaultFlag,
       },
-      [FeatureFlags.vectorSet]: {
-        flag: false,
-      },
       [FeatureFlags.array]: {
         flag: false,
       },
@@ -230,15 +227,6 @@ export const isAzureEntraIdEnabledSelector = (state: RootState): boolean => {
   const envDependentEnabled = features[FeatureFlags.envDependent]?.flag ?? false
 
   return azureEntraIdEnabled && envDependentEnabled
-}
-
-export const isVectorSetEnabledSelector = (state: RootState): boolean => {
-  if (isDevelopment) {
-    return true
-  }
-
-  const features = state.app.features.featureFlags.features
-  return features[FeatureFlags.vectorSet]?.flag ?? false
 }
 
 export const isArrayEnabledSelector = (state: RootState): boolean => {

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-elements.spec.ts
@@ -5,8 +5,6 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory, toFp32EscapedString } from 'e2eSr
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { vectorSet: true } });
-
 test.describe('Browser > Vector Set > Add Elements', () => {
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-manual.spec.ts
@@ -3,8 +3,6 @@ import { StandaloneV880ConfigFactory } from 'e2eSrc/test-data/databases';
 import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 
-test.use({ featureFlags: { vectorSet: true } });
-
 test.describe('Browser > Vector Set > Add Key (manual)', () => {
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/add-key-sample-data.spec.ts
@@ -4,8 +4,6 @@ import { DatabaseInstance } from 'e2eSrc/types';
 
 const VEC2WORD_KEY = 'vec2word';
 
-test.use({ featureFlags: { vectorSet: true } });
-
 test.describe('Browser > Vector Set > Add Key (sample data)', () => {
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/element-actions.spec.ts
@@ -4,8 +4,6 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { vectorSet: true } });
-
 test.describe('Browser > Vector Set > Element actions', () => {
   let database: DatabaseInstance;
 

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
@@ -2,10 +2,8 @@ import { test, expect } from 'e2eSrc/fixtures/base';
 import { StandaloneV8ConfigFactory, StandaloneV880ConfigFactory } from 'e2eSrc/test-data/databases';
 import { DatabaseInstance } from 'e2eSrc/types';
 
-test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => {
+test.describe('Browser > Vector Set > Gating > Redis below 8.0', () => {
   // V8 factory points at redis:8.0-M02, which reports redis_version:7.9.225.
-  test.use({ featureFlags: { vectorSet: true } });
-
   let database: DatabaseInstance;
 
   test.beforeAll(async ({ apiHelper }) => {
@@ -44,14 +42,12 @@ test.describe('Browser > Vector Set > Gating > Redis below 8.0, flag on', () => 
   });
 });
 
-test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
-  test.use({ featureFlags: { vectorSet: false } });
-
+test.describe('Browser > Vector Set > Gating > Redis 8.8.0', () => {
   let database: DatabaseInstance;
 
   test.beforeAll(async ({ apiHelper }) => {
     database = await apiHelper.createDatabase(
-      StandaloneV880ConfigFactory.build({ name: 'test-vector-set-gating-flag' }),
+      StandaloneV880ConfigFactory.build({ name: 'test-vector-set-gating-version-supported' }),
     );
   });
 
@@ -61,7 +57,7 @@ test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
     }
   });
 
-  test('hides Vector Set from the key-type filter dropdown', async ({ browserPage }) => {
+  test('shows Vector Set in the key-type filter dropdown', async ({ browserPage }) => {
     await browserPage.goto(database.id);
 
     await browserPage.keyList.keyTypeFilter.click();
@@ -69,10 +65,10 @@ test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
 
     await expect(
       browserPage.keyList.keyTypeFilterDropdown.getByRole('option', { name: 'Vector Set', exact: true }),
-    ).toHaveCount(0);
+    ).toBeVisible();
   });
 
-  test('hides Vector Set from the Add Key type dropdown', async ({ browserPage }) => {
+  test('shows Vector Set in the Add Key type dropdown', async ({ browserPage }) => {
     await browserPage.goto(database.id);
     await browserPage.openAddKeyDialog();
 
@@ -81,6 +77,6 @@ test.describe('Browser > Vector Set > Gating > Redis 8.8.0, flag off', () => {
 
     await expect(
       browserPage.addKeyDialog.keyTypeDropdown.getByRole('option', { name: 'Vector Set', exact: true }),
-    ).toHaveCount(0);
+    ).toBeVisible();
   });
 });

--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/similarity-search.spec.ts
@@ -4,8 +4,6 @@ import { TEST_KEY_PREFIX, VectorSetKeyFactory } from 'e2eSrc/test-data/browser';
 import { DatabaseInstance } from 'e2eSrc/types';
 import { seedVectorSet } from './helpers';
 
-test.use({ featureFlags: { vectorSet: true } });
-
 test.describe('Browser > Vector Set > Similarity search', () => {
   let database: DatabaseInstance;
 


### PR DESCRIPTION
# What

Removes the `vectorSet` feature flag now that the Vector Set feature is fully rolled out. The feature becomes always-on, gated only by the existing Redis-version check (`minVersion: CommandsVersions.VECTOR_SET.since`, i.e. Redis 8).

Removed from:
- **Frontend** — `FeatureFlags` enum, default feature state, `isVectorSetEnabledSelector`, and the flag gating in add-key / filter-key-type options, `DynamicTypeDetails`, and the v3.6.0 what's-new card.
- **Backend** — `KnownFeatures` enum, `knownFeatures` record, and the strategy registration in `feature-flag.provider.ts`.

`redisinsight/api/config/features-config.json` is intentionally left untouched.

# Testing

- Add-key and browser filter show **Vector Set** on Redis ≥ 8.0 and hide it below, regardless of any flag.
- Vector Set key details render normally.
- Affected unit suites pass (`AddKey`, `FilterKeyType`, `WhatsNewModal`, `DynamicTypeDetails`, features slice, backend feature-flag provider).
- `yarn type-check` reports no new errors; ESLint is clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is a deliberate rollout (flag off → always on with version gate only); no auth or data-path changes, though users on Redis 8+ will see Vector Set UI regardless of remote flag state until stale config in features-config.json is cleaned up separately.
> 
> **Overview**
> Removes the **`vectorSet`** feature flag so Vector Set support is **always on** in the UI, with visibility still limited by the existing **Redis ≥ 8.0** `minVersion` check.
> 
> **Backend:** Drops `VectorSet` from `KnownFeatures`, `knownFeatures`, and feature-flag strategy registration.
> 
> **Frontend:** Removes the flag from `FeatureFlags`, default Redux state, and `isVectorSetEnabledSelector`. Add Key, key-type filter, and key details no longer gate Vector Set on a flag (only version). The 3.6.0 What's New card for vector sets is no longer flag-gated.
> 
> **Tests:** Unit and Playwright specs drop flag seeding; gating tests now assert show/hide based on Redis version only. `WhatsNewModal` flag-gating coverage switches from vector sets to **`azureEntraId`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af73a425d70ce4bf38950b431ac672d0ec0795c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->