### PR TITLE
Add vector set integration tests

### DIFF
--- a/redisinsight/api/test/api/.mocharc.cjs
+++ b/redisinsight/api/test/api/.mocharc.cjs
@@ -1,13 +1,15 @@
 // Mocha config. Dynamic so the spec list can react to TEST_TAGS.
 //
-// When TEST_TAGS is set on an RTE (e.g. oss-st-8 sets TEST_TAGS=array
+// When TEST_TAGS is set on an RTE (e.g. oss-st-8 sets TEST_TAGS=array,vectorSet
 // because redis:8.8-alpine lacks modules and other suites fail against
 // Redis 8.8 semantics — per-field hash TTL, RediSearch flag changes,
 // etc.), mocha only loads the file globs that map to the requested tag(s).
+// TEST_TAGS is comma-separated, so an RTE can opt into several suites.
 // When TEST_TAGS is unset (every other RTE) the wildcard runs everything,
 // preserving prior behaviour exactly.
 const TAG_SPECS = {
   array: ['test/api/array/**/*.test.ts'],
+  vectorSet: ['test/api/vector-set/**/*.test.ts'],
 };
 
 const tags = (process.env.TEST_TAGS || '')

--- a/redisinsight/api/test/api/vector-set/DELETE-databases-id-vector-set-elements.test.ts
+++ b/redisinsight/api/test/api/vector-set/DELETE-databases-id-vector-set-elements.test.ts
@@ -1,0 +1,79 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  Joi,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).delete(
+    `/${constants.API.DATABASES}/${instanceId}/vector-set/elements`,
+  );
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+const responseSchema = Joi.object()
+  .keys({ affected: Joi.number().required() })
+  .required();
+
+const vcard = (key: string) => rte.client.call('VCARD', key);
+const seed = (key: string) =>
+  Promise.all([
+    rte.client.call('VADD', key, 'VALUES', '3', '1', '2', '3', 'a'),
+    rte.client.call('VADD', key, 'VALUES', '3', '4', '5', '6', 'b'),
+  ]);
+
+describe('DELETE /databases/:id/vector-set/elements', () => {
+  requirements('rte.version>=8.0');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Main', () => {
+    it('Should remove elements and report the affected count', async () => {
+      const keyName = constants.getRandomString();
+      await seed(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, elements: ['a', 'missing'] },
+        responseSchema,
+        // Only 'a' exists, so a single member is removed.
+        responseBody: { affected: 1 },
+      });
+
+      expect(await vcard(keyName)).to.eql(1);
+    });
+  });
+
+  describe('Errors', () => {
+    [
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), elements: ['a'] },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), elements: ['a'] },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set-get_elements.test.ts
+++ b/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set-get_elements.test.ts
@@ -1,0 +1,95 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  Joi,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+  JoiRedisString,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(
+    `/${constants.API.DATABASES}/${instanceId}/vector-set/get-elements`,
+  );
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+const responseSchema = Joi.object()
+  .keys({
+    keyName: JoiRedisString.required(),
+    total: Joi.number().required(),
+    nextCursor: Joi.string(),
+    isPaginationSupported: Joi.boolean().required(),
+    elements: Joi.array()
+      .items(
+        Joi.object({
+          name: JoiRedisString.required(),
+          attributes: Joi.string(),
+        }),
+      )
+      .required(),
+  })
+  .required();
+
+const seed = (key: string) =>
+  Promise.all([
+    rte.client.call('VADD', key, 'VALUES', '3', '1', '2', '3', 'a'),
+    rte.client.call('VADD', key, 'VALUES', '3', '4', '5', '6', 'b'),
+  ]);
+
+describe('POST /databases/:id/vector-set/get-elements', () => {
+  requirements('rte.version>=8.0');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Main', () => {
+    it('Should return the elements of a vector set', async () => {
+      const keyName = constants.getRandomString();
+      await seed(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, count: 10 },
+        responseSchema,
+        checkFn: ({ body }: any) => {
+          expect(body.total).to.eql(2);
+          expect(body.elements.map((e: any) => e.name).sort()).to.eql([
+            'a',
+            'b',
+          ]);
+        },
+      });
+    });
+  });
+
+  describe('Errors', () => {
+    [
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), count: 10 },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), count: 10 },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set-similarity_search.test.ts
+++ b/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set-similarity_search.test.ts
@@ -1,0 +1,117 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  Joi,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+  JoiRedisString,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(
+    `/${constants.API.DATABASES}/${instanceId}/vector-set/similarity-search`,
+  );
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+const responseSchema = Joi.object()
+  .keys({
+    keyName: JoiRedisString.required(),
+    elements: Joi.array()
+      .items(
+        Joi.object({
+          name: JoiRedisString.required(),
+          score: Joi.number().required(),
+          attributes: Joi.string(),
+        }),
+      )
+      .required(),
+  })
+  .required();
+
+const seed = (key: string) =>
+  Promise.all([
+    rte.client.call('VADD', key, 'VALUES', '3', '1', '2', '3', 'a'),
+    rte.client.call('VADD', key, 'VALUES', '3', '1', '2', '3.1', 'b'),
+    rte.client.call('VADD', key, 'VALUES', '3', '-9', '-9', '-9', 'c'),
+  ]);
+
+describe('POST /databases/:id/vector-set/similarity-search', () => {
+  requirements('rte.version>=8.0');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Main', () => {
+    it('Should return matches ordered by descending score for an element query', async () => {
+      const keyName = constants.getRandomString();
+      await seed(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: { keyName, elementName: 'a', count: 2 },
+        responseSchema,
+        checkFn: ({ body }: any) => {
+          expect(body.elements.length).to.eql(2);
+          // Querying by element 'a' returns itself first (score 1).
+          expect(body.elements[0].name).to.eql('a');
+        },
+      });
+    });
+  });
+
+  describe('Validation', () => {
+    // The "exactly one query" rule is enforced after the key-existence check,
+    // so these cases seed the key first to reach the 400 instead of a 404.
+    const validationKey = constants.getRandomString();
+
+    [
+      {
+        name: 'Should reject a payload with no query (under-specified)',
+        data: { keyName: validationKey },
+        statusCode: 400,
+        before: () => seed(validationKey),
+      },
+      {
+        name: 'Should reject a payload with more than one query (over-specified)',
+        data: {
+          keyName: validationKey,
+          elementName: 'a',
+          vectorValues: [1, 2, 3],
+        },
+        statusCode: 400,
+        before: () => seed(validationKey),
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Errors', () => {
+    [
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: { keyName: constants.getRandomString(), elementName: 'a' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: { keyName: constants.getRandomString(), elementName: 'a' },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set.test.ts
+++ b/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set.test.ts
@@ -1,0 +1,147 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+// The harness types `deps.rte` as null until initRTE runs; tests access it
+// freely (the api test layer is untyped by design), so widen it here.
+const rte = deps.rte as any;
+
+// endpoint to test
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).post(`/${constants.API.DATABASES}/${instanceId}/vector-set`);
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+// VCARD has no typed method on rte.client; assert state via `call`.
+const vcard = (key: string) => rte.client.call('VCARD', key);
+
+interface CreateVectorSetTestCase {
+  name: string;
+  data: { keyName: string } & Record<string, unknown>;
+  statusCode: number;
+  before?: () => Promise<unknown>;
+  after?: () => Promise<unknown>;
+}
+
+const createCheckFn = (testCase: CreateVectorSetTestCase) => {
+  it(testCase.name, async () => {
+    if (testCase.before) {
+      await testCase.before();
+    }
+    await validateApiCall({ endpoint, ...testCase });
+    if (testCase.after) {
+      await testCase.after();
+    }
+  });
+};
+
+describe('POST /databases/:id/vector-set', () => {
+  // Vector sets are a Redis 8.0 data type; skip where the server lacks VADD.
+  requirements('rte.version>=8.0');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Main', () => {
+    const newKey = constants.getRandomString();
+    const ttlKey = constants.getRandomString();
+
+    (
+      [
+        {
+          name: 'Should create a vector set from numeric values',
+          data: {
+            keyName: newKey,
+            elements: [
+              { name: 'a', vectorValues: [1, 2, 3] },
+              { name: 'b', vectorValues: [4, 5, 6] },
+            ],
+          },
+          statusCode: 201,
+          before: async () => {
+            expect(await rte.client.exists(newKey)).to.eql(0);
+          },
+          after: async () => {
+            expect(await rte.client.exists(newKey)).to.eql(1);
+            expect(await vcard(newKey)).to.eql(2);
+            expect(await rte.client.ttl(newKey)).to.eql(-1);
+          },
+        },
+        {
+          name: 'Should create a vector set with a TTL',
+          data: {
+            keyName: ttlKey,
+            elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
+            expire: 100,
+          },
+          statusCode: 201,
+          after: async () => {
+            expect(await vcard(ttlKey)).to.eql(1);
+            expect(await rte.client.ttl(ttlKey)).to.gte(95);
+          },
+        },
+      ] as CreateVectorSetTestCase[]
+    ).map(createCheckFn);
+  });
+
+  describe('Validation', () => {
+    [
+      {
+        name: 'Should reject an empty elements array',
+        data: { keyName: constants.getRandomString(), elements: [] },
+        statusCode: 400,
+      },
+      {
+        name: 'Should reject an element with empty vectorValues',
+        data: {
+          keyName: constants.getRandomString(),
+          elements: [{ name: 'a', vectorValues: [] }],
+        },
+        statusCode: 400,
+      },
+    ].map(mainCheckFn);
+  });
+
+  describe('Errors', () => {
+    it('Should return conflict error if key already exists', async () => {
+      const keyName = constants.getRandomString();
+      await rte.client.call('VADD', keyName, 'VALUES', '3', '1', '2', '3', 'a');
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          elements: [{ name: 'b', vectorValues: [4, 5, 6] }],
+        },
+        statusCode: 409,
+        responseBody: {
+          statusCode: 409,
+          error: 'Conflict',
+          message: 'This key name is already in use.',
+        },
+      });
+    });
+
+    [
+      {
+        name: 'Should return NotFound error if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: {
+          keyName: constants.getRandomString(),
+          elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set.test.ts
+++ b/redisinsight/api/test/api/vector-set/POST-databases-id-vector-set.test.ts
@@ -22,26 +22,6 @@ const mainCheckFn = getMainCheckFn(endpoint);
 // VCARD has no typed method on rte.client; assert state via `call`.
 const vcard = (key: string) => rte.client.call('VCARD', key);
 
-interface CreateVectorSetTestCase {
-  name: string;
-  data: { keyName: string } & Record<string, unknown>;
-  statusCode: number;
-  before?: () => Promise<unknown>;
-  after?: () => Promise<unknown>;
-}
-
-const createCheckFn = (testCase: CreateVectorSetTestCase) => {
-  it(testCase.name, async () => {
-    if (testCase.before) {
-      await testCase.before();
-    }
-    await validateApiCall({ endpoint, ...testCase });
-    if (testCase.after) {
-      await testCase.after();
-    }
-  });
-};
-
 describe('POST /databases/:id/vector-set', () => {
   // Vector sets are a Redis 8.0 data type; skip where the server lacks VADD.
   requirements('rte.version>=8.0');
@@ -51,42 +31,40 @@ describe('POST /databases/:id/vector-set', () => {
     const newKey = constants.getRandomString();
     const ttlKey = constants.getRandomString();
 
-    (
-      [
-        {
-          name: 'Should create a vector set from numeric values',
-          data: {
-            keyName: newKey,
-            elements: [
-              { name: 'a', vectorValues: [1, 2, 3] },
-              { name: 'b', vectorValues: [4, 5, 6] },
-            ],
-          },
-          statusCode: 201,
-          before: async () => {
-            expect(await rte.client.exists(newKey)).to.eql(0);
-          },
-          after: async () => {
-            expect(await rte.client.exists(newKey)).to.eql(1);
-            expect(await vcard(newKey)).to.eql(2);
-            expect(await rte.client.ttl(newKey)).to.eql(-1);
-          },
+    [
+      {
+        name: 'Should create a vector set from numeric values',
+        data: {
+          keyName: newKey,
+          elements: [
+            { name: 'a', vectorValues: [1, 2, 3] },
+            { name: 'b', vectorValues: [4, 5, 6] },
+          ],
         },
-        {
-          name: 'Should create a vector set with a TTL',
-          data: {
-            keyName: ttlKey,
-            elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
-            expire: 100,
-          },
-          statusCode: 201,
-          after: async () => {
-            expect(await vcard(ttlKey)).to.eql(1);
-            expect(await rte.client.ttl(ttlKey)).to.gte(95);
-          },
+        statusCode: 201,
+        before: async () => {
+          expect(await rte.client.exists(newKey)).to.eql(0);
         },
-      ] as CreateVectorSetTestCase[]
-    ).map(createCheckFn);
+        after: async () => {
+          expect(await rte.client.exists(newKey)).to.eql(1);
+          expect(await vcard(newKey)).to.eql(2);
+          expect(await rte.client.ttl(newKey)).to.eql(-1);
+        },
+      },
+      {
+        name: 'Should create a vector set with a TTL',
+        data: {
+          keyName: ttlKey,
+          elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
+          expire: 100,
+        },
+        statusCode: 201,
+        after: async () => {
+          expect(await vcard(ttlKey)).to.eql(1);
+          expect(await rte.client.ttl(ttlKey)).to.gte(95);
+        },
+      },
+    ].map(mainCheckFn);
   });
 
   describe('Validation', () => {

--- a/redisinsight/api/test/api/vector-set/PUT-databases-id-vector-set.test.ts
+++ b/redisinsight/api/test/api/vector-set/PUT-databases-id-vector-set.test.ts
@@ -1,0 +1,79 @@
+import {
+  expect,
+  describe,
+  it,
+  deps,
+  requirements,
+  validateApiCall,
+  getMainCheckFn,
+} from '../deps';
+
+const { server, request, constants } = deps;
+const rte = deps.rte as any;
+
+const endpoint = (instanceId = constants.TEST_INSTANCE_ID) =>
+  request(server).put(`/${constants.API.DATABASES}/${instanceId}/vector-set`);
+
+const mainCheckFn = getMainCheckFn(endpoint);
+
+const vcard = (key: string) => rte.client.call('VCARD', key);
+const seed = (key: string) =>
+  rte.client.call('VADD', key, 'VALUES', '3', '1', '2', '3', 'a');
+
+describe('PUT /databases/:id/vector-set', () => {
+  requirements('rte.version>=8.0');
+  beforeEach(async () => rte.data.truncate());
+
+  describe('Main', () => {
+    it('Should add elements to an existing vector set', async () => {
+      const keyName = constants.getRandomString();
+      await seed(keyName);
+
+      await validateApiCall({
+        endpoint,
+        data: {
+          keyName,
+          elements: [
+            { name: 'b', vectorValues: [4, 5, 6] },
+            { name: 'c', vectorValues: [7, 8, 9] },
+          ],
+        },
+        statusCode: 200,
+      });
+
+      expect(await vcard(keyName)).to.eql(3);
+    });
+  });
+
+  describe('Errors', () => {
+    [
+      {
+        name: 'Should return NotFound if key does not exist',
+        data: {
+          keyName: constants.getRandomString(),
+          elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Key with this name does not exist.',
+        },
+      },
+      {
+        name: 'Should return NotFound if instance id does not exist',
+        endpoint: () => endpoint(constants.TEST_NOT_EXISTED_INSTANCE_ID),
+        data: {
+          keyName: constants.getRandomString(),
+          elements: [{ name: 'a', vectorValues: [1, 2, 3] }],
+        },
+        statusCode: 404,
+        responseBody: {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Invalid database instance id.',
+        },
+      },
+    ].map(mainCheckFn);
+  });
+});

--- a/redisinsight/api/test/test-runs/oss-st-8/docker-compose.yml
+++ b/redisinsight/api/test/test-runs/oss-st-8/docker-compose.yml
@@ -4,11 +4,12 @@ services:
   redis:
     image: redis:8.8-alpine
 
-  # Scope the run to suites that declared `tag('array')` (the new Array data
-  # type read endpoints). redis:8.8-alpine has no modules and ships Redis 8.8
-  # semantics (per-field hash TTL, RediSearch flag changes, etc.) that other
-  # untagged suites don't tolerate, so leaving them in would produce noise
-  # unrelated to the suite this RTE was added for.
+  # Scope the run to the suites tagged for this RTE: `array` (the Array data
+  # type read endpoints) and `vectorSet` (the VectorSet endpoints — a core
+  # Redis 8.0+ type, so no modules required). redis:8.8-alpine has no modules
+  # and ships Redis 8.8 semantics (per-field hash TTL, RediSearch flag changes,
+  # etc.) that other untagged suites don't tolerate, so leaving them in would
+  # produce noise unrelated to the suites this RTE was added for.
   test:
     environment:
-      TEST_TAGS: array
+      TEST_TAGS: array,vectorSet


### PR DESCRIPTION
# What

Adds API integration tests for the vector-set browser feature, which shipped without integration coverage. Covers the core endpoints:

- `POST /databases/:id/vector-set` — creation (values, TTL, validation, 409 conflict)
- `PUT /databases/:id/vector-set` — adding elements
- `POST /databases/:id/vector-set/get-elements` — listing elements
- `DELETE /databases/:id/vector-set/elements` — removing elements
- `POST /databases/:id/vector-set/similarity-search` — VSIM query + query-shape validation

Each endpoint is its own commit. The tests follow the existing `test/api/array/` conventions (the `deps` harness, `validateApiCall`/`getMainCheckFn`, Joi response schemas, `requirements('rte.version>=8.0')` gating, per-test `truncate`).

# Testing

Requires a Redis 8.0+ RTE (tests self-skip on older versions). From `redisinsight/api`:

```bash
npm run test:api -- 'test/api/vector-set/**/*.test.ts'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and mocha/RTE configuration; no production API or runtime behavior is modified.
> 
> **Overview**
> Adds **API integration tests** for the vector-set browser endpoints that previously shipped without this coverage, using the same harness as `test/api/array/`.
> 
> New suites under `test/api/vector-set/` exercise create (`POST`), add elements (`PUT`), list (`POST …/get-elements`), delete members (`DELETE …/elements`), and similarity search (`POST …/similarity-search`), including happy paths, Joi response shapes, validation (empty elements, similarity query shape), and 404/409 errors. Tests gate on **`rte.version>=8.0`** and seed keys via Redis `VADD`/`VCARD`.
> 
> **CI tagging:** `.mocharc.cjs` gains a **`vectorSet`** tag mapped to `test/api/vector-set/**/*.test.ts`, with docs noting comma-separated `TEST_TAGS`. The **oss-st-8** docker-compose run sets `TEST_TAGS: array,vectorSet` so Redis 8.8-alpine runs array + vector-set suites without unrelated failing specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b1109788e3f70e83d7c0473aef1ab1c457d5ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->