### PR TITLE
VDP-4556: Block server-side file reads on database import for non-desktop builds

### DIFF
--- a/redisinsight/api/.tscheck.rec.json
+++ b/redisinsight/api/.tscheck.rec.json
@@ -787,10 +787,6 @@
     "TS7005": 1,
     "TS7034": 1
   },
-  "src/modules/database-import/certificate-import.service.spec.ts": {
-    "TS7005": 10,
-    "TS7034": 4
-  },
   "src/modules/database-import/certificate-import.service.ts": {
     "TS2322": 7,
     "TS2345": 10
@@ -818,10 +814,6 @@
   },
   "src/modules/database-import/dto/import.database.dto.ts": {
     "TS2345": 2
-  },
-  "src/modules/database-import/ssh-import.service.spec.ts": {
-    "TS7005": 1,
-    "TS7034": 1
   },
   "src/modules/database-import/ssh-import.service.ts": {
     "TS2322": 1

--- a/redisinsight/api/src/common/utils/certificate-import.util.spec.ts
+++ b/redisinsight/api/src/common/utils/certificate-import.util.spec.ts
@@ -1,0 +1,27 @@
+import { isImportFromFileAllowed } from 'src/common/utils';
+import config, { Config } from 'src/utils/config';
+import { BuildType } from 'src/modules/server/models/server';
+
+const mockServerConfig = config.get('server') as Config['server'];
+const originalBuildType = mockServerConfig.buildType;
+
+describe('isImportFromFileAllowed', () => {
+  afterEach(() => {
+    mockServerConfig.buildType = originalBuildType;
+  });
+
+  it('should allow reading from a path in the desktop build', () => {
+    mockServerConfig.buildType = BuildType.Electron;
+
+    expect(isImportFromFileAllowed()).toEqual(true);
+  });
+
+  it.each([BuildType.DockerOnPremise, BuildType.RedisStack, BuildType.VSCode])(
+    'should not allow reading from a path in the %s build',
+    (buildType) => {
+      mockServerConfig.buildType = buildType;
+
+      expect(isImportFromFileAllowed()).toEqual(false);
+    },
+  );
+});

--- a/redisinsight/api/src/common/utils/certificate-import.util.ts
+++ b/redisinsight/api/src/common/utils/certificate-import.util.ts
@@ -1,5 +1,14 @@
 import { parse } from 'path';
 import { readFileSync } from 'fs';
+import config, { Config } from 'src/utils/config';
+import { BuildType } from 'src/modules/server/models/server';
+
+const SERVER_CONFIG = config.get('server') as Config['server'];
+
+// Only the desktop app resolves a path; other builds take inline PEM only,
+// so an import can't read files off the host.
+export const isImportFromFileAllowed = (): boolean =>
+  SERVER_CONFIG.buildType === BuildType.Electron;
 
 export const isValidPemCertificate = (cert: string): boolean =>
   cert.startsWith('-----BEGIN CERTIFICATE-----');

--- a/redisinsight/api/src/modules/database-import/certificate-import.service.spec.ts
+++ b/redisinsight/api/src/modules/database-import/certificate-import.service.spec.ts
@@ -16,23 +16,28 @@ import {
 } from 'src/__mocks__';
 import * as utils from 'src/common/utils';
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  InvalidCaCertificateBodyException,
-  InvalidCertificateNameException,
-  InvalidClientCertificateBodyException,
-  InvalidClientPrivateKeyException,
-} from 'src/modules/database-import/exceptions';
+import config, { Config } from 'src/utils/config';
+import { BuildType } from 'src/modules/server/models/server';
 import { CertificateImportService } from 'src/modules/database-import/certificate-import.service';
 import { EncryptionService } from 'src/modules/encryption/encryption.service';
 import { Repository } from 'typeorm';
 import { CaCertificateEntity } from 'src/modules/certificate/entities/ca-certificate.entity';
 import { ClientCertificateEntity } from 'src/modules/certificate/entities/client-certificate.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  InvalidCaCertificateBodyException,
+  InvalidCertificateNameException,
+  InvalidClientCertificateBodyException,
+  InvalidClientPrivateKeyException,
+} from 'src/modules/database-import/exceptions';
 
 jest.mock('src/common/utils', () => ({
   ...(jest.requireActual('src/common/utils') as object),
   getPemBodyFromFileSync: jest.fn(),
 }));
+
+const mockServerConfig = config.get('server') as Config['server'];
+const originalBuildType = mockServerConfig.buildType;
 
 describe('CertificateImportService', () => {
   let service: CertificateImportService;
@@ -96,10 +101,10 @@ describe('CertificateImportService', () => {
       });
   });
 
-  let determineAvailableNameSpy;
-  let getPemBodyFromFileSyncSpy;
-  let prepareCaCertificateForImportSpy;
-  let prepareClientCertificateForImportSpy;
+  let determineAvailableNameSpy: jest.SpyInstance;
+  let getPemBodyFromFileSyncSpy: jest.SpyInstance;
+  let prepareCaCertificateForImportSpy: jest.SpyInstance;
+  let prepareClientCertificateForImportSpy: jest.SpyInstance;
 
   describe('processCaCertificate', () => {
     beforeEach(() => {
@@ -136,32 +141,62 @@ describe('CertificateImportService', () => {
       }
     });
 
-    it('should successfully process certificate from file', async () => {
-      const response = await service['processCaCertificate']({
-        certificate: '/path/ca.crt',
+    describe('from filesystem path (desktop build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.Electron;
       });
 
-      expect(response).toEqual(mockCaCertificate);
-      expect(prepareCaCertificateForImportSpy).toHaveBeenCalledWith({
-        name: 'ca',
-        certificate: mockCaCertificate.certificate,
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
+      });
+
+      it('should successfully process certificate from file', async () => {
+        const response = await service['processCaCertificate']({
+          certificate: '/path/ca.crt',
+        });
+
+        expect(response).toEqual(mockCaCertificate);
+        expect(prepareCaCertificateForImportSpy).toHaveBeenCalledWith({
+          name: 'ca',
+          certificate: mockCaCertificate.certificate,
+        });
+      });
+
+      it('should fail when no file found', async () => {
+        getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
+          throw new Error();
+        });
+
+        try {
+          await service['processCaCertificate']({
+            name: undefined,
+            certificate: '/path/ca.crt',
+          });
+          fail();
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidCaCertificateBodyException);
+        }
       });
     });
 
-    it('should fail when no file found', async () => {
-      getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
-        throw new Error();
+    describe('from filesystem path (network build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.DockerOnPremise;
       });
 
-      try {
-        await service['processCaCertificate']({
-          name: undefined,
-          certificate: '/path/ca.crt',
-        });
-        fail();
-      } catch (e) {
-        expect(e).toBeInstanceOf(InvalidCaCertificateBodyException);
-      }
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
+      });
+
+      it('should reject a path without reading any file', async () => {
+        await expect(
+          service['processCaCertificate']({
+            certificate: '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+          }),
+        ).rejects.toBeInstanceOf(InvalidCaCertificateBodyException);
+
+        expect(getPemBodyFromFileSyncSpy).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -264,60 +299,93 @@ describe('CertificateImportService', () => {
       }
     });
 
-    it('should successfully process certificate from file', async () => {
-      getPemBodyFromFileSyncSpy.mockReturnValueOnce(
-        mockClientCertificate.certificate,
-      );
-      getPemBodyFromFileSyncSpy.mockReturnValueOnce(mockClientCertificate.key);
-
-      const response = await service['processClientCertificate']({
-        certificate: '/path/client.crt',
-        key: '/path/key.key',
+    describe('from filesystem path (desktop build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.Electron;
       });
 
-      expect(response).toEqual(mockClientCertificate);
-      expect(prepareClientCertificateForImportSpy).toHaveBeenCalledWith({
-        name: 'client',
-        certificate: mockClientCertificate.certificate,
-        key: mockClientCertificate.key,
-      });
-    });
-
-    it('should fail when no cert file found', async () => {
-      getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
-        throw new Error();
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
       });
 
-      try {
-        await service['processClientCertificate']({
-          name: undefined,
-          certificate: '/path/client1.crt',
-          key: '/path/key1.key',
-        });
-        fail();
-      } catch (e) {
-        expect(e).toBeInstanceOf(InvalidClientCertificateBodyException);
-      }
-    });
+      it('should successfully process certificate from file', async () => {
+        getPemBodyFromFileSyncSpy.mockReturnValueOnce(
+          mockClientCertificate.certificate,
+        );
+        getPemBodyFromFileSyncSpy.mockReturnValueOnce(
+          mockClientCertificate.key,
+        );
 
-    it('should fail when no key file found', async () => {
-      getPemBodyFromFileSyncSpy.mockReturnValueOnce(
-        mockClientCertificate.certificate,
-      );
-      getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
-        throw new Error();
-      });
-
-      try {
-        await service['processClientCertificate']({
-          name: undefined,
+        const response = await service['processClientCertificate']({
           certificate: '/path/client.crt',
           key: '/path/key.key',
         });
-        fail();
-      } catch (e) {
-        expect(e).toBeInstanceOf(InvalidClientPrivateKeyException);
-      }
+
+        expect(response).toEqual(mockClientCertificate);
+        expect(prepareClientCertificateForImportSpy).toHaveBeenCalledWith({
+          name: 'client',
+          certificate: mockClientCertificate.certificate,
+          key: mockClientCertificate.key,
+        });
+      });
+
+      it('should fail when no cert file found', async () => {
+        getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
+          throw new Error();
+        });
+
+        try {
+          await service['processClientCertificate']({
+            name: undefined,
+            certificate: '/path/client1.crt',
+            key: '/path/key1.key',
+          });
+          fail();
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidClientCertificateBodyException);
+        }
+      });
+
+      it('should fail when no key file found', async () => {
+        getPemBodyFromFileSyncSpy.mockReturnValueOnce(
+          mockClientCertificate.certificate,
+        );
+        getPemBodyFromFileSyncSpy.mockImplementationOnce(() => {
+          throw new Error();
+        });
+
+        try {
+          await service['processClientCertificate']({
+            name: undefined,
+            certificate: '/path/client.crt',
+            key: '/path/key.key',
+          });
+          fail();
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidClientPrivateKeyException);
+        }
+      });
+    });
+
+    describe('from filesystem path (network build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.DockerOnPremise;
+      });
+
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
+      });
+
+      it('should reject cert and key paths without reading any file', async () => {
+        await expect(
+          service['processClientCertificate']({
+            certificate: '/etc/redis/tls/redis.crt',
+            key: '/etc/redis/tls/redis.key',
+          }),
+        ).rejects.toBeInstanceOf(InvalidClientCertificateBodyException);
+
+        expect(getPemBodyFromFileSyncSpy).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/redisinsight/api/src/modules/database-import/certificate-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/certificate-import.service.ts
@@ -11,6 +11,7 @@ import { classToClass } from 'src/utils';
 import {
   getCertNameFromFilename,
   getPemBodyFromFileSync,
+  isImportFromFileAllowed,
   isValidPemCertificate,
   isValidPemPrivateKey,
 } from 'src/common/utils';
@@ -57,7 +58,7 @@ export class CertificateImportService {
 
     if (isValidPemCertificate(cert.certificate)) {
       toImport.certificate = cert.certificate;
-    } else {
+    } else if (isImportFromFileAllowed()) {
       try {
         toImport.certificate = getPemBodyFromFileSync(cert.certificate);
         toImport.name = getCertNameFromFilename(cert.certificate);
@@ -130,7 +131,7 @@ export class CertificateImportService {
 
     if (isValidPemCertificate(cert.certificate)) {
       toImport.certificate = cert.certificate;
-    } else {
+    } else if (isImportFromFileAllowed()) {
       try {
         toImport.certificate = getPemBodyFromFileSync(cert.certificate);
         toImport.name = getCertNameFromFilename(cert.certificate);
@@ -143,7 +144,7 @@ export class CertificateImportService {
 
     if (isValidPemPrivateKey(cert.key)) {
       toImport.key = cert.key;
-    } else {
+    } else if (isImportFromFileAllowed()) {
       try {
         toImport.key = getPemBodyFromFileSync(cert.key);
       } catch (e) {

--- a/redisinsight/api/src/modules/database-import/ssh-import.service.spec.ts
+++ b/redisinsight/api/src/modules/database-import/ssh-import.service.spec.ts
@@ -2,6 +2,8 @@ import { mockSshOptionsBasic, mockSshOptionsPrivateKey } from 'src/__mocks__';
 import * as utils from 'src/common/utils';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SshImportService } from 'src/modules/database-import/ssh-import.service';
+import config, { Config } from 'src/utils/config';
+import { BuildType } from 'src/modules/server/models/server';
 import {
   InvalidSshPrivateKeyBodyException,
   InvalidSshBodyException,
@@ -12,6 +14,9 @@ jest.mock('src/common/utils', () => ({
   ...(jest.requireActual('src/common/utils') as object),
   getPemBodyFromFileSync: jest.fn(),
 }));
+
+const mockServerConfig = config.get('server') as Config['server'];
+const originalBuildType = mockServerConfig.buildType;
 
 const mockSshImportDataBasic = {
   sshHost: mockSshOptionsBasic.host,
@@ -39,7 +44,7 @@ describe('SshImportService', () => {
     service = await module.get(SshImportService);
   });
 
-  let getPemBodyFromFileSyncSpy;
+  let getPemBodyFromFileSyncSpy: jest.SpyInstance;
 
   describe('processSshOptions', () => {
     beforeEach(() => {
@@ -77,32 +82,63 @@ describe('SshImportService', () => {
       });
     });
 
-    it('should successfully process ssh PKP (from path)', async () => {
-      const response = await service.processSshOptions({
-        ...mockSshImportDataPK,
-        sshPrivateKey: '/some/path',
+    describe('from filesystem path (desktop build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.Electron;
       });
 
-      expect(response).toEqual({
-        ...mockSshOptionsPrivateKey,
-        id: undefined,
-        password: undefined,
-      });
-    });
-
-    it('should throw an error when invalid privateKey body provided', async () => {
-      getPemBodyFromFileSyncSpy.mockImplementation(() => {
-        throw new Error('no file');
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
       });
 
-      try {
-        await service.processSshOptions({
+      it('should successfully process ssh PKP (from path)', async () => {
+        const response = await service.processSshOptions({
           ...mockSshImportDataPK,
           sshPrivateKey: '/some/path',
         });
-      } catch (e) {
-        expect(e).toBeInstanceOf(InvalidSshPrivateKeyBodyException);
-      }
+
+        expect(response).toEqual({
+          ...mockSshOptionsPrivateKey,
+          id: undefined,
+          password: undefined,
+        });
+      });
+
+      it('should throw an error when invalid privateKey body provided', async () => {
+        getPemBodyFromFileSyncSpy.mockImplementation(() => {
+          throw new Error('no file');
+        });
+
+        try {
+          await service.processSshOptions({
+            ...mockSshImportDataPK,
+            sshPrivateKey: '/some/path',
+          });
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidSshPrivateKeyBodyException);
+        }
+      });
+    });
+
+    describe('from filesystem path (network build)', () => {
+      beforeEach(() => {
+        mockServerConfig.buildType = BuildType.DockerOnPremise;
+      });
+
+      afterEach(() => {
+        mockServerConfig.buildType = originalBuildType;
+      });
+
+      it('should reject a path without reading any file', async () => {
+        await expect(
+          service.processSshOptions({
+            ...mockSshImportDataPK,
+            sshPrivateKey: '/root/.ssh/id_rsa',
+          }),
+        ).rejects.toBeInstanceOf(InvalidSshPrivateKeyBodyException);
+
+        expect(getPemBodyFromFileSyncSpy).not.toHaveBeenCalled();
+      });
     });
 
     it('should throw an error when ssh agent provided', async () => {

--- a/redisinsight/api/src/modules/database-import/ssh-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/ssh-import.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { isUndefined } from 'lodash';
-import { getPemBodyFromFileSync, isValidSshPrivateKey } from 'src/common/utils';
+import {
+  getPemBodyFromFileSync,
+  isImportFromFileAllowed,
+  isValidSshPrivateKey,
+} from 'src/common/utils';
 import {
   InvalidSshPrivateKeyBodyException,
   InvalidSshBodyException,
@@ -31,13 +35,15 @@ export class SshImportService {
 
       if (isValidSshPrivateKey(data.sshPrivateKey)) {
         sshOptions.privateKey = data.sshPrivateKey;
-      } else {
+      } else if (isImportFromFileAllowed()) {
         try {
           sshOptions.privateKey = getPemBodyFromFileSync(data.sshPrivateKey);
         } catch (e) {
           // ignore error
           sshOptions = null;
         }
+      } else {
+        throw new InvalidSshPrivateKeyBodyException();
       }
     } else {
       sshOptions.password = data.sshPassword || null;

--- a/redisinsight/api/test/api/database-import/POST-databases-import.test.ts
+++ b/redisinsight/api/test/api/database-import/POST-databases-import.test.ts
@@ -244,6 +244,19 @@ const importDatabaseFormat3 = {
     : undefined,
 };
 
+// Non-desktop builds no longer resolve certificate/key paths, so importing a
+// database that references certs by path is rejected with these errors.
+const invalidCaCertBodyError = {
+  message: 'Invalid CA body',
+  statusCode: 400,
+  error: 'Invalid Ca Certificate Body',
+};
+const invalidClientCertBodyError = {
+  message: 'Invalid certificate body',
+  statusCode: 400,
+  error: 'Invalid Client Certificate Body',
+};
+
 const mainCheckFn = getMainCheckFn(endpoint);
 
 const checkConnection = async (databaseId: string, statusCode = 200) => {
@@ -1148,20 +1161,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'STANDALONE', 'STANDALONE');
+        await validatePartialImportedDatabase(name, 'STANDALONE', 'STANDALONE');
       });
       it('Import standalone with CA tls partial with no ca file (format 1)', async () => {
         await validateApiCall({
@@ -1222,20 +1236,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA tls (format 3)', async () => {
         await validateApiCall({
@@ -1254,20 +1273,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
     });
     describe('TLS AUTH', function () {
@@ -1425,20 +1449,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'STANDALONE', 'STANDALONE');
+        await validatePartialImportedDatabase(name, 'STANDALONE', 'STANDALONE');
       });
       it('Import standalone with CA + CLIENT tls partial with wrong key (format 1)', async () => {
         await validateApiCall({
@@ -1502,20 +1527,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls (format 3)', async () => {
         await validateApiCall({
@@ -1534,20 +1564,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
     });
   });
@@ -1672,20 +1707,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'STANDALONE', 'STANDALONE');
+        await validatePartialImportedDatabase(name, 'STANDALONE', 'STANDALONE');
       });
       it('Import standalone with CA + CLIENT tls + ssh PK (format 1)', async () => {
         await validateApiCall({
@@ -1705,20 +1741,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'STANDALONE', 'STANDALONE');
+        await validatePartialImportedDatabase(name, 'STANDALONE', 'STANDALONE');
       });
       it('Import standalone with CA + CLIENT tls + ssh PKP (format 1)', async () => {
         await validateApiCall({
@@ -1738,20 +1775,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'STANDALONE', 'STANDALONE');
+        await validatePartialImportedDatabase(name, 'STANDALONE', 'STANDALONE');
       });
       it('Import standalone with CA + CLIENT tls + ssh basic (format 2)', async () => {
         await validateApiCall({
@@ -1773,20 +1811,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls + ssh PK (format 2)', async () => {
         await validateApiCall({
@@ -1808,20 +1851,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls + ssh PKP (format 2)', async () => {
         await validateApiCall({
@@ -1843,20 +1891,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls + ssh basic (format 3)', async () => {
         await validateApiCall({
@@ -1876,20 +1929,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls + ssh PK (format 3)', async () => {
         await validateApiCall({
@@ -1909,20 +1967,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
       it('Import standalone with CA + CLIENT tls + ssh PKP (format 3)', async () => {
         await validateApiCall({
@@ -1942,20 +2005,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'STANDALONE');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
     });
   });
@@ -2185,20 +2253,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'CLUSTER', 'CLUSTER');
+        await validatePartialImportedDatabase(name, 'CLUSTER', 'CLUSTER');
       });
       it('Import cluster with CA tls (format 2)', async () => {
         await validateApiCall({
@@ -2220,20 +2289,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'CLUSTER', 'CLUSTER');
+        await validatePartialImportedDatabase(name, 'CLUSTER', 'CLUSTER');
       });
       it('Import cluster with CA tls (format 3)', async () => {
         await validateApiCall({
@@ -2252,20 +2322,25 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'NOT CONNECTED', 'CLUSTER');
+        await validatePartialImportedDatabase(
+          name,
+          'NOT CONNECTED',
+          'NOT CONNECTED',
+        );
       });
     });
   });
@@ -2467,20 +2542,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat1.host,
                 port: importDatabaseFormat1.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'SENTINEL', 'SENTINEL');
+        await validatePartialImportedDatabase(name, 'SENTINEL', 'SENTINEL');
       });
       it('Import sentinel with CA + CLIENT tls (format 2)', async () => {
         await validateApiCall({
@@ -2501,20 +2577,21 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat2.host,
                 port: parseInt(importDatabaseFormat2.port, 10),
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        await validateImportedDatabase(name, 'SENTINEL', 'SENTINEL');
+        await validatePartialImportedDatabase(name, 'SENTINEL', 'SENTINEL');
       });
       it('Import sentinel with CA + CLIENT tls (format 3)', async () => {
         await validateApiCall({
@@ -2533,25 +2610,24 @@ describe('POST /databases/import', () => {
           ],
           responseBody: {
             total: 1,
-            success: [
+            success: [],
+            partial: [
               {
                 index: 0,
-                status: 'success',
+                status: 'partial',
                 host: importDatabaseFormat3.host,
                 port: importDatabaseFormat3.port,
+                errors: [invalidCaCertBodyError, invalidClientCertBodyError],
               },
             ],
-            partial: [],
             fail: [],
           },
         });
 
-        // should determine connection type as standalone since we don't have sentinel auto discovery
-        await validateImportedDatabase(
+        await validatePartialImportedDatabase(
           name,
           'NOT CONNECTED',
-          'STANDALONE',
-          false,
+          'NOT CONNECTED',
         );
       });
     });


### PR DESCRIPTION
# What

Hardens database import so that certificate and SSH key fields are only
resolved from a filesystem path in the desktop (Electron) build.

These fields accept either inline PEM content or a path to a file on disk.
Resolving a path is a convenience that only makes sense for the local
desktop user. On other builds the import is now restricted to inline PEM
content; a path is rejected with the existing invalid-body error and no
file is read. Desktop behaviour is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-hardening change to import that blocks arbitrary host file reads on server deployments; breaks imports that relied on path fields unless users switch to inline PEM.
> 
> **Overview**
> **Non-desktop builds** (Docker, Redis Stack, VSCode) no longer read TLS or SSH material from **filesystem paths** during database import—only **inline PEM** is accepted. Path-like values are rejected with the existing invalid-body errors and **`readFileSync` is not invoked**.
> 
> Adds **`isImportFromFileAllowed()`** (true only for **Electron**). **Certificate** and **SSH import** services gate path resolution on that helper; SSH import on network builds throws **`InvalidSshPrivateKeyBodyException`** immediately for path-only keys.
> 
> Unit tests cover desktop vs network behavior; API import tests that use cert paths in formats 1–3 now expect **partial** imports with CA/client cert errors instead of success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448f462e3b4e3e0b3ad334df8d79be7b7f817f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->