### PR TITLE
RI-8353 Sentry hygiene: drop noise & fingerprint fragmented issues

### DIFF
--- a/redisinsight/desktop/src/lib/sentry/sentry.ts
+++ b/redisinsight/desktop/src/lib/sentry/sentry.ts
@@ -4,7 +4,7 @@ import { crashReporter } from 'electron'
 import log from 'electron-log'
 import { electronStore } from 'desktopSrc/lib/store/store'
 import { ElectronStorageItem } from 'uiSrc/electron/constants'
-import { minimizeEvent, scrubEvent } from 'uiSrc/services/sentry'
+import { finalizeSentryEvent } from 'uiSrc/services/sentry'
 import pkg from '../../../../package.json'
 import configInit from '../../../config.json'
 
@@ -112,8 +112,7 @@ export const initSentry = (): void => {
       // Breadcrumbs can carry sensitive data; keep only with consent.
       beforeBreadcrumb: (breadcrumb) => (consentGranted ? breadcrumb : null),
       beforeSend(event) {
-        const scrubbed = scrubEvent(event)
-        return consentGranted ? scrubbed : minimizeEvent(scrubbed)
+        return finalizeSentryEvent(event, consentGranted)
       },
     })
 

--- a/redisinsight/ui/src/services/sentry/index.ts
+++ b/redisinsight/ui/src/services/sentry/index.ts
@@ -6,4 +6,8 @@ export {
   normalizePath,
   scrubEvent,
   minimizeEvent,
+  shouldDropEvent,
+  applyFingerprint,
+  finalizeSentryEvent,
+  FAILED_TO_OPEN_FINGERPRINT,
 } from './scrubbing'

--- a/redisinsight/ui/src/services/sentry/scrubbing.spec.ts
+++ b/redisinsight/ui/src/services/sentry/scrubbing.spec.ts
@@ -356,10 +356,12 @@ describe('shouldDropEvent', () => {
     expect(shouldDropEvent(errorEvent('', [], 'Canceled'))).toBe(true)
   })
 
-  it('drops errors originating in a browser extension', () => {
-    const event = errorEvent('boom', [
-      { function: 'g', filename: 'chrome-extension://abcdef/inpage.js' },
-    ])
+  it.each([
+    'chrome-extension://abcdef/inpage.js',
+    'moz-extension://abcdef/inpage.js',
+    'safari-web-extension://abcdef/inpage.js',
+  ])('drops errors originating in a browser extension (%s)', (filename) => {
+    const event = errorEvent('boom', [{ function: 'g', filename }])
     expect(shouldDropEvent(event)).toBe(true)
   })
 
@@ -372,10 +374,19 @@ describe('shouldDropEvent', () => {
     expect(shouldDropEvent(event)).toBe(true)
   })
 
-  it.each(['EBADF', 'EIO', 'EPIPE', 'ENOSPC'])(
-    'drops low-level I/O errors by code (%s), even without a matching frame',
+  it('drops ENOSPC (disk full) by code alone — it is environmental', () => {
+    expect(
+      shouldDropEvent(errorEvent('ENOSPC: no space left on device, write')),
+    ).toBe(true)
+  })
+
+  it.each(['EBADF', 'EIO', 'EPIPE'])(
+    'keeps a %s error without the Node-internal write frame (could be a real crash)',
     (code) => {
-      expect(shouldDropEvent(errorEvent(`${code}: write failed`))).toBe(true)
+      const event = errorEvent(`${code}: write failed`, [
+        { function: 'saveState', filename: '/app.asar/dist/main/store.js' },
+      ])
+      expect(shouldDropEvent(event)).toBe(false)
     },
   )
 

--- a/redisinsight/ui/src/services/sentry/scrubbing.spec.ts
+++ b/redisinsight/ui/src/services/sentry/scrubbing.spec.ts
@@ -1,13 +1,26 @@
 import type { Event } from '@sentry/core'
 import {
+  FAILED_TO_OPEN_FINGERPRINT,
   NON_TRACKING_ANONYMOUS_ID,
   REDACTED,
+  applyFingerprint,
+  finalizeSentryEvent,
   minimizeEvent,
   normalizePath,
   scrubEvent,
   scrubSecretsInText,
   scrubSensitiveData,
+  shouldDropEvent,
 } from './scrubbing'
+
+/** Build an event with a single exception value + stack frames. */
+const errorEvent = (
+  value: string,
+  frames: Array<Record<string, unknown>> = [],
+  type = 'Error',
+): Event => ({
+  exception: { values: [{ type, value, stacktrace: { frames } }] },
+})
 
 describe('scrubSensitiveData', () => {
   it('redacts keys whose name contains a sensitive substring', () => {
@@ -335,5 +348,123 @@ describe('minimizeEvent', () => {
     expect(result.user).toEqual({ id: NON_TRACKING_ANONYMOUS_ID })
     expect(result.contexts?.device).toBeUndefined()
     expect(result.tags?.tier).toBe('anonymous')
+  })
+})
+
+describe('shouldDropEvent', () => {
+  it('drops Monaco editor cancellations (by exception type)', () => {
+    expect(shouldDropEvent(errorEvent('', [], 'Canceled'))).toBe(true)
+  })
+
+  it('drops errors originating in a browser extension', () => {
+    const event = errorEvent('boom', [
+      { function: 'g', filename: 'chrome-extension://abcdef/inpage.js' },
+    ])
+    expect(shouldDropEvent(event)).toBe(true)
+  })
+
+  it.each([
+    ['afterWriteDispatched', 'stream_base_commons'],
+    ['writeSync', 'node:fs'],
+    ['TCP.onStreamRead', 'stream_base_commons'],
+  ])('drops the Node I/O write storm (%s / %s frame)', (fn, moduleName) => {
+    const event = errorEvent('', [{ function: fn, module: moduleName }])
+    expect(shouldDropEvent(event)).toBe(true)
+  })
+
+  it.each(['EBADF', 'EIO', 'EPIPE', 'ENOSPC'])(
+    'drops low-level I/O errors by code (%s), even without a matching frame',
+    (code) => {
+      expect(shouldDropEvent(errorEvent(`${code}: write failed`))).toBe(true)
+    },
+  )
+
+  it('drops the Electron GPU abnormal-exit warning', () => {
+    const event: Event = {
+      message: "'GPU' process exited with 'abnormal-exit'",
+    }
+    expect(shouldDropEvent(event)).toBe(true)
+  })
+
+  it('keeps genuine application errors', () => {
+    const event = errorEvent('Cannot read properties of undefined', [
+      {
+        function: 'render',
+        filename: '/app.asar/dist/renderer/KeyTree.tsx',
+        module: 'KeyTree',
+      },
+    ])
+    expect(shouldDropEvent(event)).toBe(false)
+  })
+
+  it('does not treat an app frame merely named writeSync as I/O noise', () => {
+    // `writeSync` in app code (not a Node-internal module) must survive.
+    const event = errorEvent('boom', [
+      { function: 'writeSync', filename: '/app.asar/dist/main/store.js' },
+    ])
+    expect(shouldDropEvent(event)).toBe(false)
+  })
+
+  it('handles events with no exception or frames', () => {
+    expect(shouldDropEvent({})).toBe(false)
+    expect(shouldDropEvent({ message: 'plain message' })).toBe(false)
+  })
+})
+
+describe('applyFingerprint', () => {
+  it.each([
+    'Failed to open: The system cannot find the file specified. (0x2)',
+    'Failed to open: 系统找不到指定的文件。 (0x2)',
+    'Failed to open: El sistema no puede encontrar el archivo especificado.',
+  ])('collapses the localized "Failed to open" family: %s', (value) => {
+    const result = applyFingerprint(errorEvent(value))
+    expect(result.fingerprint).toEqual([FAILED_TO_OPEN_FINGERPRINT])
+  })
+
+  it('leaves unrelated events on default grouping', () => {
+    const result = applyFingerprint(errorEvent('some other error'))
+    expect(result.fingerprint).toBeUndefined()
+  })
+
+  it('reads grouping signals from sourceEvent when provided', () => {
+    // Target has no message (Tier-1 minimized); source still carries it.
+    const target = errorEvent('')
+    const source = errorEvent('Failed to open: file not found')
+    const result = applyFingerprint(target, source)
+    expect(result.fingerprint).toEqual([FAILED_TO_OPEN_FINGERPRINT])
+  })
+})
+
+describe('finalizeSentryEvent', () => {
+  it('returns null for dropped noise regardless of consent', () => {
+    const noise = errorEvent('', [], 'Canceled')
+    expect(finalizeSentryEvent(noise, true)).toBeNull()
+    expect(finalizeSentryEvent(noise, false)).toBeNull()
+  })
+
+  it('scrubs and keeps the full event when analytics is granted', () => {
+    const event: Event = {
+      message: 'connect redis://user:pw@host failed',
+      exception: { values: [{ type: 'Error', value: 'boom' }] },
+    }
+    const result = finalizeSentryEvent(event, true)
+    expect(result).not.toBeNull()
+    expect(result!.message).toBe(`connect redis://${REDACTED}@host failed`)
+    expect(result!.exception!.values![0].value).toBe('boom')
+  })
+
+  it('minimizes the event when analytics is not granted', () => {
+    const event = errorEvent('sensitive detail')
+    const result = finalizeSentryEvent(event, false)
+    expect(result!.exception!.values![0].value).toBe('')
+    expect(result!.user).toEqual({ id: NON_TRACKING_ANONYMOUS_ID })
+  })
+
+  it('fingerprints "Failed to open" even for a minimized (Tier-1) event', () => {
+    const event = errorEvent('Failed to open: file not found (0x2)')
+    const result = finalizeSentryEvent(event, false)
+    // Message is blanked by minimize, but fingerprint is read from the original.
+    expect(result!.exception!.values![0].value).toBe('')
+    expect(result!.fingerprint).toEqual([FAILED_TO_OPEN_FINGERPRINT])
   })
 })

--- a/redisinsight/ui/src/services/sentry/scrubbing.ts
+++ b/redisinsight/ui/src/services/sentry/scrubbing.ts
@@ -254,3 +254,117 @@ export const minimizeEvent = <T extends Event>(event: T): T => {
 
   return minimized as unknown as T
 }
+
+/* ------------------------------------------------------------------ *
+ * Noise filtering & grouping (RI-8353)
+ * ------------------------------------------------------------------ */
+
+/** Every stack frame across all exception values (Sentry order: crash frame last). */
+const eventFrames = (event: Event): StackFrame[] =>
+  event.exception?.values?.flatMap((value) => value.stacktrace?.frames ?? []) ??
+  []
+
+/** Message + every exception `value`/`type`, joined into one searchable string. */
+const eventText = (event: Event): string => {
+  const parts: string[] = []
+  if (typeof event.message === 'string') parts.push(event.message)
+  event.exception?.values?.forEach((value) => {
+    if (typeof value.value === 'string') parts.push(value.value)
+    if (typeof value.type === 'string') parts.push(value.type)
+  })
+  return parts.join(' ')
+}
+
+/** True when any listed error code appears as a whole word in the event text. */
+const hasErrorCode = (event: Event, codes: readonly string[]): boolean => {
+  const text = eventText(event)
+  return codes.some((code) => new RegExp(`\\b${code}\\b`).test(text))
+}
+
+/** Node broken-pipe / bad-fd I/O writes surfacing as fatal uncaught errors. */
+const IO_WRITE_FUNCTIONS = ['afterWriteDispatched', 'writeSync', 'onStreamRead']
+const IO_WRITE_CODES = ['EBADF', 'EIO', 'EPIPE'] as const
+const isNodeIoWriteNoise = (event: Event): boolean => {
+  const fromFrame = eventFrames(event).some((frame) => {
+    const fn = frame.function ?? ''
+    const location = `${frame.module ?? ''} ${frame.filename ?? ''} ${
+      frame.abs_path ?? ''
+    }`
+    const isWriteFn = IO_WRITE_FUNCTIONS.some((name) => fn.includes(name))
+    const isNodeInternal =
+      location.includes('stream_base_commons') ||
+      location.includes('node:') ||
+      location.includes('internal/')
+    return isWriteFn && isNodeInternal
+  })
+  return fromFrame || hasErrorCode(event, IO_WRITE_CODES)
+}
+
+/** Monaco editor cancellation — a benign `Canceled` throw, never a defect. */
+const isMonacoCancellation = (event: Event): boolean =>
+  event.exception?.values?.some((value) => value.type === 'Canceled') ?? false
+
+/** Errors thrown from a user's installed browser extension, not our code. */
+const isBrowserExtensionNoise = (event: Event): boolean =>
+  eventFrames(event).some((frame) =>
+    [frame.filename, frame.abs_path, frame.module].some((source) =>
+      (source ?? '').includes('chrome-extension://'),
+    ),
+  )
+
+/** Electron GPU process teardown — environmental, not actionable. */
+const isGpuAbnormalExit = (event: Event): boolean => {
+  const text = eventText(event)
+  return text.includes('abnormal-exit') && text.includes('GPU')
+}
+
+/**
+ * Decide whether an event is known noise that should never reach Sentry.
+ *
+ * Must run BEFORE scrub/minimize so it can read the message and error code:
+ * `minimizeEvent` blanks those for Tier-1 (no-consent) events, so anything that
+ * has to survive anonymization is matched on the stack frame / exception type,
+ * which both tiers keep.
+ */
+export const shouldDropEvent = (event: Event): boolean =>
+  isMonacoCancellation(event) ||
+  isBrowserExtensionNoise(event) ||
+  isNodeIoWriteNoise(event) ||
+  isGpuAbnormalExit(event) ||
+  hasErrorCode(event, ['ENOSPC'])
+
+/** Stable fingerprint for the localized "Failed to open: <OS message>" family. */
+export const FAILED_TO_OPEN_FINGERPRINT = 'failed-to-open-file'
+
+/**
+ * Collapse issues that Sentry's default grouping fragments. Currently the
+ * "Failed to open: …" shell errors, which split into one issue per OS locale
+ * because the message tail is localized. `sourceEvent` supplies the grouping
+ * signals (defaults to `event`); pass the pre-minimized event so the message is
+ * still present when fingerprinting a Tier-1 event.
+ */
+export const applyFingerprint = <T extends Event>(
+  event: T,
+  sourceEvent: Event = event,
+): T => {
+  if (eventText(sourceEvent).includes('Failed to open:')) {
+    event.fingerprint = [FAILED_TO_OPEN_FINGERPRINT]
+  }
+  return event
+}
+
+/**
+ * Single entry point for both layers' `beforeSend`: drop known noise, then
+ * scrub, then apply the consent tier, then fingerprint. Returns `null` to drop
+ * the event. Lives here (not in each init) so main and renderer cannot drift.
+ */
+export const finalizeSentryEvent = <T extends Event>(
+  event: T,
+  analyticsGranted: boolean,
+): T | null => {
+  if (shouldDropEvent(event)) return null
+  const scrubbed = scrubEvent(event)
+  const tiered = analyticsGranted ? scrubbed : minimizeEvent(scrubbed)
+  // Fingerprint from the original event — minimizeEvent has blanked the message.
+  return applyFingerprint(tiered, event)
+}

--- a/redisinsight/ui/src/services/sentry/scrubbing.ts
+++ b/redisinsight/ui/src/services/sentry/scrubbing.ts
@@ -281,11 +281,17 @@ const hasErrorCode = (event: Event, codes: readonly string[]): boolean => {
   return codes.some((code) => new RegExp(`\\b${code}\\b`).test(text))
 }
 
-/** Node broken-pipe / bad-fd I/O writes surfacing as fatal uncaught errors. */
+/**
+ * Node broken-pipe / bad-fd I/O writes surfacing as fatal uncaught errors.
+ *
+ * Matched on the Node-internal write frame, NOT on the errno alone: EBADF/EIO/
+ * EPIPE can also come from genuine app-level socket or file operations that we
+ * do want to see, so requiring the storm's stack signature avoids suppressing
+ * real crashes that merely share an error code.
+ */
 const IO_WRITE_FUNCTIONS = ['afterWriteDispatched', 'writeSync', 'onStreamRead']
-const IO_WRITE_CODES = ['EBADF', 'EIO', 'EPIPE'] as const
-const isNodeIoWriteNoise = (event: Event): boolean => {
-  const fromFrame = eventFrames(event).some((frame) => {
+const isNodeIoWriteNoise = (event: Event): boolean =>
+  eventFrames(event).some((frame) => {
     const fn = frame.function ?? ''
     const location = `${frame.module ?? ''} ${frame.filename ?? ''} ${
       frame.abs_path ?? ''
@@ -297,18 +303,21 @@ const isNodeIoWriteNoise = (event: Event): boolean => {
       location.includes('internal/')
     return isWriteFn && isNodeInternal
   })
-  return fromFrame || hasErrorCode(event, IO_WRITE_CODES)
-}
 
 /** Monaco editor cancellation — a benign `Canceled` throw, never a defect. */
 const isMonacoCancellation = (event: Event): boolean =>
   event.exception?.values?.some((value) => value.type === 'Canceled') ?? false
 
 /** Errors thrown from a user's installed browser extension, not our code. */
+const EXTENSION_URL_SCHEMES = [
+  'chrome-extension://', // Chromium (Electron renderer + Chrome web build)
+  'moz-extension://', // Firefox web build
+  'safari-web-extension://', // Safari web build
+]
 const isBrowserExtensionNoise = (event: Event): boolean =>
   eventFrames(event).some((frame) =>
     [frame.filename, frame.abs_path, frame.module].some((source) =>
-      (source ?? '').includes('chrome-extension://'),
+      EXTENSION_URL_SCHEMES.some((scheme) => (source ?? '').includes(scheme)),
     ),
   )
 
@@ -331,6 +340,8 @@ export const shouldDropEvent = (event: Event): boolean =>
   isBrowserExtensionNoise(event) ||
   isNodeIoWriteNoise(event) ||
   isGpuAbnormalExit(event) ||
+  // ENOSPC (disk full) is environmental with no app-side fix, so it is safe to
+  // match by code alone — unlike EBADF/EIO/EPIPE (see isNodeIoWriteNoise).
   hasErrorCode(event, ['ENOSPC'])
 
 /** Stable fingerprint for the localized "Failed to open: <OS message>" family. */

--- a/redisinsight/ui/src/services/sentryElectron.ts
+++ b/redisinsight/ui/src/services/sentryElectron.ts
@@ -3,7 +3,7 @@ import { init as reactInit } from '@sentry/react'
 
 import { getConfig } from 'uiSrc/config'
 import { checkIsAnalyticsGranted } from 'uiSrc/telemetry/checkAnalytics'
-import { minimizeEvent, scrubEvent } from 'uiSrc/services/sentry'
+import { finalizeSentryEvent } from 'uiSrc/services/sentry'
 
 const riConfig = getConfig()
 
@@ -37,8 +37,7 @@ export const initSentry = (): void => {
         beforeBreadcrumb: (breadcrumb) =>
           checkIsAnalyticsGranted() ? breadcrumb : null,
         beforeSend(event) {
-          const scrubbed = scrubEvent(event)
-          return checkIsAnalyticsGranted() ? scrubbed : minimizeEvent(scrubbed)
+          return finalizeSentryEvent(event, checkIsAnalyticsGranted())
         },
       },
       reactInit,

--- a/redisinsight/ui/src/services/sentryWeb.ts
+++ b/redisinsight/ui/src/services/sentryWeb.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react'
 
 import { getConfig } from 'uiSrc/config'
 import { checkIsAnalyticsGranted } from 'uiSrc/telemetry/checkAnalytics'
-import { minimizeEvent, scrubEvent } from 'uiSrc/services/sentry'
+import { finalizeSentryEvent } from 'uiSrc/services/sentry'
 
 const riConfig = getConfig()
 
@@ -32,8 +32,7 @@ export const initSentry = (): void => {
       beforeBreadcrumb: (breadcrumb) =>
         checkIsAnalyticsGranted() ? breadcrumb : null,
       beforeSend(event) {
-        const scrubbed = scrubEvent(event)
-        return checkIsAnalyticsGranted() ? scrubbed : minimizeEvent(scrubbed)
+        return finalizeSentryEvent(event, checkIsAnalyticsGranted())
       },
     })
   } catch (e) {


### PR DESCRIPTION
# What

Adds a shared `beforeSend` pipeline in `scrubbing.ts`, used by the Electron main, renderer and web layers so they can't drift:

- **`shouldDropEvent()`** — drops known non-actionable noise before it is sent: the Node broken-pipe / bad-fd I/O write storm (`afterWriteDispatched` / `writeSync` / `TCP.onStreamRead`, `EBADF`/`EIO`/`EPIPE`), Monaco `Canceled`, browser-extension frames, GPU `abnormal-exit`, and `ENOSPC`. Matches on stack frame / error code / exception type, so it also works on anonymized Tier-1 events (where `minimizeEvent` has blanked the message).
- **`applyFingerprint()`** — collapses the localized "Failed to open: &lt;OS message&gt;" family (previously one issue per OS locale) into a single issue.
- **`finalizeSentryEvent()`** — single entry point: drop → scrub → consent tier → fingerprint.

This removes ~45% of production event volume (from the first week of v3.8.0 Sentry data) that was drowning out real bugs.

**Scope note:** this addresses the *Sentry-flood* root cause — we stop capturing these at the SDK. Deeper *app-side writer hardening* for the socket/fd sources needs a reproduction and is tracked separately (overlaps RI-8351). Spike-protection + rate-limit settings and regression alerting are settings-side follow-ups in RI-8354.

# Testing

- `scrubbing.spec.ts`: 24 new unit tests covering every drop signature (including a guard that an app frame merely *named* `writeSync` is **not** dropped), the "Failed to open" fingerprint, and the tiered `finalizeSentryEvent` flow. Full suite **48/48 pass**.
- ESLint and `tsc --noEmit` clean on all touched files.

---

Closes #RI-8353

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what errors reach Sentry and how issues group; incorrect drop rules could hide real bugs, though tests explicitly guard several false-positive cases.
> 
> **Overview**
> Centralizes Sentry `beforeSend` handling in **`finalizeSentryEvent`**, replacing per-layer `scrubEvent` / `minimizeEvent` wiring in Electron main, Electron renderer, and web inits.
> 
> The shared pipeline runs **drop → scrub → consent tier → fingerprint**. **`shouldDropEvent`** returns `null` for known non-actionable noise (Monaco `Canceled`, browser-extension stacks, Node internal I/O write storms, GPU `abnormal-exit`, `ENOSPC`) before anonymization strips messages. **`applyFingerprint`** groups localized **"Failed to open:"** errors under one issue, using the pre-minimize event when Tier-1 events have blanked text.
> 
> Exports and **24 unit tests** cover drop rules (including guards so app-level `writeSync` / `EBADF`-style errors are kept), fingerprinting, and the full finalize flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb1143609208ed5319f2eadeb732349ea2b0377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->