### PR TITLE
docs: use Refs instead of Closes in PR template

### DIFF
--- a/.ai/skills/pull-requests/SKILL.md
+++ b/.ai/skills/pull-requests/SKILL.md
@@ -32,7 +32,7 @@ Describe how to test the changes.
 
 ---
 
-Closes #RI-123
+Refs #RI-123
 ```
 
 **PR Description Guidelines:**
@@ -41,6 +41,7 @@ Closes #RI-123
 - **Focus on high-level changes** - Don't list every code change in the #What section
 - **Brief and to the point** - The diff shows the details; describe the "why" and "what" at a high level
 - **Technical decisions** - Only mention significant architectural or design decisions if relevant
+- **Link, don't auto-close** - Use `Refs #RI-123` / `Addresses #RI-123`, not `Closes`/`Fixes`/`Resolves` - those keywords auto-close the issue when the PR merges, and tickets should be closed manually, not by the merge
 
 ## Review Process
 


### PR DESCRIPTION
# What

Updates the `pull-requests` skill's PR description template to use `Refs #RI-123` instead of `Closes #RI-123`, and adds a guideline explaining why.

# Testing

Docs-only change, no functional testing needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an AI skill file; no runtime or product behavior.
> 
> **Overview**
> Updates the **pull-requests** skill so the sample PR footer uses **`Refs #RI-123`** instead of **`Closes #RI-123`**.
> 
> Adds a guideline to link issues with **`Refs`** / **`Addresses`** and avoid **`Closes`**, **`Fixes`**, or **`Resolves`**, so merging a PR does not auto-close tickets—issues stay open until closed manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446b440bd3cb8bd15246cbffcd6c51198044b31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->