### PR TITLE
Fix flaky AutoRefresh interval test

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.spec.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.spec.tsx
@@ -22,6 +22,10 @@ describe('AutoRefresh', () => {
     jest.clearAllMocks()
     jest.spyOn(localStorageService, 'get').mockImplementation(() => null)
   })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
   it('should render', () => {
     expect(render(<AutoRefresh {...instance(mockedProps)} />)).toBeTruthy()
   })
@@ -157,12 +161,14 @@ describe('AutoRefresh', () => {
     })
 
     it('should call onRefresh after enable auto-refresh and set 1 sec', async () => {
+      jest.useFakeTimers()
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
       const onRefresh = jest.fn()
       render(<AutoRefresh {...instance(mockedProps)} onRefresh={onRefresh} />)
 
-      await userEvent.click(screen.getByTestId('auto-refresh-config-btn'))
+      await user.click(screen.getByTestId('auto-refresh-config-btn'))
       await waitForRiPopoverVisible()
-      await userEvent.click(screen.getByTestId('auto-refresh-switch'))
+      await user.click(screen.getByTestId('auto-refresh-switch'))
       fireEvent.click(screen.getByTestId('refresh-rate'))
 
       fireEvent.change(screen.getByTestId(INLINE_ITEM_EDITOR), {
@@ -170,21 +176,20 @@ describe('AutoRefresh', () => {
       })
       expect(screen.getByTestId(INLINE_ITEM_EDITOR)).toHaveValue('1')
 
-      await userEvent.click(screen.getByTestId(/apply-btn/))
-      // screen.getByTestId(/apply-btn/).click()
+      await user.click(screen.getByTestId(/apply-btn/))
 
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1300))
+      act(() => {
+        jest.advanceTimersByTime(1_000)
       })
       expect(onRefresh).toHaveBeenCalledTimes(1)
 
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1300))
+      act(() => {
+        jest.advanceTimersByTime(1_000)
       })
       expect(onRefresh).toHaveBeenCalledTimes(2)
 
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1300))
+      act(() => {
+        jest.advanceTimersByTime(1_000)
       })
       expect(onRefresh).toHaveBeenCalledTimes(3)
     })
@@ -263,14 +268,16 @@ describe('AutoRefresh', () => {
   })
 
   it('should NOT call onRefresh with disabled state', async () => {
+    jest.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
     const onRefresh = jest.fn()
     const { rerender } = render(
       <AutoRefresh {...instance(mockedProps)} onRefresh={onRefresh} />,
     )
 
-    await userEvent.click(screen.getByTestId('auto-refresh-config-btn'))
+    await user.click(screen.getByTestId('auto-refresh-config-btn'))
     await waitForRiPopoverVisible()
-    await userEvent.click(screen.getByTestId('auto-refresh-switch'))
+    await user.click(screen.getByTestId('auto-refresh-switch'))
     fireEvent.click(screen.getByTestId('refresh-rate'))
     fireEvent.change(screen.getByTestId(INLINE_ITEM_EDITOR), {
       target: { value: '1' },
@@ -278,9 +285,11 @@ describe('AutoRefresh', () => {
 
     expect(screen.getByTestId(INLINE_ITEM_EDITOR)).toHaveValue('1')
 
-    screen.getByTestId(/apply-btn/).click()
+    act(() => {
+      screen.getByTestId(/apply-btn/).click()
+    })
 
-    await act(async () => {
+    act(() => {
       rerender(
         <AutoRefresh
           {...instance(mockedProps)}
@@ -290,17 +299,17 @@ describe('AutoRefresh', () => {
       )
     })
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 1300))
+    act(() => {
+      jest.advanceTimersByTime(1_000)
     })
     expect(onRefresh).toHaveBeenCalledTimes(0)
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 1300))
+    act(() => {
+      jest.advanceTimersByTime(1_000)
     })
     expect(onRefresh).toHaveBeenCalledTimes(0)
 
-    await act(async () => {
+    act(() => {
       rerender(
         <AutoRefresh
           {...instance(mockedProps)}
@@ -310,8 +319,8 @@ describe('AutoRefresh', () => {
       )
     })
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 1300))
+    act(() => {
+      jest.advanceTimersByTime(1_000)
     })
     expect(onRefresh).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
# What

`AutoRefresh.spec.tsx` had two tests that slept on real wall-clock time (3x 1300ms) while asserting exact `setInterval` tick counts at a 1s refresh rate. That left only ~100ms of margin before a 4th tick, so any CI slowness pushed past it and failed the count assertion - this is what's failing regularly in CI, e.g. [this run](https://github.com/redis/RedisInsight/actions/runs/31087038116/job/92569616873).

Switched both tests to Jest fake timers driven by `jest.advanceTimersByTime`, making tick counts deterministic. No production code changed.

# Testing

- `node 'node_modules/.bin/jest' 'redisinsight/ui/src/components/auto-refresh/AutoRefresh.spec.tsx' -c 'jest.config.cjs'` - all 23 tests pass, timing tests now finish in ~100ms instead of ~4s each
- Ran the spec 10x in a row to confirm determinism
- `StatisticsPage.spec.tsx` (consumer of `AutoRefresh`) still passes
- `npx eslint` clean on the changed file

---

Refs #6326

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to AutoRefresh specs; no runtime behavior or production paths modified.
> 
> **Overview**
> Fixes flaky CI in **`AutoRefresh.spec.tsx`** by replacing real `setTimeout` waits (~1300ms per step) with **Jest fake timers** and **`jest.advanceTimersByTime(1_000)`** so 1s auto-refresh tick counts are deterministic.
> 
> The two affected specs (**enable auto-refresh at 1s** and **disabled state blocks refresh**) now use **`userEvent.setup({ advanceTimers })`**, wrap timer advances in **`act`**, and add a suite **`afterEach`** that calls **`jest.useRealTimers()`** so fake timers do not leak to other tests.
> 
> **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f822a26a7e86b221a8c4344e79322dd5a4e7cb85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->