### PR TITLE
RI-8347 Fix Workbench autocomplete crash on commands without an argument spec

### DIFF
--- a/redisinsight/ui/src/pages/workbench/utils/query.ts
+++ b/redisinsight/ui/src/pages/workbench/utils/query.ts
@@ -331,8 +331,13 @@ export const findStopArgumentWithSuggestions = (
   currentBlock: BlockTokensTree,
 ): Nullable<FoundCommandArgument> => {
   const { queryArgs, command } = currentBlock
+  const stopArgumentResult = findStopArgument(queryArgs, command)
+  // findStopArgument returns null when the command has no argument spec
+  // (e.g. a token-only command); there are no suggestions to offer, so bail
+  // out instead of destructuring null.
+  if (!stopArgumentResult) return null
   const { isBlocked, stopArgument, skippedArguments, blockParent } =
-    findStopArgument(queryArgs, command)
+    stopArgumentResult
 
   if (isBlocked) {
     const isBlockedWithSuggestions =

--- a/redisinsight/ui/src/pages/workbench/utils/tests/query.spec.ts
+++ b/redisinsight/ui/src/pages/workbench/utils/tests/query.spec.ts
@@ -57,6 +57,21 @@ describe('findSuggestionsByQueryArgs', () => {
   })
 })
 
+describe('findSuggestionsByQueryArgs — command without an argument spec (RI-8347)', () => {
+  it('returns null instead of throwing when the matched command has no arguments', () => {
+    // A token-only command definition (no `arguments`): findStopArgument
+    // returns null for it, which previously crashed the destructure in
+    // findStopArgumentWithSuggestions ("Cannot destructure property 'isBlocked'
+    // of null").
+    const commands = [
+      { token: 'PING', type: ICommandTokenType.Block },
+    ] as unknown as IRedisCommand[]
+
+    expect(() => findSuggestionsByQueryArgs(commands, ['PING'])).not.toThrow()
+    expect(findSuggestionsByQueryArgs(commands, ['PING'])).toBeNull()
+  })
+})
+
 const generateDetailTests: Array<{ input: Maybe<IRedisCommand>; result: any }> =
   [
     {


### PR DESCRIPTION
# What

Fixes the Workbench autocomplete crash `TypeError: Cannot destructure property 'isBlocked' of ... as it is null` (~416 events / top code-mapped issue in the first week of v3.8.0 Sentry data).

`findStopArgument` returns `null` when a command has no argument spec (a token-only command), but `findStopArgumentWithSuggestions` destructured the result directly. The fix bails out with `null` before the destructure — the function is already typed `Nullable<FoundCommandArgument>` and its only caller (`findSuggestionsByQueryArgs` → consumers) handles `null` via optional chaining. This mirrors the `|| {}` guard the recursive `findStopArgument` call site already uses.

# Testing

- New regression test in `query.spec.ts`: a matched command with no `arguments` now returns `null` instead of throwing (fails on the unpatched code).
- Full `query.spec.ts` suite: **53/53 pass**. ESLint + `tsc --noEmit` clean.

Reproduce in app:
1. connect to a database and open Workbench
2. open console (cmd+shift+i)
3. type any of these commands:
  DBSIZE 
  RANDOMKEY 
  LASTSAVE 
  COMMAND COUNT 
  CLIENT ID 
  CLUSTER INFO 
  MEMORY DOCTOR 
  ACL WHOAMI 
4. press space

---

Closes #RI-8347

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guard in Workbench query suggestion logic with a regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes a Workbench autocomplete crash when the user types a **token-only** Redis command (e.g. `PING`) whose metadata has no `arguments` array.
> 
> `findStopArgument` already returns `null` in that case, but `findStopArgumentWithSuggestions` destructured the result immediately and threw `Cannot destructure property 'isBlocked' of null`. The change stores the result, returns `null` when it is missing, and only then builds suggestions—matching the existing `Nullable<FoundCommandArgument>` contract and how callers already use optional chaining.
> 
> A regression test asserts `findSuggestionsByQueryArgs` returns `null` without throwing for a command with no argument spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fa86814cd0c70ee5f150876441288e5daf334f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->