### PR TITLE
Update Vector Set gating e2e for promoted-disabled key types

### DIFF
--- a/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
+++ b/tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts
@@ -29,16 +29,21 @@ test.describe('Browser > Vector Set > Gating > Redis below 8.0', () => {
     ).toHaveCount(0);
   });
 
-  test('hides Vector Set from the Add Key type dropdown', async ({ browserPage }) => {
+  test('shows Vector Set as disabled in the Add Key type dropdown', async ({ browserPage }) => {
     await browserPage.goto(database.id);
     await browserPage.openAddKeyDialog();
 
     await browserPage.addKeyDialog.keyTypeSelect.click();
     await expect(browserPage.addKeyDialog.keyTypeDropdown).toBeVisible();
 
-    await expect(
-      browserPage.addKeyDialog.keyTypeDropdown.getByRole('option', { name: 'Vector Set', exact: true }),
-    ).toHaveCount(0);
+    // The type is promoted (visible) but disabled instead of being hidden.
+    const vectorSetOption = browserPage.addKeyDialog.keyTypeDropdown.getByRole('option', {
+      name: 'Vector Set',
+      exact: true,
+    });
+    await expect(vectorSetOption).toBeVisible();
+    await expect(vectorSetOption).toBeDisabled();
+    await expect(browserPage.addKeyDialog.keyTypeDropdown.getByTestId('vectorset-disabled')).toBeVisible();
   });
 });
 
@@ -68,15 +73,19 @@ test.describe('Browser > Vector Set > Gating > Redis 8.8.0', () => {
     ).toBeVisible();
   });
 
-  test('shows Vector Set in the Add Key type dropdown', async ({ browserPage }) => {
+  test('shows Vector Set as enabled in the Add Key type dropdown', async ({ browserPage }) => {
     await browserPage.goto(database.id);
     await browserPage.openAddKeyDialog();
 
     await browserPage.addKeyDialog.keyTypeSelect.click();
     await expect(browserPage.addKeyDialog.keyTypeDropdown).toBeVisible();
 
-    await expect(
-      browserPage.addKeyDialog.keyTypeDropdown.getByRole('option', { name: 'Vector Set', exact: true }),
-    ).toBeVisible();
+    const vectorSetOption = browserPage.addKeyDialog.keyTypeDropdown.getByRole('option', {
+      name: 'Vector Set',
+      exact: true,
+    });
+    await expect(vectorSetOption).toBeVisible();
+    await expect(vectorSetOption).toBeEnabled();
+    await expect(browserPage.addKeyDialog.keyTypeDropdown.getByTestId('vectorset-disabled')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
# What

Update the Vector Set gating e2e test to match the promoted-disabled key-type behaviour shipped in #6302 (now on `main`).

On Redis versions that don't support Vector Set / Array, the **Add Key** type dropdown now shows these types **greyed-out (disabled)** with a lock icon and a "Requires Redis x.y+" tooltip, instead of hiding them.

- Redis < 8.0 → asserts Vector Set is **visible but disabled** in the Add Key dropdown (`toBeDisabled()` + `vectorset-disabled` testid), instead of hidden.
- Redis 8.8.0 → asserts Vector Set is **enabled** (no disabled wrapper).
- The key-type **filter** dropdown still hides unsupported types (unchanged), so its gating assertions are left as-is.

# Testing

Playwright e2e: `tests/e2e-playwright/tests/parallel/browser/vector-set/gating.spec.ts` (runs against Redis 7.9.x and 8.8.0 RTE instances).

---

Follows up on #6302.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playwright test-only changes with no production code impact.
> 
> **Overview**
> Updates **Vector Set** Playwright gating specs to match the **Add Key** type dropdown behaviour from #6302: unsupported types stay **visible but disabled** (lock/tooltip) instead of omitted.
> 
> On **Redis &lt; 8.0**, the Add Key test now asserts the Vector Set option is visible, **disabled**, and wrapped with the `vectorset-disabled` test id. On **Redis 8.8.0**, it asserts the option is **enabled** and that disabled wrapper is absent.
> 
> **Key-type filter** gating tests are unchanged (unsupported types remain hidden there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa07cd7e843ca4e69bad0076cc087770b4654b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->