### PR TITLE
Add dependency drift report and manual CI workflow

### DIFF
--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -1,0 +1,54 @@
+name: Dependency Drift
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch/ref to report drift for'
+        type: string
+        default: 'main'
+      show_ignored:
+        description: 'Expand the ignored / low-priority list'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Report dependency drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.branch || 'main' }}
+
+      # `npm outdated` queries the registry and the report reads `current` from
+      # the committed lockfiles; the core tests are plain `node --test`. None of
+      # it needs `node_modules`, so we only set up Node.
+      - name: Setup Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Run dependency-drift core tests
+        run: npm run test:scripts
+
+      - name: Report dependency drift
+        env:
+          SHOW_IGNORED: ${{ inputs.show_ignored }}
+        run: |
+          flag=""
+          if [ "$SHOW_IGNORED" = "true" ]; then flag="--show-ignored"; fi
+          {
+            echo "### Dependency drift — \`${{ inputs.branch || 'main' }}\`"
+            echo ''
+            echo '```'
+            node scripts/dependency-drift-report.mjs $flag | tee /dev/stderr
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sb": "storybook dev -p 6006",
     "build-sb": "storybook build",
     "deps:audit": "node scripts/dependency-audit-report.mjs",
+    "deps:drift": "node scripts/dependency-drift-report.mjs",
     "test:scripts": "node --test scripts/lib/*.test.mjs"
   },
   "lint-staged": {

--- a/scripts/dependency-drift-report.mjs
+++ b/scripts/dependency-drift-report.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Reports how far each direct dependency is behind its latest release, across
+// every lockfile, highlighting the Tier-1 build/runtime spine so core upgrades
+// can be planned before the migration cost compounds. Report-only: always
+// exits 0. (Vulnerabilities live in `deps:audit`; this is the drift signal.)
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  AUDIT_DIRS,
+  analyzeTree,
+  buildReport,
+  formatTable,
+  topLevelVersions,
+} from './lib/dependency-drift-core.mjs';
+
+const ROOT = process.cwd();
+
+function readCurrentVersions(cwd) {
+  try {
+    return topLevelVersions(
+      JSON.parse(readFileSync(join(cwd, 'package-lock.json'), 'utf8')),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function runOutdated(dir, warnings) {
+  const cwd = join(ROOT, dir);
+  if (!existsSync(join(cwd, 'package-lock.json'))) {
+    const msg = `no lockfile in ${dir}; tree not scanned`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
+    return null;
+  }
+  let raw;
+  try {
+    raw = execFileSync('npm', ['outdated', '--json'], {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 1 << 28,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch (err) {
+    // `npm outdated` exits non-zero when anything is out of date but still
+    // prints the JSON report on stdout.
+    raw = err.stdout;
+    if (!raw) {
+      const msg = `npm outdated failed for ${dir}; tree not scanned`;
+      console.error(`WARN: ${msg}`);
+      warnings.push(msg);
+      return null;
+    }
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const msg = `npm outdated produced unparsable output for ${dir}`;
+    console.error(`WARN: ${msg}`);
+    warnings.push(msg);
+    return null;
+  }
+}
+
+const flags = process.argv.slice(2);
+const asJson = flags.includes('--json');
+const showIgnored = flags.includes('--show-ignored');
+
+try {
+  const warnings = [];
+  const trees = AUDIT_DIRS.map((dir) => {
+    const outdated = runOutdated(dir, warnings);
+    if (!outdated) return null;
+    const currentVersions = readCurrentVersions(join(ROOT, dir));
+    return analyzeTree({
+      tree: dir === '.' ? 'root' : dir,
+      outdated,
+      currentVersions,
+    });
+  }).filter(Boolean);
+
+  const report = buildReport({ trees });
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify({ ...report, warnings }, null, 2) + '\n',
+    );
+  } else {
+    process.stdout.write(formatTable(report, { showIgnored }) + '\n');
+    for (const w of warnings) console.error(`WARN: ${w}`);
+  }
+} catch (err) {
+  console.error(
+    `ERROR: dependency-drift-report failed unexpectedly: ${err.stack || err.message}`,
+  );
+}
+
+process.exit(0);

--- a/scripts/lib/dependency-drift-core.mjs
+++ b/scripts/lib/dependency-drift-core.mjs
@@ -1,0 +1,241 @@
+// Pure helpers for the dependency-drift report. No I/O, no shelling out.
+// The lockfile directory list is owned by the audit core so both reports scan
+// the same trees.
+export { AUDIT_DIRS } from './dependency-audit-core.mjs';
+
+// A dependency's bucket is decided by WHAT IT IS, not how far it has drifted,
+// so importance drives the report ahead of version distance. Edit these two
+// lists to change what you track. Entries are exact names or scope globs
+// (a trailing `/*` matches the whole scope). IGNORED wins over CORE.
+
+// CORE — the build/runtime spine worth standing upgrade tasks for.
+export const CORE = [
+  // Build
+  'vite',
+  'webpack',
+  'esbuild',
+  'electron',
+  'typescript',
+  // Framework
+  'react',
+  'react-dom',
+  '@reduxjs/toolkit',
+  '@nestjs/*',
+  // Test / tooling
+  'jest',
+  '@playwright/test',
+  'storybook',
+  'eslint',
+];
+
+// IGNORED — deps we deliberately do not track (being removed, or too niche to
+// plan upgrades around). Kept out of the Core/Other signal.
+export const IGNORED = [
+  '@elastic/*', // migrating off EUI — see the EUI removal effort
+];
+
+const SEVERITY_RANK = { major: 3, minor: 2, patch: 1, none: 0 };
+
+function matches(name, patterns) {
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) {
+      if (name.startsWith(pattern.slice(0, -1))) return true;
+    } else if (name === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// 'ignored' | 'core' | 'other'. IGNORED takes precedence over CORE.
+export function classify(name) {
+  if (matches(name, IGNORED)) return 'ignored';
+  if (matches(name, CORE)) return 'core';
+  return 'other';
+}
+
+// A version we can compare on the registry semver line: digits and dots only at
+// the front. `git:`/`file:`/`workspace:`/`link:` specs and blanks return null.
+function parseVersion(spec) {
+  if (typeof spec !== 'string') return null;
+  const cleaned = spec.trim().replace(/^[\^~>=<v\s]+/, '');
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function majorsBehind(current, latest) {
+  const c = parseVersion(current);
+  const l = parseVersion(latest);
+  if (!c || !l) return 0;
+  return Math.max(0, l.major - c.major);
+}
+
+export function driftSeverity(current, latest) {
+  const c = parseVersion(current);
+  const l = parseVersion(latest);
+  if (!c || !l) return 'none';
+  if (l.major > c.major) return 'major';
+  if (l.major < c.major) return 'none';
+  if (l.minor > c.minor) return 'minor';
+  if (l.minor < c.minor) return 'none';
+  if (l.patch > c.patch) return 'patch';
+  return 'none';
+}
+
+// Resolved versions of the top-level dependencies from a parsed package-lock
+// (lockfileVersion 3). Used as the `current` fallback so the report works
+// without `node_modules` — `npm outdated` only fills `current` from an
+// installed tree, but the committed lockfile always has it.
+const TOP_LEVEL_KEY = /^node_modules\/(@[^/]+\/[^/]+|[^/]+)$/;
+export function topLevelVersions(lockfile) {
+  const packages = lockfile?.packages ?? {};
+  const versions = {};
+  for (const [key, entry] of Object.entries(packages)) {
+    const match = key.match(TOP_LEVEL_KEY);
+    if (match && entry?.version) versions[match[1]] = entry.version;
+  }
+  return versions;
+}
+
+// Map one `npm outdated --json` object to normalised drift records. npm reports
+// each package as an object, or occasionally an array of locations — take the
+// first either way. `currentVersions` (from the lockfile) backfills `current`
+// when npm omits it.
+export function analyzeTree({ tree, outdated, currentVersions = {} }) {
+  const deps = Object.entries(outdated || {}).map(([name, info]) => {
+    const rec = Array.isArray(info) ? info[0] : info;
+    const current = rec?.current ?? currentVersions[name] ?? null;
+    const wanted = rec?.wanted ?? null;
+    const latest = rec?.latest ?? null;
+    return {
+      tree,
+      name,
+      current,
+      wanted,
+      latest,
+      majorsBehind: majorsBehind(current, latest),
+      severity: driftSeverity(current, latest),
+      bucket: classify(name),
+    };
+  });
+  return { tree, deps };
+}
+
+function sortDrift(a, b) {
+  if (b.majorsBehind !== a.majorsBehind) return b.majorsBehind - a.majorsBehind;
+  const rank = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+  if (rank !== 0) return rank;
+  if (a.tree !== b.tree) return a.tree.localeCompare(b.tree);
+  return a.name.localeCompare(b.name);
+}
+
+function countSeverities(deps) {
+  const counts = { major: 0, minor: 0, patch: 0 };
+  for (const d of deps) {
+    if (d.severity !== 'none') counts[d.severity] += 1;
+  }
+  return counts;
+}
+
+export function buildReport({ trees }) {
+  const flat = trees.flatMap((t) => t.deps);
+  const drifting = flat.filter((d) => d.severity !== 'none');
+  const inBucket = (bucket) =>
+    drifting.filter((d) => d.bucket === bucket).sort(sortDrift);
+  const core = inBucket('core');
+  const other = inBucket('other');
+  const ignored = inBucket('ignored');
+  // Records we could not compare on the semver line (non-registry specs or an
+  // unknown current version) — surfaced as a count so the report never reads as
+  // "everything checked" when some entries were skipped.
+  const skipped = flat.length - drifting.length;
+  return {
+    core,
+    other,
+    ignored,
+    skipped,
+    treesScanned: trees.length,
+    summary: {
+      core: countSeverities(core),
+      other: countSeverities(other),
+      ignored: countSeverities(ignored),
+    },
+  };
+}
+
+function driftLabel(dep) {
+  if (dep.severity === 'major') return `${dep.majorsBehind} major`;
+  return dep.severity;
+}
+
+function formatRows(deps) {
+  const cols = deps.map((d) => [
+    d.tree,
+    d.name,
+    d.current ?? '—',
+    d.latest ?? '—',
+    driftLabel(d),
+  ]);
+  const widths = [0, 1, 2, 3].map((i) =>
+    cols.reduce((w, row) => Math.max(w, row[i].length), 0),
+  );
+  return cols
+    .map(
+      (row) =>
+        `  ${row[0].padEnd(widths[0])}  ${row[1].padEnd(widths[1])}  ` +
+        `${row[2].padEnd(widths[2])} → ${row[3].padEnd(widths[3])}  ${row[4]}`,
+    )
+    .join('\n');
+}
+
+// Condense the ignored bucket to `name ×treeCount` pairs, worst drift first.
+function summariseIgnored(ignored) {
+  const byName = new Map();
+  for (const d of ignored) {
+    const entry = byName.get(d.name) || { count: 0, majorsBehind: 0 };
+    entry.count += 1;
+    entry.majorsBehind = Math.max(entry.majorsBehind, d.majorsBehind);
+    byName.set(d.name, entry);
+  }
+  return [...byName.entries()]
+    .sort((a, b) => b[1].majorsBehind - a[1].majorsBehind)
+    .map(([name, e]) => (e.count > 1 ? `${name} ×${e.count}` : name));
+}
+
+function severityPhrase(counts) {
+  return `${counts.major} major, ${counts.minor} minor, ${counts.patch} patch`;
+}
+
+export function formatTable(report, { showIgnored = false } = {}) {
+  const lines = [];
+  lines.push('Core dependencies behind latest:');
+  lines.push(report.core.length ? formatRows(report.core) : '  (none)');
+  lines.push('');
+  lines.push('Other outdated direct dependencies:');
+  lines.push(report.other.length ? formatRows(report.other) : '  (none)');
+  lines.push('');
+  if (showIgnored) {
+    lines.push('Ignored / low-priority (not tracked):');
+    lines.push(report.ignored.length ? formatRows(report.ignored) : '  (none)');
+  } else {
+    const names = summariseIgnored(report.ignored);
+    lines.push(
+      report.ignored.length
+        ? `Ignored / low-priority (not tracked): ${report.ignored.length} behind — ${names.join(', ')}  [--show-ignored to list]`
+        : 'Ignored / low-priority (not tracked): none behind',
+    );
+  }
+  lines.push('');
+  lines.push(
+    `Summary: Core — ${severityPhrase(report.summary.core)} · ` +
+      `other — ${severityPhrase(report.summary.other)} · ` +
+      `ignored — ${severityPhrase(report.summary.ignored)} · ` +
+      `${report.skipped} uncomparable · scanned ${report.treesScanned} trees`,
+  );
+  return lines.join('\n');
+}

--- a/scripts/lib/dependency-drift-core.test.mjs
+++ b/scripts/lib/dependency-drift-core.test.mjs
@@ -1,0 +1,197 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  majorsBehind,
+  driftSeverity,
+  classify,
+  analyzeTree,
+  buildReport,
+  formatTable,
+  topLevelVersions,
+} from './dependency-drift-core.mjs';
+
+test('majorsBehind counts whole majors, tolerating range prefixes', () => {
+  assert.equal(majorsBehind('6.4.3', '8.1.5'), 2);
+  assert.equal(majorsBehind('^6.4.3', '8.1.5'), 2);
+  assert.equal(majorsBehind('10.4.1', '11.0.2'), 1);
+  assert.equal(majorsBehind('8.1.5', '8.1.5'), 0);
+  assert.equal(majorsBehind('1.0.0-beta.1', '1.0.0'), 0); // same major
+});
+
+test('majorsBehind returns 0 for uncomparable specs', () => {
+  assert.equal(majorsBehind('git+https://x/y.git', '1.0.0'), 0);
+  assert.equal(majorsBehind('file:../local', '1.0.0'), 0);
+  assert.equal(majorsBehind('workspace:*', '1.0.0'), 0);
+  assert.equal(majorsBehind('', '1.0.0'), 0);
+  assert.equal(majorsBehind(undefined, '1.0.0'), 0);
+  assert.equal(majorsBehind('1.0.0', undefined), 0);
+});
+
+test('driftSeverity classifies major/minor/patch/none', () => {
+  assert.equal(driftSeverity('6.4.3', '8.1.5'), 'major');
+  assert.equal(driftSeverity('6.4.3', '6.6.0'), 'minor');
+  assert.equal(driftSeverity('6.4.3', '6.4.9'), 'patch');
+  assert.equal(driftSeverity('6.4.3', '6.4.3'), 'none');
+  assert.equal(driftSeverity('git:x', '1.0.0'), 'none');
+});
+
+test('classify buckets into core, ignored, and other; ignored wins', () => {
+  assert.equal(classify('vite'), 'core');
+  assert.equal(classify('react'), 'core');
+  assert.equal(classify('@playwright/test'), 'core');
+  assert.equal(classify('@nestjs/core'), 'core'); // scope glob
+  assert.equal(classify('@nestjs/anything'), 'core');
+  assert.equal(classify('@elastic/eui'), 'ignored'); // scope glob
+  assert.equal(classify('@elastic/datemath'), 'ignored');
+  assert.equal(classify('lodash'), 'other');
+  assert.equal(classify('googleapis'), 'other');
+});
+
+test('analyzeTree normalises npm outdated output', () => {
+  const outdated = {
+    vite: { current: '6.4.3', wanted: '6.4.3', latest: '8.1.5' },
+    lodash: { current: '4.17.20', wanted: '4.17.21', latest: '4.17.21' },
+    '@elastic/eui': { current: '34.6.0', wanted: '34.6.0', latest: '117.1.0' },
+  };
+  const { tree, deps } = analyzeTree({ tree: 'root', outdated });
+  assert.equal(tree, 'root');
+  const byName = Object.fromEntries(deps.map((d) => [d.name, d]));
+  assert.deepEqual(
+    { ...byName.vite },
+    {
+      tree: 'root',
+      name: 'vite',
+      current: '6.4.3',
+      wanted: '6.4.3',
+      latest: '8.1.5',
+      majorsBehind: 2,
+      severity: 'major',
+      bucket: 'core',
+    },
+  );
+  assert.equal(byName.lodash.bucket, 'other');
+  assert.equal(byName['@elastic/eui'].bucket, 'ignored');
+});
+
+test('analyzeTree accepts array-form entries and missing current', () => {
+  const outdated = {
+    esbuild: [{ current: '0.25.11', wanted: '0.28.1', latest: '0.28.1' }],
+    typescript: { wanted: '5.9.0', latest: '5.9.0' }, // current absent
+  };
+  const { deps } = analyzeTree({ tree: 'root', outdated });
+  const byName = Object.fromEntries(deps.map((d) => [d.name, d]));
+  assert.equal(byName.esbuild.current, '0.25.11');
+  assert.equal(byName.typescript.current, null);
+  assert.equal(byName.typescript.severity, 'none'); // uncomparable → skipped later
+});
+
+test('analyzeTree tolerates empty/missing outdated', () => {
+  assert.deepEqual(analyzeTree({ tree: 'x', outdated: {} }).deps, []);
+  assert.deepEqual(analyzeTree({ tree: 'x', outdated: null }).deps, []);
+});
+
+test('topLevelVersions extracts direct-dep versions from a v3 lockfile', () => {
+  const lock = {
+    lockfileVersion: 3,
+    packages: {
+      '': { name: 'root' },
+      'node_modules/react': { version: '18.3.1' },
+      'node_modules/@nestjs/core': { version: '11.1.18' },
+      'node_modules/react/node_modules/scheduler': { version: '0.23.0' }, // nested, skipped
+    },
+  };
+  assert.deepEqual(topLevelVersions(lock), {
+    react: '18.3.1',
+    '@nestjs/core': '11.1.18',
+  });
+  assert.deepEqual(topLevelVersions(null), {});
+  assert.deepEqual(topLevelVersions({}), {});
+});
+
+test('analyzeTree backfills current from lockfile versions when npm omits it', () => {
+  // npm outdated without node_modules omits `current`; the lockfile supplies it.
+  const outdated = { vite: { wanted: '8.1.5', latest: '8.1.5' } };
+  const { deps } = analyzeTree({
+    tree: 'root',
+    outdated,
+    currentVersions: { vite: '6.4.3' },
+  });
+  assert.equal(deps[0].current, '6.4.3');
+  assert.equal(deps[0].majorsBehind, 2);
+  assert.equal(deps[0].severity, 'major');
+});
+
+test('buildReport splits by bucket, sorts by drift, and counts', () => {
+  const trees = [
+    analyzeTree({
+      tree: 'root',
+      outdated: {
+        vite: { current: '6.4.3', latest: '8.1.5' }, // core major x2
+        storybook: { current: '9.1.19', latest: '10.5.3' }, // core major x1
+        eslint: { current: '9.0.0', latest: '9.1.0' }, // core minor
+        lodash: { current: '4.17.20', latest: '4.17.21' }, // other patch
+        got: { current: '11.0.0', latest: '14.0.0' }, // other major x3
+        '@elastic/eui': { current: '34.6.0', latest: '117.1.0' }, // ignored
+        linked: { latest: '2.0.0' }, // uncomparable → skipped
+      },
+    }),
+  ];
+  const report = buildReport({ trees });
+  assert.deepEqual(
+    report.core.map((d) => d.name),
+    ['vite', 'storybook', 'eslint'],
+  );
+  assert.equal(report.other[0].name, 'got'); // biggest drift first
+  assert.deepEqual(
+    report.ignored.map((d) => d.name),
+    ['@elastic/eui'],
+  );
+  assert.equal(report.skipped, 1); // linked
+  assert.deepEqual(report.summary.core, { major: 2, minor: 1, patch: 0 });
+  assert.deepEqual(report.summary.other, { major: 1, minor: 0, patch: 1 });
+  assert.deepEqual(report.summary.ignored, { major: 1, minor: 0, patch: 0 });
+  assert.equal(report.treesScanned, 1);
+});
+
+test('formatTable condenses ignored to a count line by default', () => {
+  const report = buildReport({
+    trees: [
+      analyzeTree({
+        tree: 'root',
+        outdated: {
+          vite: { current: '6.4.3', latest: '8.1.5' },
+          '@elastic/eui': { current: '34.6.0', latest: '117.1.0' },
+        },
+      }),
+      analyzeTree({
+        tree: 'redisinsight/ui/src/packages/redisearch',
+        outdated: {
+          '@elastic/eui': { current: '34.6.0', latest: '117.1.0' },
+        },
+      }),
+    ],
+  });
+  const out = formatTable(report);
+  assert.match(out, /Core dependencies behind latest:/);
+  assert.match(out, /vite/);
+  assert.match(out, /2 major/);
+  assert.match(out, /Ignored \/ low-priority .*: 2 behind — @elastic\/eui ×2/);
+  assert.doesNotMatch(out, /34\.6\.0/); // ignored rows not expanded
+  assert.match(out, /Summary: Core/);
+});
+
+test('formatTable expands ignored rows with showIgnored', () => {
+  const report = buildReport({
+    trees: [
+      analyzeTree({
+        tree: 'root',
+        outdated: {
+          '@elastic/eui': { current: '34.6.0', latest: '117.1.0' },
+        },
+      }),
+    ],
+  });
+  const out = formatTable(report, { showIgnored: true });
+  assert.match(out, /Ignored \/ low-priority \(not tracked\):/);
+  assert.match(out, /34\.6\.0 → 117\.1\.0/); // full row shown
+});


### PR DESCRIPTION
# What

I wanted to check where we stand on our dependency versions, so I put together
a small script to report it. It turned out useful enough that I figured it's
worth keeping around, so I'm committing it.

`npm run deps:drift` is a report-only sibling of `npm run deps:audit`: instead
of vulnerabilities, it shows how far each direct dependency (across all
lockfiles) is behind its latest release. It sorts **by importance first, then
by version**:

- **Core** - the build/runtime spine worth tracking (react, vite, typescript,
  electron, `@nestjs/*`, webpack, jest, storybook, eslint, ...).
- **Other** - everything else.
- **Ignored** - deps we deliberately don't track (e.g. `@elastic/*`, which
  we're migrating off), condensed to a one-line count so they don't drown out
  the signal.

`current` versions are read straight from the committed lockfiles, so it runs
without `node_modules`. A manually-triggered workflow (`workflow_dispatch`,
branch input defaulting to `main`) runs the unit tests and writes the report
into the run's step summary.

The Core/Ignored lists are two plain arrays at the top of
`scripts/lib/dependency-drift-core.mjs`, so tuning what we track is a one-line
edit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New reporting tooling and CI only; no application runtime or dependency version changes.
> 
> **Overview**
> Adds **`npm run deps:drift`**, a report-only complement to `deps:audit` that shows how far **direct** dependencies lag behind registry **latest** across the same lockfile trees as the audit script (`AUDIT_DIRS`).
> 
> The report groups outdated packages into **Core** (build/runtime spine), **Other**, and **Ignored** (e.g. `@elastic/*`), sorted by importance then drift severity. **Current** versions come from committed `package-lock.json` when `npm outdated` omits them, so it works **without** `node_modules`. Output supports `--json` and `--show-ignored`; the CLI always exits **0**.
> 
> A new **manual** GitHub Actions workflow runs `test:scripts`, then writes the drift table to the job **step summary** (optional branch ref and expanded ignored list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d64257529d269a09ce0c11691203a8c3a508a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->