### PR TITLE
Promote Array & Vector Set key types on unsupported Redis versions

### DIFF
--- a/redisinsight/ui/src/components/base/icons/RiHighlightedIcon.tsx
+++ b/redisinsight/ui/src/components/base/icons/RiHighlightedIcon.tsx
@@ -1,0 +1,1 @@
+export { HighlightedIcon as RiHighlightedIcon } from '@redis-ui/components'

--- a/redisinsight/ui/src/components/base/icons/index.ts
+++ b/redisinsight/ui/src/components/base/icons/index.ts
@@ -2,5 +2,7 @@
 export * from './Icon'
 // New centralized icon system
 export * from './RiIcon'
+// Highlighted (chip-style) icon wrapper
+export * from './RiHighlightedIcon'
 // Export all individual icons from the registry
 export * from './iconRegistry'

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -556,6 +556,7 @@
   "browser.addKey.form.value.placeholder": "Въведете стойност",
   "browser.addKey.hash.ttlPlaceholder": "Въведете TTL",
   "browser.addKey.keyType": "Тип ключ",
+  "browser.addKey.requiresVersion": "Изисква Redis {{version}}+",
   "browser.addKey.selectKeyType": "Изберете тип ключ",
   "browser.addKey.stream.entryIdError": "Форматът на ID на записа е неправилен",
   "browser.addKey.title": "Добави нов ключ",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -556,6 +556,7 @@
   "browser.addKey.form.value.placeholder": "Enter Value",
   "browser.addKey.hash.ttlPlaceholder": "Enter TTL",
   "browser.addKey.keyType": "Key Type",
+  "browser.addKey.requiresVersion": "Requires Redis {{version}}+",
   "browser.addKey.selectKeyType": "Select key type",
   "browser.addKey.stream.entryIdError": "Entry ID format is incorrect",
   "browser.addKey.title": "New Key",

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.spec.tsx
@@ -152,20 +152,24 @@ describe('AddKey', () => {
     ])
   })
 
-  it('should show Vector Set option when redis version >= 8.0', async () => {
+  it('should show Vector Set option as enabled when redis version >= 8.0', async () => {
     mockRedisVersion('8.0.0')
     renderAddKey()
 
     await userEvent.click(screen.getByTestId('select-key-type'))
     expect(await screen.findByText('Vector Set')).toBeInTheDocument()
+    // no promotion tag/wrapper when the type is supported
+    expect(screen.queryByTestId('vectorset-disabled')).not.toBeInTheDocument()
   })
 
-  it('should hide Vector Set option when redis version < 8.0', async () => {
+  it('should promote Vector Set as a disabled option with a version tag when redis version < 8.0', async () => {
     mockRedisVersion('7.4.0')
     renderAddKey()
 
     await userEvent.click(screen.getByTestId('select-key-type'))
-    expect(screen.queryByText('Vector Set')).not.toBeInTheDocument()
+    // still visible (promoted), not removed from the list, rendered as disabled
+    expect(await screen.findByText('Vector Set')).toBeInTheDocument()
+    expect(screen.getByTestId('vectorset-disabled')).toBeInTheDocument()
   })
 
   it('should not show text if db contains ReJSON module', async () => {

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -33,12 +33,12 @@ import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { CancelSlimIcon } from 'uiSrc/components/base/icons'
-import { HealthText } from 'uiSrc/components/base/text/HealthText'
 import { Title } from 'uiSrc/components/base/text/Title'
 import { RiTooltip } from 'uiSrc/components'
 import { Spacer } from 'uiSrc/components/base/layout'
 import { useTranslation } from 'uiSrc/i18n'
 import { ADD_KEY_TYPE_OPTIONS } from './constants/key-type-options'
+import { KeyTypeOption } from './KeyTypeOption/KeyTypeOption'
 import AddKeyHash from './AddKeyHash'
 import AddKeyZset from './AddKeyZset'
 import AddKeyString from './AddKeyString'
@@ -89,27 +89,18 @@ const AddKey = (props: Props) => {
     [],
   )
 
-  const options = enabledOptions
-    .filter(
-      ({ minVersion }) =>
-        !minVersion || isVersionHigherOrEquals(version, minVersion),
-    )
-    .map((item) => {
-      const { value, color, text } = item
-      return {
-        value,
-        inputDisplay: (
-          <HealthText
-            color={color}
-            style={{ lineHeight: 'inherit' }}
-            data-test-subj={value}
-            data-testid={value}
-          >
-            {t(text)}
-          </HealthText>
-        ),
-      }
-    })
+  // Version-gated types (e.g. Vector Set, Array) stay in the list as disabled
+  // entries on unsupported Redis versions instead of being hidden.
+  const options = enabledOptions.map((item) => {
+    const isSupported =
+      !item.minVersion || isVersionHigherOrEquals(version, item.minVersion)
+
+    return {
+      value: item.value,
+      disabled: !isSupported,
+      inputDisplay: <KeyTypeOption option={item} disabled={!isSupported} />,
+    }
+  })
   const [typeSelected, setTypeSelected] = useState<string>(
     options[0]?.value ?? KeyTypes.Hash,
   )
@@ -118,6 +109,9 @@ const AddKey = (props: Props) => {
   const [keyNameDisabled, setKeyNameDisabled] = useState<boolean>(false)
 
   const onChangeType = (value: string) => {
+    if (options.find((option) => option.value === value)?.disabled) {
+      return
+    }
     setTypeSelected(value)
   }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+import { KeyTypes } from 'uiSrc/constants'
+import { KeyTypeOption, KeyTypeOptionProps } from './KeyTypeOption'
+
+const defaultProps: KeyTypeOptionProps = {
+  option: {
+    text: 'common.keyType.vectorSet',
+    value: KeyTypes.VectorSet,
+    color: 'blue',
+    minVersion: '8.0',
+  },
+}
+
+const renderComponent = (propsOverride?: Partial<KeyTypeOptionProps>) =>
+  render(<KeyTypeOption {...defaultProps} {...propsOverride} />)
+
+describe('KeyTypeOption', () => {
+  it('should render only the label when enabled', () => {
+    renderComponent({ disabled: false })
+
+    expect(screen.getByTestId(KeyTypes.VectorSet)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`${KeyTypes.VectorSet}-disabled`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render a disabled row with the label when disabled', () => {
+    renderComponent({ disabled: true })
+
+    expect(screen.getByText('Vector Set')).toBeInTheDocument()
+    expect(
+      screen.getByTestId(`${KeyTypes.VectorSet}-disabled`),
+    ).toBeInTheDocument()
+  })
+
+  it('should not render the disabled row when the type has no minVersion', () => {
+    renderComponent({
+      option: {
+        text: 'common.keyType.hash',
+        value: KeyTypes.Hash,
+        color: 'blue',
+      },
+      disabled: true,
+    })
+
+    expect(
+      screen.queryByTestId(`${KeyTypes.Hash}-disabled`),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.styles.ts
+++ b/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import { HealthText } from 'uiSrc/components/base/text'
+
+export const OptionRow = styled(Row)`
+  width: 100%;
+`
+
+export const Label = styled(HealthText)`
+  line-height: inherit;
+`

--- a/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/KeyTypeOption/KeyTypeOption.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { useTranslation } from 'uiSrc/i18n'
+import { RiTooltip } from 'uiSrc/components'
+import { LockedIcon, RiHighlightedIcon } from 'uiSrc/components/base/icons'
+
+import { AddKeyTypeOption } from '../AddKey.types'
+import * as S from './KeyTypeOption.styles'
+
+export interface KeyTypeOptionProps {
+  option: AddKeyTypeOption
+  disabled?: boolean
+}
+
+export const KeyTypeOption = ({ option, disabled }: KeyTypeOptionProps) => {
+  const { t } = useTranslation()
+  const { text, value, color, minVersion } = option
+
+  const label = (
+    <S.Label color={color} data-test-subj={value} data-testid={value}>
+      {t(text)}
+    </S.Label>
+  )
+
+  if (!disabled || !minVersion) {
+    return label
+  }
+
+  return (
+    <S.OptionRow
+      align="center"
+      justify="between"
+      gap="s"
+      data-testid={`${value}-disabled`}
+    >
+      {label}
+      <RiTooltip
+        content={t('browser.addKey.requiresVersion', {
+          version: minVersion,
+        })}
+        position="top"
+      >
+        <RiHighlightedIcon icon={LockedIcon} size="S" />
+      </RiTooltip>
+    </S.OptionRow>
+  )
+}


### PR DESCRIPTION
# What

Promote the Array (Redis 8.8+) and Vector Set (Redis 8.0+) key types on databases that don't support them yet.

Previously these types were hidden from the **Add Key** type dropdown on unsupported Redis versions. Now they stay visible but **greyed-out (disabled)**, with a highlighted **lock icon** on the right and a tooltip **"Requires Redis x.y+"** on hover — nudging users to upgrade rather than silently hiding the feature.

- Feature-flag gating is unchanged: an unreleased type (behind a flag) is still hidden entirely, never shown as a disabled teaser.
- Disabled options can't be selected.
- Option rendering is extracted into a colocated `KeyTypeOption` component (styles/constants/tests); a `RiHighlightedIcon` internal wrapper is added around the `@redis-ui` `HighlightedIcon`.

UI-only; no API or data changes.

# Testing

- Connect a Redis **< 8.0** (e.g. 6.2 / 7.2) → open **Add Key** → type dropdown: Vector Set (and Array when its flag is on) appear greyed-out with a lock icon; hovering the lock shows "Requires Redis 8.0+"; they cannot be selected.
- Connect Redis **8.0 / 8.8** → the respective types are enabled and selectable.
- Unit tests: `AddKey.spec.tsx`, `KeyTypeOption.spec.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to Add Key dropdown rendering and selection guards; no API or data path changes.
> 
> **Overview**
> **Add Key** no longer hides Redis version–gated types (e.g. Vector Set, Array) when the connected instance is too old. They stay in the key-type dropdown as **disabled** rows so users see the feature exists but cannot select it.
> 
> Unsupported options use a new **`KeyTypeOption`** row: colored label plus a lock **`RiHighlightedIcon`** with tooltip **`browser.addKey.requiresVersion`** (“Requires Redis {{version}}+”). **`AddKey`** maps all enabled options with `disabled` + `inputDisplay`, blocks `onChangeType` for disabled values, and drops the old filter that removed low-version types. Feature-flag–gated types are unchanged (still omitted, not teased).
> 
> Adds **`RiHighlightedIcon`** re-export, en/bg i18n, and unit tests for **`AddKey`** / **`KeyTypeOption`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc69fca2fe9e68ede5df3f7fb3a448380b38bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->