### PR TITLE
RI-8357 Add search to the index drop-down and the search indexes list

### DIFF
--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -1691,6 +1691,7 @@
   "vectorSearch.list.header.description": "Индексът за търсене организира данните ви, за да позволи бързо векторно, пълнотекстово, хибридно и числово търсене в Redis.",
   "vectorSearch.list.header.learnMore": "Научете повече",
   "vectorSearch.list.header.title": "Индекси за търсене",
+  "vectorSearch.list.search.placeholder": "Търсене на индекс",
   "vectorSearch.list.tooltip.docs": "Брой на текущо индексираните документи.",
   "vectorSearch.list.tooltip.fields": "Общ брой полета, дефинирани в схемата на индекса.",
   "vectorSearch.list.tooltip.prefix": "Ключовете, съвпадащи с този префикс, се индексират автоматично.",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -1691,6 +1691,7 @@
   "vectorSearch.list.header.description": "A search index organizes your data to enable fast Vector, full-text, hybrid, and numeric searches in Redis.",
   "vectorSearch.list.header.learnMore": "Learn more",
   "vectorSearch.list.header.title": "Search indexes",
+  "vectorSearch.list.search.placeholder": "Search index",
   "vectorSearch.list.tooltip.docs": "Number of documents currently indexed.",
   "vectorSearch.list.tooltip.fields": "Total number of fields defined in the index schema.",
   "vectorSearch.list.tooltip.prefix": "Keys matching this prefix are automatically indexed.",

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.spec.tsx
@@ -222,6 +222,27 @@ describe('RediSearchIndexesList', () => {
     expect(fetchKeysMock).toHaveBeenCalled()
   })
 
+  it('should filter the options by the drop-down search, keeping Create Index', async () => {
+    ;(redisearchListSelector as jest.Mock).mockReturnValue({
+      data: [stringToBuffer('products-idx'), stringToBuffer('users-idx')],
+      loading: false,
+      error: '',
+      selectedIndex: null,
+    })
+
+    renderRediSearchIndexesList(instance(mockedProps))
+
+    await userEvent.click(screen.getByTestId('select-search-mode'))
+    await userEvent.type(
+      screen.getByLabelText('Search', { selector: 'input' }),
+      'USERS',
+    )
+
+    expect(screen.getByText('users-idx')).toBeInTheDocument()
+    expect(screen.queryByText('products-idx')).not.toBeInTheDocument()
+    expect(screen.getByText('Create Index')).toBeInTheDocument()
+  })
+
   it('should load indexes after click on refresh', () => {
     ;(connectedInstanceSelector as jest.Mock).mockImplementation(() => ({
       host: '123.23.1.1',

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { useAppDispatch, useAppSelector } from 'uiSrc/slices/hooks'
 import { useHistory, useLocation } from 'react-router-dom'
 
@@ -19,11 +19,7 @@ import {
 } from 'uiSrc/slices/browser/keys'
 import { setBrowserSelectedKey } from 'uiSrc/slices/app/context'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import {
-  bufferToString,
-  formatLongName,
-  isRedisearchAvailable,
-} from 'uiSrc/utils'
+import { bufferToString, isRedisearchAvailable } from 'uiSrc/utils'
 import {
   SCAN_COUNT_DEFAULT,
   SCAN_TREE_COUNT_DEFAULT,
@@ -40,9 +36,12 @@ import {
 } from 'uiSrc/components/base/forms/select/RiSelect'
 import { Text } from 'uiSrc/components/base/text'
 import { Row } from 'uiSrc/components/base/layout/flex'
-import { getIndexDisplayName } from 'uiSrc/pages/vector-search/utils'
 import { useTranslation } from 'uiSrc/i18n'
 import * as S from './RediSearchIndexesList.styles'
+import {
+  getIndexOptionLabel,
+  getIndexOptionsWidth,
+} from './RediSearchIndexesList.utils'
 
 export const CREATE = JSON.stringify('create')
 
@@ -129,13 +128,14 @@ const RediSearchIndexesList = (props: Props) => {
     [],
   )
 
+  const contentWidth = useMemo(
+    () => getIndexOptionsWidth(list.map((item) => bufferToString(item))),
+    [list],
+  )
+
   const options = list.map((item) => {
     const stringValue = bufferToString(item)
-    const displayValue = formatLongName(
-      getIndexDisplayName(stringValue),
-      100,
-      10,
-    )
+    const displayValue = getIndexOptionLabel(stringValue)
 
     return {
       value: stringValue,
@@ -222,6 +222,9 @@ const RediSearchIndexesList = (props: Props) => {
         options={options}
         value={selectedValue}
         onChange={onChangeIndex}
+        customCompare={(option, search) =>
+          option.value === CREATE || option.value.toLowerCase().includes(search)
+        }
       >
         <RiSelect.Trigger.Compose data-testid="select-search-mode">
           <RiSelect.Trigger.Value
@@ -245,7 +248,11 @@ const RediSearchIndexesList = (props: Props) => {
             </RiTooltip>
           </div>
         </RiSelect.Trigger.Compose>
-        <RiSelect.Content optionValueRender={selectValueRender} />
+        <RiSelect.Content
+          searchable
+          contentWidth={contentWidth}
+          optionValueRender={selectValueRender}
+        />
       </RiSelect.Compose>
     </S.Container>
   )

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.tsx
@@ -41,6 +41,7 @@ import * as S from './RediSearchIndexesList.styles'
 import {
   getIndexOptionLabel,
   getIndexOptionsWidth,
+  matchesIndexSearch,
 } from './RediSearchIndexesList.utils'
 
 export const CREATE = JSON.stringify('create')
@@ -223,7 +224,7 @@ const RediSearchIndexesList = (props: Props) => {
         value={selectedValue}
         onChange={onChangeIndex}
         customCompare={(option, search) =>
-          option.value === CREATE || option.value.toLowerCase().includes(search)
+          option.value === CREATE || matchesIndexSearch(option.value, search)
         }
       >
         <RiSelect.Trigger.Compose data-testid="select-search-mode">

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import {
   getIndexOptionLabel,
   getIndexOptionsWidth,
+  matchesIndexSearch,
 } from './RediSearchIndexesList.utils'
 
 describe('getIndexOptionLabel', () => {
@@ -14,6 +15,23 @@ describe('getIndexOptionLabel', () => {
 
   it('should label an unnamed index instead of rendering nothing', () => {
     expect(getIndexOptionLabel('')).not.toEqual('')
+  })
+})
+
+describe('matchesIndexSearch', () => {
+  it('should match on the index name, case-insensitively', () => {
+    expect(matchesIndexSearch('idx:Restaurant', 'restaur')).toBe(true)
+    expect(matchesIndexSearch('idx:Restaurant', 'bicycle')).toBe(false)
+  })
+
+  it('should match an unnamed index by its displayed label', () => {
+    expect(matchesIndexSearch('', 'empty')).toBe(true)
+  })
+
+  it('should keep an unnamed index reachable for any term it displays', () => {
+    // '' matches no term by name alone, which would hide the option entirely
+    expect(matchesIndexSearch('', 'name')).toBe(true)
+    expect(matchesIndexSearch('', 'bicycle')).toBe(false)
   })
 })
 

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
@@ -33,6 +33,15 @@ describe('matchesIndexSearch', () => {
     expect(matchesIndexSearch('', 'name')).toBe(true)
     expect(matchesIndexSearch('', 'bicycle')).toBe(false)
   })
+
+  it('should treat a whitespace-only term as no filter', () => {
+    expect(matchesIndexSearch('idx:bicycle', ' ')).toBe(true)
+    expect(matchesIndexSearch('idx:bicycle', '   ')).toBe(true)
+  })
+
+  it('should ignore padding around a real term', () => {
+    expect(matchesIndexSearch('idx:bicycle', '  bicycle  ')).toBe(true)
+  })
 })
 
 describe('getIndexOptionsWidth', () => {

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.spec.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker'
+
+import {
+  getIndexOptionLabel,
+  getIndexOptionsWidth,
+} from './RediSearchIndexesList.utils'
+
+describe('getIndexOptionLabel', () => {
+  it('should return the index name unchanged when it is short', () => {
+    const name = `idx:${faker.word.noun()}`
+
+    expect(getIndexOptionLabel(name)).toEqual(name)
+  })
+
+  it('should label an unnamed index instead of rendering nothing', () => {
+    expect(getIndexOptionLabel('')).not.toEqual('')
+  })
+})
+
+describe('getIndexOptionsWidth', () => {
+  it('should fall back to the trigger width when there are no indexes', () => {
+    expect(getIndexOptionsWidth([])).toEqual(
+      'max(var(--radix-select-trigger-width), 6ch)',
+    )
+  })
+
+  it('should size to the longest name so filtering cannot resize the popover', () => {
+    const names = ['idx:a', 'idx:abcdefghij', 'idx:abc']
+
+    const width = getIndexOptionsWidth(names)
+
+    expect(width).toEqual('max(var(--radix-select-trigger-width), 20ch)')
+    // narrowing the list to any subset keeps the width the longest name asked for
+    expect(getIndexOptionsWidth(['idx:abcdefghij'])).toEqual(width)
+  })
+})

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
@@ -1,0 +1,29 @@
+import { formatLongName } from 'uiSrc/utils'
+import { getIndexDisplayName } from 'uiSrc/pages/vector-search/utils'
+
+const MAX_LABEL_LENGTH = 100
+const LABEL_END_PART_LENGTH = 10
+
+// Characters reserved for option padding and the selection indicator
+const OPTION_CHROME_CH = 6
+
+export const getIndexOptionLabel = (indexName: string) =>
+  formatLongName(
+    getIndexDisplayName(indexName),
+    MAX_LABEL_LENGTH,
+    LABEL_END_PART_LENGTH,
+  )
+
+/**
+ * Width for the index drop-down, derived from the longest label in the whole list so
+ * that filtering the options never resizes the popover. `ch` approximates the label
+ * width; the popover floor stays the trigger width.
+ */
+export const getIndexOptionsWidth = (indexNames: string[]) => {
+  const longestLabel = Math.max(
+    0,
+    ...indexNames.map((name) => getIndexOptionLabel(name).length),
+  )
+
+  return `max(var(--radix-select-trigger-width), ${longestLabel + OPTION_CHROME_CH}ch)`
+}

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
@@ -20,7 +20,8 @@ export const getIndexOptionLabel = (indexName: string) =>
  * "(empty name)" — stays reachable.
  */
 export const matchesIndexSearch = (indexName: string, search: string) => {
-  const term = search.toLowerCase()
+  const term = search.trim().toLowerCase()
+  if (!term) return true
 
   return (
     indexName.toLowerCase().includes(term) ||

--- a/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
+++ b/redisinsight/ui/src/pages/browser/components/redisearch-key-list/RediSearchIndexesList.utils.ts
@@ -15,6 +15,20 @@ export const getIndexOptionLabel = (indexName: string) =>
   )
 
 /**
+ * Matches an index against a drop-down search term by both its name and its displayed
+ * label, so an index whose label differs from its name — an unnamed index renders as
+ * "(empty name)" — stays reachable.
+ */
+export const matchesIndexSearch = (indexName: string, search: string) => {
+  const term = search.toLowerCase()
+
+  return (
+    indexName.toLowerCase().includes(term) ||
+    getIndexOptionLabel(indexName).toLowerCase().includes(term)
+  )
+}
+
+/**
  * Width for the index drop-down, derived from the longest label in the whole list so
  * that filtering the options never resizes the popover. `ch` approximates the label
  * width; the popover floor stays the trigger width.

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.spec.tsx
@@ -162,6 +162,19 @@ describe('IndexList', () => {
 
       expect(screen.getByText(mockIndexListData[0].name)).toBeInTheDocument()
     })
+
+    it('should show No results found when a filter matches nothing', () => {
+      renderComponent({ data: [], loading: false, isFiltered: true })
+
+      expect(screen.getByText('No results found')).toBeInTheDocument()
+    })
+
+    it('should keep No results found while a refetch is loading', () => {
+      renderComponent({ data: [], loading: true, isFiltered: true })
+
+      expect(screen.getByText('No results found')).toBeInTheDocument()
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+    })
   })
 
   describe('Column header tooltips', () => {

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.spec.tsx
@@ -169,11 +169,12 @@ describe('IndexList', () => {
       expect(screen.getByText('No results found')).toBeInTheDocument()
     })
 
-    it('should keep No results found while a refetch is loading', () => {
+    it('should not claim No results found while rows are still loading', () => {
+      // a refetch means the index list changed, so the filtered rows are stale
       renderComponent({ data: [], loading: true, isFiltered: true })
 
-      expect(screen.getByText('No results found')).toBeInTheDocument()
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
+      expect(screen.getByText('Loading...')).toBeInTheDocument()
+      expect(screen.queryByText('No results found')).not.toBeInTheDocument()
     })
   })
 

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
@@ -22,11 +22,13 @@ export const IndexList = memo(
     )
 
     const emptyMessage = useMemo(() => {
-      if (loading) {
-        return t('vectorSearch.list.empty.loading')
-      }
+      // A filter that matches nothing is a definitive answer, so it outranks a
+      // background refetch flipping `loading` back on
       if (isFiltered) {
         return t('vectorSearch.list.empty.noResults')
+      }
+      if (loading) {
+        return t('vectorSearch.list.empty.loading')
       }
       return t('vectorSearch.list.empty.noIndexes')
     }, [loading, isFiltered, t])

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
@@ -10,6 +10,7 @@ export const IndexList = memo(
   ({
     data,
     loading,
+    hasSearch,
     dataTestId = 'index-list',
     onQueryClick,
     actions,
@@ -20,17 +21,15 @@ export const IndexList = memo(
       [onQueryClick, actions],
     )
 
-    const hasIndexes = useMemo(() => !!data?.length, [data])
-
     const emptyMessage = useMemo(() => {
       if (loading) {
         return t('vectorSearch.list.empty.loading')
       }
-      if (!hasIndexes) {
-        return t('vectorSearch.list.empty.noIndexes')
+      if (hasSearch) {
+        return t('vectorSearch.list.empty.noResults')
       }
-      return t('vectorSearch.list.empty.noResults')
-    }, [loading, hasIndexes, t])
+      return t('vectorSearch.list.empty.noIndexes')
+    }, [loading, hasSearch, t])
 
     return (
       <Table

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
@@ -22,13 +22,13 @@ export const IndexList = memo(
     )
 
     const emptyMessage = useMemo(() => {
-      // A filter that matches nothing is a definitive answer, so it outranks a
-      // background refetch flipping `loading` back on
-      if (isFiltered) {
-        return t('vectorSearch.list.empty.noResults')
-      }
+      // Index info is only refetched when the index list itself changes, so while
+      // it loads the rows are stale and a filter over them can't be trusted
       if (loading) {
         return t('vectorSearch.list.empty.loading')
+      }
+      if (isFiltered) {
+        return t('vectorSearch.list.empty.noResults')
       }
       return t('vectorSearch.list.empty.noIndexes')
     }, [loading, isFiltered, t])

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.tsx
@@ -10,7 +10,7 @@ export const IndexList = memo(
   ({
     data,
     loading,
-    hasSearch,
+    isFiltered,
     dataTestId = 'index-list',
     onQueryClick,
     actions,
@@ -25,11 +25,11 @@ export const IndexList = memo(
       if (loading) {
         return t('vectorSearch.list.empty.loading')
       }
-      if (hasSearch) {
+      if (isFiltered) {
         return t('vectorSearch.list.empty.noResults')
       }
       return t('vectorSearch.list.empty.noIndexes')
-    }, [loading, hasSearch, t])
+    }, [loading, isFiltered, t])
 
     return (
       <Table

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.types.ts
@@ -46,6 +46,8 @@ export interface IndexListProps {
   data: IndexListRow[]
   /** Whether the list data is currently loading */
   loading?: boolean
+  /** Whether `data` has been narrowed by a search term, to pick the empty-state message */
+  hasSearch?: boolean
   /** Test ID for the list container */
   dataTestId?: string
   /** Callback when the Query button is clicked (index name is passed) */

--- a/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/index-list/IndexList.types.ts
@@ -47,7 +47,7 @@ export interface IndexListProps {
   /** Whether the list data is currently loading */
   loading?: boolean
   /** Whether `data` has been narrowed by a search term, to pick the empty-state message */
-  hasSearch?: boolean
+  isFiltered?: boolean
   /** Test ID for the list container */
   dataTestId?: string
   /** Callback when the Query button is clicked (index name is passed) */

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
@@ -11,6 +11,10 @@ import {
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { SearchIndexDetailsSource } from 'uiSrc/pages/vector-search/telemetry.constants'
+import {
+  exampleIndexListRows,
+  mockIndexListData,
+} from 'uiSrc/mocks/factories/vector-search/indexList.factory'
 
 import { useListContent } from './useListContent'
 import { useIndexListData } from '../useIndexListData'
@@ -99,6 +103,45 @@ describe('useListContent', () => {
 
     expect(result.current.data).toBe(mockData)
     expect(result.current.loading).toBe(true)
+  })
+
+  describe('search', () => {
+    beforeEach(() => {
+      ;(useIndexListData as jest.Mock).mockReturnValue({
+        data: mockIndexListData,
+        loading: false,
+      })
+    })
+
+    it('should return every row and hasSearch false without a search term', () => {
+      const { result } = renderHook(() => useListContent())
+
+      expect(result.current.data).toEqual(mockIndexListData)
+      expect(result.current.hasSearch).toBe(false)
+    })
+
+    it('should keep only rows whose name matches the term, case-insensitively', () => {
+      const { result } = renderHook(() => useListContent('USER'))
+
+      expect(result.current.data).toEqual([exampleIndexListRows.users])
+      expect(result.current.hasSearch).toBe(true)
+    })
+
+    it('should return no rows when nothing matches', () => {
+      const { result } = renderHook(() =>
+        useListContent(faker.string.alpha(20)),
+      )
+
+      expect(result.current.data).toEqual([])
+      expect(result.current.hasSearch).toBe(true)
+    })
+
+    it('should treat a whitespace-only term as no search', () => {
+      const { result } = renderHook(() => useListContent('   '))
+
+      expect(result.current.data).toEqual(mockIndexListData)
+      expect(result.current.hasSearch).toBe(false)
+    })
   })
 
   it('should return three actions', () => {

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.spec.ts
@@ -113,18 +113,18 @@ describe('useListContent', () => {
       })
     })
 
-    it('should return every row and hasSearch false without a search term', () => {
+    it('should return every row and isFiltered false without a search term', () => {
       const { result } = renderHook(() => useListContent())
 
       expect(result.current.data).toEqual(mockIndexListData)
-      expect(result.current.hasSearch).toBe(false)
+      expect(result.current.isFiltered).toBe(false)
     })
 
     it('should keep only rows whose name matches the term, case-insensitively', () => {
       const { result } = renderHook(() => useListContent('USER'))
 
       expect(result.current.data).toEqual([exampleIndexListRows.users])
-      expect(result.current.hasSearch).toBe(true)
+      expect(result.current.isFiltered).toBe(true)
     })
 
     it('should return no rows when nothing matches', () => {
@@ -133,14 +133,25 @@ describe('useListContent', () => {
       )
 
       expect(result.current.data).toEqual([])
-      expect(result.current.hasSearch).toBe(true)
+      expect(result.current.isFiltered).toBe(true)
     })
 
     it('should treat a whitespace-only term as no search', () => {
       const { result } = renderHook(() => useListContent('   '))
 
       expect(result.current.data).toEqual(mockIndexListData)
-      expect(result.current.hasSearch).toBe(false)
+      expect(result.current.isFiltered).toBe(false)
+    })
+
+    it('should not report a filter when there are no indexes to filter', () => {
+      ;(useIndexListData as jest.Mock).mockReturnValue({
+        data: [],
+        loading: false,
+      })
+
+      const { result } = renderHook(() => useListContent(faker.string.alpha(5)))
+
+      expect(result.current.isFiltered).toBe(false)
     })
   })
 

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -43,13 +43,16 @@ export const useListContent = (search = '') => {
   )
 
   const { data: allRows, loading } = useIndexListData(indexes)
+  const searchTerm = search.trim().toLowerCase()
 
   const data = useMemo(() => {
-    const term = search.trim().toLowerCase()
-    if (!term) return allRows
+    if (!searchTerm) return allRows
 
-    return allRows.filter((row) => row.name.toLowerCase().includes(term))
-  }, [allRows, search])
+    return allRows.filter((row) => row.name.toLowerCase().includes(searchTerm))
+  }, [allRows, searchTerm])
+
+  // A search over an empty list is not a filter — the list page still has no indexes to show
+  const isFiltered = !!searchTerm && allRows.length > 0
 
   const [pendingDeleteIndex, setPendingDeleteIndex] = useState<string | null>(
     null,
@@ -180,7 +183,7 @@ export const useListContent = (search = '') => {
   return {
     data,
     loading,
-    hasSearch: !!search.trim(),
+    isFiltered,
     actions,
     onQueryClick: handleQueryClick,
     viewingIndexName,

--- a/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
+++ b/redisinsight/ui/src/pages/vector-search/hooks/useListContent/useListContent.ts
@@ -29,7 +29,7 @@ import { localStorageService } from 'uiSrc/services'
 import { IndexListAction } from '../../components/index-list/IndexList.types'
 import { useIndexListData } from '../useIndexListData'
 
-export const useListContent = () => {
+export const useListContent = (search = '') => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const history = useHistory()
@@ -42,7 +42,14 @@ export const useListContent = () => {
     [rawIndexes],
   )
 
-  const { data, loading } = useIndexListData(indexes)
+  const { data: allRows, loading } = useIndexListData(indexes)
+
+  const data = useMemo(() => {
+    const term = search.trim().toLowerCase()
+    if (!term) return allRows
+
+    return allRows.filter((row) => row.name.toLowerCase().includes(term))
+  }, [allRows, search])
 
   const [pendingDeleteIndex, setPendingDeleteIndex] = useState<string | null>(
     null,
@@ -173,6 +180,7 @@ export const useListContent = () => {
   return {
     data,
     loading,
+    hasSearch: !!search.trim(),
     actions,
     onQueryClick: handleQueryClick,
     viewingIndexName,

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.styles.ts
@@ -8,7 +8,7 @@ export const HeaderRow = styled(Row).attrs({ grow: false })`
 
 // Fixed width so the reset button appearing on input does not resize the field
 export const IndexSearchInput = styled(SearchInput)`
-  width: 266px;
+  width: calc(${({ theme }) => theme.core.space.space550} * 6); // 264px
 `
 
 export const PageLayout = styled(Col).attrs({ gap: 'l' })`

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.styles.ts
@@ -1,8 +1,14 @@
 import styled from 'styled-components'
 import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { SearchInput } from 'uiSrc/components/base/inputs'
 
 export const HeaderRow = styled(Row).attrs({ grow: false })`
   align-items: center;
+`
+
+// Fixed width so the reset button appearing on input does not resize the field
+export const IndexSearchInput = styled(SearchInput)`
+  width: 266px;
 `
 
 export const PageLayout = styled(Col).attrs({ gap: 'l' })`

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/VectorSearchListPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { useRedisInstanceCompatibility } from '../../hooks'
 import { UpgradeRedisBanner } from '../../components/upgrade-redis-banner'
@@ -15,13 +15,14 @@ import * as S from './VectorSearchListPage.styles'
  */
 export const VectorSearchListPage = () => {
   const { hasSupportedVersion } = useRedisInstanceCompatibility()
+  const [search, setSearch] = useState('')
 
   return (
     <S.PageLayout data-testid="vector-search--list--page">
       {hasSupportedVersion === false && <UpgradeRedisBanner />}
 
-      <ListHeader />
-      <ListContent />
+      <ListHeader search={search} onSearchChange={setSearch} />
+      <ListContent search={search} />
     </S.PageLayout>
   )
 }

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/ListHeader.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/ListHeader.tsx
@@ -1,13 +1,29 @@
 import React from 'react'
 
+import { useTranslation } from 'uiSrc/i18n'
+import { Row } from 'uiSrc/components/base/layout/flex'
+
 import { HeaderTitle } from './header-title'
 import { CreateIndexMenu } from './create-index-menu'
 
 import * as S from '../VectorSearchListPage.styles'
+import { ListHeaderProps } from './ListHeader.types'
 
-export const ListHeader = () => (
-  <S.HeaderRow justify="between" data-testid="vector-search--list--header">
-    <HeaderTitle />
-    <CreateIndexMenu />
-  </S.HeaderRow>
-)
+export const ListHeader = ({ search, onSearchChange }: ListHeaderProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <S.HeaderRow justify="between" data-testid="vector-search--list--header">
+      <HeaderTitle />
+      <Row grow={false} align="center" gap="m">
+        <S.IndexSearchInput
+          placeholder={t('vectorSearch.list.search.placeholder')}
+          value={search}
+          onChange={onSearchChange}
+          data-testid="vector-search--list--search"
+        />
+        <CreateIndexMenu />
+      </Row>
+    </S.HeaderRow>
+  )
+}

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/ListHeader.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/ListHeader.types.ts
@@ -1,0 +1,6 @@
+export interface ListHeaderProps {
+  /** Current index-name search term */
+  search: string
+  /** Called with the new term as the user types */
+  onSearchChange: (value: string) => void
+}

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.spec.tsx
@@ -32,6 +32,7 @@ const mockDeleteCallback = jest.fn()
 const defaultHookReturn: UseListContentReturn = {
   data: [],
   loading: false,
+  hasSearch: false,
   actions: [
     { name: 'View index', icon: ShowIcon, callback: mockViewIndexCallback },
     {
@@ -94,6 +95,13 @@ describe('ListContent', () => {
     renderComponent()
 
     expect(screen.getByText('No indexes found')).toBeInTheDocument()
+  })
+
+  it('should render no-results empty state when a search filtered everything out', () => {
+    setupHook({ hasSearch: true })
+    renderComponent()
+
+    expect(screen.getByText('No results found')).toBeInTheDocument()
   })
 
   it('should not render view index panel when viewingIndexName is null', () => {

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.spec.tsx
@@ -32,7 +32,7 @@ const mockDeleteCallback = jest.fn()
 const defaultHookReturn: UseListContentReturn = {
   data: [],
   loading: false,
-  hasSearch: false,
+  isFiltered: false,
   actions: [
     { name: 'View index', icon: ShowIcon, callback: mockViewIndexCallback },
     {
@@ -98,7 +98,7 @@ describe('ListContent', () => {
   })
 
   it('should render no-results empty state when a search filtered everything out', () => {
-    setupHook({ hasSearch: true })
+    setupHook({ isFiltered: true })
     renderComponent()
 
     expect(screen.getByText('No results found')).toBeInTheDocument()

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
@@ -11,12 +11,14 @@ import { IndexInfoSidePanel } from 'uiSrc/pages/vector-search/components/index-i
 import { useListContent } from 'uiSrc/pages/vector-search/hooks/useListContent'
 
 import * as S from './ListContent.styles'
+import { ListContentProps } from './ListContent.types'
 import { DeleteIndexConfirmation } from '../delete-index-confirmation/DeleteIndexConfirmation'
 
-export const ListContent = () => {
+export const ListContent = ({ search }: ListContentProps) => {
   const {
     data,
     loading,
+    hasSearch,
     actions,
     onQueryClick,
     viewingIndexName,
@@ -24,7 +26,7 @@ export const ListContent = () => {
     pendingDeleteIndex,
     onConfirmDelete,
     onCloseDelete,
-  } = useListContent()
+  } = useListContent(search)
 
   return (
     <S.ContentArea>
@@ -40,6 +42,7 @@ export const ListContent = () => {
               <IndexList
                 data={data}
                 loading={loading}
+                hasSearch={hasSearch}
                 onQueryClick={onQueryClick}
                 actions={actions}
                 dataTestId="vector-search--list--table"

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.tsx
@@ -18,7 +18,7 @@ export const ListContent = ({ search }: ListContentProps) => {
   const {
     data,
     loading,
-    hasSearch,
+    isFiltered,
     actions,
     onQueryClick,
     viewingIndexName,
@@ -42,7 +42,7 @@ export const ListContent = ({ search }: ListContentProps) => {
               <IndexList
                 data={data}
                 loading={loading}
-                hasSearch={hasSearch}
+                isFiltered={isFiltered}
                 onQueryClick={onQueryClick}
                 actions={actions}
                 dataTestId="vector-search--list--table"

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.types.ts
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchListPage/components/list-content/ListContent.types.ts
@@ -1,0 +1,4 @@
+export interface ListContentProps {
+  /** Index-name search term used to narrow the table rows */
+  search?: string
+}


### PR DESCRIPTION
# What

Databases with hundreds of indexes are hard to navigate, so both places that list indexes now have a search box:

- **Browser index drop-down** — uses the Select's built-in search. `Create Index` stays pinned while filtering.
- **Search indexes list page** — a search field in the header filters the table by index name.

The query-page breadcrumb picker already had search, so it is untouched.

Both fields are sized so that typing cannot resize them: the drop-down popover width comes from the longest name in the whole index list rather than the currently rendered subset, and the list-page field has a fixed width matching the existing auto-discover header search.

# Testing

## Before
<img width="1556" height="370" alt="Screenshot 2026-08-05 at 13 42 47" src="https://github.com/user-attachments/assets/fe9b9d5d-12fd-4061-80c6-9452dbfceabd" />
<img width="1502" height="596" alt="Screenshot 2026-08-05 at 13 58 08" src="https://github.com/user-attachments/assets/a5cd0c1b-0578-4976-bda6-ac991f923d23" />

## After 

https://github.com/user-attachments/assets/387f7960-98b6-40ae-82aa-a9283ae7fe0c

https://github.com/user-attachments/assets/e3604b09-1b76-4628-b6c1-8ad1bb8d227c



---

Refs #RI-8357


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side UI filtering and empty-state messaging only; no API, auth, or data-layer changes.
> 
> **Overview**
> Adds **search** in both places users pick or browse search indexes, aimed at databases with large index lists.
> 
> The **Browser** RediSearch index selector is now a **searchable** `RiSelect`: options filter case-insensitively by index name and display label (so unnamed indexes stay findable), **Create Index** always stays visible, and dropdown width is fixed from the longest label so filtering does not resize the popover. Label/search/width logic lives in new `RediSearchIndexesList.utils`.
> 
> The **Search indexes** list page gets a header **search field** (new i18n placeholder in `en`/`bg`) with fixed width; `useListContent(search)` filters rows by index name and exposes **`isFiltered`** so the table shows **No results found** vs **No indexes found**, and prefers **Loading...** over a false empty filter while data is refetching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae530e8fa561a124c5eb80f997860e5f701e0fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->