### PR TITLE
RI-8349 Fix VirtualGrid crash on an expanded row without a recorded height

### DIFF
--- a/redisinsight/ui/src/components/virtual-grid/VirtualGrid.tsx
+++ b/redisinsight/ui/src/components/virtual-grid/VirtualGrid.tsx
@@ -13,7 +13,11 @@ import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { ProgressBarLoader } from 'uiSrc/components/base/display'
 import { Row } from 'uiSrc/components/base/layout/flex'
 import { IProps } from './interfaces'
-import { getColumnWidth, useInnerElementType } from './utils'
+import {
+  getColumnWidth,
+  getExpandedRowHeight,
+  useInnerElementType,
+} from './utils'
 
 import styles from './styles.module.scss'
 
@@ -68,9 +72,7 @@ const VirtualGrid = (props: IProps) => {
   )
 
   const getRowHeight = (index: number) =>
-    expandedRows.indexOf(index) !== -1
-      ? Math.max(...Object.values(rowHeightsMap.current[index]))
-      : rowHeight
+    getExpandedRowHeight(index, expandedRows, rowHeightsMap.current, rowHeight)
 
   useEffect(
     () => () => {

--- a/redisinsight/ui/src/components/virtual-grid/tests/utils.spec.ts
+++ b/redisinsight/ui/src/components/virtual-grid/tests/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getColumnWidth } from '../utils'
+import { getColumnWidth, getExpandedRowHeight } from '../utils'
 
 const getColumnWidthTests: any[] = [
   [0, 500, [{ maxWidth: 70, minWidth: 50 }], 50],
@@ -32,4 +32,32 @@ describe('getColumnWidth', () => {
       expect(result).toBe(expected)
     },
   )
+})
+
+describe('getExpandedRowHeight (RI-8349)', () => {
+  const DEFAULT = 43
+
+  it('returns the default height for a non-expanded row', () => {
+    expect(getExpandedRowHeight(0, [], { 0: { 0: 100 } }, DEFAULT)).toBe(
+      DEFAULT,
+    )
+  })
+
+  it('returns the tallest recorded column height for an expanded row', () => {
+    expect(
+      getExpandedRowHeight(1, [1], { 1: { 0: 80, 1: 120, 2: 50 } }, DEFAULT),
+    ).toBe(120)
+  })
+
+  it('falls back to the default when an expanded row has no recorded height (no crash)', () => {
+    // Row flagged expanded before setRowHeight ran — previously threw
+    // "Cannot convert undefined or null to object" on Object.values(undefined).
+    expect(() => getExpandedRowHeight(2, [2], {}, DEFAULT)).not.toThrow()
+    expect(getExpandedRowHeight(2, [2], {}, DEFAULT)).toBe(DEFAULT)
+  })
+
+  it('falls back to the default when the recorded height map is empty', () => {
+    // Guards Math.max() with no args returning -Infinity.
+    expect(getExpandedRowHeight(3, [3], { 3: {} }, DEFAULT)).toBe(DEFAULT)
+  })
 })

--- a/redisinsight/ui/src/components/virtual-grid/utils.tsx
+++ b/redisinsight/ui/src/components/virtual-grid/utils.tsx
@@ -230,6 +230,29 @@ export const useInnerElementType = (
     [Cell, columnWidth, rowHeight, columnCount, tableWidth],
   )
 
+/**
+ * Row height for a virtual-grid row. Expanded rows use the tallest recorded
+ * column height; everything else uses the default.
+ *
+ * A row can be flagged expanded before any column height has been recorded (or
+ * after the height map is reset), so `rowHeights[index]` may be missing/empty.
+ * Fall back to the default in that case rather than calling `Object.values()`
+ * on `undefined` ("Cannot convert undefined or null to object") or `Math.max()`
+ * with no args (`-Infinity`).
+ */
+export const getExpandedRowHeight = (
+  index: number,
+  expandedRows: number[],
+  rowHeights: { [key: number]: { [key: number]: number } },
+  defaultRowHeight: number,
+): number => {
+  if (expandedRows.indexOf(index) === -1) return defaultRowHeight
+
+  const columnHeights = rowHeights[index]
+  const sizes = columnHeights ? Object.values(columnHeights) : []
+  return sizes.length ? Math.max(...sizes) : defaultRowHeight
+}
+
 export const getColumnWidth = (
   i: number,
   width: number,


### PR DESCRIPTION
# What

Fixes `TypeError: Cannot convert undefined or null to object` in `VirtualGrid.getRowHeight` (~105 events across two fingerprints in the first week of v3.8.0 Sentry data).

An expanded row can be laid out before `setRowHeight` has recorded its column heights (or after the height map is reset on unmount/prop change), leaving `rowHeightsMap.current[index]` `undefined`. The old code then called `Object.values(undefined)` → throw.

The height logic is extracted into a pure `getExpandedRowHeight()` helper in `utils.tsx` that falls back to the default row height when the map entry is missing or empty (which also avoids the `Math.max()` → `-Infinity` case for an empty entry). `VirtualGrid` now delegates to it.

# Testing

- New unit tests in `tests/utils.spec.ts` cover: non-expanded row → default; expanded with recorded heights → tallest; **expanded with no entry → default, no throw** (the regression); expanded with empty entry → default.
- `virtual-grid` suites: **9/9 pass**. ESLint clean. Touched files type-check clean (verified via targeted `tsc`; the change is a typed pure helper).

---

Closes #RI-8349

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive UI fix in virtual grid row sizing with unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes a **production crash** (`TypeError: Cannot convert undefined or null to object`) in `VirtualGrid` when a row is expanded before `setRowHeight` has stored column heights, or after the height map is cleared on unmount or when `totalItemsCount` changes.
> 
> Row height for expanded rows is moved into **`getExpandedRowHeight`** in `utils.tsx`. It uses the tallest recorded column height when present, and otherwise returns the default row height instead of calling `Object.values` on `undefined` or `Math.max()` on an empty list.
> 
> `VirtualGrid` delegates `getRowHeight` to that helper. **Unit tests** cover the missing/empty map cases that caused the regression (RI-8349).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6db12197a704c88f1771568c65f3d019bee3466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->